### PR TITLE
handle multiple data collector case

### DIFF
--- a/app/views/embeddable/data_collectors/_show.otml.haml
+++ b/app/views/embeddable/data_collectors/_show.otml.haml
@@ -27,7 +27,7 @@
     - case data_collector.graph_type
       - when 'Sensor'
         - if data_collector.multiple_graphable_enabled
-          - # (used as prototype when 'new' is clicked in multigraph
+          - # used as prototype when 'new' is clicked in multigraph
           %prototypeGraphables 
             %OTDataGraphable{ :local_id => ot_local_id_for(data_collector,  :source, :prototype_graphable),
               :connectPoints => data_collector.connect_points.to_s,
@@ -50,6 +50,15 @@
             %dataStore
               = generate_otml_datastore(data_collector)
       - else
+        - if data_collector.multiple_graphable_enabled && !data_collector.static
+          - # used as prototype when 'new' is clicked in multigraph
+          - # it isn't clear what the new button should do with a static graph
+          %prototypeGraphables
+            %OTDataGraphable{ :local_id => ot_local_id_for(data_collector, :source, :prototype_graphable),
+              :controllable => (!data_collector.static).to_s,
+              :connectPoints => data_collector.connect_points.to_s,
+              :drawMarks => data_collector.draw_marks.to_s, :color => "0xff0000",
+              :xColumn => "0", :lineWidth => "2.0", :visible => "true" }
         %source
           %OTDataGraphable{ :local_id => ot_local_id_for(data_collector, :source, :data_graphable),
             :controllable => (!data_collector.static).to_s,


### PR DESCRIPTION
This fixes a bug when authoring a multiple prediction if the original line is deleted then new lines that are created break.
