### PR TITLE
Updates to schoology sso

### DIFF
--- a/app/controllers/misc_controller.rb
+++ b/app/controllers/misc_controller.rb
@@ -113,6 +113,13 @@ class MiscController < ActionController::Base
     if params[:realm] && params[:realm_id] && params[:realm] == "user"
       uid = params[:realm_id]
     end
+
+    if request.referer && (host = URI(request.referer).host) && host !~ /concord\.org$/
+      session[:schoology_host] = host
+    else
+      session.delete :schoology_host
+    end
+
     generic_check(provider, uid)
   end
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -208,7 +208,13 @@ Devise.setup do |config|
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', :scope => 'user,public_repo'
   if ENV['SCHOOLOGY_CONSUMER_KEY'] && ENV['SCHOOLOGY_CONSUMER_SECRET']
-    config.omniauth 'schoology', ENV['SCHOOLOGY_CONSUMER_KEY'], ENV['SCHOOLOGY_CONSUMER_SECRET'], scope: 'user', strategy_class: 'OmniAuth::Strategies::Schoology'
+    SETUP_PROC = lambda do |env|
+      host = env['rack.session'][:schoology_host]
+      if host
+        env['omniauth.strategy'].options[:client_options][:authorize_url] = "https://#{host}/oauth/authorize"
+      end
+    end
+    config.omniauth 'schoology', ENV['SCHOOLOGY_CONSUMER_KEY'], ENV['SCHOOLOGY_CONSUMER_SECRET'], scope: 'user', strategy_class: 'OmniAuth::Strategies::Schoology', setup: SETUP_PROC
   end
 
   # ==> Warden configuration

--- a/lib/omni_auth/strategies/schoology.rb
+++ b/lib/omni_auth/strategies/schoology.rb
@@ -10,7 +10,7 @@ module OmniAuth
         :http_method => :get,
         :access_token_path => "/v1/oauth/access_token",
         :request_token_path => "/v1/oauth/request_token",
-        :authorize_url => "https://www.schoology.com/oauth/authorize"
+        :authorize_url => "https://app.schoology.com/oauth/authorize"
       }
 
       # These are called after authentication has succeeded. If


### PR DESCRIPTION
Record where the schoology auth request comes from, and use that host
instead of the default. Also, change the default to app.schoology.com
instead of www.schoology.com.