### PR TITLE
Add `cursor: pointer; trick` to get clickable bins for React < 0.14

### DIFF
--- a/app/assets/stylesheets/components/materials_bin.scss
+++ b/app/assets/stylesheets/components/materials_bin.scss
@@ -26,7 +26,7 @@
   font-size: 15px;
 }
 
-.mb-clickable:hover {
+.mb-clickable {
   cursor: pointer;
 }
 


### PR DESCRIPTION
@scytacki  have a look?  :)

@see https://github.com/facebook/react/issues/134