### PR TITLE
Fixed insert error for column named 'name' in newer mysql versions

### DIFF
--- a/lib/tasks/data_load_and_save.rake
+++ b/lib/tasks/data_load_and_save.rake
@@ -204,7 +204,7 @@ namespace :db do
                     data[c.name] = user_id
                   end
                 end
-                ActiveRecord::Base.connection.execute "INSERT INTO #{tbl} (#{data.keys.join(",")}) VALUES (#{data.values.collect { |value| ActiveRecord::Base.connection.quote(value) }.join(",")})", 'Fixture Insert'
+                ActiveRecord::Base.connection.execute "INSERT INTO #{tbl} (#{data.keys.collect {|value| "`#{value}`"}.join(",")}) VALUES (#{data.values.collect { |value| ActiveRecord::Base.connection.quote(value) }.join(",")})", 'Fixture Insert'
               end        
             rescue StandardError => e
               puts e


### PR DESCRIPTION
In later versions of MySQL you will get an insert error if you don't backquote columns that have the same name as MySQL functions names.  The ri_gse_domains and rs_gse_unifying_themes tables have a column named 'name' and name is a MySQL function.  This fix backquotes the bare insert in data_load_and_save.rake.