### PR TITLE
Project admin can edit material settings

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,6 @@
 module ApplicationHelper
   include Clipboard
+  include Pundit
 
   def current_settings
     @_settings ||= Admin::Settings.default_settings

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -444,7 +444,7 @@ module ApplicationHelper
   end
 
   def delete_button_for(model, options={})
-    if model.changeable? current_visitor
+    if policy(model).destroy?
       # find the page_element for the embeddable
       embeddable = (model.respond_to? :embeddable) ? model.embeddable : model
       controller = "#{model.class.name.pluralize.underscore}"

--- a/app/models/external_activity.rb
+++ b/app/models/external_activity.rb
@@ -85,7 +85,6 @@ class ExternalActivity < ActiveRecord::Base
   acts_as_replicatable
 
   include Cohorts
-  include Changeable
   include Publishable
   include SearchModelInterface
 

--- a/app/models/interactive.rb
+++ b/app/models/interactive.rb
@@ -1,7 +1,6 @@
 class Interactive < ActiveRecord::Base
   include Cohorts
   include Publishable
-  include Changeable
   include SearchModelInterface
 
   acts_as_taggable_on :model_types

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -1,2 +1,3 @@
 class ActivityPolicy < ApplicationPolicy
+  include MaterialSharedPolicy
 end

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -1,3 +1,3 @@
 class ActivityPolicy < ApplicationPolicy
-  include MaterialSharedPolicy
+  include OldMaterialSharedPolicy
 end

--- a/app/policies/admin/project_policy.rb
+++ b/app/policies/admin/project_policy.rb
@@ -24,7 +24,12 @@ class Admin::ProjectPolicy < ApplicationPolicy
     admin_or_project_admin?
   end
 
+  # Visible on the search page, home page, navigation bar, etc.
   def visible?
     record.public || admin? || user && user.is_project_member?(record)
+  end
+
+  def assign_to_material?
+    admin? || user && user.is_project_admin?(record)
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -137,6 +137,10 @@ class ApplicationPolicy
     user && user.has_role?(*roles)
   end
 
+  def owner?
+    user && record.respond_to?(:user) && record.user == user
+  end
+
   # from peer access
 
   def request_is_peer?

--- a/app/policies/external_activity_policy.rb
+++ b/app/policies/external_activity_policy.rb
@@ -6,7 +6,7 @@ class ExternalActivityPolicy < ApplicationPolicy
   end
 
   def publish?
-    new_or_create?
+    new_or_create? || author?
   end
 
   def republish?

--- a/app/policies/external_activity_policy.rb
+++ b/app/policies/external_activity_policy.rb
@@ -1,4 +1,5 @@
 class ExternalActivityPolicy < ApplicationPolicy
+  include MaterialSharedPolicy
 
   def preview_index?
     true

--- a/app/policies/interactive_policy.rb
+++ b/app/policies/interactive_policy.rb
@@ -1,4 +1,5 @@
 class InteractivePolicy < ApplicationPolicy
+  include MaterialSharedPolicy
 
   def new_or_create?
     admin?

--- a/app/policies/investigation_policy.rb
+++ b/app/policies/investigation_policy.rb
@@ -1,3 +1,3 @@
 class InvestigationPolicy < ApplicationPolicy
-  include MaterialSharedPolicy
+  include OldMaterialSharedPolicy
 end

--- a/app/policies/investigation_policy.rb
+++ b/app/policies/investigation_policy.rb
@@ -1,2 +1,3 @@
 class InvestigationPolicy < ApplicationPolicy
+  include MaterialSharedPolicy
 end

--- a/app/policies/material_shared_policy.rb
+++ b/app/policies/material_shared_policy.rb
@@ -1,0 +1,22 @@
+module MaterialSharedPolicy
+
+  def edit_all?
+    admin? || user && (user.admin_for_projects & record.projects).length > 0
+  end
+
+  def edit_projects_or_cohorts?
+    admin? || project_admin?
+  end
+
+  def edit?
+    edit_all? || edit_projects_or_cohorts?
+  end
+
+  def update?
+    # That's simplification. Theoretically we should also divide update process
+    # and authorize separately for projects/cohorts update and other options update.
+    # However it doesn't really make sense, as a project admin can assign material to
+    # his own project and then edit other settings too. It would be pseudo-security.
+    edit?
+  end
+end

--- a/app/policies/material_shared_policy.rb
+++ b/app/policies/material_shared_policy.rb
@@ -1,6 +1,10 @@
 module MaterialSharedPolicy
 
-  def edit_all?
+  def new_or_create?
+    admin? || project_admin?
+  end
+
+  def edit_settings?
     # Admin or admin of a project assigned to this material.
     admin? || user && (user.admin_for_projects & record.projects).length > 0
   end
@@ -16,14 +20,18 @@ module MaterialSharedPolicy
   end
 
   def edit?
-    edit_all? || edit_projects? || edit_cohorts?
+    edit_settings? || edit_projects? || edit_cohorts?
   end
 
   def update?
     # That's simplification. Theoretically we should also divide update process
     # and authorize separately for projects/cohorts update and other options update.
     # However it doesn't really make sense, as a project admin can assign material to
-    # his own project and then edit other settings too. It would be pseudo-security.
+    # his own project and then edit other settings too.
     edit?
+  end
+
+  def destroy?
+    admin?
   end
 end

--- a/app/policies/material_shared_policy.rb
+++ b/app/policies/material_shared_policy.rb
@@ -1,15 +1,22 @@
 module MaterialSharedPolicy
 
   def edit_all?
+    # Admin or admin of a project assigned to this material.
     admin? || user && (user.admin_for_projects & record.projects).length > 0
   end
 
-  def edit_projects_or_cohorts?
+  def edit_projects?
+    # Admin or admin of any project.
+    admin? || project_admin?
+  end
+
+  def edit_cohorts?
+    # Admin or admin of any project.
     admin? || project_admin?
   end
 
   def edit?
-    edit_all? || edit_projects_or_cohorts?
+    edit_all? || edit_projects? || edit_cohorts?
   end
 
   def update?

--- a/app/policies/old_material_shared_policy.rb
+++ b/app/policies/old_material_shared_policy.rb
@@ -1,0 +1,15 @@
+# Old materials (non-external activities and investigations) follow
+# general rules defined in the material policy, but they can also
+# be authored by regular users that have author role and edited by their owner.
+
+module OldMaterialSharedPolicy
+  include MaterialSharedPolicy
+
+  def new_or_create?
+    super || author?
+  end
+
+  def edit_settings?
+    super || owner?
+  end
+end

--- a/app/policies/resource_page_policy.rb
+++ b/app/policies/resource_page_policy.rb
@@ -1,2 +1,5 @@
 class ResourcePagePolicy < ApplicationPolicy
+  def edit_cohorts?
+    admin?
+  end
 end

--- a/app/views/activities/_form.html.haml
+++ b/app/views/activities/_form.html.haml
@@ -1,7 +1,7 @@
 = form_for(@activity) do |f|
   = f.error_messages
   = edit_menu_for(@activity, f)
-  - if policy(@activity).edit_all?
+  - if @activity.new_record? || policy(@activity).edit_settings?
     - if @activity.investigation
       = f.hidden_field 'investigation_id', :value =>@activity.investigation.id
     = field_set_tag 'Activity Name' do

--- a/app/views/activities/_form.html.haml
+++ b/app/views/activities/_form.html.haml
@@ -1,45 +1,47 @@
 = form_for(@activity) do |f|
   = f.error_messages
-  = edit_menu_for(@activity, f)  
-  - if @activity.investigation
-    = f.hidden_field 'investigation_id', :value =>@activity.investigation.id
-  = field_set_tag 'Activity Name' do
-    = f.text_field :name
-  = field_set_tag 'Activity Description' do
-    = f.text_area :description, :cols => 80, :rows => 5, :class => 'mceNoEditor'
-  = field_set_tag 'Activity Description for Teacher' do
-    = t('authoring.description_for_teacher_description')
-    = f.text_area :description_for_teacher, :cols => 80, :rows => 5, :class => 'mceNoEditor'
-  = field_set_tag 'Teacher Guide (URL)' do
-    = f.text_field :teacher_guide_url, :size => 60
-  = field_set_tag 'Thumbnail image URL (300 x 250 px)' do
-    = f.text_field :thumbnail_url, :size => 60
-  = field_set_tag 'Publication Status' do
-    = f.select :publication_status, Activity.publication_states.map {|s| s.to_s}
-    #br
-    If this Activity is part of a #{Investigation.display_name} and the #{Investigation.display_name}'s publication_status is 'published',
-    then this Activity will be published too regardless of the publication status here.
-  = field_set_tag 'Feature On Landing Page' do
-    - if current_user.has_role? 'admin','manager'
-      = f.check_box :is_featured 
-    - else
-      = f.check_box :is_featured, :disabled => true
-    (check here if this activity should be displayed to anonymous users on the landing page)
-  = field_set_tag 'Teacher only' do
-    = f.check_box :teacher_only 
-    (check here if this activity is for teachers only)
-  = field_set_tag 'Student Report Enabled' do
-    = f.check_box :student_report_enabled
-    #{t('authoring.student_report_enabled_description')} (this only applies if this activity is assigned individually)
-  = field_set_tag 'Show Score' do
-    = f.check_box :show_score
-    #{t('authoring.show_score_description')} (this only applies if this activity is assigned individually)
+  = edit_menu_for(@activity, f)
+  - if policy(@activity).edit_all?
+    - if @activity.investigation
+      = f.hidden_field 'investigation_id', :value =>@activity.investigation.id
+    = field_set_tag 'Activity Name' do
+      = f.text_field :name
+    = field_set_tag 'Activity Description' do
+      = f.text_area :description, :cols => 80, :rows => 5, :class => 'mceNoEditor'
+    = field_set_tag 'Activity Description for Teacher' do
+      = t('authoring.description_for_teacher_description')
+      = f.text_area :description_for_teacher, :cols => 80, :rows => 5, :class => 'mceNoEditor'
+    = field_set_tag 'Teacher Guide (URL)' do
+      = f.text_field :teacher_guide_url, :size => 60
+    = field_set_tag 'Thumbnail image URL (300 x 250 px)' do
+      = f.text_field :thumbnail_url, :size => 60
+    = field_set_tag 'Publication Status' do
+      = f.select :publication_status, Activity.publication_states.map {|s| s.to_s}
+      #br
+      If this Activity is part of a #{Investigation.display_name} and the #{Investigation.display_name}'s publication_status is 'published',
+      then this Activity will be published too regardless of the publication status here.
+    = field_set_tag 'Feature On Landing Page' do
+      - if current_user.has_role? 'admin','manager'
+        = f.check_box :is_featured
+      - else
+        = f.check_box :is_featured, :disabled => true
+      (check here if this activity should be displayed to anonymous users on the landing page)
+    = field_set_tag 'Teacher only' do
+      = f.check_box :teacher_only
+      (check here if this activity is for teachers only)
+    = field_set_tag 'Student Report Enabled' do
+      = f.check_box :student_report_enabled
+      #{t('authoring.student_report_enabled_description')} (this only applies if this activity is assigned individually)
+    = field_set_tag 'Show Score' do
+      = f.check_box :show_score
+      #{t('authoring.show_score_description')} (this only applies if this activity is assigned individually)
 
-  = render :partial => 'shared/is_assessment_item', :locals => { :form => f }
-  = render :partial => 'shared/material_properties_edit', :locals => { :object => @activity }
-  = render :partial => 'shared/cohorts_edit', :locals => { :object => @activity }
-  = render :partial => 'shared/grade_levels_edit', :locals => { :object => @activity }
-  = render :partial => 'shared/subject_areas_edit', :locals => { :object => @activity }
+    = render :partial => 'shared/is_assessment_item', :locals => { :form => f }
+    = render :partial => 'shared/material_properties_edit', :locals => { :object => @activity }
+    = render :partial => 'shared/grade_levels_edit', :locals => { :object => @activity }
+    = render :partial => 'shared/subject_areas_edit', :locals => { :object => @activity }
+  -# Partials below can be available for project admins (separate policy method).
   = render :partial => 'shared/projects_edit', :locals => { :object => @activity }
+  = render :partial => 'shared/cohorts_edit', :locals => { :object => @activity }
 
 = javascript_tag("focus_first_field();");

--- a/app/views/activities/_runnable_list.html.haml
+++ b/app/views/activities/_runnable_list.html.haml
@@ -22,9 +22,9 @@
             = activity.user.name
         %div.action_menu_header_right
           %ul.menu
-            - unless(current_visitor.anonymous?)
+            - if policy(activity).new?
               %li.menu=link_to 'duplicate', duplicate_activity_url(activity)
-            - if (activity.changeable?(current_visitor))
+            - if policy(activity).destroy?
               %li.menu=link_to 'delete', activity, :class => 'delete', :data => { :confirm => "Are you sure you want to delete #{TOP_LEVEL_CONTAINER_NAME_PLURAL} #{activity.id}" }, :method => :delete
       %div{:id => dom_id_for(activity, :details), :class => 'tiny'}
         %p=activity.description

--- a/app/views/activities/index.html.haml
+++ b/app/views/activities/index.html.haml
@@ -29,7 +29,7 @@
               - unless(current_visitor.anonymous?)
                 %li.menu=link_to 'duplicate', duplicate_activity_url(activity)
               %li.menu=link_to 'export (xml)', export_activity_url(activity)
-              - if (activity.changeable?(current_visitor))
+              - if policy(activity).destroy?
                 %li.menu=link_to 'delete', activity, :class => 'delete', :data => { :confirm => "Are you sure you want to delete activity #{activity.id}" }, :method => :delete
         %div{:id => dom_id_for(activity, :details), :class => 'tiny'}
           %p=activity.description

--- a/app/views/activities/show.html.haml
+++ b/app/views/activities/show.html.haml
@@ -10,5 +10,5 @@
   %ul#activity_sections_list.menu
     - @activity.sections.each do |section|
       =render :partial => 'section_list_item', :locals => {:section => section}
-      -if (@activity.changeable?(current_visitor))
+      -if policy(@activity).edit?
         =sortable_element :activity_sections_list, :handle=> 'sort-handle', :dropOnEmpty => true, :url=> {:action => 'sort_sections', :params => {:activity_id => @activity.id }}

--- a/app/views/external_activities/_form.html.haml
+++ b/app/views/external_activities/_form.html.haml
@@ -1,71 +1,73 @@
 = form_for(@external_activity) do |f|
   = f.error_messages
   = edit_menu_for(@external_activity, f)
-  = field_set_tag 'Activity Name' do
-    = f.text_field :name
-  = field_set_tag 'Activity Description' do
-    = f.text_area :description, :cols => 80, :rows => 5, :class => 'mceNoEditor'
-  = field_set_tag 'Activity Abstract' do
-    = f.text_area :abstract, :cols => 80, :rows => 5, :class => 'mceNoEditor'
-  = field_set_tag 'Activity Description for Teacher' do
-    = t('authoring.description_for_teacher_description')
-    = f.text_area :description_for_teacher, :cols => 80, :rows => 5, :class => 'mceNoEditor'
-  = field_set_tag 'URL' do
-    = f.text_field :url, :size => 60
-  = field_set_tag 'Launch URL' do
-    = f.text_field :launch_url, :size => 60
-    %br
-    = t('authoring.launch_url_description')
-  = field_set_tag 'Teacher Guide (URL)' do
-    = f.text_field :teacher_guide_url, :size => 60
-  = field_set_tag 'Thumbnail image URL (300 x 250 px)' do
-    = f.text_field :thumbnail_url, :size => 60
-  = field_set_tag 'Publication status' do
-    = f.select :publication_status, ExternalActivity.publication_states.map {|s| s.to_s}
-  = field_set_tag 'Feature On Landing Page' do
-    - if current_user.has_role? 'admin','manager'
-      = f.check_box :is_featured
-    - else
-      = f.check_box :is_featured, :disabled => true
-    This activity should be displayed to anonymous users on the landing page
-  = field_set_tag 'Has Pre And Post Tests' do
-    = f.check_box :has_pretest
-    This unit has pre- and post-tests available.
-  = field_set_tag 'Student Report Enabled' do
-    = f.check_box :student_report_enabled
-    = t('authoring.student_report_enabled_description')
-  = field_set_tag 'Extra Options' do
-    .config
-      = f.check_box :popup
-      Open the url in a new window
-    .config
-      = f.check_box :allow_collaboration
-      Allow students to run this activity with collaborators
-    .config
-      = f.check_box :append_learner_id_to_url
-      Append the learner id to the url (e.g. http://foo.com/bar?learner=4)
-    .config
-      = f.check_box :append_survey_monkey_uid
-      Append a unique Survey Monkey user id to the url (e.g. http://www.surveymonkey.com/s/H2Y9H27?c=00001)
-    - if current_visitor.has_role?('admin', 'manager','researcher')
+  - if policy(@external_activity).edit_all?
+    = field_set_tag 'Activity Name' do
+      = f.text_field :name
+    = field_set_tag 'Activity Description' do
+      = f.text_area :description, :cols => 80, :rows => 5, :class => 'mceNoEditor'
+    = field_set_tag 'Activity Abstract' do
+      = f.text_area :abstract, :cols => 80, :rows => 5, :class => 'mceNoEditor'
+    = field_set_tag 'Activity Description for Teacher' do
+      = t('authoring.description_for_teacher_description')
+      = f.text_area :description_for_teacher, :cols => 80, :rows => 5, :class => 'mceNoEditor'
+    = field_set_tag 'URL' do
+      = f.text_field :url, :size => 60
+    = field_set_tag 'Launch URL' do
+      = f.text_field :launch_url, :size => 60
+      %br
+      = t('authoring.launch_url_description')
+    = field_set_tag 'Teacher Guide (URL)' do
+      = f.text_field :teacher_guide_url, :size => 60
+    = field_set_tag 'Thumbnail image URL (300 x 250 px)' do
+      = f.text_field :thumbnail_url, :size => 60
+    = field_set_tag 'Publication status' do
+      = f.select :publication_status, ExternalActivity.publication_states.map {|s| s.to_s}
+    = field_set_tag 'Feature On Landing Page' do
+      - if current_user.has_role? 'admin','manager'
+        = f.check_box :is_featured
+      - else
+        = f.check_box :is_featured, :disabled => true
+      This activity should be displayed to anonymous users on the landing page
+    = field_set_tag 'Has Pre And Post Tests' do
+      = f.check_box :has_pretest
+      This unit has pre- and post-tests available.
+    = field_set_tag 'Student Report Enabled' do
+      = f.check_box :student_report_enabled
+      = t('authoring.student_report_enabled_description')
+    = field_set_tag 'Extra Options' do
       .config
-        = f.check_box :is_official
-        Designate this as an "official" Concord activity in lists
+        = f.check_box :popup
+        Open the url in a new window
       .config
-        = f.check_box :logging
-        Enable logging on this activity (for activities that support it)
-    - if current_visitor.has_role? 'admin'
+        = f.check_box :allow_collaboration
+        Allow students to run this activity with collaborators
       .config
-        = f.check_box :is_locked
-        Do not allow to copy this activity.
-  = field_set_tag 'Save Path' do
-    = f.text_field :save_path
-  = render :partial => 'shared/is_assessment_item', :locals => { :form => f }
-  = render :partial => 'shared/material_properties_edit', :locals => { :object => @external_activity }
-  = render :partial => 'shared/cohorts_edit', :locals => { :object => @external_activity }
-  = render :partial => 'shared/grade_levels_edit', :locals => { :object => @external_activity }
-  = render :partial => 'shared/subject_areas_edit', :locals => { :object => @external_activity }
+        = f.check_box :append_learner_id_to_url
+        Append the learner id to the url (e.g. http://foo.com/bar?learner=4)
+      .config
+        = f.check_box :append_survey_monkey_uid
+        Append a unique Survey Monkey user id to the url (e.g. http://www.surveymonkey.com/s/H2Y9H27?c=00001)
+      - if current_visitor.has_role?('admin', 'manager','researcher')
+        .config
+          = f.check_box :is_official
+          Designate this as an "official" Concord activity in lists
+        .config
+          = f.check_box :logging
+          Enable logging on this activity (for activities that support it)
+      - if current_visitor.has_role? 'admin'
+        .config
+          = f.check_box :is_locked
+          Do not allow to copy this activity.
+    = field_set_tag 'Save Path' do
+      = f.text_field :save_path
+    = render :partial => 'shared/is_assessment_item', :locals => { :form => f }
+    = render :partial => 'shared/material_properties_edit', :locals => { :object => @external_activity }
+    = render :partial => 'shared/grade_levels_edit', :locals => { :object => @external_activity }
+    = render :partial => 'shared/subject_areas_edit', :locals => { :object => @external_activity }
+    = render :partial => 'shared/sensors_edit', :locals => { :object => @external_activity }
+  -# Partials below can be available for project admins (separate policy method).
   = render :partial => 'shared/projects_edit', :locals => { :object => @external_activity }
-  = render :partial => 'shared/sensors_edit', :locals => { :object => @external_activity }
+  = render :partial => 'shared/cohorts_edit', :locals => { :object => @external_activity }
 
 = javascript_tag("focus_first_field();");

--- a/app/views/external_activities/_form.html.haml
+++ b/app/views/external_activities/_form.html.haml
@@ -1,7 +1,7 @@
 = form_for(@external_activity) do |f|
   = f.error_messages
   = edit_menu_for(@external_activity, f)
-  - if policy(@external_activity).edit_all?
+  - if @external_activity.new_record? || policy(@external_activity).edit_settings?
     = field_set_tag 'Activity Name' do
       = f.text_field :name
     = field_set_tag 'Activity Description' do

--- a/app/views/external_activities/_form.html.haml
+++ b/app/views/external_activities/_form.html.haml
@@ -48,7 +48,7 @@
       .config
         = f.check_box :append_survey_monkey_uid
         Append a unique Survey Monkey user id to the url (e.g. http://www.surveymonkey.com/s/H2Y9H27?c=00001)
-      - if current_visitor.has_role?('admin', 'manager','researcher')
+      - if current_visitor.has_role? 'admin'
         .config
           = f.check_box :is_official
           Designate this as an "official" Concord activity in lists

--- a/app/views/external_activities/_runnable_list.html.haml
+++ b/app/views/external_activities/_runnable_list.html.haml
@@ -24,7 +24,7 @@
           %ul.menu
             - if current_visitor.has_role? "author"
               %li.menu=link_to 'duplicate', duplicate_external_activity_url(external_activity)
-            - if (external_activity.changeable?(current_visitor))
+            - if policy(external_activity).edit?
               %li.menu=link_to 'edit', edit_external_activity_url(external_activity)
               %li.menu=link_to 'delete', external_activity, :class => 'delete', :data => { :confirm => "Are you sure you want to delete #{TOP_LEVEL_CONTAINER_NAME_PLURAL} #{external_activity.id}" }, :method => :delete
       %div{:id => dom_id_for(external_activity, :details), :class => 'tiny'}

--- a/app/views/interactives/_form.html.haml
+++ b/app/views/interactives/_form.html.haml
@@ -1,28 +1,31 @@
 = form_for(@interactive) do |f|
   = f.error_messages
   = edit_menu_for(@interactive, f)
-  = field_set_tag 'Interactive Name' do
-    = f.text_field :name
-  = field_set_tag 'Interactive Description' do
-    = f.text_area :description, :cols => 80, :rows => 5, :class => 'mceNoEditor'
-  = field_set_tag 'Publication Status' do
-    = f.select :publication_status, Interactive.publication_states.map {|s| s.to_s}
-  = field_set_tag 'Interactive URL' do
-    = f.text_field :url, :size => 60
-  = field_set_tag 'Interactive Sizing' do
-    Scale:
-    = f.text_field :scale, :size => 5
-    Width
-    = f.text_field :width, :size => 5
-    Height
-    = f.text_field :height, :size => 5
-  = field_set_tag 'Interactive Image URL' do
-    = f.text_field :image_url
-  = field_set_tag 'Credits' do
-    = f.text_field :credits
-  = render :partial => 'shared/material_properties_edit', :locals => { :object => @interactive }
-  = render :partial => 'shared/grade_levels_edit', :locals => { :object => @interactive }
-  = render :partial => 'shared/subject_areas_edit', :locals => { :object => @interactive }
-  = render :partial => 'shared/model_types_edit', :locals => { :object => @interactive }
+  - if policy(@interactive).edit_all?
+    = field_set_tag 'Interactive Name' do
+      = f.text_field :name
+    = field_set_tag 'Interactive Description' do
+      = f.text_area :description, :cols => 80, :rows => 5, :class => 'mceNoEditor'
+    = field_set_tag 'Publication Status' do
+      = f.select :publication_status, Interactive.publication_states.map {|s| s.to_s}
+    = field_set_tag 'Interactive URL' do
+      = f.text_field :url, :size => 60
+    = field_set_tag 'Interactive Sizing' do
+      Scale:
+      = f.text_field :scale, :size => 5
+      Width
+      = f.text_field :width, :size => 5
+      Height
+      = f.text_field :height, :size => 5
+    = field_set_tag 'Interactive Image URL' do
+      = f.text_field :image_url
+    = field_set_tag 'Credits' do
+      = f.text_field :credits
+    = render :partial => 'shared/material_properties_edit', :locals => { :object => @interactive }
+    = render :partial => 'shared/grade_levels_edit', :locals => { :object => @interactive }
+    = render :partial => 'shared/subject_areas_edit', :locals => { :object => @interactive }
+    = render :partial => 'shared/model_types_edit', :locals => { :object => @interactive }
+  -# Partials below can be available for project admins (separate policy method).
   = render :partial => 'shared/projects_edit', :locals => { :object => @interactive }
+  = render :partial => 'shared/cohorts_edit', :locals => { :object => @interactive }
 = javascript_tag("focus_first_field();");

--- a/app/views/interactives/_form.html.haml
+++ b/app/views/interactives/_form.html.haml
@@ -1,7 +1,7 @@
 = form_for(@interactive) do |f|
   = f.error_messages
   = edit_menu_for(@interactive, f)
-  - if policy(@interactive).edit_all?
+  - if @interactive.new_record? || policy(@interactive).edit_settings?
     = field_set_tag 'Interactive Name' do
       = f.text_field :name
     = field_set_tag 'Interactive Description' do

--- a/app/views/interactives/index.html.haml
+++ b/app/views/interactives/index.html.haml
@@ -25,8 +25,9 @@
             = link_to_container(interactive)
           %div.action_menu_header_right
             %ul.menu
-              - if (interactive.changeable?(current_visitor))
+              - if policy(interactive).edit?
                 %li.menu=link_to 'edit', edit_interactive_path(interactive), :class => 'edit'
+              - if policy(interactive).destroy?
                 %li.menu=link_to 'delete', interactive, :class => 'delete', :data => { :confirm => "Are you sure you want to delete interactive #{interactive.id}" }, :method => :delete
         %div{:id => dom_id_for(interactive, :details), :class => 'tiny'}
           %p=render :partial => 'show',:locals => {:interactive => interactive, :show_thumbnail => true}

--- a/app/views/investigations/_activity_list_item.html.haml
+++ b/app/views/investigations/_activity_list_item.html.haml
@@ -6,7 +6,7 @@
       %div.action_menu_header_right   
         %ul.menu
           /%li= run_link_for(activity)
-          - if (activity.changeable?(current_visitor))
+          - if policy(activity).destroy?
             /%li= link_to 'duplicate', duplicate_activity_url(activity)
             / %li= link_to 'edit', activity
             / %li.menu=toggle_more activity

--- a/app/views/investigations/_form.html.haml
+++ b/app/views/investigations/_form.html.haml
@@ -1,6 +1,6 @@
 = edit_menu_for(investigation, f)
 = field_set_tag "#{TOP_LEVEL_CONTAINER_NAME_PLURAL.humanize} details" do
-  - if policy(investigation).edit_all?
+  - if investigation.new_record? || policy(investigation).edit_settings?
     .aligned
       %ol
         %li

--- a/app/views/investigations/_form.html.haml
+++ b/app/views/investigations/_form.html.haml
@@ -1,63 +1,65 @@
 = edit_menu_for(investigation, f)
 = field_set_tag "#{TOP_LEVEL_CONTAINER_NAME_PLURAL.humanize} details" do
-  .aligned
-    %ol
-      %li
-        %label.right Name
-        = f.text_field :name
-      // without publication status options, projects won't be able to set investigations as active...
-      %li
-        %label.right Publication Status
-        = f.select :publication_status, Investigation.publication_states.map {|s| s.to_s}
-      %li
-        %label.right Feature On Landing Page
-        - if current_user.has_role? 'admin','manager'
-          = f.check_box :is_featured
-        - else
-          = f.check_box :is_featured, disabled: true
-        %br
-        When checked this #{t(:investigation)} will appear on the landing page, and seen by anonymous users.
-      %li
-        %label.right Student Report Enabled
-        = f.check_box :student_report_enabled
-        %br
-        = t('authoring.student_report_enabled_description')
-      %li
-        %label.right Allow Activity Assignment
-        = f.check_box :allow_activity_assignment
-        %br
-        Allow a teacher to assign the individual activities of this #{t(:investigation)} outside of this #{t(:investigation)}. This means that on the browse materials listing, teachers will see the #{t(:investigation)} listed in the #{t(:investigation)}s section, and each of its activities listed in the activities section. By default this is enabled so teachers can cherry pick activities out of a large #{t(:investigation)}. If you don't want teachers to cherry pick activities out of this #{t(:investigation)}, disable this option.
-      %li
-        %label.right Show Score
-        = f.check_box :show_score
-        %br
-        = t('authoring.show_score_description')
-      %li
-        %label Description
-        = f.text_area :description, :id => 'description_field', :rows => 4, :cols => 60, :class => 'mceNoEditor'
-      %li
-        %label Abstract
-        = f.text_area :abstract, :id => 'abstract_field', :rows => 4, :cols => 60, :class => 'mceNoEditor'
-      %li
-        %label Description for Teacher
-        %br
-        = t('authoring.description_for_teacher_description')
-        = f.text_area :description_for_teacher, :id => 'description_field', :rows => 4, :cols => 60, :class => 'mceNoEditor'
-      %li
-        %label Teacher Guide URL
-        %br
-        = f.text_field :teacher_guide_url, :size => 60
-      %li
-        %label Thumbnail image URL (300 x 250 px)
-        %br
-        = f.text_field :thumbnail_url, :size => 60
+  - if policy(investigation).edit_all?
+    .aligned
+      %ol
+        %li
+          %label.right Name
+          = f.text_field :name
+        // without publication status options, projects won't be able to set investigations as active...
+        %li
+          %label.right Publication Status
+          = f.select :publication_status, Investigation.publication_states.map {|s| s.to_s}
+        %li
+          %label.right Feature On Landing Page
+          - if current_user.has_role? 'admin','manager'
+            = f.check_box :is_featured
+          - else
+            = f.check_box :is_featured, disabled: true
+          %br
+          When checked this #{t(:investigation)} will appear on the landing page, and seen by anonymous users.
+        %li
+          %label.right Student Report Enabled
+          = f.check_box :student_report_enabled
+          %br
+          = t('authoring.student_report_enabled_description')
+        %li
+          %label.right Allow Activity Assignment
+          = f.check_box :allow_activity_assignment
+          %br
+          Allow a teacher to assign the individual activities of this #{t(:investigation)} outside of this #{t(:investigation)}. This means that on the browse materials listing, teachers will see the #{t(:investigation)} listed in the #{t(:investigation)}s section, and each of its activities listed in the activities section. By default this is enabled so teachers can cherry pick activities out of a large #{t(:investigation)}. If you don't want teachers to cherry pick activities out of this #{t(:investigation)}, disable this option.
+        %li
+          %label.right Show Score
+          = f.check_box :show_score
+          %br
+          = t('authoring.show_score_description')
+        %li
+          %label Description
+          = f.text_area :description, :id => 'description_field', :rows => 4, :cols => 60, :class => 'mceNoEditor'
+        %li
+          %label Abstract
+          = f.text_area :abstract, :id => 'abstract_field', :rows => 4, :cols => 60, :class => 'mceNoEditor'
+        %li
+          %label Description for Teacher
+          %br
+          = t('authoring.description_for_teacher_description')
+          = f.text_area :description_for_teacher, :id => 'description_field', :rows => 4, :cols => 60, :class => 'mceNoEditor'
+        %li
+          %label Teacher Guide URL
+          %br
+          = f.text_field :teacher_guide_url, :size => 60
+        %li
+          %label Thumbnail image URL (300 x 250 px)
+          %br
+          = f.text_field :thumbnail_url, :size => 60
 
-  = render :partial => 'shared/is_assessment_item', :locals => { :form => f }
-  = render :partial => 'shared/material_properties_edit', :locals => { :object => investigation }
-  = render :partial => 'shared/cohorts_edit', :locals => { :object => investigation }
-  = render :partial => 'shared/grade_levels_edit', :locals => { :object => investigation }
-  = render :partial => 'shared/subject_areas_edit', :locals => { :object => investigation }
+    = render :partial => 'shared/is_assessment_item', :locals => { :form => f }
+    = render :partial => 'shared/material_properties_edit', :locals => { :object => investigation }
+    = render :partial => 'shared/grade_levels_edit', :locals => { :object => investigation }
+    = render :partial => 'shared/subject_areas_edit', :locals => { :object => investigation }
+  -# Partials below can be available for project admins (separate policy method).
   = render :partial => 'shared/projects_edit', :locals => { :object => investigation }
+  = render :partial => 'shared/cohorts_edit', :locals => { :object => investigation }
 
 / = field_set_tag 'Select GSE' do
 /   = field_set_tag 'filter' do

--- a/app/views/investigations/_search_list.html.haml
+++ b/app/views/investigations/_search_list.html.haml
@@ -24,10 +24,10 @@
         %div.action_menu_header_right   
           %ul.menu
             %li= run_link_for(investigation)
-            - unless(current_visitor.anonymous?)
+            - if policy(investigation).new?
               %li.menu=link_to 'duplicate', duplicate_investigation_url(investigation)
             %li.menu=link_to 'export (xml)', export_investigation_url(investigation)
-            - if (investigation.changeable?(current_visitor))
+            - if policy(investigation).destroy?
               %li.menu=link_to 'delete', investigation, :class => 'delete', :data => { :confirm => "Are you sure you want to delete #{TOP_LEVEL_CONTAINER_NAME_PLURAL} #{investigation.id}" }, :method => :delete 
       %div{:id => dom_id_for(investigation, :details), :class => 'tiny'}
         %p=investigation.description

--- a/app/views/investigations/show.html.haml
+++ b/app/views/investigations/show.html.haml
@@ -10,5 +10,5 @@
   %ul#investigation_activities_list.menu
     - @investigation.activities.each do |activity|
       =render :partial => 'activity_list_item', :locals => {:activity => activity}
-      -if (@investigation.changeable?(current_visitor))
+      -if policy(@investigation).edit?
         =sortable_element :investigation_activities_list, :handle=> 'sort-handle', :dropOnEmpty => true, :url=> {:action => 'sort_activities', :params => {:investigation_id => @investigation.id }}

--- a/app/views/shared/_activity_header.haml
+++ b/app/views/shared/_activity_header.haml
@@ -6,8 +6,9 @@
     %li= print_link_for(@activity, {:teacher_mode => true}) 
     %li#copy_link copy (disabled)
     %li= toggle_all('sections')
-    - if (activity.changeable?(current_visitor))
+    - if policy(activity).new?
       %li=duplicate_link_for(@activity)
+    - if policy(activity).edit?
       %li=edit_link_for(@activity)
       %li#paste_link= paste_link_for(['section'],{:container_id => @container_id}) # see pages_helper.rb
 
@@ -27,7 +28,7 @@
   .action_menu_header_right
     = render :partial => "shared/notes_menu", :locals => {:authorable => activity}
     = dropdown_button "actions.png", :title => "actions for this activity"
-    - if (activity.changeable?(current_visitor))
+    - if policy(activity).destroy?
       = dropdown_button "add.png"
       - if (activity.investigation)
         = delete_button_for(activity, :redirect => url_for(activity.investigation))

--- a/app/views/shared/_cohorts_edit.html.haml
+++ b/app/views/shared/_cohorts_edit.html.haml
@@ -1,5 +1,5 @@
 -# Expects locals: object
-- if object && object.respond_to?("cohorts") && current_visitor.has_role?("admin", "manager")
+- if object && object.respond_to?('cohorts') && policy(object).edit_projects_or_cohorts?
   - field_set_title = 'Cohorts' unless local_assigns[:field_set_title]
   = field_set_tag field_set_title do
     .aligned

--- a/app/views/shared/_cohorts_edit.html.haml
+++ b/app/views/shared/_cohorts_edit.html.haml
@@ -1,5 +1,5 @@
 -# Expects locals: object
-- if object && object.respond_to?('cohorts') && policy(object).edit_projects_or_cohorts?
+- if object && object.respond_to?('cohorts') && policy(object).edit_cohorts?
   - field_set_title = 'Cohorts' unless local_assigns[:field_set_title]
   = field_set_tag field_set_title do
     .aligned

--- a/app/views/shared/_external_activity_header.html.haml
+++ b/app/views/shared/_external_activity_header.html.haml
@@ -2,7 +2,7 @@
   %ul
     %li= run_link_for(@external_activity)
     %li#copy_link copy (disabled)
-    - if (external_activity.changeable?(current_visitor))
+    - if policy(external_activity).edit?
       %li=duplicate_link_for(@external_activity)
       %li=edit_link_for(@external_activity)
       %li#paste_link= paste_link_for(['section'],{:container_id => @container_id}) # see pages_helper.rb
@@ -12,7 +12,7 @@
 %div{:id => dom_id_for(external_activity,:item), :class => view_class }
   .action_menu_header_left
     .padded_content
-      - if (@external_activity.changeable?(current_visitor))
+      - if policy(@external_activity).edit?
         %h3= "Activity: #{in_place_editor_field :external_activity, 'name'}".html_safe
         .tiny=in_place_editor_field :external_activity, 'description', {},{:rows=>3, :cols=>80}
         .tiny=in_place_editor_field :external_activity, 'url', {},{:rows=>3, :cols=>80}
@@ -25,7 +25,7 @@
       .tiny= "Subject Areas: #{@external_activity.subject_area_list.join(', ')}"
   .action_menu_header_right
     = dropdown_button "actions.png", :title => "actions for this external_activity"
-    - if (external_activity.changeable?(current_visitor))
+    - if policy(external_activity).edit?
       = delete_button_for(external_activity)
     - else
       = link_button "disabled.png", "#"

--- a/app/views/shared/_projects_edit.html.haml
+++ b/app/views/shared/_projects_edit.html.haml
@@ -1,5 +1,5 @@
 -# Expects locals: object
-- if object && object.respond_to?('projects') && policy(object).edit_projects_or_cohorts?
+- if object && object.respond_to?('projects') && policy(object).edit_projects?
   = field_set_tag 'Projects' do
     .aligned
       %ul.menu_h

--- a/app/views/shared/_projects_edit.html.haml
+++ b/app/views/shared/_projects_edit.html.haml
@@ -1,5 +1,5 @@
 -# Expects locals: object
-- if object && object.respond_to?('projects') && current_visitor.has_role?('admin', 'manager')
+- if object && object.respond_to?('projects') && policy(object).edit_projects_or_cohorts?
   = field_set_tag 'Projects' do
     .aligned
       %ul.menu_h
@@ -8,7 +8,11 @@
         = hidden_field_tag prop_name
         - project_assigned = Hash[object.projects.map { |p| [p.id, true ] }]
         - Admin::Project.all.each do |project|
-          %li
-            - label_str = "project_#{project.id}"
-            = label_tag label_str, project.name
-            = check_box_tag prop_name, project.id, project_assigned[project.id], id: label_str
+          - if policy(project).assign_to_material?
+            %li
+              - label_str = "project_#{project.id}"
+              = label_tag label_str, project.name
+              = check_box_tag prop_name, project.id, project_assigned[project.id], id: label_str
+          - elsif project_assigned[project.id]
+            -# This is necessary to keep hidden projects still assigned to the material.
+            = hidden_field_tag prop_name, project.id

--- a/lib/materials/data_helpers.rb
+++ b/lib/materials/data_helpers.rb
@@ -71,7 +71,7 @@ module Materials
           publication_status: material.publication_status,
           links: links_for_material(material),
           preview_url: view_context.run_url_for(material, (material.teacher_only? ? {:teacher_mode => true} : {})),
-          edit_url: material.changeable?(current_visitor) ? view_context.matedit_external_activity_url(material, iFrame: true) : nil,
+          edit_url: policy(material).edit_all? ? view_context.matedit_external_activity_url(material, iFrame: true) : nil,
           copy_url: external_copyable(material) ? view_context.copy_external_activity_url(material) : nil,
           assign_to_class_url: current_visitor.portal_teacher && material.respond_to?(:offerings) ? "javascript:get_Assign_To_Class_Popup(#{material.id},'#{material.class.to_s}','#{t('material').pluralize.capitalize}')" : nil,
           assign_to_collection_url: current_visitor.has_role?('admin') && material.respond_to?(:materials_collections) ? "javascript:get_Assign_To_Collection_Popup(#{material.id},'#{material.class.to_s}')" : nil,
@@ -203,7 +203,7 @@ module Materials
         end
       end
 
-      if current_visitor.has_role?('admin','manager')
+      if policy(material).edit?
         links[:edit] = {
           text: "(portal settings)",
           url: edit_polymorphic_url(material),

--- a/lib/materials/data_helpers.rb
+++ b/lib/materials/data_helpers.rb
@@ -71,7 +71,7 @@ module Materials
           publication_status: material.publication_status,
           links: links_for_material(material),
           preview_url: view_context.run_url_for(material, (material.teacher_only? ? {:teacher_mode => true} : {})),
-          edit_url: policy(material).edit_all? ? view_context.matedit_external_activity_url(material, iFrame: true) : nil,
+          edit_url: policy(material).edit_settings? ? view_context.matedit_external_activity_url(material, iFrame: true) : nil,
           copy_url: external_copyable(material) ? view_context.copy_external_activity_url(material) : nil,
           assign_to_class_url: current_visitor.portal_teacher && material.respond_to?(:offerings) ? "javascript:get_Assign_To_Class_Popup(#{material.id},'#{material.class.to_s}','#{t('material').pluralize.capitalize}')" : nil,
           assign_to_collection_url: current_visitor.has_role?('admin') && material.respond_to?(:materials_collections) ? "javascript:get_Assign_To_Collection_Popup(#{material.id},'#{material.class.to_s}')" : nil,

--- a/spec/support/projects_listing_shared_examples.rb
+++ b/spec/support/projects_listing_shared_examples.rb
@@ -8,6 +8,13 @@ shared_examples 'projects listing' do
     before(:each) do
       view.stub!(:current_visitor).and_return(Factory.next(:admin_user))
       view.stub!(:current_user).and_return(Factory.next(:admin_user))
+      # For some reason policy is undefined in shared view examples.
+      # Stub it too.
+      view.stub!(:policy).and_return(
+        Class.new do
+          def method_missing(*args, &block); true; end
+        end.new
+      )
     end
     it 'should be visible' do
       render
@@ -19,6 +26,13 @@ shared_examples 'projects listing' do
     before(:each) do
       view.stub!(:current_visitor).and_return(Factory.next(:author_user))
       view.stub!(:current_user).and_return(Factory.next(:author_user))
+      # For some reason policy is undefined in shared view examples.
+      # Stub it too.
+      view.stub!(:policy).and_return(
+        Class.new do
+          def method_missing(*args, &block); false; end
+        end.new
+      )
     end
     it 'should not be visible' do
       render

--- a/spec/support/projects_listing_shared_examples.rb
+++ b/spec/support/projects_listing_shared_examples.rb
@@ -8,13 +8,6 @@ shared_examples 'projects listing' do
     before(:each) do
       view.stub!(:current_visitor).and_return(Factory.next(:admin_user))
       view.stub!(:current_user).and_return(Factory.next(:admin_user))
-      # For some reason policy is undefined in shared view examples.
-      # Stub it too.
-      view.stub!(:policy).and_return(
-        Class.new do
-          def method_missing(*args, &block); true; end
-        end.new
-      )
     end
     it 'should be visible' do
       render
@@ -26,13 +19,6 @@ shared_examples 'projects listing' do
     before(:each) do
       view.stub!(:current_visitor).and_return(Factory.next(:author_user))
       view.stub!(:current_user).and_return(Factory.next(:author_user))
-      # For some reason policy is undefined in shared view examples.
-      # Stub it too.
-      view.stub!(:policy).and_return(
-        Class.new do
-          def method_missing(*args, &block); false; end
-        end.new
-      )
     end
     it 'should not be visible' do
       render

--- a/spec/views/external_activities/edit.html.haml_spec.rb
+++ b/spec/views/external_activities/edit.html.haml_spec.rb
@@ -5,8 +5,8 @@ describe "/external_activities/edit.html.haml" do
 
   before(:each) do
     assigns[:external_activity] = @external_activity = ext_act
-    view.stub!(:current_visitor).and_return(Factory.next(:researcher_user))
-    view.stub!(:current_user).and_return(Factory.next(:researcher_user))
+    view.stub!(:current_visitor).and_return(Factory.next(:admin_user))
+    view.stub!(:current_user).and_return(Factory.next(:admin_user))
   end
 
   it 'should have an is_official check box to designate official activities' do

--- a/themes/itsisu/views/shared/_activity_header.haml
+++ b/themes/itsisu/views/shared/_activity_header.haml
@@ -4,10 +4,10 @@
     /%li= run_link_for(@activity,'teacher',{:teacher_mode=>true})
     /%li= print_link_for(@activity)
     /%li= toggle_all('sections')
-    - if (activity.changeable?(current_visitor))
+    - if policy(activity).new?
       %li= duplicate_link_for(@activity,:text=> "duplicate activity #{@activity.name}")
+    - if policy(activity).edit?
       %li=edit_link_for(@activity)      
-    - if (activity.changeable?(current_visitor))
       %li#copy_link.copy_paste_disabled copy (disabled)
     %li#paste_link= paste_link_for(['section'],{:container_id => @container_id}) # see pages_helper.rb
 
@@ -28,9 +28,10 @@
   .action_menu_header_right
     = render :partial => "shared/notes_menu", :locals => {:authorable => activity}
     = dropdown_button "actions.png", :title => "actions for this activitiy"
-    - if (activity.changeable?(current_visitor))
+    - if policy(activity).edit?
       = dropdown_button "add.png"
     - else
       = link_button "add_disabled.png", "#", :title => "can't add to this activity"
     = render :partial => "shared/dot_pager", :locals => {:node => activity}
-    = delete_button_for activity
+    - if policy(activity).destroy?
+      = delete_button_for activity


### PR DESCRIPTION
Project admin can edit material settings now. Initially he can only modify its projects or cohorts. Once he assigns a material to his project, he can also change other settings.

It should work for all the material types - external activities, interactives, activities and investigations.

There are new Pundit policies and they are a bit different for "new" and "old" material types (new: external activity, interactive; old: activity, investigation).

I've also tried to reduce use of the old `#changeable` method and removed `Changeable` module from `ExternalActivity` and `Interactive` models.
