### PR TITLE
Hide Assessment items from non-teachers

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -95,6 +95,7 @@ class Activity < ActiveRecord::Base
     end
     boolean :is_official
     boolean :is_template
+    boolean :is_assessment_item
 
     time    :updated_at
     time    :created_at

--- a/app/models/external_activity.rb
+++ b/app/models/external_activity.rb
@@ -24,6 +24,7 @@ class ExternalActivity < ActiveRecord::Base
 
     integer :offerings_count
     boolean :is_official
+    boolean :is_assessment_item
     boolean :is_template do
       false
     end

--- a/app/models/investigation.rb
+++ b/app/models/investigation.rb
@@ -36,6 +36,7 @@ class Investigation < ActiveRecord::Base
     integer :offerings_count
     boolean :is_official
     boolean :is_template
+    boolean :is_assessment_item
 
     time    :updated_at
     time    :created_at

--- a/app/views/activities/_form.html.haml
+++ b/app/views/activities/_form.html.haml
@@ -34,6 +34,8 @@
   = field_set_tag 'Show Score' do
     = f.check_box :show_score
     #{t('authoring.show_score_description')} (this only applies if this activity is assigned individually)
+
+  = render :partial => 'shared/is_assessment_item', :locals => { :form => f }
   = render :partial => 'shared/material_properties_edit', :locals => { :object => @activity }
   = render :partial => 'shared/cohorts_edit', :locals => { :object => @activity }
   = render :partial => 'shared/grade_levels_edit', :locals => { :object => @activity }

--- a/app/views/external_activities/_form.html.haml
+++ b/app/views/external_activities/_form.html.haml
@@ -57,6 +57,7 @@
   = field_set_tag 'Save Path' do
     = f.text_field :save_path
   = render :partial => 'shared/material_properties_edit', :locals => { :object => @external_activity }
+  = render :partial => 'shared/material_properties_edit', :locals => { :object => @external_activity }
   = render :partial => 'shared/cohorts_edit', :locals => { :object => @external_activity }
   = render :partial => 'shared/grade_levels_edit', :locals => { :object => @external_activity }
   = render :partial => 'shared/subject_areas_edit', :locals => { :object => @external_activity }

--- a/app/views/investigations/_form.html.haml
+++ b/app/views/investigations/_form.html.haml
@@ -51,6 +51,8 @@
         %label Thumbnail image URL (300 x 250 px)
         %br
         = f.text_field :thumbnail_url, :size => 60
+
+  = render :partial => 'shared/is_assessment_item', :locals => { :form => f }
   = render :partial => 'shared/material_properties_edit', :locals => { :object => investigation }
   = render :partial => 'shared/cohorts_edit', :locals => { :object => investigation }
   = render :partial => 'shared/grade_levels_edit', :locals => { :object => investigation }

--- a/app/views/shared/_is_assessment_item.html.haml
+++ b/app/views/shared/_is_assessment_item.html.haml
@@ -1,0 +1,3 @@
+= field_set_tag t('authoring.is_assessment_item') do
+  = form.check_box :is_assessment_item
+  = t('authoring.is_assessment_item_description')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,6 +74,8 @@ en:
     student_report_enabled_description: Show a link to the student so they can see all their answers and see if they are correct
     show_score_description: Show the score in the report
     description_for_teacher_description: "If this description is filled in, it will be shown in the search page when a teacher is logged in"
+    is_assessment_item: Student assessment item.
+    is_assessment_item_description: Materials marked as student assessment items are not displayed to students or visitors in search results.
   "Requires download": Requires download
   "Runs in browser": Runs in browser
   StudentHasntRun: Not run yet

--- a/db/migrate/20151204212409_add_is_assessment_item_to_materials.rb
+++ b/db/migrate/20151204212409_add_is_assessment_item_to_materials.rb
@@ -1,0 +1,7 @@
+class AddIsAssessmentItemToMaterials < ActiveRecord::Migration
+  def change
+    add_column :investigations, :is_assessment_item, :boolean, :default =>false
+    add_column :activities, :is_assessment_item, :boolean, :default =>false
+    add_column :external_activities, :is_assessment_item, :boolean, :default =>false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20151111213007) do
+ActiveRecord::Schema.define(:version => 20151204212409) do
 
   create_table "access_grants", :force => true do |t|
     t.string   "code"
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(:version => 20151111213007) do
     t.string   "teacher_guide_url"
     t.string   "thumbnail_url"
     t.boolean  "is_featured",                           :default => false
+    t.boolean  "is_assessment_item",                    :default => false
   end
 
   add_index "activities", ["investigation_id", "position"], :name => "index_activities_on_investigation_id_and_position"
@@ -864,6 +865,7 @@ ActiveRecord::Schema.define(:version => 20151111213007) do
     t.string   "author_email"
     t.boolean  "is_locked"
     t.boolean  "logging",                  :default => false
+    t.boolean  "is_assessment_item",       :default => false
   end
 
   add_index "external_activities", ["is_featured", "publication_status"], :name => "featured_public"
@@ -973,6 +975,7 @@ ActiveRecord::Schema.define(:version => 20151111213007) do
     t.boolean  "is_featured",                             :default => false
     t.text     "abstract"
     t.string   "author_email"
+    t.boolean  "is_assessment_item",                      :default => false
   end
 
   add_index "investigations", ["is_featured", "publication_status"], :name => "featured_public"
@@ -1968,6 +1971,7 @@ ActiveRecord::Schema.define(:version => 20151111213007) do
   end
 
   add_index "portal_offerings", ["clazz_id"], :name => "index_portal_offerings_on_clazz_id"
+  add_index "portal_offerings", ["runnable_id", "runnable_type"], :name => "runnable"
 
   create_table "portal_permission_forms", :force => true do |t|
     t.string   "name"
@@ -1992,6 +1996,7 @@ ActiveRecord::Schema.define(:version => 20151111213007) do
 
   add_index "portal_school_memberships", ["member_type", "member_id"], :name => "member_type_id_index"
   add_index "portal_school_memberships", ["school_id", "member_id", "member_type"], :name => "school_memberships_long_idx"
+  add_index "portal_school_memberships", ["school_id"], :name => "index_portal_school_memberships_on_school_id"
 
   create_table "portal_schools", :force => true do |t|
     t.string   "uuid",           :limit => 36
@@ -2562,6 +2567,7 @@ ActiveRecord::Schema.define(:version => 20151111213007) do
 
   add_index "taggings", ["tag_id"], :name => "index_taggings_on_tag_id"
   add_index "taggings", ["taggable_id", "taggable_type", "context"], :name => "index_taggings_on_taggable_id_and_taggable_type_and_context"
+  add_index "taggings", ["tagger_id", "tagger_type"], :name => "index_taggings_on_tagger_id_and_tagger_type"
 
   create_table "tags", :force => true do |t|
     t.string "name"


### PR DESCRIPTION
In the Learn portal, only teachers (not students or anonymous users) can see pre/post tests, without them having to be tagged with a cohort ( [PT Story](https://www.pivotaltracker.com/story/show/100149408) )

This PR addresses everything except for materials bin view. 