### PR TITLE
Add class to hide elements if guest visitor [#100512234]

### DIFF
--- a/app/assets/stylesheets/web/app.scss
+++ b/app/assets/stylesheets/web/app.scss
@@ -108,6 +108,24 @@ body {
   &.main-nav-hidden {
     background-image: image-url("styles/bg-body-no-nav.png");
   }
+
+  .hide-from-all-visitors {
+    display: none !important;
+  }
+  $role-list: guest member admin manager researcher author;
+  @each $role in $role-list {
+    &.#{$role}-visitor {
+      .show-to-#{$role}-visitor {
+        display: block !important;
+      }
+      .show-inline-to-#{$role}-visitor {
+        display: inline !important;
+      }
+      .hide-from-#{$role}-visitor {
+        display: none !important;
+      }
+    }
+  }
 }
 
 body#tinymce {

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -57,7 +57,7 @@
     - if USING_GOOGLE_ANALYTICS
       = javascript_tag google_analytics_config
     = javascript_tag "jQuery(function(){jQuery('input[placeholder], textarea[placeholder]').placeholder();});"
-  %body{:class => current_visitor.has_role?('guest') ? 'main-nav-hidden' : nil, :'ng-app' => 'cc-portal'}
+  %body{:class => current_visitor.role_names.map{ |role_name| "#{role_name}-visitor" }.unshift(current_visitor.has_role?('guest') ? 'main-nav-hidden' : '').join(' ').squish, :'ng-app' => 'cc-portal'}
 
     #note{:style=>"display: none;"}
     = content_for :lightboxes


### PR DESCRIPTION
NOTE: This PR has been changed to a more generic role based class system instead of a guest visitor focused change.  The body tag now has a 'xxx-visitor' class assigned per role, eg 'guest-visitor' and 'author-visitor'.  There are additional classes created in a loop in the web.scss file to:

1. Hide an element from all visitors: body .hide-from-all-visitors
2. Show an element for only a specific role: body.guest-visitor .show-to-guest-visitor
3. Show an element inline for only a specific role: body.guest-visitor .show-inline-to-guest-visitor
4. Hide an element for only a specific role: body.guest-visitor .hide-from-guest-visitor

To show the "Create Activity" button only to authors the ITSI project landing page content needs to have the linked wrapped in an element with the "hide-from-all-visitors show-to-author-visitor" classes.  I've added it to https://itsi-master-staging.concord.org/itsi already.

    <p class="hide-from-all-visitors show-to-author-visitor">
      <a href="https://itsi-master-staging.concord.org/eresources/433/copy" class="button pie" target="_blank">Create ITSI Activity</a>
    </p>