### PR TITLE
Fix "My activities" bin (don't list templates)

### DIFF
--- a/app/controllers/api/v1/materials_controller.rb
+++ b/app/controllers/api/v1/materials_controller.rb
@@ -2,8 +2,13 @@ class API::V1::MaterialsController < API::APIController
   include Materials::DataHelpers
 
   # GET /api/v1/materials/own
+  # Template materials are not listed.
   def own
-    render json: materials_data(current_visitor.materials)
+    # Filter out template objects.
+    materials = current_visitor.external_activities +
+                current_visitor.activities.is_template(false) +
+                current_visitor.investigations.is_template(false)
+    render json: materials_data(materials)
   end
 
   # GET /api/v1/materials/featured

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -184,6 +184,15 @@ class Activity < ActiveRecord::Base
   scope :assigned, where('offerings_count > 0')
 
   scope :ordered_by, lambda { |order| { :order => order } }
+
+  scope :is_template, ->(v) do
+    joins(['LEFT OUTER JOIN investigations ON investigations.id = activities.investigation_id',
+           'LEFT OUTER JOIN external_activities',
+           'ON (external_activities.template_id = activities.id AND external_activities.template_type = "Activity")',
+           'OR (external_activities.template_id = investigations.id AND external_activities.template_type = "Investigation")'])
+        .where("external_activities.id IS #{v ? 'NOT' : ''} NULL")
+        .uniq
+  end
   # End scope weeding zone
 
   def parent

--- a/app/models/investigation.rb
+++ b/app/models/investigation.rb
@@ -175,6 +175,15 @@ class Investigation < ActiveRecord::Base
 
   scope :ordered_by, lambda { |order| { :order => order } }
 
+  scope :is_template, ->(v) do
+    joins(['LEFT OUTER JOIN activities ON investigations.id = activities.investigation_id',
+           'LEFT OUTER JOIN external_activities',
+           'ON (external_activities.template_id = activities.id AND external_activities.template_type = "Activity")',
+           'OR (external_activities.template_id = investigations.id AND external_activities.template_type = "Investigation")'])
+        .where("external_activities.id IS #{v ? 'NOT' : ''} NULL")
+        .uniq
+  end
+
   include Changeable
   include Noteable # convenience methods for notes...
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -447,10 +447,6 @@ class User < ActiveRecord::Base
     self.state != "suspended" && self.state != "disabled"
   end
 
-  def materials
-    external_activities + activities + investigations
-  end
-
   protected
   def make_activation_code
     self.deleted_at = nil

--- a/spec/controllers/api/v1/materials_controller_spec.rb
+++ b/spec/controllers/api/v1/materials_controller_spec.rb
@@ -36,4 +36,29 @@ describe API::V1::MaterialsController do
       end
     end
   end
+
+  describe 'GET own' do
+    let(:user) { FactoryGirl.create(:confirmed_user) }
+    before(:each) do
+      sign_in user
+      @m1 = FactoryGirl.create(:external_activity, user: user)
+      @m2 = FactoryGirl.create(:activity, user: user)
+      @m3 = FactoryGirl.create(:investigation, user: user)
+      # Materials defined below should NOT be listed:
+      e1 = FactoryGirl.create(:external_activity)
+      e2 = FactoryGirl.create(:external_activity)
+      FactoryGirl.create(:activity, user: user, external_activities: [e1])      # template
+      FactoryGirl.create(:investigation, user: user, external_activities: [e2]) # template
+    end
+
+    it 'should return own materials, but filter out all templates' do
+      get :own
+      expect(response.status).to eql(200)
+      materials = JSON.parse(response.body)
+      expect(materials.length).to eql(3)
+      expect(materials[0]['id']).to eql(@m1.id)
+      expect(materials[1]['id']).to eql(@m2.id)
+      expect(materials[2]['id']).to eql(@m3.id)
+    end
+  end
 end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -124,7 +124,7 @@ describe Activity do
     let (:page_element) { Factory.create(:page_element, :page => page, :embeddable => embeddable_data_collectors) }
   end
 
-  describe "#is_template" do
+  describe "#is_template method" do
     let(:investigation_with_template)    { mock_model(Investigation, :external_activities =>[1,2,3])}
     let(:investigation_without_template) { mock_model(Investigation, :external_activities =>[] )}
     let(:investigation)        { nil }
@@ -154,6 +154,28 @@ describe Activity do
           it { should be_false }
         end
       end
+    end
+  end
+
+  describe '#is_template scope' do
+    before(:each) do
+      e1 = Factory.create(:external_activity)
+      e2 = Factory.create(:external_activity)
+      i = Factory.create(:investigation, external_activities: [e2])
+      @a1 = Factory.create(:activity)
+      @a2 = Factory.create(:activity, external_activities: [e1])
+      @a3 = Factory.create(:activity, investigation: i)
+    end
+
+    it 'should return activities which are not templates if provided argument is false' do
+      expect(Activity.is_template(false).count).to eql(1)
+      expect(Activity.is_template(false).first).to eql(@a1)
+    end
+
+    it 'should return activities which are templates if provided argument is true' do
+      expect(Activity.is_template(true).count).to eql(2)
+      expect(Activity.is_template(true).first).to eql(@a2)
+      expect(Activity.is_template(true).last).to eql(@a3)
     end
   end
 

--- a/spec/models/investigation_spec.rb
+++ b/spec/models/investigation_spec.rb
@@ -464,7 +464,7 @@ describe Investigation do
     end # deleting broken investigations
   end
 
-  describe "#is_template" do
+  describe "#is_template method" do
     let(:investigation)        { nil }
     let(:external_activities)  { [] }
     let(:activity_externals)    { [] }
@@ -491,6 +491,29 @@ describe Investigation do
       end
     end  
   end
+
+  describe '#is_template scope' do
+    before(:each) do
+      e1 = Factory.create(:external_activity)
+      e2 = Factory.create(:external_activity)
+      a = Factory.create(:activity, external_activities: [e2])
+      @i1 = Factory.create(:investigation)
+      @i2 = Factory.create(:investigation, external_activities: [e1])
+      @i3 = Factory.create(:investigation, activities: [a])
+    end
+
+    it 'should return investigations which are not templates if provided argument is false' do
+      expect(Investigation.is_template(false).count).to eql(1)
+      expect(Investigation.is_template(false).first).to eql(@i1)
+    end
+
+    it 'should return investigations which are templates if provided argument is true' do
+      expect(Investigation.is_template(true).count).to eql(2)
+      expect(Investigation.is_template(true).first).to eql(@i2)
+      expect(Investigation.is_template(true).last).to eql(@i3)
+    end
+  end
+
 
   describe "abstract_text" do
     let(:abstract)    { nil }


### PR DESCRIPTION
"My activities" ITSI bin was listing template materials. I've just added a new scope to investigation and activity models: `is_template`. Then I used it to filter out templates in API. There are related specs too.

However it's yet another non-trivial scope / query I had to add (not too difficult either, but still). I'm slowly leaning towards using SOLR, as most of those things could be handled by it. I somehow don't like idea of using it for regular queries (which are not full-text search), but we already do it. Also, keeping SOLR stuff up to date can be sometimes annoying, but we need to do it anyway due to search page.

Any opinions on that? Not important now, but if we touch materials listing / filtering again, I think we should decide (cc @scytacki).