### PR TITLE
Style/layout adjustments for ITSI header login box [#102772390]

### DIFF
--- a/app/assets/themes/itsi-learn/stylesheets/application.scss
+++ b/app/assets/themes/itsi-learn/stylesheets/application.scss
@@ -6,8 +6,11 @@
   background: transparent image-url("banners/itsi-portal-banner.jpg") 0 0px no-repeat;
 }
 .welcome-box {
+  background-color: rgba(0, 0, 0, 0.25);
+  height: 95px;
+  margin-right: 0;
+  padding: 25px 20px 0;
   td {
-    background-color: rgba(0, 0, 0, 0.25);
     color: #fff;
     padding: 20px;
 
@@ -19,9 +22,45 @@
 .header-login-box {
   background-color: rgba(0, 0, 0, 0.25);
   color: #fff;
-  padding: 20px;
+  height: 75px;
+  padding: 15px 20px 20px;
 
   a {
     color: #fff;
+  }
+  form
+    table
+      tr.first-row
+      {
+        td
+        {
+          padding-bottom: 3px;
+        }
+        td.login-box
+        {
+          padding-bottom: 3px;
+          padding-left: 10px;
+        }
+      }
+  .login-buttons{
+    padding-top: 4px;
+    .segmented{
+     border-left: none;
+    }
+    .login-links {
+      bottom: -18px;
+      display: block;
+      margin-top: 2px;
+      position: absolute;
+      right: 3px;
+      .segmented{
+        border-left: 1px solid #fff;
+        padding: 0 0.35em 0 0.5em;
+        &.first {
+          padding-left: 0px;
+          border-left: none;
+        }
+      }
+    }
   }
 }

--- a/app/views/shared/_header_login_box.html.haml
+++ b/app/views/shared/_header_login_box.html.haml
@@ -14,11 +14,12 @@
             %td.password-box
               = f.password_field :password,:id=>'header_password',:class=>'text'
       .login-buttons
-        %span.segmented.first
-          =link_to "Can't log in?",forgot_password_path, :id=>"link_forgot_password"
-        - unless defined? @hide_signup_link
-          %span.segmented
-            =link_to 'Sign Up', home_path
+        %span.login-links
+          %span.segmented.first
+            =link_to "Can't log in?",forgot_password_path, :id=>"link_forgot_password"
+          - unless defined? @hide_signup_link
+            %span.segmented
+              =link_to 'Sign Up', home_path
         %span.segmented
           = f.submit "Log In", :id=>"LoginSubmitButtonHeader"
         - Devise.omniauth_providers.each do |provider|


### PR DESCRIPTION
In addition to moving the "Can't log in" link below the login buttons, I made some minor style and layout changes. These changes should only affect the header login box in the itsi-learn theme. I added a new span tag to app/views/shared/_header_login_box.html.haml but it shouldn't affect other themes.