### PR TITLE
Update mysql2 gem and provide mysql 5.7.3 fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -357,7 +357,8 @@ GEM
     mime-types (1.25.1)
     multi_json (1.11.1)
     multi_xml (0.5.1)
-    mysql2 (0.3.15)
+    mysql2 (0.3.20)
+    mysql2 (0.3.20-x86-mingw32)
     nested_form (0.3.2)
     net-http-digest_auth (1.3)
     net-http-persistent (2.8)
@@ -728,4 +729,4 @@ DEPENDENCIES
   yui-compressor
 
 BUNDLED WITH
-   1.11.0
+   1.11.2

--- a/config/initializers/abstract_mysql_adapter.rb
+++ b/config/initializers/abstract_mysql_adapter.rb
@@ -1,0 +1,3 @@
+class ActiveRecord::ConnectionAdapters::Mysql2Adapter
+  NATIVE_DATABASE_TYPES[:primary_key] = "int(11) auto_increment PRIMARY KEY"
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1971,7 +1971,6 @@ ActiveRecord::Schema.define(:version => 20151204212409) do
   end
 
   add_index "portal_offerings", ["clazz_id"], :name => "index_portal_offerings_on_clazz_id"
-  add_index "portal_offerings", ["runnable_id", "runnable_type"], :name => "runnable"
 
   create_table "portal_permission_forms", :force => true do |t|
     t.string   "name"
@@ -1996,7 +1995,6 @@ ActiveRecord::Schema.define(:version => 20151204212409) do
 
   add_index "portal_school_memberships", ["member_type", "member_id"], :name => "member_type_id_index"
   add_index "portal_school_memberships", ["school_id", "member_id", "member_type"], :name => "school_memberships_long_idx"
-  add_index "portal_school_memberships", ["school_id"], :name => "index_portal_school_memberships_on_school_id"
 
   create_table "portal_schools", :force => true do |t|
     t.string   "uuid",           :limit => 36
@@ -2567,7 +2565,6 @@ ActiveRecord::Schema.define(:version => 20151204212409) do
 
   add_index "taggings", ["tag_id"], :name => "index_taggings_on_tag_id"
   add_index "taggings", ["taggable_id", "taggable_type", "context"], :name => "index_taggings_on_taggable_id_and_taggable_type_and_context"
-  add_index "taggings", ["tagger_id", "tagger_type"], :name => "index_taggings_on_tagger_id_and_tagger_type"
 
   create_table "tags", :force => true do |t|
     t.string "name"


### PR DESCRIPTION
1. Old version of mysql2 gem didn't work on my system for some reason.
2. abstract_mysql_adapter.rb fixes this issue (it showed up after I had updated mysql version):
http://stackoverflow.com/questions/21075515/creating-tables-and-problems-with-primary-key-in-rails