### PR TITLE
Verify bearer token devise strategy accounts for token expiration

### DIFF
--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -14,9 +14,7 @@ class AuthController < ApplicationController
   def welcome
     render :text => "Hiya! #{current_user.first_name} #{current_user.last_name}"
   end
-  def self.authorize
-    debugger
-  end
+
   def oauth_authorize
     AccessGrant.prune!
     access_grant = current_user.access_grants.create({:client => application, :state => params[:state]}, :without_protection => true)

--- a/spec/libs/bearer_token/bearer_token_spec.rb
+++ b/spec/libs/bearer_token/bearer_token_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+require 'delorean'
+def addToken(user, client, expires_at)
+  grant = user.access_grants.create({
+      :client => client,
+      :state => nil,
+      :access_token_expires_at => expires_at },
+    :without_protection => true
+  )
+  grant.access_token
+end
+
+describe BearerToken:BearerTokenAuthenticatable do
+  after(:each) { Delorean.back_to_the_present }
+
+  let(:strategy)  { BearerTokenAuthenticatable::BearerToken.new(nil) }
+  let(:request)   { mock('request') }
+  let(:mapping)   { Devise.mappings[:user] }
+  let(:expires)   { Time.now + 10.minutes}
+  let(:token)     { addToken(user, client, expires) }
+  let(:headers)   { {"Authorization" => "Bearer #{token}"} }
+  let(:user)      { FactoryGirl.create(:user) }
+  let(:params)    { {} }
+  let(:client)    { Client.find_or_create_by_name(
+         :name       => "test_api_client",
+         :app_id     => "test_api_client",
+         :app_secret => SecureRandom.uuid
+  )}
+  before(:each) {
+    request.stub!(:headers).and_return(headers)
+    request.stub!(:params).and_return(params)
+    strategy.stub!(:mapping).and_return(mapping)
+    strategy.stub!(:request).and_return(request)
+  }
+
+  context 'a user with a short-lived authentication token' do
+    let(:expires) { Time.now + 10.minutes}
+    it 'should authenticate the user' do
+      strategy.authenticate!.should eql :success
+    end
+
+    it 'the token should expire 12 minutes into the futre' do
+      Delorean.jump(12 * 60) # move 12 minutes into the future
+      strategy.authenticate!.should eql :failure
+    end
+  end
+
+  context 'a user with an expired authentication token' do
+    let(:expires) { Time.now - 10.minutes}
+    it 'should NOT authenticate the user' do
+      strategy.authenticate!.should eql :failure
+    end
+  end
+
+  context 'a user with one expired authentication token, and a valid token' do
+    let(:good_token)    { addToken(user, client, Time.now + 10.minutes) }
+    let(:expired_token) { addToken(user, client, Time.now - 10.minutes) }
+    context 'when sending the good bearer token' do
+      let(:token){ good_token }
+      it "should authenticate" do
+        strategy.authenticate!.should eql :success
+      end
+    end
+    context 'when sending the expired token' do
+      let(:token){ expired_token }
+      it "authentication should fail" do
+        strategy.authenticate!.should eql :failure
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
@scytacki @pjanik -- I believe that this test confirms that at least for Bearer token authentication, the expiration time is used when authenticating.

I would have thought we can use short lived tokens, without worrying about other authentication mechanisms. But parts of the [PT story](https://www.pivotaltracker.com/story/show/111242640)  have me second guessing this:

> Need to check the case where the `domain` param is sent to LARA from the portal. In this case LARA will look to see if the current user has a token for this domain and user. And if it does, LARA might assume the token is valid without checking its expiration date. If LARA then makes a request to get user information using the token then the request might fail.  LARA should know if the token is expired, and if so it should do the usual redirect to the portal in order to get a new token.

Although I can't see how this would happen as described, I would like to write a test for it.  Thoughts on which controller methods to test for this sort of interaction would be appreciated.
