### PR TITLE
Fixed join class button in IE [#56437442]

### DIFF
--- a/app/controllers/portal/students_controller.rb
+++ b/app/controllers/portal/students_controller.rb
@@ -322,7 +322,7 @@ class Portal::StudentsController < ApplicationController
     @class_word = params[:clazz][:class_word]
     render :update do |page|
       page.remove "invalid_word"
-      page.insert_html :top, "word_form", :partial => "confirmation",
+      page.insert_html :before, "word_form", :partial => "confirmation",
         :locals => {:class_word => @class_word,
                     :clazz      => @portal_clazz,
                     :portal_student => Portal::Student.new}


### PR DESCRIPTION
Moves the confirmation form with the join button to be before the class word form instead of inside of it.  IE does not support forms embedded within other forms.