### PR TITLE
Add materials bin tests

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,6 +2,7 @@
  // TODO: consider moving assets from zeus into
  // package (mange_classes,instructional_materials, &etc.)
 
+= require 'portal-namespace'
 = require 'prototype'
 = require 'prototype-ui/prototype-ui'
 = require 'globals'

--- a/app/assets/javascripts/components/materials_bin/materials_category.js.coffee
+++ b/app/assets/javascripts/components/materials_bin/materials_category.js.coffee
@@ -14,7 +14,7 @@ window.MBMaterialsCategoryClass = React.createClass
     @props.handleClick @props.column, @props.slug
 
   render: ->
-    className = "mb-cell mb-category mb-clickable #{@props.customClass} #{@getVisibilityClass()} #{@getSelectionClass()}"
+    className = "mb-cell mb-category mb-clickable #{@props.customClass || ''} #{@getVisibilityClass()} #{@getSelectionClass()}"
     (div {className: className, onClick: @handleClick},
       @props.children
     )

--- a/app/assets/javascripts/portal-namespace.js
+++ b/app/assets/javascripts/portal-namespace.js
@@ -1,0 +1,5 @@
+if (typeof Portal === 'undefined') {
+  Portal = {
+    API_V1: {}
+  };
+}

--- a/features/step_definitions/admin_projects_steps.rb
+++ b/features/step_definitions/admin_projects_steps.rb
@@ -4,7 +4,7 @@ Given /^the default projects exist using factories$/ do
   Factory.create(:project, name: 'project 3', landing_page_slug: 'project-3')
 end
 
-Given /^the project "([^"]+)" has landing page "([^"]+)" and slug "([^"]+)"$/ do |name, page_cont, slug|
+Given /^the project "([^"]+)" has slug "([^"]+)" and landing page$/ do |name, slug, page_cont|
   Factory.create(:project, name: name, landing_page_slug: slug, landing_page_content: page_cont)
 end
 

--- a/features/step_definitions/materials_bin_steps.rb
+++ b/features/step_definitions/materials_bin_steps.rb
@@ -1,0 +1,50 @@
+Given /^the project "([^"]+)" has slug "([^"]+)" and ITSI bin$/ do |name, slug, page_cont|
+  # Replace material collection names with IDs.
+  page_cont.gsub!(/Collection \d/) { |name| MaterialsCollection.find_by_name(name).id }
+  Factory.create(:project, name: name, landing_page_slug: slug, landing_page_content: page_cont)
+end
+
+Then /^category "([^"]+)" should be visible$/ do |category_name|
+  page.has_css?('.mb-category', text: category_name, visible: true)
+end
+
+Then /^category "([^"]+)" with class "([^"]+)" should be visible$/ do |category_name, class_name|
+  page.has_css?(".mb-category.#{class_name}", text: category_name, visible: true)
+end
+
+Then /^category "([^"]+)" should not be visible$/ do |category_name|
+  page.has_css?('.mb-category', text: category_name, visible: false)
+end
+
+Then /^(\d+) materials should be visible$/ do |materials_count|
+  page.has_css?('.mb-material', visible: true, count: materials_count)
+end
+
+Then /^"([^"]+)" material should be visible$/ do |material|
+  page.has_css?('.mb-material', visible: true, text: material)
+end
+
+Then /^some materials should be visible$/ do
+  page.has_css?('.mb-material', visible: true)
+end
+
+Then /^no materials should be visible$/ do
+  page.has_no_css?('.mb-material', visible: true)
+end
+
+Then /^authors list should be visible$/ do
+  page.has_css?('.mb-collection-name.mb-clickable', visible: true)
+end
+
+Then /^I click "([^"]+)" author name$/ do |author|
+  find('.mb-collection-name.mb-clickable', visible: true, text: author).click
+end
+
+Then /^I click category "([^"]+)"$/ do |category_name|
+  find('.mb-category', text: category_name, visible: true).click
+end
+
+Given /^user "([^"]+)" authored unofficial material "([^"]+)"$/ do |user_name, act_name|
+  author = Factory.create(:confirmed_user, first_name: user_name, last_name: '')
+  Factory.create(:external_activity, name: act_name, is_official: false, user: author)
+end

--- a/features/user_vistits_project_landing_page.feature
+++ b/features/user_vistits_project_landing_page.feature
@@ -6,7 +6,10 @@ Feature: User can visit custom project landing page
   Background:
     Given The default settings and jnlp resources exist using factories
     And the database has been seeded
-    And the project "FooBar" has landing page "Hello, <span id='foo-bar'></span><script>jQuery('#foo-bar').text('it is FooBar page!');</script>" and slug "foo-bar"
+    And the project "FooBar" has slug "foo-bar" and landing page
+      """
+      Hello, <span id='foo-bar'></span><script>jQuery('#foo-bar').text('it is FooBar page!');</script>
+      """
 
   @javascript
   Scenario: Logged in user vists projects landing page

--- a/features/user_works_with_materials_bin.feature
+++ b/features/user_works_with_materials_bin.feature
@@ -1,0 +1,117 @@
+Feature: User works with materials bin
+
+  As an user (logged in or not)
+  I can see materials bin
+
+  Background:
+    Given The default settings and jnlp resources exist using factories
+    And the database has been seeded
+    And the project "FooBar" has slug "foo-bar" and ITSI bin
+      """
+      <div id="bin-view"></div>
+      <script>
+        var MATERIALS = [
+          {
+            category: "Cat A",
+            className: "custom-category-class",
+            children: [
+              {
+                category: "Cat A1",
+                children: [
+                  {
+                    collections: [
+                      {id: Collection 2}
+                     ]
+                  }
+                ]
+              },
+              {
+                category: "Cat A2",
+                children: []
+              }
+            ]
+          },
+          {
+            category: "Cat B",
+            children: [
+              {
+                category: "Cat B1",
+                children: [
+                  {
+                    collections: [
+                      {id: Collection 3}
+                     ]
+                  }
+                ]
+              },
+              {
+                category: "Cat B2",
+                children: []
+              }
+            ]
+          },
+          {
+            category: "Cat C",
+            loginRequired: true,
+            children: [
+              {
+                ownMaterials: true
+              }
+            ]
+          },
+          {
+            category: "Cat D",
+            children: [
+              {
+                materialsByAuthor: true
+              }
+            ]
+          }
+        ];
+        Portal.renderMaterialsBin(MATERIALS, '#bin-view');
+      </script>
+      """
+
+  @javascript
+  Scenario: User sees materials bin
+    When I visit the route /foo-bar
+    Then category "Cat A" with class "custom-category-class" should be visible
+    And category "Cat A1" should be visible
+    And category "Cat A2" should be visible
+    And category "Cat B" should be visible
+    But category "Cat B1" should not be visible
+    And category "Cat B2" should not be visible
+    And category "Cat C" should not be visible
+    And 2 materials should be visible
+
+  @javascript
+  Scenario: User changes category
+    When I visit the route /foo-bar
+    And I click category "Cat B"
+    And I click category "Cat B1"
+    Then 6 materials should be visible
+
+  @javascript
+  Scenario: Logged in user can see special categories
+    Given I am logged in with the username author
+    When I visit the route /foo-bar
+    Then category "Cat C" should be visible
+
+  @javascript
+  Scenario: Author can see his own materials
+    Given I am logged in with the username author
+    When I visit the route /foo-bar
+    And I click category "Cat C"
+    Then I should see "My activities"
+    And some materials should be visible
+
+  @javascript
+  Scenario: User can see materials grouped by authors
+    Given I am logged in with the username teacher
+    And user "foobar" authored unofficial material "ext act"
+    When I visit the route /foo-bar
+    And I click category "Cat D"
+    Then authors list should be visible
+    But no materials should be visible
+    When I click "foobar" author name
+    Then "ext act" material should be visible

--- a/spec/javascripts/components/materials_bin/material_category_spec.js.coffee
+++ b/spec/javascripts/components/materials_bin/material_category_spec.js.coffee
@@ -6,21 +6,21 @@ describe 'MBMaterialsCategoryClass', ->
     Portal.currentUser = {isAnonymous: true}
 
   describe 'when loginRequired property is set to true', ->
-    it 'it should be hidden for anonymous user', ->
+    it 'should be hidden for anonymous user', ->
       result = renderStatic MBMaterialsCategoryClass, visible: true, loginRequired: true
       expect(result).toEqual jasmine.stringMatching 'mb-hidden'
 
-    it 'it should be visible for logged in user', ->
+    it 'should be visible for logged in user', ->
       Portal.currentUser.isAnonymous = false
       result = renderStatic MBMaterialsCategoryClass, visible: true, loginRequired: true
       expect(result).not.toEqual jasmine.stringMatching 'mb-hidden'
 
   describe 'when loginRequired property is set to false', ->
-    it 'it should be visible for anonymous user', ->
+    it 'should be visible for anonymous user', ->
       result = renderStatic MBMaterialsCategoryClass, visible: true
       expect(result).not.toEqual jasmine.stringMatching 'mb-hidden'
 
-    it 'it should be visible for logged in user', ->
+    it 'should be visible for logged in user', ->
       Portal.currentUser.isAnonymous = false
       result = renderStatic MBMaterialsCategoryClass, visible: true, loginRequired: false
       expect(result).not.toEqual jasmine.stringMatching 'mb-hidden'

--- a/spec/javascripts/components/materials_bin/material_category_spec.js.coffee
+++ b/spec/javascripts/components/materials_bin/material_category_spec.js.coffee
@@ -1,0 +1,26 @@
+#= require helpers/react_helper
+#= require component
+
+describe 'MBMaterialsCategoryClass', ->
+  beforeEach ->
+    Portal.currentUser = {isAnonymous: true}
+
+  describe 'when loginRequired property is set to true', ->
+    it 'it should be hidden for anonymous user', ->
+      result = renderStatic MBMaterialsCategoryClass, visible: true, loginRequired: true
+      expect(result).toEqual jasmine.stringMatching 'mb-hidden'
+
+    it 'it should be visible for logged in user', ->
+      Portal.currentUser.isAnonymous = false
+      result = renderStatic MBMaterialsCategoryClass, visible: true, loginRequired: true
+      expect(result).not.toEqual jasmine.stringMatching 'mb-hidden'
+
+  describe 'when loginRequired property is set to false', ->
+    it 'it should be visible for anonymous user', ->
+      result = renderStatic MBMaterialsCategoryClass, visible: true
+      expect(result).not.toEqual jasmine.stringMatching 'mb-hidden'
+
+    it 'it should be visible for logged in user', ->
+      Portal.currentUser.isAnonymous = false
+      result = renderStatic MBMaterialsCategoryClass, visible: true, loginRequired: false
+      expect(result).not.toEqual jasmine.stringMatching 'mb-hidden'

--- a/spec/javascripts/components/materials_bin/material_spec.js.coffee
+++ b/spec/javascripts/components/materials_bin/material_spec.js.coffee
@@ -1,0 +1,35 @@
+#= require helpers/react_helper
+#= require component
+
+describe 'MBMaterialClass', ->
+  beforeEach ->
+    Portal.currentUser = {isTeacher: false, isAdmin: false}
+
+  it 'renders material name and description', ->
+    result = renderStatic MBMaterialClass, material: {name: 'name foobar', description: 'desc barfoo'}
+    expect(result).toEqual jasmine.stringMatching 'name foobar'
+    expect(result).toEqual jasmine.stringMatching 'desc barfoo'
+
+  it 'renders preview link', ->
+    result = renderStatic MBMaterialClass, material: {preview_url: 'http://run.activity'}
+    expect(result).toEqual jasmine.stringMatching 'http://run.activity'
+
+  it 'renders description toggle', ->
+    result = renderStatic MBMaterialClass, material: {description: 'foobar'}
+    expect(result).toEqual jasmine.stringMatching 'mb-toggle-info-text'
+
+  it 'renders assign to class link only if user is a teacher', ->
+    result = renderStatic MBMaterialClass, material: {}
+    expect(result).not.toEqual jasmine.stringMatching 'mb-assign-to-class'
+
+    Portal.currentUser.isTeacher = true
+    result = renderStatic MBMaterialClass, material: {}
+    expect(result).toEqual jasmine.stringMatching 'mb-assign-to-class'
+
+  it 'renders assign to collection link only if user is a teacher', ->
+    result = renderStatic MBMaterialClass, material: {}
+    expect(result).not.toEqual jasmine.stringMatching 'mb-assign-to-collection'
+
+    Portal.currentUser.isAdmin = true
+    result = renderStatic MBMaterialClass, material: {}
+    expect(result).toEqual jasmine.stringMatching 'mb-assign-to-collection'


### PR DESCRIPTION
I was planning to use more Jasmine tests, but I finally I added mainly Cucumber integration tests.
I think in this case integration tests are even more useful, as this feature probably is not expected to be under active development (when small unit tests could help). Cucumber is slower, but I could avoid extensive mocking of everything and simulating browser events in Jasmine. I also couldn't find a pattern that I liked for Jasmine tests in this case - comparing rendered string seems to be pretty inflexible (blocks every single change in component) and has obvious limits, regexp could be too flexible and it's not very handy. I could use jQuery and write manual DOM matchers, but in that case I prefer to use Capybara.