### PR TITLE
Changed "Help" links to open in new tab/window instead of popup.

### DIFF
--- a/app/views/shared/_main_nav_trail.html.haml
+++ b/app/views/shared/_main_nav_trail.html.haml
@@ -28,9 +28,9 @@
       - if current_settings && (current_visitor.has_role?('admin') || current_visitor.portal_teacher)
         - case current_settings.help_type
         - when 'external url'
-          %li.trail=link_to'Help', 'javascript: void(0)', :id=>'help',:onclick=>"window.open('/help','help_page','height = 700 width = 800, resizable = yes, scrollbars = yes');"
+          %li.trail=link_to'Help', '/help', :id=>'help', :target=>"_blank"
         - when 'help custom html'
-          %li.trail=link_to'Help', 'javascript: void(0)', :id=>'help',:onclick=>"window.open('/help','help_page','height = 700 width = 800, resizable = yes, scrollbars = yes');"
+          %li.trail=link_to'Help', '/help', :id=>'help', :target=>"_blank"
         - when 'no help'
           %li.trail.hide-menu-item{:style=>"display:none"}=link_to'Help', 'javascript: void(0)', :id=>'help'
 

--- a/app/views/shared/_project_header.html.haml
+++ b/app/views/shared/_project_header.html.haml
@@ -14,7 +14,7 @@
               = "#{current_visitor.name}"
             %br
             - if current_settings && ((current_settings.help_type == 'external url') || (current_settings.help_type == 'help custom html'))
-              = link_to 'Help | ', 'javascript: void(0)', :onclick => "window.open('/help','help_page','height = 700, width = 800, resizable = yes, scrollbars = yes');"
+              = link_to 'Help | ', '/help', :target=>"_blank"
             = link_to 'My Preferences', preferences_user_path(current_visitor)
             - if @original_user != current_visitor
               |


### PR DESCRIPTION
I also noticed, the code for external and custom/internal help links appear to be identical. Should that be fixed somehow or consolidated? Or is it intentional?