### PR TITLE
fix errors with bundler 1.11.0 clean install

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -165,6 +165,7 @@ group :development do
   gem "what_methods"
   gem "hirb"
   gem "ruby-debug",   :platforms => [:mri_18, :mingw_18]
+  gem "debugger-ruby_core_source", "~> 1.3.8", :platforms => [:mri_19]
   gem "debugger", :platforms => [:mri_19]
   gem "pry-debugger"
   gem "awesome_print"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,11 +89,11 @@ GIT
 
 GIT
   remote: git://github.com/concord-consortium/themes_for_rails
-  revision: eea2c31d181af30f787c5f493c74acdbe0bbf324
+  revision: 90ce15e3ba9216b87e4fbafa1f2b867bff09707f
   branch: asset-pipeline-only
   specs:
     themes_for_rails (0.5.1)
-      rails (>= 3.0.0)
+      rails (>= 3.0.11)
 
 GEM
   remote: http://rubygems.org/
@@ -200,7 +200,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.1.1)
-    columnize (0.8.9)
+    columnize (0.9.0)
     compass (1.0.3)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.2)
@@ -233,13 +233,12 @@ GEM
       nokogiri (>= 1.5.0)
     daemons (1.1.8)
     database_cleaner (0.7.2)
-    debugger (1.1.4)
+    debugger (1.6.8)
       columnize (>= 0.3.1)
-      debugger-linecache (~> 1.1.1)
-      debugger-ruby_core_source (~> 1.1.3)
-    debugger-linecache (1.1.2)
-      debugger-ruby_core_source (>= 1.1.1)
-    debugger-ruby_core_source (1.1.9)
+      debugger-linecache (~> 1.2.0)
+      debugger-ruby_core_source (~> 1.3.5)
+    debugger-linecache (1.2.0)
+    debugger-ruby_core_source (1.3.8)
     default_value_for (2.0.1)
     delayed_job (3.0.3)
       activesupport (~> 3.0)
@@ -403,18 +402,13 @@ GEM
     prawn_rails (0.0.8)
       prawn (>= 0.11.1)
       rails (>= 3.0.0)
-    pry (0.9.12.6)
-      coderay (~> 1.0)
-      method_source (~> 0.8)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
       slop (~> 3.4)
-    pry (0.9.12.6-x86-mingw32)
-      coderay (~> 1.0)
-      method_source (~> 0.8)
-      slop (~> 3.4)
-      win32console (~> 1.3)
-    pry-debugger (0.2.0)
-      debugger (~> 1.1.3)
-      pry (~> 0.9.9)
+    pry-debugger (0.2.3)
+      debugger (~> 1.3)
+      pry (>= 0.9.10, < 0.11.0)
     pundit (1.0.1)
       activesupport (>= 3.0.0)
     rack (1.4.5)
@@ -590,7 +584,6 @@ GEM
     what_methods (1.0.1)
     will_paginate (3.0.3)
     win32-open3 (0.3.2-x86-mingw32)
-    win32console (1.3.2-x86-mingw32)
     wirble (0.1.3)
     xpath (0.1.4)
       nokogiri (~> 1.3)
@@ -637,6 +630,7 @@ DEPENDENCIES
   daemons (~> 1.1.8)
   database_cleaner (~> 0.7.2)
   debugger
+  debugger-ruby_core_source (~> 1.3.8)
   default_value_for (~> 2.0.1)
   delayed_job (~> 3.0.1)
   delayed_job_active_record (~> 0.3.2)
@@ -732,3 +726,6 @@ DEPENDENCIES
   wirble
   xray-rails
   yui-compressor
+
+BUNDLED WITH
+   1.11.0


### PR DESCRIPTION
needed to clean up gemspec of themes_for_rails
and update pry, debugger, debugger dependencies

@knowuh and @dougmartin can you try checking out this branch locally and see if you can still run `bundle install` as well as running the local server and your favorite debugging tool: pry or debugger.