### PR TITLE
Support CommonJS modules using browserify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ solr/data
 solr/pids
 log
 app_environment_variables.rb
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,16 @@ before_script:
   - ./bin/rake db:schema:load
   - ./bin/rake db:migrate
   - ./bin/rake db:test:prepare
+  - npm install
   - RAILS_GROUPS=assets ./bin/rake assets:precompile:all
 
 # uncomment this line if your project needs to run something other than `rake`:
 script: ./bin/rake $TEST_SUITE
 
-cache: bundler
+cache:
+  bundler: true
+  directories:
+    - node_modules
 
 bundler_args: --binstubs --without development
 

--- a/Gemfile
+++ b/Gemfile
@@ -121,6 +121,7 @@ source "http://rubygems.org"
   gem 'useragent'  # detect browser types
 
   gem 'react-rails', '~> 1.0'
+  gem 'browserify-rails', '~> 0.9.1'
 
 # see above; for production asset compilation.
 # as per http://guides.rubyonrails.org/asset_pipeline.html#precompiling-assets

--- a/Gemfile
+++ b/Gemfile
@@ -107,7 +107,7 @@ source "http://rubygems.org"
   gem 'select2-rails'
   gem 'uglifier'
   gem 'yui-compressor'
-  gem "turbo-sprockets-rails3", "~> 0.3.6"
+  gem "turbo-sprockets-rails3", "~> 0.3.14"
 #      ⬆         ⬆  needed for setup tasks in production and dev :(
 
   gem 'sunspot_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,8 @@ GEM
     better_errors (1.1.0)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
+    browserify-rails (0.9.1)
+      sprockets (~> 2.2)
     builder (3.0.4)
     bullet (4.14.0)
       activesupport (>= 3.0.0)
@@ -591,6 +593,7 @@ DEPENDENCIES
   awesome_print
   aws-sdk (~> 1.55.0)
   better_errors (~> 1.1.0)
+  browserify-rails (~> 0.9.1)
   bullet
   calpicker!
   capistrano (~> 2.14.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -539,9 +539,9 @@ GEM
       polyglot
       polyglot (>= 0.3.1)
     ttfunk (1.0.3)
-    turbo-sprockets-rails3 (0.3.6)
+    turbo-sprockets-rails3 (0.3.14)
       railties (> 3.2.8, < 4.0.0)
-      sprockets (>= 2.0.0)
+      sprockets (>= 2.2.0)
     tzinfo (0.3.41)
     uglifier (1.2.7)
       execjs (>= 0.3.0)
@@ -693,7 +693,7 @@ DEPENDENCIES
   themes_for_rails!
   therubyracer (~> 0.12.1)
   tinymce-rails (~> 3.5.6)
-  turbo-sprockets-rails3 (~> 0.3.6)
+  turbo-sprockets-rails3 (~> 0.3.14)
   uglifier
   useragent
   uuidtools (~> 2.1.2)

--- a/app/assets/javascripts/component.js
+++ b/app/assets/javascripts/component.js
@@ -1,2 +1,3 @@
 //= require ./jquery.paging
-//= require_tree ./components
+//= require_tree ./components/search
+require('components/helper_api');

--- a/app/assets/javascripts/components/featured_materials/featured_materials.js.coffee
+++ b/app/assets/javascripts/components/featured_materials/featured_materials.js.coffee
@@ -1,6 +1,6 @@
 {div} = React.DOM
 
-window.FeaturedMaterialsClass = React.createClass
+module.exports = React.createClass
   getInitialState: ->
     materials: []
 
@@ -14,10 +14,3 @@ window.FeaturedMaterialsClass = React.createClass
 
   render: ->
     (SMaterialsList {materials: @state.materials})
-
-window.FeaturedMaterials = React.createFactory FeaturedMaterialsClass
-
-Portal.renderFeaturedMaterials = (selectorOrElement) ->
-  query = window.location.search
-  query = query.slice(1) if query[0] == '?'
-  React.render FeaturedMaterials(queryString: query), jQuery(selectorOrElement)[0]

--- a/app/assets/javascripts/components/helper_api.js.coffee
+++ b/app/assets/javascripts/components/helper_api.js.coffee
@@ -1,0 +1,14 @@
+MaterialsBin = React.createFactory require 'components/materials_bin/materials_bin'
+MaterialsCollection = React.createFactory require 'components/materials_collection/materials_collection'
+FeaturedMaterials = React.createFactory require 'components/featured_materials/featured_materials'
+
+Portal.renderMaterialsBin = (definition, selectorOrElement) ->
+  React.render(MaterialsBin({materials: definition}), jQuery(selectorOrElement)[0])
+
+Portal.renderMaterialsCollection = (collectionId, selectorOrElement, limit = Infinity) ->
+  React.render MaterialsCollection(collection: collectionId, limit: limit), jQuery(selectorOrElement)[0]
+
+Portal.renderFeaturedMaterials = (selectorOrElement) ->
+  query = window.location.search
+  query = query.slice(1) if query[0] == '?'
+  React.render FeaturedMaterials(queryString: query), jQuery(selectorOrElement)[0]

--- a/app/assets/javascripts/components/materials_bin/collections.js.coffee
+++ b/app/assets/javascripts/components/materials_bin/collections.js.coffee
@@ -1,8 +1,9 @@
 fetchDataMixin = require 'components/materials_bin/fetch_data_mixin'
+MaterialsCollection = React.createFactory require 'components/materials_bin/materials_collection'
 
 {div} = React.DOM
 
-window.MBCollectionsClass = React.createClass
+module.exports = React.createClass
   mixins: [fetchDataMixin]
   # --- MBFetchDataMixin config ---
   dataStateKey: 'collectionsData'
@@ -16,7 +17,7 @@ window.MBCollectionsClass = React.createClass
     (div {className: className},
       if @state.collectionsData?
         for collection, idx in @state.collectionsData
-          (MBMaterialsCollection
+          (MaterialsCollection
             key: idx
             name: collection.name
             materials: collection.materials
@@ -26,5 +27,3 @@ window.MBCollectionsClass = React.createClass
       else
         (div {}, 'Loading...')
     )
-
-window.MBCollections = React.createFactory MBCollectionsClass

--- a/app/assets/javascripts/components/materials_bin/collections.js.coffee
+++ b/app/assets/javascripts/components/materials_bin/collections.js.coffee
@@ -1,7 +1,9 @@
+fetchDataMixin = require 'components/materials_bin/fetch_data_mixin'
+
 {div} = React.DOM
 
 window.MBCollectionsClass = React.createClass
-  mixins: [MBFetchDataMixin]
+  mixins: [fetchDataMixin]
   # --- MBFetchDataMixin config ---
   dataStateKey: 'collectionsData'
   dataUrl: Portal.API_V1.MATERIALS_BIN_COLLECTIONS

--- a/app/assets/javascripts/components/materials_bin/fetch_data_mixin.js.coffee
+++ b/app/assets/javascripts/components/materials_bin/fetch_data_mixin.js.coffee
@@ -6,7 +6,8 @@
 # but it can also define:
 #  - .requestParams property (hash), argument of jQuery.ajax
 #  - .processData() (method), it can process raw AJAX response before state is updated
-window.MBFetchDataMixin =
+
+module.exports =
   getInitialState: ->
     state = {}
     state[@dataStateKey] = null

--- a/app/assets/javascripts/components/materials_bin/material.js.coffee
+++ b/app/assets/javascripts/components/materials_bin/material.js.coffee
@@ -1,6 +1,17 @@
 {div, span, a} = React.DOM
 
-window.MBMaterialClass = React.createClass
+MaterialDescription = React.createFactory React.createClass
+  getVisibilityClass: ->
+    unless @props.visible then 'mb-hidden' else ''
+
+  render: ->
+    (div
+      className: "mb-material-description #{@getVisibilityClass()}"
+      # It's already sanitized by server!
+      dangerouslySetInnerHTML: {__html: @props.description}
+    )
+
+module.exports = React.createClass
   getInitialState: ->
     {
       descriptionVisible: false
@@ -44,23 +55,8 @@ window.MBMaterialClass = React.createClass
       )
       (span {className: 'mb-material-name'}, data.name)
       if @hasDescription()
-        (MBMaterialDescription
+        (MaterialDescription
           description: data.description
           visible: @state.descriptionVisible
         )
-    )
-
-window.MBMaterial = React.createFactory MBMaterialClass
-
-# Helper components:
-
-MBMaterialDescription = React.createFactory React.createClass
-  getVisibilityClass: ->
-    unless @props.visible then 'mb-hidden' else ''
-
-  render: ->
-    (div
-      className: "mb-material-description #{@getVisibilityClass()}"
-      # It's already sanitized by server!
-      dangerouslySetInnerHTML: {__html: @props.description}
     )

--- a/app/assets/javascripts/components/materials_bin/materials_bin.js.coffee
+++ b/app/assets/javascripts/components/materials_bin/materials_bin.js.coffee
@@ -1,6 +1,11 @@
+MaterialsCategory = React.createFactory require 'components/materials_bin/materials_category'
+Collections = React.createFactory require 'components/materials_bin/collections'
+OwnMaterials = React.createFactory require 'components/materials_bin/own_materials'
+MaterialsByAuthor = React.createFactory require 'components/materials_bin/materials_by_author'
+
 {div} = React.DOM
 
-window.MaterialsBinClass = React.createClass
+module.exports = React.createClass
   propTypes:
     materials: React.PropTypes.array.isRequired
 
@@ -76,7 +81,7 @@ window.MaterialsBinClass = React.createClass
         selected = @isSlugSelected columnIdx, cellDef.slug
         rowIdx = columns[columnIdx].length
         columns[columnIdx].push if cellDef.category
-                                  (MBMaterialsCategory {
+                                  (MaterialsCategory {
                                       key: rowIdx
                                       visible: visible
                                       selected: selected
@@ -89,15 +94,15 @@ window.MaterialsBinClass = React.createClass
                                     cellDef.category
                                   )
                                 else if cellDef.collections
-                                  (MBCollections
+                                  (Collections
                                     key: rowIdx
                                     visible: visible
                                     collections: cellDef.collections
                                   )
                                 else if cellDef.ownMaterials
-                                  (MBOwnMaterials key: rowIdx, visible: visible)
+                                  (OwnMaterials key: rowIdx, visible: visible)
                                 else if cellDef.materialsByAuthor
-                                  (MBMaterialsByAuthor key: rowIdx, visible: visible)
+                                  (MaterialsByAuthor key: rowIdx, visible: visible)
         if cellDef.children
           # Recursively go to children array, add its elements to column + 1
           # and mark them visible only if current cell is selected.
@@ -111,8 +116,3 @@ window.MaterialsBinClass = React.createClass
       for column, idx in @_getColumns()
         (div {key: idx, className: 'mb-column'}, column)
     )
-
-window.MaterialsBin = React.createFactory MaterialsBinClass
-
-Portal.renderMaterialsBin = (definition, selectorOrElement) ->
-  React.render MaterialsBin(materials: definition), jQuery(selectorOrElement)[0]

--- a/app/assets/javascripts/components/materials_bin/materials_by_author.js.coffee
+++ b/app/assets/javascripts/components/materials_bin/materials_by_author.js.coffee
@@ -1,7 +1,9 @@
+fetchDataMixin = require 'components/materials_bin/fetch_data_mixin'
+
 {div} = React.DOM
 
 window.MBMaterialsByAuthorClass = React.createClass
-  mixins: [MBFetchDataMixin]
+  mixins: [fetchDataMixin]
   # --- MBFetchDataMixin config ---
   dataUrl: Portal.API_V1.MATERIALS_BIN_UNOFFICIAL_MATERIALS_AUTHORS
   dataStateKey: 'authors'

--- a/app/assets/javascripts/components/materials_bin/materials_by_author.js.coffee
+++ b/app/assets/javascripts/components/materials_bin/materials_by_author.js.coffee
@@ -1,8 +1,9 @@
 fetchDataMixin = require 'components/materials_bin/fetch_data_mixin'
+UserMaterials = React.createFactory require 'components/materials_bin/user_materials'
 
 {div} = React.DOM
 
-window.MBMaterialsByAuthorClass = React.createClass
+module.exports = React.createClass
   mixins: [fetchDataMixin]
   # --- MBFetchDataMixin config ---
   dataUrl: Portal.API_V1.MATERIALS_BIN_UNOFFICIAL_MATERIALS_AUTHORS
@@ -14,7 +15,7 @@ window.MBMaterialsByAuthorClass = React.createClass
     (div {className: className},
       if @state.authors?
         for author in @state.authors
-          (MBUserMaterials
+          (UserMaterials
             key: author.id
             name: author.name
             userId: author.id
@@ -23,4 +24,3 @@ window.MBMaterialsByAuthorClass = React.createClass
         (div {}, 'Loading...')
     )
 
-window.MBMaterialsByAuthor = React.createFactory MBMaterialsByAuthorClass

--- a/app/assets/javascripts/components/materials_bin/materials_category.js.coffee
+++ b/app/assets/javascripts/components/materials_bin/materials_category.js.coffee
@@ -1,6 +1,6 @@
 {div} = React.DOM
 
-window.MBMaterialsCategoryClass = React.createClass
+module.exports = React.createClass
   hideForAnonymous: ->
     @props.loginRequired && Portal.currentUser.isAnonymous
 
@@ -19,4 +19,3 @@ window.MBMaterialsCategoryClass = React.createClass
       @props.children
     )
 
-window.MBMaterialsCategory = React.createFactory MBMaterialsCategoryClass

--- a/app/assets/javascripts/components/materials_bin/materials_collection.js.coffee
+++ b/app/assets/javascripts/components/materials_bin/materials_collection.js.coffee
@@ -1,6 +1,8 @@
+Material = React.createFactory require 'components/materials_bin/material'
+
 {div, a} = React.DOM
 
-window.MBMaterialsCollectionClass = React.createClass
+module.exports = React.createClass
   renderTeacherGuide: ->
     if Portal.currentUser.isTeacher and @props.teacherGuideUrl?
       (a {href: @props.teacherGuideUrl, target: '_blank'}, 'Teacher Guide')
@@ -10,7 +12,5 @@ window.MBMaterialsCollectionClass = React.createClass
       (div {className: 'mb-collection-name'}, @props.name)
       @renderTeacherGuide()
       for material in @props.materials or []
-        (MBMaterial key: "#{material.class_name}#{material.id}", material: material)
+        (Material key: "#{material.class_name}#{material.id}", material: material)
     )
-
-window.MBMaterialsCollection = React.createFactory MBMaterialsCollectionClass

--- a/app/assets/javascripts/components/materials_bin/own_materials.js.coffee
+++ b/app/assets/javascripts/components/materials_bin/own_materials.js.coffee
@@ -1,8 +1,9 @@
 fetchDataMixin = require 'components/materials_bin/fetch_data_mixin'
+MaterialsCollection = React.createFactory require 'components/materials_bin/materials_collection'
 
 {div} = React.DOM
 
-window.MBOwnMaterialsClass = React.createClass
+module.exports = React.createClass
   mixins: [fetchDataMixin]
   # --- MBFetchDataMixin config ---
   dataStateKey: 'materials'
@@ -13,12 +14,10 @@ window.MBOwnMaterialsClass = React.createClass
     className = "mb-cell #{@getVisibilityClass()}"
     (div {className: className},
       if @state.materials?
-        (MBMaterialsCollection
+        (MaterialsCollection
           name: 'My activities'
           materials: @state.materials
         )
       else
         (div {}, 'Loading...')
     )
-
-window.MBOwnMaterials = React.createFactory MBOwnMaterialsClass

--- a/app/assets/javascripts/components/materials_bin/own_materials.js.coffee
+++ b/app/assets/javascripts/components/materials_bin/own_materials.js.coffee
@@ -1,7 +1,9 @@
+fetchDataMixin = require 'components/materials_bin/fetch_data_mixin'
+
 {div} = React.DOM
 
 window.MBOwnMaterialsClass = React.createClass
-  mixins: [MBFetchDataMixin]
+  mixins: [fetchDataMixin]
   # --- MBFetchDataMixin config ---
   dataStateKey: 'materials'
   dataUrl: Portal.API_V1.MATERIALS_OWN

--- a/app/assets/javascripts/components/materials_bin/user_materials.js.coffee
+++ b/app/assets/javascripts/components/materials_bin/user_materials.js.coffee
@@ -1,6 +1,8 @@
+UserMaterialsContainer = React.createFactory require 'components/materials_bin/user_materials_container'
+
 {div, span} = React.DOM
 
-window.MBUserMaterialsClass = React.createClass
+module.exports = React.createClass
   getInitialState: ->
     materialsVisible: false
 
@@ -17,7 +19,5 @@ window.MBUserMaterialsClass = React.createClass
         ' '
         @props.name
       )
-      (MBUserMaterialsContainer userId: @props.userId, visible: @state.materialsVisible)
+      (UserMaterialsContainer userId: @props.userId, visible: @state.materialsVisible)
     )
-
-window.MBUserMaterials = React.createFactory MBUserMaterialsClass

--- a/app/assets/javascripts/components/materials_bin/user_materials_container.js.coffee
+++ b/app/assets/javascripts/components/materials_bin/user_materials_container.js.coffee
@@ -1,8 +1,9 @@
 fetchDataMixin = require 'components/materials_bin/fetch_data_mixin'
+MaterialsCollection = React.createFactory require 'components/materials_bin/materials_collection'
 
 {div} = React.DOM
 
-window.MBUserMaterialsContainerClass = React.createClass
+module.exports = React.createClass
   mixins: [fetchDataMixin]
   # --- MBFetchDataMixin config ---
   dataStateKey: 'materials'
@@ -14,9 +15,7 @@ window.MBUserMaterialsContainerClass = React.createClass
   render: ->
     (div {className: @getVisibilityClass()},
       if @state.materials
-        (MBMaterialsCollection materials: @state.materials)
+        (MaterialsCollection materials: @state.materials)
       else
         (div {}, 'Loading...')
     )
-
-window.MBUserMaterialsContainer = React.createFactory MBUserMaterialsContainerClass

--- a/app/assets/javascripts/components/materials_bin/user_materials_container.js.coffee
+++ b/app/assets/javascripts/components/materials_bin/user_materials_container.js.coffee
@@ -1,7 +1,9 @@
+fetchDataMixin = require 'components/materials_bin/fetch_data_mixin'
+
 {div} = React.DOM
 
 window.MBUserMaterialsContainerClass = React.createClass
-  mixins: [MBFetchDataMixin]
+  mixins: [fetchDataMixin]
   # --- MBFetchDataMixin config ---
   dataStateKey: 'materials'
   dataUrl: Portal.API_V1.MATERIALS_BIN_UNOFFICIAL_MATERIALS

--- a/app/assets/javascripts/components/materials_collection/materials_collection.js.coffee
+++ b/app/assets/javascripts/components/materials_collection/materials_collection.js.coffee
@@ -1,6 +1,6 @@
 {div, span, a, i} = React.DOM
 
-window.MaterialsCollectionClass = React.createClass
+module.exports = React.createClass
   getInitialState: ->
     materials: []
     truncated: true
@@ -37,8 +37,3 @@ window.MaterialsCollectionClass = React.createClass
       (SMaterialsList {materials: @getMaterialsList()})
       @renderTruncationToggle()
     )
-
-window.MaterialsCollection = React.createFactory MaterialsCollectionClass
-
-Portal.renderMaterialsCollection = (collectionId, selectorOrElement, limit = Infinity) ->
-  React.render MaterialsCollection(collection: collectionId, limit: limit), jQuery(selectorOrElement)[0]

--- a/config/application.rb
+++ b/config/application.rb
@@ -90,6 +90,8 @@ module RailsPortal
   
     config.react.variant = :development
 
+    config.browserify_rails.commandline_options = "-t coffeeify --extension=\".js.coffee\""
+
     # Use SQL instead of Active Record's schema dumper when creating the test database.
     # This is necessary if your schema can't be completely dumped by the schema dumper,
     # like if you have constraints or database-specific column types

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -309,6 +309,11 @@ namespace :deploy do
   #   # run "cd #{deploy_to}/current && bundle exec compass compile --sass-dir public/stylesheets/scss/ --css-dir public/stylesheets/ -s compact --force"
   #   run "cd #{deploy_to}/current && bundle exec rake assets:precompile --trace"
   # end
+
+  desc "install npm packages"
+  task :npm_install, :roles => :app do
+    run "cd #{release_path} && npm install"
+  end
 end
 
 namespace :setup do
@@ -330,10 +335,10 @@ namespace :setup do
 
   desc "setup the NCES districts: download and configure NCES districts"
   task :districts, :roles => :app do
-    run_remote_rake "portal:setup:download_nces_data --trace"  
+    run_remote_rake "portal:setup:download_nces_data --trace"
     run_remote_rake "portal:setup:import_nces_from_files --trace"
     run_remote_rake "portal:setup:create_districts_and_schools_from_nces_data --trace"
-  end 
+  end
 end
 
 #############################################################
@@ -713,6 +718,9 @@ after "deploy:stop",    "delayed_job:stop"
 after "deploy:start",   "delayed_job:start"
 after "deploy:restart", "delayed_job:restart"
 after "deploy:restart", "solr:restart"
+
+# Install NPM modules before assets compilation (browserify_rails)
+before 'deploy:assets:precompile', 'deploy:npm_install'
 
 # Make the default behavior be to NOT autoscale
 set(:autoscaling_instance_type, "c3.large")

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "rigse",
+  "description": "CC Rails Portal Activity Authoring, Deployment, and Reporting System",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/concord-consortium/rigse.git"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "browserify": "^6.3.4",
+    "browserify-incremental": "^1.5.0",
+    "coffeeify": "^0.6.0"
+  }
+}


### PR DESCRIPTION
I think I hit the wall while working on this. It's not ready to merge, but I'm creating pull request so maybe other devs can take a look at it or propose alternative solution. 

The current state is:
- some components are using CommonJS modules and browserify
- assets compilation works
- deployment works (you need to fix the server first: https://github.com/concord-consortium/littlechef-servers/pull/1)
- basically everything seems to work fine locally and on server (has.staging is using this branch)
- TravisCI should work
- Jasime tests **do not** work :cry: 

I hoped we could require JS files from Jasmine specs directly, but apparently not. I added `spec/javascripts` to browserify paths, exactly the same as someone did here:
https://github.com/browserify-rails/browserify-rails/issues/12
but it's not enough. Spec file isn't browserified, I end up with unrecognised `require` calls.

Theoretically we could switch to nodejs Jasmine version now. But that brings new set of problems - we could test only the code which is using CommonJS, we would need to install all necessary JS libs using npm (e.g. React and anything else we need) and all the dependencies on old Portal would need to be mocked. I don't like it. Not to mention LARA which has its own set of Jasmine tests that wouldn't work with Node setup.

We could also export all the components that we want to test to global namespace in some helper JS file that is under `app/assets/javascripts/` (so it's browserified), but that seems to be annoying long term.