### PR TITLE
Fix search components (missing react keys and tbody el)

### DIFF
--- a/app/assets/javascripts/components/search/material_info.js.coffee
+++ b/app/assets/javascripts/components/search/material_info.js.coffee
@@ -1,9 +1,9 @@
-{div, table, tr, td, span} = React.DOM
+{div, table, tbody, tr, td, span} = React.DOM
 
 window.SMaterialInfoClass = React.createClass
   renderLinks: ->
     material = @props.material
-    for own key,link of material.links
+    for own key, link of material.links
       link.key = key
 
     links = []
@@ -35,17 +35,19 @@ window.SMaterialInfoClass = React.createClass
     (div {},
       (div {style: {overflow: 'hidden'}},
         (table {width: '100%'},
-          (tr {}, (td {},
-            @renderLinks()
-          ))
-          (tr {}, (td {},
-            (SMaterialHeader {material: @props.material})
-            @renderParentInfo()
-            @renderAuthorInfo()
-          ))
-          (tr {}, (td {},
-            @renderClassInfo()
-          ))
+          (tbody {},
+            (tr {}, (td {},
+              @renderLinks()
+            ))
+            (tr {}, (td {},
+              (SMaterialHeader {material: @props.material})
+              @renderParentInfo()
+              @renderAuthorInfo()
+            ))
+            (tr {}, (td {},
+              @renderClassInfo()
+            ))
+          )
         )
       )
     )

--- a/app/assets/javascripts/components/search/material_links.js.coffee
+++ b/app/assets/javascripts/components/search/material_links.js.coffee
@@ -3,11 +3,11 @@
 window.SMaterialLinksClass = React.createClass
   render: ->
     (div {},
-      for link in @props.links
+      for link, idx in @props.links
         if link.type is 'dropdown'
-          (SMaterialDropdownLink {link: link})
+          (SMaterialDropdownLink {key: idx, link: link})
         else
-          (SMaterialLink {link: link})
+          (SMaterialLink {key: idx, link: link})
     )
 
 window.SMaterialLinks = React.createFactory SMaterialLinksClass
@@ -56,8 +56,8 @@ window.SMaterialDropdownLinkClass = React.createClass
     (div {key: link.key, style: {float: 'right'}},
       (SGenericLink {link: link})
       (div {className: 'Expand_Collapse Expand_Collapse_preview', style: {display: 'none'}},
-        for item in link.options
-          (div {className: 'preview_link'},
+        for item, idx in link.options
+          (div {key: idx, className: 'preview_link'},
             (SGenericLink {link: item})
           )
       )

--- a/app/assets/javascripts/components/search/materials_list.js.coffee
+++ b/app/assets/javascripts/components/search/materials_list.js.coffee
@@ -4,7 +4,7 @@ window.SMaterialsListClass = React.createClass
   render: ->
     (div {className: 'material_list'},
       for material in @props.materials
-        (SMaterial {material: material, key: material.id})
+        (SMaterial {material: material, key: "#{material.class_name}#{material.id}"})
     )
 
 window.SMaterialsList = React.createFactory SMaterialsListClass

--- a/app/assets/javascripts/components/search/results.js.coffee
+++ b/app/assets/javascripts/components/search/results.js.coffee
@@ -6,14 +6,14 @@ window.SearchResultsClass = React.createClass
       window.scrollTo 0, $("#{type}_bookmark").offsetTop
 
   renderMessage: ->
-    message = for group in @props.results
+    message = for group, idx in @props.results
       link = {url: 'javascript:void(0)', onclick: @generateScrollTo(group.type), text: group.header, className: ''}
-      (span {},
-        group.pagination.total_items, ' ', (SGenericLink {link: link})
+      (span {key: group.type},
+        group.pagination.total_items
+        ' '
+        (SGenericLink {link: link})
+        if idx != @props.results.length - 1 then ', ' else ''
       )
-    if @props.results.length > 1
-      for i in [(@props.results.length - 1)..1] by -1
-        message.splice i, 0, (span {}, ', ')
     message
 
   renderAllResults: ->


### PR DESCRIPTION
Search results paging:
https://learn.staging.concord.org/search?search_term=&sort_order=Newest&model_types=All&investigation_page=2&activity_page=1&interactive_page=1 
seems to be broken on staging. Also, Jen noticed probably related bug:
https://www.pivotaltracker.com/story/show/96254054

This pull request is just adding react keys and missing `tbody` element what might cause these issues.