### PR TITLE
Search form fix

### DIFF
--- a/app/assets/javascripts/components/search/result_group.js.coffee.erb
+++ b/app/assets/javascripts/components/search/result_group.js.coffee.erb
@@ -12,7 +12,7 @@ window.SearchResultGroupClass = React.createClass
       window.updateSearchUrl(query)
 
       # strip out all material_types[] params
-      query = query.replace(/(^|&)material_types(\[|%5B)(\]|%5D)=[^&]*/, '')
+      query = query.replace(/(^|&)material_types(\[|%5B)(\]|%5D)=[^&]*/g, '')
 
       # add back the one for this group's material type
       query += "&material_types[]=#{@materialType}"

--- a/app/assets/javascripts/components/search/results.js.coffee
+++ b/app/assets/javascripts/components/search/results.js.coffee
@@ -38,5 +38,5 @@ window.SearchResultsClass = React.createClass
 
 window.SearchResults = React.createFactory SearchResultsClass
 
-window.renderSearchResults = (results, dest) ->
-  React.render SearchResults(results), jQuery(dest)[0]
+Portal.renderSearchResults = (results, dest) ->
+  React.render SearchResults(results: results), jQuery(dest)[0]

--- a/app/assets/javascripts/search_materials.js.erb
+++ b/app/assets/javascripts/search_materials.js.erb
@@ -185,27 +185,8 @@ function showHideFilters(linkElement, animationDuration) {
     return true;
 }
 
-function setInputsEnabled(selector, value) {
-    var parent = jQuery(selector);
-    value ? parent.removeClass('disabledfilters') : parent.addClass('disabledfilters');
-    parent.find(':input').prop('disabled', !value);
-}
-function disableAllInputs() {
-    setInputsEnabled('#filter_container', false);
-    setInputsEnabled('#search_term', false);
-    setInputsEnabled('#go-button', false);
-}
-function enableAllInputs() {
-    setInputsEnabled('#filter_container', true);
-    setInputsEnabled('#search_term', true);
-    setInputsEnabled('#go-button', true);
-}
-
 function submitForm() {
     jQuery('#material_search_form').submit();
-    // So user can see that form has been submitted and he can't modify it anymore.
-    disableAllInputs();
-
     // hide the search suggestions
     jQuery('#search_suggestions').hide();
 }

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -3,10 +3,10 @@ class API::V1::SearchController < API::APIController
 
   def search
     opts = params.merge(:user_id => current_visitor.id)
-    opts[:include_official] = true if request.query_parameters.empty?
     begin
       @search = Search.new(opts)
-      render json: search_results_data
+      # Return query string, so the response can be identified by the client code.
+      render json: {query: request.query_string, results: search_results_data}
     rescue => e
       ExceptionNotifier::Notifier.exception_notification(request.env, e).deliver
       error('Search unavailable')
@@ -21,7 +21,7 @@ class API::V1::SearchController < API::APIController
       next if type == :all
       results.push group_data(type.downcase, values)
     end
-    { results: results }
+    results
   end
 
   def group_data(type, collection)

--- a/app/views/search/index.html.haml
+++ b/app/views/search/index.html.haml
@@ -28,7 +28,7 @@
         apiBase = '#{api_v1_search_search_path}?',
         searchBase = '#{search_path}?';
 
-    window.updateSearchUrl = function(query) {
+    updateSearchUrl = function(query) {
       if (window.history) {
         window.history.replaceState({}, 'Materials Search' , searchBase + query);
       } else {
@@ -46,14 +46,17 @@
       jQuery("#interactive_page").val(1);
       var query = jQuery(this).serialize();
 
-      window.updateSearchUrl(query);
+      updateSearchUrl(query);
 
       jQuery.ajax({
         dataType: "json",
         url: apiBase + query,
-        success: function(results) {
-          window.renderSearchResults(results, dest);
-          enableAllInputs();
+        success: function(data) {
+          // Check if response matches current query (rm '?' character from window.location.search first).
+          // If not, it means it's outdated result and it doesn't make sense to render it.
+          if (data.query === window.location.search.slice(1)) {
+            Portal.renderSearchResults(data.results, dest);
+          }
         }
       });
     });

--- a/app/views/search/index.html.haml
+++ b/app/views/search/index.html.haml
@@ -28,7 +28,7 @@
         apiBase = '#{api_v1_search_search_path}?',
         searchBase = '#{search_path}?';
 
-    updateSearchUrl = function(query) {
+    window.updateSearchUrl = function(query) {
       if (window.history) {
         window.history.replaceState({}, 'Materials Search' , searchBase + query);
       } else {
@@ -46,7 +46,7 @@
       jQuery("#interactive_page").val(1);
       var query = jQuery(this).serialize();
 
-      updateSearchUrl(query);
+      window.updateSearchUrl(query);
 
       jQuery.ajax({
         dataType: "json",

--- a/features/teacher_filters_instructional_materials.feature
+++ b/features/teacher_filters_instructional_materials.feature
@@ -17,21 +17,18 @@ Feature: Teacher can search and filter instructional materials
   @javascript
   Scenario: Teacher should be able to filter the search results on the basis of domains
     When I check "Biological Science"
-    And I should wait 2 seconds
     Then I should see "Digestive System"
 
 
   @javascript
   Scenario: Teacher should be able to filter the search results on the basis of grades
     When I check "10-11"
-    And I should wait 2 seconds
     Then I should see "Digestive System"
     And I should see "Bile Juice"
 
 
   @javascript
   Scenario: Teacher views all investigations and activities for all grades
-    When I wait 2 seconds
     Then I should see "Digestive System"
     And I should see "Bile Juice"
 
@@ -39,19 +36,15 @@ Feature: Teacher can search and filter instructional materials
   @javascript
   Scenario: Teacher should be able to filter the search results on the basis of probes
     When I check "Temperature"
-    And I should wait 2 seconds
     And I should see "A Weather Underground"
     And I should see "A heat spontaneously"
     And I should not see "Digestive System"
     And I should not see "Bile Juice"
     And I uncheck "Temperature"
-    And I should wait 2 seconds
     And I check "UVA Intensity"
-    And I should wait 2 seconds
     Then I should not see "A Weather Underground"
     And I should not see "A heat spontaneously"
     And I check "Temperature"
-    And I should wait 2 seconds
     And I should see "A Weather Underground"
     And I should see "A heat spontaneously"
 
@@ -59,9 +52,7 @@ Feature: Teacher can search and filter instructional materials
   @javascript
   Scenario: Teacher views all investigations and activities with sensors
     When I follow "check all"
-    And I should wait 2 seconds
     And I uncheck "Sensors Not Necessary"
-    And I should wait 2 seconds
     Then I should see "A Weather Underground"
     And I should see "A heat spontaneously"
     And I should not see "Digestive System"
@@ -71,12 +62,9 @@ Feature: Teacher can search and filter instructional materials
   @javascript
   Scenario: Teacher views investigations and activities without sensors
     When I check "Sensors Not Necessary"
-    And I should wait 2 seconds
     Then I should not see "A Weather Underground"
     And I should not see "A heat spontaneously"
     When I uncheck "Sensors Not Necessary"
-    And I should wait 2 seconds
     And I follow "clear"
-    And I should wait 2 seconds
     And I should see "A Weather Underground"
     And I should see "A heat spontaneously"

--- a/spec/controllers/api/v1/search_controller_spec.rb
+++ b/spec/controllers/api/v1/search_controller_spec.rb
@@ -74,7 +74,7 @@ describe API::V1::SearchController do
       end
 
       describe "with no filter parameters" do
-        it "should return search results that show only official materials" do
+        it "should return search results that show all the materials" do
           assigns[:search].should_not be_nil
           assigns[:search].results[Search::InvestigationMaterial].should_not be_nil
           assigns[:search].results[Search::InvestigationMaterial].length.should be(5)
@@ -82,9 +82,9 @@ describe API::V1::SearchController do
             all_investigations.should include(investigation)
           end
           assigns[:search].results[Search::ActivityMaterial].should_not be_nil
-          assigns[:search].results[Search::ActivityMaterial].length.should be(6)
+          assigns[:search].results[Search::ActivityMaterial].length.should be(7)
           assigns[:search].results[Search::ActivityMaterial].each do |activity|
-            official_activities.should include(activity)
+            all_activities.should include(activity)
           end
         end
       end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -74,6 +74,13 @@ describe SearchController do
         response.should redirect_to("/")
       end
     end
+
+    describe "when there are no query parameters" do
+      it "should redirect to ?include_official=1" do
+        get :index
+        response.should redirect_to action: :index, include_official: '1'
+      end
+    end
   end
 
   describe "Post get_current_material_unassigned_clazzes" do


### PR DESCRIPTION
Cucumber tests were failing, because we were disabling the search form each time it was submitted. It was breaking sequence of capybara check / uncheck actions. 

Disabling the form was reasonable when we were reloading page, but I don't think it makes sense now. So, instead of fixing the test itself, I just removed disabling of the form, as user experience should improve a bit. The code makes sure now that we don't render outdated results. 

One possible improvement would be to add some timeout and don't submit form too often. But it's not too obvious, long timeout is annoying, short doesn't change much. Anyway, the current situation is the same as it was previously, form disabling didn't help here.

The pull request also fixes this bug:
https://www.pivotaltracker.com/story/show/95149844
It's present on production.

I also removed default `include_official` filter from `API::SearchController`. That's handled by regular `SearchController` that redirects to `search?include_official=1` in case of need.