### PR TITLE
Fix  NPE in `learner_updated_at_path` when student has run yet. [#104…

### DIFF
--- a/app/assets/javascripts/student_lightbox_report.js.coffee.erb
+++ b/app/assets/javascripts/student_lightbox_report.js.coffee.erb
@@ -10,7 +10,7 @@ class LightboxReport
     @last_update_time    = 0
     @report_dom   = 'report'
     @report_elm   = $(@report_dom)
-    @close_elm    = $('lightbox_closer')    
+    @close_elm    = $('lightbox_closer')
     @interval_id  = null
     @update_interval_ms = 5 * 1000
     @rebindEvents()
@@ -46,6 +46,9 @@ class LightboxReport
             @updateReport()
             @restore_scroll_position()
           @timeout_id = setTimeout(update_func, @update_interval_ms)
+        onFailure: (transport) =>
+          @timeout_id = setTimeout(update_func, @update_interval_ms)
+    
     @timeout_id = setTimeout(update_func, @update_interval_ms)
     @rebindEvents()
 
@@ -87,11 +90,11 @@ class LightboxReport
     should_we_udpate
 
 
-    
+
   handleKedown: (e) ->
-    if (e.keyCode)    
+    if (e.keyCode)
       code = e.keyCode
-    else if (e.which) 
+    else if (e.which)
       code = e.which
     switch code
       when 27

--- a/app/controllers/report/learner_controller.rb
+++ b/app/controllers/report/learner_controller.rb
@@ -97,13 +97,23 @@ class Report::LearnerController < ApplicationController
   def updated_at
     learner = Report::Learner.find_by_user_id_and_offering_id(current_visitor.id,params[:id])
     if learner
-      modification_time = learner.last_run.strftime("%s")
+      last_run = learner.last_run
+      status = 400
+      hasnt_run_text  = I18n.t "StudentHasntRun"
+      json_response = { error_msg: hasnt_run_text }
+      text_response = hasnt_run_text
+      if last_run
+        status = 200
+        modification_time = last_run.strftime("%s")
+        json_response = {modification_time: modification_time }
+        text_response = modification_time
+      end
       respond_to do |format|
         format.html do
-          render :text => modification_time
+          render :text => text_response, :status => status
         end
         format.json do
-          render :json => {:modification_time => modification_time }
+          render :json => json_response, :status => status
         end
       end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,7 +76,7 @@ en:
     description_for_teacher_description: "If this description is filled in, it will be shown in the search page when a teacher is logged in"
   JNLPJavaRequirement: Requires download
   NoJavaRequirement: Runs in browser
-
+  StudentHasntRun: Not run yet
 'en-HAS':
   activerecord:
     models:

--- a/spec/controllers/report/learner_controller_spec.rb
+++ b/spec/controllers/report/learner_controller_spec.rb
@@ -1,0 +1,69 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+describe Report::LearnerController do
+
+  def newLearner(learner_stubs)
+    learner = Factory(:full_portal_learner)
+    learner_stubs.keys.each do |key|
+      learner.stub(key).and_return(learner_stubs[key])
+    end
+    learner
+  end
+
+  before(:each) do
+    Report::Learner.stub(:find_by_user_id_and_offering_id).and_return(learner)
+  end
+
+  let(:learner_stubs)   { {}                }
+  let(:learner)         { newLearner(learner_stubs) }
+  describe "A working test setup" do
+    it "The learner should exist" do
+      learner.should_not be_nil
+    end
+  end
+
+  describe "GET updated_at" do
+    describe "when the learner has a valid updated_at" do
+      let(:learner_stubs) { { last_run: Date.parse("1970-12-23") } }
+      describe 'json format' do
+        it "should return a json hash containing update_at time" do
+          get :updated_at, :format => :json, :id => learner.id
+          response.status.should eq 200
+          json = JSON.parse(response.body)
+          json['modification_time'].should == '30758400'
+        end
+      end
+      describe 'html format' do
+        it "should return a string containing formatted time" do
+          get :updated_at, :format => :html, :id => learner.id
+          response.status.should eq 200
+          response.body.should match '30758400'
+        end
+      end
+    end
+
+    describe "when the leraner hasn't run anything yet" do
+      let(:learner_stubs) { { last_run: nil } }
+      let(:not_run_text)  { I18n.t "StudentHasntRun"}
+      describe 'json format' do
+        # Not sure about this.  I don't know what calls this method.
+        it "should return an empty string" do
+          get :updated_at, :format => :json, :id => learner.id
+          json = JSON.parse(response.body)
+          response.status.should eq 400
+          json['modification_time'].should be_nil
+          json['error_msg'].should match not_run_text
+        end
+      end
+      describe 'html format' do
+        it "should return a string containing formatted time" do
+          get :updated_at, :format => :html, :id => learner.id
+          response.status.should eq 400
+          response.body.should match not_run_text
+        end
+      end
+    end
+  end
+
+
+end

--- a/spec/controllers/report/learner_controller_spec.rb
+++ b/spec/controllers/report/learner_controller_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path('../../../spec_helper', __FILE__)
 
 describe Report::LearnerController do
 
-  def newLearner(learner_stubs)
+  def new_learner(learner_stubs)
     learner = Factory(:full_portal_learner)
     learner_stubs.keys.each do |key|
       learner.stub(key).and_return(learner_stubs[key])
@@ -15,7 +15,7 @@ describe Report::LearnerController do
   end
 
   let(:learner_stubs)   { {}                }
-  let(:learner)         { newLearner(learner_stubs) }
+  let(:learner)         { new_learner(learner_stubs) }
   describe "A working test setup" do
     it "The learner should exist" do
       learner.should_not be_nil
@@ -42,7 +42,7 @@ describe Report::LearnerController do
       end
     end
 
-    describe "when the leraner hasn't run anything yet" do
+    describe "when the learner hasn't run anything yet" do
       let(:learner_stubs) { { last_run: nil } }
       let(:not_run_text)  { I18n.t "StudentHasntRun"}
       describe 'json format' do


### PR DESCRIPTION
…427626]

Added tests for the controller.  Could / should add tests for Coffeescript.

https://www.pivotaltracker.com/story/show/104427626

The main consumer of this controller endpoint is for student reports:
`app/assets/javascripts/student_lightbox_report.js.coffee.erb`

To QA this,  it might be necessary to create a new learner (either by joining a new class or something similar)

For Local QA I simply nulled-out the `last_run` field  for my test Report::Learner.