### PR TITLE
Changed save button on edit resource options to reload iframed page [#100175262]

### DIFF
--- a/app/assets/javascripts/external_activities/matedit.js.erb
+++ b/app/assets/javascripts/external_activities/matedit.js.erb
@@ -9,7 +9,7 @@ function get_edit_resource_popup(external_activity_id, popup_options){
     var target_url = "<%= URLResolver.getUrl('edit_external_activity_path',:id => 999) %>";
     target_url = target_url.replace('999',external_activity_id);
     if (popup_options && popup_options.use_short_form) {
-      target_url += "?use_short_form=1"
+      target_url += "?use_short_form=1&redirect_to=" + window.location
     }
     var options = {
         method: 'get',

--- a/app/controllers/external_activities_controller.rb
+++ b/app/controllers/external_activities_controller.rb
@@ -131,7 +131,7 @@ class ExternalActivitiesController < ApplicationController
   def edit
     @external_activity = ExternalActivity.find(params[:id])
     if request.xhr?
-      render :partial => (params['use_short_form'] ? 'short_form' : 'form')
+      render :partial => (params['use_short_form'] ? 'short_form' : 'form'), :locals => {:redirect_to => params['redirect_to']}
     end
   end
 
@@ -214,7 +214,12 @@ class ExternalActivitiesController < ApplicationController
       respond_to do |format|
         if @external_activity.update_attributes(params[:external_activity])
           flash[:notice] = 'ExternalActivity was successfully updated.'
-          format.html { redirect_to(@external_activity) }
+          if params.has_key?(:redirect_to) && params[:redirect_to].has_key?(:url)
+            redirect_url = params[:redirect_to][:url]
+          else
+            redirect_url = @external_activity
+          end
+          format.html { redirect_to(redirect_url) }
           format.xml  { head :ok }
         else
           format.html { render :action => "edit" }

--- a/app/views/external_activities/_short_form.html.haml
+++ b/app/views/external_activities/_short_form.html.haml
@@ -1,5 +1,6 @@
 = form_for(@external_activity) do |f|
   = f.error_messages
+  = hidden_field(:redirect_to, :url, :value => redirect_to)
   = edit_menu_for(@external_activity, f)
   = field_set_tag 'Publication status' do
     = f.select :publication_status, ExternalActivity.publication_states.map {|s| s.to_s}


### PR DESCRIPTION
Adds an optional redirect_to url parameter to the external resource edit url that if present is used as the redirect url on a successful save instead of the external resource show page.  The short form then sets this value to the iframed edit page when the popup is loaded.