### PR TITLE
Add assign to specific class feature to ITSI binview [#100062734]

### DIFF
--- a/app/assets/javascripts/components/materials_bin/collections.js.coffee
+++ b/app/assets/javascripts/components/materials_bin/collections.js.coffee
@@ -6,7 +6,11 @@ window.MBCollectionsClass = React.createClass
   dataStateKey: 'collectionsData'
   dataUrl: Portal.API_V1.MATERIALS_BIN_COLLECTIONS
   requestParams: ->
-    id: @props.collections.map (c) -> c.id
+    if @props.assignToSpecificClass
+      id: @props.collections.map (c) -> c.id
+      assigned_to_class: @props.assignToSpecificClass
+    else
+      id: @props.collections.map (c) -> c.id
   # ---
 
   render: ->
@@ -20,6 +24,7 @@ window.MBCollectionsClass = React.createClass
             materials: collection.materials
             # Merge extra properties that can be provided in collections array.
             teacherGuideUrl: @props.collections[idx].teacherGuideUrl
+            assignToSpecificClass: @props.assignToSpecificClass
           )
       else
         (div {}, 'Loading...')

--- a/app/assets/javascripts/components/materials_bin/material.js.coffee
+++ b/app/assets/javascripts/components/materials_bin/material.js.coffee
@@ -1,10 +1,15 @@
-{div, span, a} = React.DOM
+{div, span, a, input} = React.DOM
 
 window.MBMaterialClass = React.createClass
   getInitialState: ->
     {
       descriptionVisible: false
+      assigned: @props.material.assigned
     }
+
+  assignToSpecificClass: (e) ->
+    Portal.assignMaterialToSpecificClass e.target.checked, @props.assignToSpecificClass, @props.material.id, @props.material.class_name
+    @setState assigned: e.target.checked
 
   toggleDescription: (e) ->
     @setState descriptionVisible: not @state.descriptionVisible
@@ -25,6 +30,8 @@ window.MBMaterialClass = React.createClass
     data = @props.material
     (div {className: 'mb-material'},
       (span {className: 'mb-material-links'},
+        if @props.assignToSpecificClass
+          (input {type: 'checkbox', onChange: @assignToSpecificClass, checked: @state.assigned})
         if data.edit_url?
           (a {className: 'mb-edit', href: data.edit_url, target: '_blank', title: 'Edit this activity'},
             (span {className: 'mb-edit-text'}, 'Edit')
@@ -41,7 +48,7 @@ window.MBMaterialClass = React.createClass
           (a {className: 'mb-run', href: data.preview_url, target: '_blank', title: 'Run this activity in the browser'},
             (span {className: 'mb-run-text'}, 'Run')
           )
-        if data.assign_to_class_url?
+        if not @props.assignToSpecificClass and data.assign_to_class_url?
           (a {className: 'mb-assign-to-class', href: data.assign_to_class_url, onClick: @assignToClass, title: 'Assign this activity to a class'},
             (span {className: 'mb-assign-to-class-text'}, 'Assign to class')
           )

--- a/app/assets/javascripts/components/materials_bin/materials_bin.js.coffee
+++ b/app/assets/javascripts/components/materials_bin/materials_bin.js.coffee
@@ -85,6 +85,7 @@ window.MaterialsBinClass = React.createClass
                                       customClass: cellDef.className
                                       loginRequired: cellDef.loginRequired
                                       handleClick: @handleCellClick
+                                      assignToSpecificClass: @props.assignToSpecificClass
                                     },
                                     cellDef.category
                                   )
@@ -93,11 +94,12 @@ window.MaterialsBinClass = React.createClass
                                     key: rowIdx
                                     visible: visible
                                     collections: cellDef.collections
+                                    assignToSpecificClass: @props.assignToSpecificClass
                                   )
                                 else if cellDef.ownMaterials
-                                  (MBOwnMaterials key: rowIdx, visible: visible)
+                                  (MBOwnMaterials key: rowIdx, visible: visible, assignToSpecificClass: @props.assignToSpecificClass)
                                 else if cellDef.materialsByAuthor
-                                  (MBMaterialsByAuthor key: rowIdx, visible: visible)
+                                  (MBMaterialsByAuthor key: rowIdx, visible: visible, assignToSpecificClass: @props.assignToSpecificClass)
         if cellDef.children
           # Recursively go to children array, add its elements to column + 1
           # and mark them visible only if current cell is selected.
@@ -114,5 +116,8 @@ window.MaterialsBinClass = React.createClass
 
 window.MaterialsBin = React.createFactory MaterialsBinClass
 
-Portal.renderMaterialsBin = (definition, selectorOrElement) ->
-  React.render MaterialsBin(materials: definition), jQuery(selectorOrElement)[0]
+Portal.renderMaterialsBin = (definition, selectorOrElement, queryString = null) ->
+  queryString = window.location.search if queryString is null
+  matches = queryString.match(/assign_to_class=(\d+)/)
+  assignToSpecificClass = if matches then matches[1] else null
+  React.render MaterialsBin({materials: definition, assignToSpecificClass: assignToSpecificClass}), jQuery(selectorOrElement)[0]

--- a/app/assets/javascripts/components/materials_bin/materials_by_author.js.coffee
+++ b/app/assets/javascripts/components/materials_bin/materials_by_author.js.coffee
@@ -5,6 +5,11 @@ window.MBMaterialsByAuthorClass = React.createClass
   # --- MBFetchDataMixin config ---
   dataUrl: Portal.API_V1.MATERIALS_BIN_UNOFFICIAL_MATERIALS_AUTHORS
   dataStateKey: 'authors'
+  requestParams: ->
+    if @props.assignToSpecificClass
+      assigned_to_class: @props.assignToSpecificClass
+    else
+      {}
   # ---
 
   render: ->
@@ -16,6 +21,7 @@ window.MBMaterialsByAuthorClass = React.createClass
             key: author.id
             name: author.name
             userId: author.id
+            assignToSpecificClass: @props.assignToSpecificClass
           )
       else
         (div {}, 'Loading...')

--- a/app/assets/javascripts/components/materials_bin/materials_collection.js.coffee
+++ b/app/assets/javascripts/components/materials_bin/materials_collection.js.coffee
@@ -10,7 +10,7 @@ window.MBMaterialsCollectionClass = React.createClass
       (div {className: 'mb-collection-name'}, @props.name)
       @renderTeacherGuide()
       for material in @props.materials or []
-        (MBMaterial key: "#{material.class_name}#{material.id}", material: material)
+        (MBMaterial key: "#{material.class_name}#{material.id}", material: material, assignToSpecificClass: @props.assignToSpecificClass)
     )
 
 window.MBMaterialsCollection = React.createFactory MBMaterialsCollectionClass

--- a/app/assets/javascripts/components/materials_bin/own_materials.js.coffee
+++ b/app/assets/javascripts/components/materials_bin/own_materials.js.coffee
@@ -5,6 +5,11 @@ window.MBOwnMaterialsClass = React.createClass
   # --- MBFetchDataMixin config ---
   dataStateKey: 'materials'
   dataUrl: Portal.API_V1.MATERIALS_OWN
+  requestParams: ->
+    if @props.assignToSpecificClass
+      assigned_to_class: @props.assignToSpecificClass
+    else
+      {}
   # ---
 
   render: ->
@@ -14,6 +19,7 @@ window.MBOwnMaterialsClass = React.createClass
         (MBMaterialsCollection
           name: 'My activities'
           materials: @state.materials
+          assignToSpecificClass: @props.assignToSpecificClass
         )
       else
         (div {}, 'Loading...')

--- a/app/assets/javascripts/components/materials_bin/user_materials.js.coffee
+++ b/app/assets/javascripts/components/materials_bin/user_materials.js.coffee
@@ -17,7 +17,7 @@ window.MBUserMaterialsClass = React.createClass
         ' '
         @props.name
       )
-      (MBUserMaterialsContainer userId: @props.userId, visible: @state.materialsVisible)
+      (MBUserMaterialsContainer userId: @props.userId, visible: @state.materialsVisible, assignToSpecificClass: @props.assignToSpecificClass)
     )
 
 window.MBUserMaterials = React.createFactory MBUserMaterialsClass

--- a/app/assets/javascripts/components/materials_bin/user_materials_container.js.coffee
+++ b/app/assets/javascripts/components/materials_bin/user_materials_container.js.coffee
@@ -6,13 +6,17 @@ window.MBUserMaterialsContainerClass = React.createClass
   dataStateKey: 'materials'
   dataUrl: Portal.API_V1.MATERIALS_BIN_UNOFFICIAL_MATERIALS
   requestParams: ->
-    user_id: @props.userId
+    if @props.assignToSpecificClass
+      user_id: @props.userId
+      assigned_to_class: @props.assignToSpecificClass
+    else
+      user_id: @props.userId
   # ---
 
   render: ->
     (div {className: @getVisibilityClass()},
       if @state.materials
-        (MBMaterialsCollection materials: @state.materials)
+        (MBMaterialsCollection materials: @state.materials, assignToSpecificClass: @props.assignToSpecificClass)
       else
         (div {}, 'Loading...')
     )

--- a/app/assets/javascripts/search_materials_add_to_collection.js.erb
+++ b/app/assets/javascripts/search_materials_add_to_collection.js.erb
@@ -68,3 +68,13 @@ function getDataForAssignToCollectionPopup()
 Portal.assignMaterialToCollection = function(id, className) {
     get_Assign_To_Collection_Popup(id, className);
 };
+
+Portal.assignMaterialToSpecificClass = function(assign, classId, materialId, materialClassName) {
+    params = {
+      assign: assign ? 1 : 0,
+      class_id: classId,
+      material_id: materialId,
+      material_type: materialClassName
+    };
+    jQuery.post(Portal.API_V1.ASSIGN_MATERIAL_TO_CLASS, params);
+};

--- a/app/assets/stylesheets/components/materials_bin.scss
+++ b/app/assets/stylesheets/components/materials_bin.scss
@@ -55,6 +55,10 @@
 .mb-material {
   padding: 8px;
 
+  input[type=checkbox] {
+    margin-right: 10px;
+  }
+
   .mb-material-links {
     margin-right: 10px;
 

--- a/app/controllers/api/v1/materials_bin_controller.rb
+++ b/app/controllers/api/v1/materials_bin_controller.rb
@@ -11,7 +11,7 @@ class API::V1::MaterialsBinController < API::APIController
     collection_by_id = MaterialsCollection.where(id: params[:id]).index_by { |mc| mc.id.to_s }
     collections = Array(params[:id]).map do |id|
       col = collection_by_id[id]
-      materials_collection_data(col.name, col.materials(allowed_cohorts))
+      materials_collection_data(col.name, col.materials(allowed_cohorts), params[:assigned_to_class])
     end
     render json: collections
   end
@@ -26,7 +26,7 @@ class API::V1::MaterialsBinController < API::APIController
     materials = ExternalActivity.filtered_by_cohorts(allowed_cohorts)
                                 .where(user_id: user_id, is_official: false)
                                 .order('name ASC')
-    render json: materials_data(materials)
+    render json: materials_data(materials, params[:assigned_to_class])
   end
 
   # GET /api/v1/materials_bin/unofficial_materials_authors
@@ -50,10 +50,10 @@ class API::V1::MaterialsBinController < API::APIController
     current_visitor.portal_teacher ? current_visitor.portal_teacher.cohort_list : []
   end
 
-  def materials_collection_data(name, materials)
+  def materials_collection_data(name, materials, assigned_to_class)
     {
         name: name,
-        materials: materials_data(materials)
+        materials: materials_data(materials, assigned_to_class)
     }
   end
 end

--- a/app/views/dynamic_scripts/_api_paths.html.haml
+++ b/app/views/dynamic_scripts/_api_paths.html.haml
@@ -19,5 +19,6 @@
     MATERIALS_BIN_COLLECTIONS: "#{api_v1_materials_bin_collections_path}",
     MATERIALS_BIN_UNOFFICIAL_MATERIALS: "#{api_v1_materials_bin_unofficial_materials_path}",
     MATERIALS_BIN_UNOFFICIAL_MATERIALS_AUTHORS: "#{api_v1_materials_bin_unofficial_materials_authors_path}",
-    SEARCH: "#{api_v1_search_search_path}"
+    SEARCH: "#{api_v1_search_search_path}",
+    ASSIGN_MATERIAL_TO_CLASS: "#{api_v1_materials_assign_to_class_path}"
   };

--- a/app/views/portal/clazzes/_materials.html.haml
+++ b/app/views/portal/clazzes/_materials.html.haml
@@ -14,7 +14,7 @@
           %td
             = link_to 'Manage Materials', edit_portal_clazz_url(portal_clazz), :class=>"button pie"
           %td{:style => "padding-left:10px"}
-            = link_to 'Assign Materials', search_url, :class=>"button pie"
+            = link_to 'Assign Materials', assign_materials_link, :class=>"button pie"
       %br.clearboth
       %br.clearboth
       - if clazz_offerings.length > 0

--- a/app/views/portal/clazzes/materials.html.haml
+++ b/app/views/portal/clazzes/materials.html.haml
@@ -1,2 +1,2 @@
 = form_for(@portal_clazz) do |f|
-  = render :partial => 'materials', :locals => { :portal_clazz => @portal_clazz, :f => f }
+  = render :partial => 'materials', :locals => { :portal_clazz => @portal_clazz, :f => f, :assign_materials_link => search_url }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -661,6 +661,7 @@ RailsPortal::Application.routes.draw do
         namespace :materials do
           get :own
           get :featured
+          post :assign_to_class
         end
         namespace :materials_bin do
           get :collections

--- a/lib/materials/data_helpers.rb
+++ b/lib/materials/data_helpers.rb
@@ -11,8 +11,15 @@ module Materials
       Sanitize.fragment(html_fragment, Sanitize::Config::BASIC)
     end
 
-    def materials_data(materials)
+    def materials_data(materials, assigned_to_class=nil)
       data = []
+
+      if assigned_to_class
+        portal_clazz = Portal::Clazz.find(assigned_to_class)
+        assigned_materials = portal_clazz.offerings.map { |offering| "#{offering.runnable_type}::#{offering.runnable_id}" }
+      else
+        assigned_materials = []
+      end
 
       materials.each do |material|
         parent_data = nil
@@ -76,7 +83,8 @@ module Materials
           activities: has_activities ? material.activities.map{ |a| {id: a.id, name: a.name} } : [],
           lara_activity_or_sequence: material.respond_to?(:lara_activity_or_sequence?) ? material.lara_activity_or_sequence? : false,
           parent: parent_data,
-          user: user_data
+          user: user_data,
+          assigned: assigned_materials.include?("#{material.class.name}::#{material.id}")
         }
 
         data.push mat_data

--- a/themes/itsi-learn/views/portal/clazzes/materials.html.haml
+++ b/themes/itsi-learn/views/portal/clazzes/materials.html.haml
@@ -1,0 +1,2 @@
+= form_for(@portal_clazz) do |f|
+  = render :partial => 'materials', :locals => { :portal_clazz => @portal_clazz, :f => f, :assign_materials_link => "/itsi?assign_to_class=#{@portal_clazz.id}" }


### PR DESCRIPTION
Allows the binview to assign materials to classes by passing an "assign_to_class=<id>" parameter to the binview page.  When that parameter exists it propagates down the materials bin react components and alters the material view to include a leading checkbox and removes the assign to classes icon.  The class id parameter is also passed to the server api endpoints using an "assigned_to_class=<id>" parameter that causes the api endpoint to fill an "assigned" property on the returned data so that the checkbox can be set if the material is already assigned.  When the checkbox is toggled a new api endpoint is called to assign/remove the materials from the class.  

The class materials page is also themed in this commit to change the "Assign Materials" button to point to "/itsi?assign_to_class=<id>", where id is the id of the current class being viewed.