### PR TITLE
Isolate embeddable lookup by embeddable type in process_external_acti…

### DIFF
--- a/app/models/dataservice/process_external_activity_data_job.rb
+++ b/app/models/dataservice/process_external_activity_data_job.rb
@@ -6,7 +6,6 @@ class Dataservice::ProcessExternalActivityDataJob < Struct.new(:learner_id, :con
     learner = Portal::Learner.find(learner_id)
     offering = learner.offering
     template = offering.runnable.template
-    embeddables = [template.open_responses, template.multiple_choices, template.image_questions].flatten.compact.uniq
 
     # setup for SaveableExtraction
     @learner_id = learner_id
@@ -14,13 +13,15 @@ class Dataservice::ProcessExternalActivityDataJob < Struct.new(:learner_id, :con
 
     # process the json data
     all_data.each do |student_response|
-      embeddable = embeddables.detect {|e| e.external_id == student_response["question_id"]}
       case student_response["type"]
       when "open_response"
+        embeddable = template.open_responses.detect {|e| e.external_id == student_response["question_id"]}
         internal_process_open_response(student_response, embeddable)
       when "multiple_choice"
+        embeddable = template.multiple_choices.detect {|e| e.external_id == student_response["question_id"]}
         internal_process_multiple_choice(student_response, embeddable)
       when "image_question"
+        embeddable = template.image_questions.detect {|e| e.external_id == student_response["question_id"]}
         internal_process_image_question(student_response, embeddable)
       end
     end


### PR DESCRIPTION
In LARA we are not sending very unique ID's to the portal (as we should)

Instead we are just sending the type and the id of the obj. in Lara.

Obviously the long range solution would be to make better ID's

But for activities that are already published, scoping to embeddable type seems like a good fallback.

For some background see this PT ticket: https://www.pivotaltracker.com/story/show/59297132
