### PR TITLE
An administrator can search material collections by project [#94104142]

### DIFF
--- a/app/assets/stylesheets/web/action_menu_tab.scss
+++ b/app/assets/stylesheets/web/action_menu_tab.scss
@@ -89,6 +89,10 @@ a.rollover:hover {
       margin-right: 5px; }
     p {
       clear: both; } }
+    select {
+      padding: 3px;
+      margin: 5px;
+    }
   .action_menu_header_right {
     background: transparent;
     float: right;

--- a/app/controllers/materials_collections_controller.rb
+++ b/app/controllers/materials_collections_controller.rb
@@ -5,7 +5,9 @@ class MaterialsCollectionsController < ApplicationController
   # GET /materials_collections
   # GET /materials_collections.json
   def index
-    @materials_collections = MaterialsCollection.search(params[:search], params[:page], nil)
+    # restrict search to project_id if provided
+    filtered = params[:project_id].to_s.length > 0 ? MaterialsCollection.where({:project_id => params[:project_id]}) : MaterialsCollection
+    @materials_collections = filtered.search(params[:search], params[:page], nil)
 
     respond_to do |format|
       format.html # index.html.erb

--- a/app/views/materials_collections/index.html.haml
+++ b/app/views/materials_collections/index.html.haml
@@ -1,2 +1,3 @@
-= render :partial => 'shared/collection_menu', :locals => { :collection => @materials_collections, :collection_class => MaterialsCollection }
+- extra_search_fields = select_tag :project_id, options_from_collection_for_select(Admin::Project.all, "id", "name", selected: params[:project_id]), prompt: "Select project..."
+= render :partial => 'shared/collection_menu', :locals => { :collection => @materials_collections, :collection_class => MaterialsCollection, :extra_collection_search_fields => extra_search_fields }
 = render :partial => 'list_show', :collection => @materials_collections, :as => :materials_collection

--- a/app/views/shared/_collection_menu.html.haml
+++ b/app/views/shared/_collection_menu.html.haml
@@ -5,6 +5,8 @@
         = content_tag :label do
           = text_field_tag :search, params[:search], :size => 20
         %input{ :type => "submit", :value => "Search"}
+        - if defined? extra_collection_search_fields
+          %p= extra_collection_search_fields
       - if collection
         %p= page_entries_info collection, :model => collection_class.display_name
       %p.paginator


### PR DESCRIPTION
This adds a generic "where" hash to the SearchableModel#search method parameters that takes the following form:

```{col => [op, value]}```

where col is the column name, op is the operation and value is the right handle value of the operation.  In this commit the search is limited by project_id by passing the following from the materials collection controller:

```{:project_id => ["=", params[:project_id]]}```
