### PR TITLE
Added lara_activity? method on external_activities

### DIFF
--- a/app/models/external_activity.rb
+++ b/app/models/external_activity.rb
@@ -144,7 +144,7 @@ class ExternalActivity < ActiveRecord::Base
   def material_type
     template_type ? template_type : 'Activity'
   end
-  
+
   def display_name
     return template.display_name if template
     return ExternalActivity.display_name
@@ -193,6 +193,22 @@ class ExternalActivity < ActiveRecord::Base
 
   def report_format
     :run_resource_html
+  end
+
+  def launch_domain
+    begin
+      URI.parse(launch_url).host
+    rescue
+      ""
+    end
+  end
+
+  def lara_launch_domain?
+    (launch_domain.start_with? "learn.") or (launch_domain == ENV['LOCAL_LARA_DOMAIN'])
+  end
+
+  def lara_activity?
+    material_type == 'Activity' && lara_launch_domain?
   end
 
   private

--- a/spec/models/external_activity_spec.rb
+++ b/spec/models/external_activity_spec.rb
@@ -102,4 +102,49 @@ describe ExternalActivity do
       expect(activity.projects.count).to eql(1)
     end
   end
+
+  describe "external" do
+    let(:lara_launch_url_attributes) { {
+        :user_id => 1,
+        :uuid => "value for uuid",
+        :name => "value for name",
+        :description => "value for description",
+        :publication_status => "value for publication_status",
+        :is_official => true,
+        :url => "http://www.concord.org/",
+        :template_type => "Activity",
+        :launch_url => "http://learn.concord.org/"
+    } }
+    let(:activity) { ExternalActivity.create!(lara_launch_url_attributes)}
+
+    it "activities from LARA should return true for lara_activity?" do
+      expect(activity.lara_activity?).to be true
+    end
+    it "activities from LOCAL_LARA_DOMAIN should return true for lara_activity?" do
+      ENV["LOCAL_LARA_DOMAIN"] = "localhost"
+      activity.launch_url = "http://localhost/"
+      expect(activity.lara_activity?).to be true
+      ENV.delete "LOCAL_LARA_DOMAIN"
+    end
+    it "activities from non-LARA sources should return false for lara_activity?" do
+      activity.launch_url = "http://somewhere.org/"
+      expect(activity.lara_activity?).to be false
+    end
+    it "investigations from LARA should return false for lara_activity?" do
+      activity.template_type = "Investigation"
+      expect(activity.lara_activity?).to be false
+    end
+    it "investigations from LOCAL_LARA_DOMAIN should return false for lara_activity?" do
+      ENV["LOCAL_LARA_DOMAIN"] = "localhost"
+      activity.template_type = "Investigation"
+      activity.launch_url = "http://localhost/"
+      expect(activity.lara_activity?).to be false
+      ENV.delete "LOCAL_LARA_DOMAIN"
+    end
+    it "investigations from non-LARA sources should return false for lara_activity?" do
+      activity.template_type = "Investigation"
+      activity.launch_url = "http://somewhere.org/"
+      expect(activity.lara_activity?).to be false
+    end
+  end
 end


### PR DESCRIPTION
This is need for queued stories that need to know if the activity is a LARA activity.  Right now it checks the launch url to see if it starts with "learn." and optionally an environment variable so developers can test against local LARA installs.