### PR TITLE
Add more stats to the class student roster  [#103127914]

### DIFF
--- a/app/assets/stylesheets/web/app.scss
+++ b/app/assets/stylesheets/web/app.scss
@@ -1495,18 +1495,21 @@ ul.quiet_list {
 
 table.teacher_class_table th, table.teacher_class_table td
 {
+    font-size: 12px;
     border: 1px solid #242323;
-    padding-left:10px;
+    padding-left: 1em;
+    padding-top: 5px;
+    padding-bottom: 5px;
     /*text-align: center !important; /*Forcely added !important as in Action_menu_tab.scss Align Left is marked !important*/
-
+  a {white-space: nowrap}
    .change_password
   {
-    padding-left:20px;
+    padding: 1em;
   }
 
   .remove_student
   {
-    padding-left:20px;
+    padding: 1em;
   }
 }
 
@@ -1561,8 +1564,8 @@ table.teacher_class_table th, table.teacher_class_table td
 #student_roster #students_listing{padding-right:0px !important}
 
 table.add_student, table.roster_student_list{margin:0;clear:both;}
-table.roster_student_list .action_link_container{width:235px;padding-left:0px}
-table.roster_student_list a.change_password{padding-left:10px}
+table.roster_student_list .action_link_container{padding-left:0px}
+table.roster_student_list a { white-space: 'nowrap'}
 
 .contentdiv{float:left;}
 .linkdiv{float:right;}
@@ -1878,4 +1881,3 @@ p.school_description {
     background-color: #ccc;
   }
 }
-

--- a/app/models/student_roster.rb
+++ b/app/models/student_roster.rb
@@ -1,0 +1,28 @@
+# encoding: UTF-8
+
+# Returns itterable StudentRosterRows
+# (students_in_class(portal_clazz.students)) }
+# - roster_row = StudentRosterRow.new portal_student, portal_clazz
+class StudentRoster
+
+  attr_accessor :clazz
+  attr_accessor :rows
+
+  def initialize(_clazz)
+    self.clazz = _clazz
+    self.rows = self.clazz.students
+      .includes( [:user, :learners => [:offering]] )
+      .sort    { |a,b| (a.user.last_name.casecmp(b.user.last_name)) }
+      .map     { |s| StudentRosterRow.new(s, self.clazz)            }
+  end
+
+  def empty?
+    self.rows.length < 1
+  end
+
+  def each
+    if block_given?
+      self.rows.each { |e| yield(e) }
+    end
+  end
+end

--- a/app/models/student_roster_row.rb
+++ b/app/models/student_roster_row.rb
@@ -1,0 +1,66 @@
+# encoding: UTF-8
+
+include ActionView::Helpers::DateHelper
+
+# |Name|User Name|Last Login|Assignments Started|
+
+class StudentRosterRow
+  NO_NAME                = I18n.t "RosterNoName"
+  NO_LOGIN               = I18n.t "RosterNoLogin"
+  NO_LAST_LOGIN          = I18n.t "RosterNoLastLogin"
+  NO_ASSIGNMENTS         = I18n.t "RosterNoAssignments"
+  AGO                    = I18n.t "RosterTimeAgo"
+  NEVER                  = I18n.t "RosterNeverLoggedIn"
+
+  attr_accessor :student
+  attr_accessor :clazz
+  attr_accessor :portal_student_clazz
+  attr_accessor :name
+  attr_accessor :login
+  attr_accessor :last_login
+  attr_accessor :assignments_started
+
+  def initialize(_student, _clazz)
+    self.student = _student
+    self.clazz = _clazz
+    self.portal_student_clazz = self.clazz.student_clazzes.find_by_student_id(self.student.id)
+  end
+
+  def name
+    begin
+      name = "#{self.student.user.last_name }, #{self.student.user.first_name}"
+      name.truncate(33)
+    rescue
+      NO_NAME
+    end
+  end
+
+  def login
+    begin
+      self.student.user.login.truncate(20)
+    rescue
+      NO_LOGIN
+    end
+  end
+
+  def last_login
+    begin
+      date = self.student.user.last_sign_in_at
+      return NEVER unless date
+      wordtime = "#{time_ago_in_words(date)} #{AGO}"
+      datetime = date.strftime "%Y-%m-%d %l:%M %Z"
+      wordtime
+    rescue
+      NO_LAST_LOGIN
+    end
+  end
+
+  def assignments_started
+    begin
+      self.student.learners.select { |l| l.offering.clazz_id == self.clazz.id }.length
+    rescue
+      NO_ASSIGNMENTS
+    end
+  end
+
+end

--- a/app/models/student_roster_row.rb
+++ b/app/models/student_roster_row.rb
@@ -46,9 +46,7 @@ class StudentRosterRow
     begin
       date = self.student.user.last_sign_in_at
       return NEVER unless date
-      wordtime = "#{time_ago_in_words(date)} #{AGO}"
-      datetime = date.strftime "%Y-%m-%d %l:%M %Z"
-      wordtime
+      "#{time_ago_in_words(date)} #{AGO}"
     rescue
       NO_LAST_LOGIN
     end

--- a/app/models/student_roster_row.rb
+++ b/app/models/student_roster_row.rb
@@ -15,7 +15,6 @@ class StudentRosterRow
   attr_accessor :student
   attr_accessor :clazz
   attr_accessor :portal_student_clazz
-  attr_accessor :name
   attr_accessor :login
   attr_accessor :last_login
   attr_accessor :assignments_started
@@ -61,6 +60,10 @@ class StudentRosterRow
     rescue
       NO_ASSIGNMENTS
     end
+  end
+
+  def confirm_delete_message
+    I18n.t "RosterConfirmDelete", name: self.name, clazz: self.clazz.name
   end
 
 end

--- a/app/views/portal/students/_table_for_clazz.html.haml
+++ b/app/views/portal/students/_table_for_clazz.html.haml
@@ -1,5 +1,8 @@
-- student_list = (students_in_class(portal_clazz.students)).sort { |a,b| (a.user.last_name.casecmp(b.user.last_name)) }
-- if student_list.length > 0
+- roster = StudentRoster.new(portal_clazz)
+- if roster.empty?
+  %br
+  .message_text No students registered for this class yet.
+- else
   %table.teacher_class_table{:width=>"100%"}
     %tr
       %td.show_border
@@ -12,22 +15,27 @@
         %b= I18n.t "RosterAssignmentsHeading"
       %td.hide_in_print
 
-    - student_list.each do |portal_student|
-      - roster_row = StudentRosterRow.new portal_student, portal_clazz
+    - roster.each do |roster_row|
       %tr{:id=>dom_id_for(roster_row.portal_student_clazz)}
         %td.show_border
           = roster_row.name
-        %td.show_border{:title=>roster_row.login}
+        %td.show_border{:title => roster_row.login}
           = roster_row.login
-        %td.show_border{:title=>"Last Login"}
+        %td.show_border{:title => I18n.t("RosterNoLastLoginHeading") }
           = roster_row.last_login
-        %td.show_border{:title=>"Assignments Started"}
+        %td.show_border{:title => I18n.t("RosterAssignmentsHeading") }
           = roster_row.assignments_started
         %td.remove.hide_in_print.action_link_container
           - if portal_clazz.changeable?(current_visitor)
-            = link_to_remote "Remove Student", :url => portal_clazz_student_clazz_url(portal_clazz, roster_row.portal_student_clazz), :confirm => "This action will remove the student: '#{portal_student.name}' from the class: #{portal_clazz.name}. \nAre you sure you want to do this?", :method => :delete, :html => {:title => "Remove #{portal_student.name} from #{portal_clazz.name}" , :class => "change_password"}
-          - if portal_student.user.changeable?(current_visitor)
-            = link_to 'Change Password', reset_password_user_path(portal_student.user),:title => "Change password for #{portal_student.name}",:class => "change_password"
-- else
-  %br
-  .message_text No students registered for this class yet.
+            = link_to_remote I18n.t("RosterRemoveStudent"),
+              :url => portal_clazz_student_clazz_url(roster_row.clazz, roster_row.portal_student_clazz),
+              :confirm => roster_row.confirm_delete_message,
+              :method => :delete,
+              :html => {  title: I18n.t("RosterRemoveStudentLong",
+                          name: roster_row.name, clazz: roster.clazz.name),
+                          class: "change_password" }
+                          
+          - if roster_row.student.user.changeable?(current_visitor)
+            = link_to 'Change Password', reset_password_user_path(roster_row.student.user),
+              :title => I18n.t("RosterChangePassword", name: roster_row.name),
+              :class => "change_password"

--- a/app/views/portal/students/_table_for_clazz.html.haml
+++ b/app/views/portal/students/_table_for_clazz.html.haml
@@ -3,21 +3,29 @@
   %table.teacher_class_table{:width=>"100%"}
     %tr
       %td.show_border
-        %b Name
+        %b= I18n.t "RosterNameHeading"
       %td.show_border
-        %b User Name
+        %b= I18n.t "RosterUsernameHeading"
+      %td.show_border
+        %b= I18n.t "RosterNoLastLoginHeading"
+      %td.show_border
+        %b= I18n.t "RosterAssignmentsHeading"
       %td.hide_in_print
 
     - student_list.each do |portal_student|
-      - portal_student_clazz = portal_clazz.student_clazzes.find_by_student_id(portal_student.id)
-      %tr{:id=>dom_id_for(portal_student_clazz)}
+      - roster_row = StudentRosterRow.new portal_student, portal_clazz
+      %tr{:id=>dom_id_for(roster_row.portal_student_clazz)}
         %td.show_border
-          = (portal_student.user.last_name + ", " +portal_student.user.first_name).truncate(33)
-        %td.show_border{:title=>"#{portal_student.user.login}"}
-          = portal_student.user.login.truncate(20)
+          = roster_row.name
+        %td.show_border{:title=>roster_row.login}
+          = roster_row.login
+        %td.show_border{:title=>"Last Login"}
+          = roster_row.last_login
+        %td.show_border{:title=>"Assignments Started"}
+          = roster_row.assignments_started
         %td.remove.hide_in_print.action_link_container
           - if portal_clazz.changeable?(current_visitor)
-            = link_to_remote "Remove Student", :url => portal_clazz_student_clazz_url(portal_clazz, portal_student_clazz), :confirm => "This action will remove the student: '#{portal_student.name}' from the class: #{portal_clazz.name}. \nAre you sure you want to do this?", :method => :delete, :html => {:title => "Remove #{portal_student.name} from #{portal_clazz.name}" , :class => "change_password"}
+            = link_to_remote "Remove Student", :url => portal_clazz_student_clazz_url(portal_clazz, roster_row.portal_student_clazz), :confirm => "This action will remove the student: '#{portal_student.name}' from the class: #{portal_clazz.name}. \nAre you sure you want to do this?", :method => :delete, :html => {:title => "Remove #{portal_student.name} from #{portal_clazz.name}" , :class => "change_password"}
           - if portal_student.user.changeable?(current_visitor)
             = link_to 'Change Password', reset_password_user_path(portal_student.user),:title => "Change password for #{portal_student.name}",:class => "change_password"
 - else

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,6 +77,19 @@ en:
   JNLPJavaRequirement: Requires download
   NoJavaRequirement: Runs in browser
   StudentHasntRun: Not run yet
+
+  RosterNameHeading: Name
+  RosterUsernameHeading: Username
+  RosterNoLastLoginHeading: Last login
+  RosterAssignmentsHeading: Assignments started
+
+  RosterNoName: No Name
+  RosterNoLogin: No Username
+  RosterNoLastLogin: Unknown
+  RosterNoAssignments: Unknown
+  RosterTimeAgo: ago
+  RosterNeverLoggedIn: Never
+
 'en-HAS':
   activerecord:
     models:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,6 +89,10 @@ en:
   RosterNoAssignments: Unknown
   RosterTimeAgo: ago
   RosterNeverLoggedIn: Never
+  RosterConfirmDelete: "This action will remove the student: '%{name}' from the class: %{clazz}. \nAre you sure you want to do this?"
+  RosterRemoveStudent: "Remove Student"
+  RosterRemoveStudentLong: "Remove Student %{name} from %{clazz}"
+  RosterChangePassword: "Change password for %{name}"
 
 'en-HAS':
   activerecord:

--- a/spec/models/student_roster_row_spec.rb
+++ b/spec/models/student_roster_row_spec.rb
@@ -1,0 +1,81 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+
+describe StudentRosterRow do
+  let(:clazz)              { mock_model Portal::Clazz, id:4077  }
+  let(:incomplete_student) { mock_model Portal::Student,
+    user: nil,
+    learners: nil
+  }
+  let(:login_time)         { nil }
+  let(:good_login_time)    { Time.now - 1.hour }
+  let(:completed_student)  { mock_model Portal::Student,
+    user: mock_model(User, {
+      last_name: "Malfoy",
+      first_name: "Draco",
+      login: "dmalfoy",
+      last_sign_in_at: login_time
+    }),
+    learners: learners
+  }
+  let(:student)           { incomplete_student         }
+  let(:name)              { nil                        }
+  let(:login)             { nil                        }
+  let(:signin_at)         { nil                        }
+  let(:learners)          { nil                        }
+  let(:good_learner)      { mock_model Portal::Learner }
+  let(:roster_item)       { StudentRosterRow.new(student,clazz) }
+
+  before(:each) do
+    clazz.stub_chain(:student_clazzes,:find_by_student_id).and_return(clazz)
+  end
+
+  describe "A student without a valid user" do
+    it "should use default values" do
+      roster_item.name.should eql "No Name"
+      roster_item.login.should eql "No Username"
+      roster_item.last_login.should eql "Unknown"
+      roster_item.assignments_started.should eql "Unknown"
+    end
+  end
+
+  describe "A valid student" do
+    let(:student) { completed_student }
+    let(:learners) { [] }
+
+    it "should use user attributes for fields" do
+      roster_item.name.should eql "Malfoy, Draco"
+      roster_item.login.should eql "dmalfoy"
+    end
+
+    describe "When the student has not done any work" do
+      it "should list 0 assingments started" do
+        roster_item.assignments_started.should eql 0
+          roster_item.last_login.should eql "Never"
+      end
+    end
+
+    describe "When the students learners are messed up" do
+      let(:learners)   { [Object.new]    }
+      let(:login_time) { good_login_time }
+      it "should list 0 assingments started" do
+        roster_item.assignments_started.should eql "Unknown"
+        roster_item.last_login.should eql "about 1 hour ago"
+      end
+    end
+    describe "when the student has started 2 activities in this class, and 1 in another class" do
+      let(:item1) { Object.new }
+      let(:item2) { Object.new }
+      let(:item3) { Object.new }
+      let(:learners) { [item1, item2] }
+      it "should list 2 assignments started" do
+        item1.stub_chain(:offering, :clazz_id).and_return(clazz.id)
+        item2.stub_chain(:offering, :clazz_id).and_return(clazz.id)
+        item3.stub_chain(:offering, :clazz_id).and_return(404)
+        roster_item.assignments_started.should eql 2
+      end
+    end
+  end
+end


### PR DESCRIPTION
In order to help teachers identify active and non active students, add more stats to the class student roster.

Columns:
| Name |  Username | Last Login | Assignments Started |

Because there were a number of loops and calculations in the view, I extracted `student_roster_row.rb`.

Also I18n'd the strings, created some tests, and modified styles to accommodate more info in the table row.

We don't have a nice folder structure for view-models like `student_roster_row.rb` -- there are other instances of these kinds of objects, but they all sit at the root of `models`.  

https://www.pivotaltracker.com/story/show/103127914