### PR TITLE
Fix run urls in materials bin

### DIFF
--- a/app/assets/javascripts/components/materials_bin/material.js.coffee
+++ b/app/assets/javascripts/components/materials_bin/material.js.coffee
@@ -29,8 +29,8 @@ window.MBMaterialClass = React.createClass
           (a {className: 'mb-toggle-info', href: '', onClick: @toggleDescription},
             (span {className: 'mb-toggle-info-text'}, 'Info')
           )
-        if data.links? && data.links.preview?
-          (a {className: 'mb-run', href: data.links.preview.url, target: '_blank'},
+        if data.preview_url?
+          (a {className: 'mb-run', href: data.preview_url, target: '_blank'},
             (span {className: 'mb-run-text'}, 'Run')
           )
         if Portal.currentUser.isTeacher

--- a/lib/materials/data_helpers.rb
+++ b/lib/materials/data_helpers.rb
@@ -55,6 +55,7 @@ module Materials
           is_official: material.is_official,
           publication_status: material.publication_status,
           links: links_for_material(material),
+          preview_url: view_context.run_url_for(material, (material.teacher_only? ? {:teacher_mode => true} : {})),
           assigned_classes: assigned_clazz_names(material),
           class_count: material_count,
           sensors: view_context.probe_types(material).map { |p| p.name },


### PR DESCRIPTION
Materials data helper provides `link` structure which is very UI-oriented and sometimes `links[:preview][:url]` was equal to ... `javascript:void(0)`.
I've just added preview URL separately, so components that declare UI themselves can use it instead.