### PR TITLE
Teacher clazzes change

### DIFF
--- a/app/models/portal/teacher_clazz.rb
+++ b/app/models/portal/teacher_clazz.rb
@@ -2,24 +2,12 @@ class Portal::TeacherClazz < ActiveRecord::Base
   self.table_name = :portal_teacher_clazzes
   
   acts_as_replicatable
+  acts_as_list :scope => :teacher
   
   belongs_to :clazz, :class_name => "Portal::Clazz", :foreign_key => "clazz_id"
   belongs_to :teacher, :class_name => "Portal::Teacher", :foreign_key => "teacher_id"
   default_scope :order => 'position ASC'
   
   [:name, :description].each { |m| delegate m, :to => :clazz }
-  
-  # def before_validation
-  #   # Portal::TeacherClazz.count(:conditions => "`clazz_id` = '#{self.clazz_id}' AND `teacher_id` = '#{self.teacher_id}'") == 0
-  #   sc = Portal::TeacherClazz.find(:first, :conditions => "`clazz_id` = '#{self.clazz_id}' AND `teacher_id` = '#{self.teacher_id}'")
-  #   self.id = sc.id
-  # end
-  
-  before_save do |teacher_clazz|
-    if teacher_clazz.id.nil?
-      position = teacher_clazz.teacher.teacher_clazzes.length + 1
-      teacher_clazz.position = position
-    end
-  end
   
 end

--- a/spec/models/portal/teacher_clazz_spec.rb
+++ b/spec/models/portal/teacher_clazz_spec.rb
@@ -85,17 +85,6 @@ describe Portal::TeacherClazz do
       teacher.clazzes.should have(1).things
     end
     
-    it "clazz.teacher reader should return the first teacher if there is one" do
-      teacher = Factory :portal_teacher, {:clazzes => []}
-      second_teacher = Factory :portal_teacher, {:clazzes => []}
-      clazz = Factory :portal_clazz
-      clazz.teacher = teacher
-      clazz.teacher = second_teacher
-      teacher.reload
-      clazz.reload
-      clazz.teacher.should == teacher
-    end
-    
     it "clazz.teacher should return nil if there isn't a teacher" do
       clazz = Factory :portal_clazz
       clazz.teacher.should be_nil


### PR DESCRIPTION
This is an alternative to: https://github.com/concord-consortium/rigse/pull/101 
It removes the test that makes sure the teachers are in order, because it really seems we don't need that anymore.
It also replaces the custom ordering code with acts_as_list.

@knowuh I prefer this approach. It seems to pass the tests.