### PR TITLE
Remove project membership, use cohorts instead

### DIFF
--- a/app/models/admin/settings.rb
+++ b/app/models/admin/settings.rb
@@ -11,7 +11,7 @@ class Admin::Settings < ActiveRecord::Base
 
   belongs_to :user
 
-  belongs_to :default_project, :class_name => "Admin::Project"
+  belongs_to :default_cohort, :class_name => "Admin::Cohort"
 
   has_many :settings_vendor_interfaces, :dependent => :destroy , :class_name => "Admin::SettingsVendorInterface", :foreign_key => "admin_settings_id"
   has_many :enabled_vendor_interfaces, :through => :settings_vendor_interfaces, :class_name => "Probe::VendorInterface", :source => :probe_vendor_interface

--- a/app/models/portal/teacher.rb
+++ b/app/models/portal/teacher.rb
@@ -40,6 +40,8 @@ class Portal::Teacher < ActiveRecord::Base
 
   validates_presence_of :user,  :message => "user association not specified"
 
+  after_create :add_to_default_cohort
+
   # Added to force Teachers to belong to at least one school, virtual or otherwise.
   # There should be no Teachers without schools, but if there are any that predate this change,
   # it could cause problems, so it's disabled until we discuss it further. -- Cantina-CMH 6/9/10
@@ -151,6 +153,15 @@ class Portal::Teacher < ActiveRecord::Base
   def possibly_add_authoring_role
     if self.class.can_author?
       self.user.add_role('author')
+    end
+  end
+
+  private
+
+  def add_to_default_cohort
+    default_cohort = Admin::Settings.default_settings && Admin::Settings.default_settings.default_cohort
+    if default_cohort
+      self.cohorts << default_cohort
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -591,7 +591,7 @@ class User < ActiveRecord::Base
   end
 
   def projects
-    cohort_projects.concat(admin_for_projects).concat(researcher_for_projects).flatten.uniq || []
+    (cohort_projects + admin_for_projects + researcher_for_projects).flatten.uniq || []
   end
 
   def changeable?(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,11 +55,9 @@ class User < ActiveRecord::Base
   has_many :student_cohort_projects, :through => :portal_student, :source => :projects
 
   has_many :project_users, class_name: 'Admin::ProjectUser'
-  has_many :projects, :through => :project_users
 
   has_many :admin_for_projects, :through => :project_users, :class_name => 'Admin::Project', :source => :project, :conditions => ['admin_project_users.is_admin = ?', true]
   has_many :researcher_for_projects, :through => :project_users, :class_name => 'Admin::Project', :source => :project, :conditions => ['admin_project_users.is_researcher = ?', true]
-  has_many :member_of_projects, :through => :project_users, :class_name => 'Admin::Project', :source => :project, :conditions => ['admin_project_users.is_member = ?', true]
 
   has_one :notice_user_display_status, :dependent => :destroy ,:class_name => "Admin::NoticeUserDisplayStatus", :foreign_key => "user_id"
 
@@ -91,7 +89,6 @@ class User < ActiveRecord::Base
 
   after_update :set_passive_users_as_pending
   after_create :set_passive_users_as_pending
-  after_create :add_to_default_project
 
   # strip leading and trailing spaces from names, login and email
   def strip_spaces
@@ -523,17 +520,6 @@ class User < ActiveRecord::Base
     self.reload
   end
 
-  def add_to_default_project
-    default_project = Admin::Settings.default_settings && Admin::Settings.default_settings.default_project
-    if default_project
-      self.projects << default_project
-    end
-  end
-
-  def projects_with_landing_pages
-    self.projects.where("landing_page_slug <> ''")
-  end
-
   def suspend!
     self.update_attribute(:state, 'suspended')
     self.reload
@@ -602,6 +588,10 @@ class User < ActiveRecord::Base
 
   def cohort_projects
     teacher_cohort_projects || student_cohort_projects
+  end
+
+  def projects
+    cohort_projects.concat(admin_for_projects).concat(researcher_for_projects).flatten.uniq || []
   end
 
   def changeable?(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -405,8 +405,7 @@ class User < ActiveRecord::Base
       project_user = project_users.find_by_project_id project.id
       if project_ids.find { |id| id.to_i == project.id }
         if !project_user
-          projects << project
-          project_user = project_users.find_by_project_id project.id
+          project_user = Admin::ProjectUser.create!(project_id: project.id, user_id: user.id)
         end
         project_user[role_attribute] = true
       elsif project_user

--- a/app/views/admin/settings/_form.html.haml
+++ b/app/views/admin/settings/_form.html.haml
@@ -25,8 +25,8 @@
             %br
             (This option will allow students to reset their own passwords.)
           %li
-            = f.label :default_project_id,  "Default Project:"
-            = f.collection_select(:default_project_id, Admin::Project.all, :id, :name, {include_blank: 'none'})
+            = f.label :default_cohort_id,  "Default Cohort:"
+            = f.collection_select(:default_cohort_id, Admin::Cohort.all, :id, :fullname, {include_blank: 'none'})
             %br
             (This option will cause that new users will be automatically added to the selected project.)
           %li

--- a/app/views/admin/settings/_form.html.haml
+++ b/app/views/admin/settings/_form.html.haml
@@ -28,7 +28,7 @@
             = f.label :default_cohort_id,  "Default Cohort:"
             = f.collection_select(:default_cohort_id, Admin::Cohort.all, :id, :fullname, {include_blank: 'none'})
             %br
-            (This option will cause that new users will be automatically added to the selected project.)
+            (New teachers will be automatically added to the selected cohort.)
           %li
             = f.label :enable_grade_levels, "Enable Grade Levels for Classes:", :style => "display:inline;"
             = f.check_box :enable_grade_levels

--- a/app/views/admin/settings/_show.html.haml
+++ b/app/views/admin/settings/_show.html.haml
@@ -47,10 +47,10 @@
                     disabled.
                 (This option will allow students to register without a class word.)
               %li
-                Default Project:
+                Default Cohort:
                 %b
-                  = admin_settings.default_project ? admin_settings.default_project.name : 'none'
-                (This option will cause that new users will be automatically added to the selected project.)
+                  = admin_settings.default_cohort ? admin_settings.default_cohort.fullname : 'none'
+                (This option will cause that new users will be automatically added to the selected cohort.)
               %li
                 Grade Levels for Classes:
                 %b

--- a/app/views/admin/settings/_show.html.haml
+++ b/app/views/admin/settings/_show.html.haml
@@ -50,7 +50,7 @@
                 Default Cohort:
                 %b
                   = admin_settings.default_cohort ? admin_settings.default_cohort.fullname : 'none'
-                (This option will cause that new users will be automatically added to the selected cohort.)
+                (New teachers will be automatically added to this cohort.)
               %li
                 Grade Levels for Classes:
                 %b

--- a/app/views/users/_member_of_projects.html.haml
+++ b/app/views/users/_member_of_projects.html.haml
@@ -1,9 +1,0 @@
-= hidden_field(:user, :has_projects_in_form, :value => true)
-%fieldset
-  %legend
-    Member of Projects
-  %ul.menu_h
-    - projects.each do |p|
-      %li
-        = p.name
-        = check_box_tag "user[member_project_ids][]", p.id, @user.member_of_projects.include?(p)

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -41,8 +41,6 @@
         %li
           Roles:
           = user.roles.map{|r| r.title.capitalize}.join(', ')
-          Projects:
-          = user.projects.map{|p| p.name}.sort().join(', ')
         - if user.portal_teacher
           %li
             Cohorts:

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -22,6 +22,4 @@
         = render :partial => 'researcher_for_projects', :locals => { :f => form, :projects => policy_scope(Admin::Project) }
         - if @user.portal_teacher
           = render :partial => 'project_cohorts', :locals => { :f => form, :projects => policy_scope(Admin::Project) }
-      - if current_visitor.has_role?("admin", "manager")
-        = render :partial => 'member_of_projects', :locals => { :f => form, :projects => policy_scope(Admin::Project) }
       = render :partial => 'shared/vendor_interface', :locals => { :f => form, :vendor_interface => @user.vendor_interface }

--- a/db/migrate/20160106025342_remove_default_project_from_admin_settings.rb
+++ b/db/migrate/20160106025342_remove_default_project_from_admin_settings.rb
@@ -1,0 +1,9 @@
+class RemoveDefaultProjectFromAdminSettings < ActiveRecord::Migration
+  def up
+    remove_column :admin_settings, :default_project_id
+  end
+
+  def down
+    add_column :admin_settings, :default_project_id, :integer
+  end
+end

--- a/db/migrate/20160106025450_add_default_cohort_to_admin_settings.rb
+++ b/db/migrate/20160106025450_add_default_cohort_to_admin_settings.rb
@@ -1,0 +1,5 @@
+class AddDefaultCohortToAdminSettings < ActiveRecord::Migration
+  def change
+    add_column :admin_settings, :default_cohort_id, :integer
+  end
+end

--- a/db/migrate/20160106034419_remove_is_member_from_admin_project_user.rb
+++ b/db/migrate/20160106034419_remove_is_member_from_admin_project_user.rb
@@ -1,0 +1,15 @@
+class RemoveIsMemberFromAdminProjectUser < ActiveRecord::Migration
+  class Admin::ProjectUser < ActiveRecord::Base
+    self.table_name = 'admin_project_users'
+  end
+
+  def up
+    remove_column :admin_project_users, :is_member
+    # Remove objects that are redundant now.
+    Admin::ProjectUser.where(is_admin: false, is_researcher: false).delete_all
+  end
+
+  def down
+    add_column :admin_project_users, :is_member, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160104235843) do
+ActiveRecord::Schema.define(:version => 20160106034419) do
 
   create_table "access_grants", :force => true do |t|
     t.string   "code"
@@ -100,7 +100,6 @@ ActiveRecord::Schema.define(:version => 20160104235843) do
     t.integer "user_id"
     t.boolean "is_admin",      :default => false
     t.boolean "is_researcher", :default => false
-    t.boolean "is_member",     :default => false
   end
 
   add_index "admin_project_users", ["project_id", "user_id"], :name => "admin_proj_user_uniq_idx", :unique => true
@@ -147,9 +146,9 @@ ActiveRecord::Schema.define(:version => 20160104235843) do
     t.integer  "pub_interval",                                 :default => 10
     t.boolean  "anonymous_can_browse_materials",               :default => true
     t.string   "jnlp_url"
-    t.integer  "default_project_id"
     t.boolean  "show_collections_menu",                        :default => false
     t.boolean  "auto_set_teachers_as_authors",                 :default => false
+    t.integer  "default_cohort_id"
   end
 
   create_table "admin_settings_vendor_interfaces", :force => true do |t|

--- a/features/step_definitions/project_links_steps.rb
+++ b/features/step_definitions/project_links_steps.rb
@@ -1,5 +1,9 @@
 Given /^the default project links exist using factories$/ do
   project = Factory.create(:project, name: 'project 1', landing_page_slug: 'project-1')
+  Factory(:admin_cohort, {
+    :project_id => project.id,
+    :name => 'project 1 cohort'
+  })
   Factory(:project_link, {
     :project_id => project.id,
     :name => "Foo Project Link",
@@ -13,12 +17,10 @@ Given /^the default project links exist using factories$/ do
 end
 
 Given /^the "([^"]*)" user is added to the default project$/ do |username|
-  userId = User.find_by_login(username).id
-  projectId = Admin::Project.find_by_name('project 1').id
-  Factory(:project_user, {
-    :project_id => projectId,
-    :user_id => userId
-  })
+  cohort = Admin::Cohort.find_by_name('project 1 cohort')
+  user = User.find_by_login(username)
+  teacher = user.portal_teacher || user.portal_student.teachers.first
+  teacher.cohorts << cohort
 end
 
 Then /^I should see a project link labeled "([^"]*)" linking to "([^"]*)"$/ do |link, href|

--- a/spec/controllers/external_activities_controller_spec.rb
+++ b/spec/controllers/external_activities_controller_spec.rb
@@ -116,7 +116,7 @@ describe ExternalActivitiesController do
       :use_student_security_questions => false,
       :use_bitmap_snapshots? => false,
       :require_user_consent? => false,
-      :default_project => nil)
+      :default_cohort => nil)
     Admin::Settings.stub!(:default_settings).and_return(@current_settings)
     controller.stub(:before_render) {
       response.template.stub(:net_logo_package_name).and_return("blah")

--- a/spec/controllers/investigations_controller_spec.rb
+++ b/spec/controllers/investigations_controller_spec.rb
@@ -8,7 +8,7 @@ describe InvestigationsController do
       :use_student_security_questions => false,
       :use_bitmap_snapshots? => false,
       :require_user_consent? => false,
-      :default_project => nil)
+      :default_cohort => nil)
     Admin::Settings.stub!(:default_settings).and_return(@current_settings)
     controller.stub(:before_render) {
       response.template.stub(:net_logo_package_name).and_return("blah")

--- a/spec/controllers/portal/clazzes_controller_spec.rb
+++ b/spec/controllers/portal/clazzes_controller_spec.rb
@@ -44,7 +44,7 @@ describe Portal::ClazzesController do
     @mock_settings.stub(:allow_default_class).and_return(false)
     @mock_settings.stub(:use_student_security_questions).and_return(false)
     @mock_settings.stub!(:require_user_consent?).and_return(false)
-    @mock_settings.stub!(:default_project).and_return(nil)
+    @mock_settings.stub!(:default_cohort).and_return(nil)
     Admin::Settings.stub(:default_settings).and_return(@mock_settings)
   end
 

--- a/spec/models/portal/teacher_spec.rb
+++ b/spec/models/portal/teacher_spec.rb
@@ -79,4 +79,28 @@ describe Portal::Teacher do
     end
   end
 
+  describe '[default cohort support]' do
+    let(:settings) { Factory.create(:admin_settings) }
+    let(:teacher) { Factory(:portal_teacher) }
+    before(:each) do
+      Admin::Settings.stub!(:default_settings).and_return(settings)
+    end
+
+    describe 'when default cohort is not specified in portal settings' do
+      it 'has empty list of cohorts' do
+        expect(teacher.cohorts.length).to eql(0)
+      end
+    end
+
+    describe 'when default cohort is specified in portal settings' do
+      let(:cohort) { Factory.create(:admin_cohort) }
+      let(:settings) { Factory.create(:admin_settings, default_cohort: cohort) }
+
+      it 'is added to the default cohort' do
+        expect(teacher.cohorts.length).to eql(1)
+        expect(teacher.cohorts[0]).to eql(cohort)
+      end
+    end
+  end
+
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -28,31 +28,6 @@ describe User do
       @user.reload
       assert_equal @user.state, 'pending'
     end
-
-    describe '[default project support]' do
-      let(:settings) { Factory.create(:admin_settings) }
-      before(:each) do
-        Admin::Settings.stub!(:default_settings).and_return(settings)
-      end
-
-      describe 'when default project is not specified in portal settings' do
-        it 'has empty list of projects' do
-          @creating_user.call
-          expect(@user.projects.length).to eql(0)
-        end
-      end
-
-      describe 'when default project is specified in portal settings' do
-        let(:project) { Factory.create(:project) }
-        let(:settings) { Factory.create(:admin_settings, default_project: project) }
-
-        it 'is added to the default project' do
-          @creating_user.call
-          expect(@user.projects.length).to eql(1)
-          expect(@user.projects[0]).to eql(project)
-        end
-      end
-    end
   end
 
   #

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -79,7 +79,7 @@ def generate_default_settings_and_jnlps_with_mocks
     :require_user_consent?          => false,
     :allow_default_class            => false,
     :allow_default_class?           => false,
-    :default_project                => nil,
+    :default_cohort                 => nil,
     :jnlp_cdn_hostname              => '',
     :enabled_bookmark_types         => []
   )


### PR DESCRIPTION
Remove explicit project membership, use cohorts to infer project membership instead. Also, remove default project and replace it with default cohort (portal settings).

It should be reasonably safe, as the main changes are:
1. `member_of_projects` association and features using it are removed
2. `projects` association is replaced with method

I think 2. is used only to display project links, but it should just work as it used to. Well, unless something explicitly assumes that `projects` is association, but haven't found anything like this, tests are passing too.

I wasn't trying to recreate existing memberships in migrations because:
- all the ITSI teachers should be added to one cohort, we need to do it manually once this code is deployed
- project membership isn't important in other portals