### PR TITLE
Added private option for activity copies [#102768308]

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -558,6 +558,7 @@ RailsPortal::Application.routes.draw do
       member do
         get :duplicate
         get :matedit
+        get :set_private_before_matedit
         get :copy
       end
     end


### PR DESCRIPTION
I had this done last night but ran out of time to push it.

To enable private ITSI copies just add ?private=1 or ?private=true to the create activity button in the ITSI project page.