### PR TITLE
Secure remote endpoint

### DIFF
--- a/app/controllers/admin/learner_details_controller.rb
+++ b/app/controllers/admin/learner_details_controller.rb
@@ -14,7 +14,7 @@ class Admin::LearnerDetailsController < ApplicationController
   # GET /learner_details/1.json
   def show
     authorize Admin::LearnerDetails
-    learner = Portal::Learner.find(params[:id])
+    learner = Portal::Learner.find_by_id_or_key(params[:id_or_key])
     @learner_details = LearnerDetail.new learner
     respond_to do |format|
       format.text  { render :text => @learner_details.display }

--- a/app/controllers/dataservice/external_activity_data_controller.rb
+++ b/app/controllers/dataservice/external_activity_data_controller.rb
@@ -5,7 +5,7 @@ class Dataservice::ExternalActivityDataController < ApplicationController
   private
 
   def pundit_user_not_authorized(exception)
-    learner_id = params[:id]
+    learner = Portal::Learner.find_by_id_or_key(params[:id] || params[:key])
     learner_deets = LearnerDetail.new(learner)
     visitor = current_visitor ? current_visitor.name : 'anonymous'
     error_string = "Auth error for #{visitor} - #{learner_deets}"
@@ -15,14 +15,11 @@ class Dataservice::ExternalActivityDataController < ApplicationController
   public
 
   def create
-    learner_id = params[:id]
-    if learner = Portal::Learner.find(learner_id)
-      authorize Dataservice::ProcessExternalActivityDataJob
-      # TODO: wrap this in a begin/rescue/end and return a real-ish error
-      Delayed::Job.enqueue Dataservice::ProcessExternalActivityDataJob.new(learner_id, request.body.read)
-      render :status => 201, :nothing => true and return
-    end
-    raise ActionController::RoutingError.new('Not Found')
+    authorize Dataservice::ProcessExternalActivityDataJob
+    learner = Portal::Learner.find_by_id_or_key(params[:id_or_key])
+    # TODO: wrap this in a begin/rescue/end and return a real-ish error
+    Delayed::Job.enqueue Dataservice::ProcessExternalActivityDataJob.new(learner.id, request.body.read)
+    render :status => 201, :nothing => true
   end
 
 end

--- a/app/controllers/dataservice/external_activity_data_controller.rb
+++ b/app/controllers/dataservice/external_activity_data_controller.rb
@@ -5,7 +5,7 @@ class Dataservice::ExternalActivityDataController < ApplicationController
   private
 
   def pundit_user_not_authorized(exception)
-    learner = Portal::Learner.find_by_id_or_key(params[:id] || params[:key])
+    learner = Portal::Learner.find_by_id_or_key(params[:id_or_key])
     learner_deets = LearnerDetail.new(learner)
     visitor = current_visitor ? current_visitor.name : 'anonymous'
     error_string = "Auth error for #{visitor} - #{learner_deets}"

--- a/app/controllers/portal/offerings_controller.rb
+++ b/app/controllers/portal/offerings_controller.rb
@@ -82,7 +82,7 @@ class Portal::OfferingsController < ApplicationController
            uri.query = {
              :domain => root_url,
              :externalId => learner.id,
-             :returnUrl => external_activity_return_url(learner.id),
+             :returnUrl => learner.remote_endpoint_url(request.protocol, request.host_with_port),
              :logging => @offering.clazz.logging || @offering.runnable.logging,
              :domain_uid => current_visitor.id
            }.to_query

--- a/app/controllers/report/learner_controller.rb
+++ b/app/controllers/report/learner_controller.rb
@@ -31,7 +31,7 @@ class Report::LearnerController < ApplicationController
 
   def logs_query
     authorize Report::Learner
-    @remote_endpoints = @select_learners.map { |l| external_activity_return_url(l.learner_id) }
+    @remote_endpoints = @select_learners.map { |l| l.learner.remote_endpoint_url(request.protocol, request.host_with_port) }
     render :layout => false
   end
 
@@ -189,7 +189,7 @@ class Report::LearnerController < ApplicationController
 
     @report_url = "#{authoring_sites.first}/c_rater/argumentation_blocks/report"
     @remote_endpoints = learners.map do |learner|
-      external_activity_return_url(learner.learner_id)
+      learner.learner.remote_endpoint_url(request.protocol, request.host_with_port)
     end
 
     # intentionally leave out student name - results should be semi-anonymized
@@ -199,7 +199,7 @@ class Report::LearnerController < ApplicationController
     rows = learners.map do |learner|
       columns.map do |column|
         # except for remote_endpoint, column names are just names of Report::Learner instance methods
-        column == :remote_endpoint ? external_activity_return_url(learner.learner_id) : learner.send(column)
+        column == :remote_endpoint ? learner.learner.remote_endpoint_url(request.protocol, request.host_with_port) : learner.send(column)
       end
     end
 

--- a/app/models/portal/learner.rb
+++ b/app/models/portal/learner.rb
@@ -1,5 +1,9 @@
 class Portal::Learner < ActiveRecord::Base
+  include Rails.application.routes.url_helpers
+
   self.table_name = :portal_learners
+
+  KEY_PREFIX = 'key:'
   
   default_scope :order => 'student_id ASC'
   
@@ -45,6 +49,10 @@ class Portal::Learner < ActiveRecord::Base
   has_one :report_learner, :dependent => :destroy, :class_name => "Report::Learner", :foreign_key => "learner_id"
 
   has_many :lightweight_blobs, :dependent => :destroy, :class_name => "Dataservice::Blob"
+
+  default_value_for :key do
+    KEY_PREFIX + UUIDTools::UUID.random_create.to_s
+  end
 
   # automatically make the report learner if it doesn't exist yet
   def report_learner
@@ -109,6 +117,14 @@ class Portal::Learner < ActiveRecord::Base
       @@searchable_attributes
     end
 
+    def find_by_id_or_key(id_or_key)
+      if id_or_key.is_a?(String) && id_or_key.start_with?(KEY_PREFIX)
+        Portal::Learner.find_by_key!(id_or_key)
+      else
+        Portal::Learner.find(id_or_key)
+      end
+    end
+
   end
   
   # for the view system ...
@@ -164,5 +180,21 @@ class Portal::Learner < ActiveRecord::Base
 
   def reportable?
     offering.individual_reportable?
+  end
+
+  def remote_endpoint_path
+    if key.present?
+      external_activity_return_path(key)
+    else
+      external_activity_return_path(id)
+    end
+  end
+
+  def remote_endpoint_url(protocol, host_with_port)
+    if key.present?
+      external_activity_return_url(key, protocol: protocol, host: host_with_port)
+    else
+      external_activity_return_url(id, protocol: protocol, host: host_with_port)
+    end
   end
 end

--- a/app/policies/dataservice/process_external_activity_data_job_policy.rb
+++ b/app/policies/dataservice/process_external_activity_data_job_policy.rb
@@ -1,7 +1,7 @@
 class Dataservice::ProcessExternalActivityDataJobPolicy < ApplicationPolicy
 
   def create?
-    learner = Portal::Learner.find(params[:id])
+    learner = Portal::Learner.find_by_id_or_key(params[:id_or_key])
     admin_or_manager? || (user == learner.user) ||  request_is_peer?
   end
 

--- a/app/services/api/v1/show_collaborators_data.rb
+++ b/app/services/api/v1/show_collaborators_data.rb
@@ -27,7 +27,7 @@ class API::V1::ShowCollaboratorsData
         # Not sure why this is needed, but currently LARA expects that value for regular activity run.
         learner_id: learner.id,
         # This URL can be used by external activity system to publish back  student answers.
-        endpoint_url: external_activity_return_url(learner.id, protocol: self.protocol, host: self.host_with_port)
+        endpoint_url: learner.remote_endpoint_url(self.protocol, self.host_with_port)
       }
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -343,8 +343,10 @@ RailsPortal::Application.routes.draw do
     post '/dataservice/bucket_loggers/name/:name/bucket_log_items(.:format)' => 'dataservice/bucket_log_items_metal#create_by_name',     :constraints => { :format => 'bundle' }, :as => 'dataservice_bucket_log_items_by_name'
     get  '/dataservice/bucket_loggers/name/:name/bucket_log_items(.:format)' => 'dataservice/bucket_loggers#show_log_items_by_name',     :constraints => { :format => 'bundle' }, :as => 'dataservice_bucket_loggers_log_items_by_name'
 
-    # external activity return url (:id refers learner's ID)
-    post '/dataservice/external_activity_data/:id' => 'dataservice/external_activity_data#create', :as => 'external_activity_return'
+    # external activity return url (:id_or_key refers learner's ID or key)
+    # - key is a random UUID string, so it's impossible to guess somebody's else endpoint (more secure)
+    # - we still need to support basic ID, as LARA might store this form of URLs
+    post '/dataservice/external_activity_data/:id_or_key' => 'dataservice/external_activity_data#create', :as => 'external_activity_return'
 
     # A prettier version of the blob w/ token url
     match 'dataservice/blobs/:id/:token.:format' => 'dataservice/blobs#show', :as => :dataservice_blob_raw_pretty, :constraints => { :token => /[a-zA-Z0-9]{32}/ }
@@ -373,7 +375,7 @@ RailsPortal::Application.routes.draw do
           #post :manage_classes_save, :as => 'manage_save'
         end
       end
-      get '/learner_detail/:id.:format' => 'learner_details#show',  :as => :learner_detail
+      get '/learner_detail/:id_or_key.:format' => 'learner_details#show',  :as => :learner_detail
     end
 
     resources :materials_collections do

--- a/db/migrate/20160114213904_add_key_to_portal_learners.rb
+++ b/db/migrate/20160114213904_add_key_to_portal_learners.rb
@@ -1,0 +1,6 @@
+class AddKeyToPortalLearners < ActiveRecord::Migration
+  def change
+    add_column :portal_learners, :key, :string
+    add_index :portal_learners, :key, name: 'index_portal_learners_on_key', unique: true
+  end
+end

--- a/db/migrate/20160114213904_add_key_to_portal_learners.rb
+++ b/db/migrate/20160114213904_add_key_to_portal_learners.rb
@@ -1,6 +1,0 @@
-class AddKeyToPortalLearners < ActiveRecord::Migration
-  def change
-    add_column :portal_learners, :key, :string
-    add_index :portal_learners, :key, name: 'index_portal_learners_on_key', unique: true
-  end
-end

--- a/db/migrate/20160114213904_add_secure_key_to_portal_learners.rb
+++ b/db/migrate/20160114213904_add_secure_key_to_portal_learners.rb
@@ -1,0 +1,6 @@
+class AddSecureKeyToPortalLearners < ActiveRecord::Migration
+  def change
+    add_column :portal_learners, :secure_key, :string
+    add_index :portal_learners, :secure_key, name: 'index_portal_learners_on_sec_key', unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1267,10 +1267,12 @@ ActiveRecord::Schema.define(:version => 20160115171143) do
     t.datetime "updated_at",                      :null => false
     t.integer  "bundle_logger_id"
     t.integer  "console_logger_id"
+    t.string   "key"
   end
 
   add_index "portal_learners", ["bundle_logger_id"], :name => "index_portal_learners_on_bundle_logger_id"
   add_index "portal_learners", ["console_logger_id"], :name => "index_portal_learners_on_console_logger_id"
+  add_index "portal_learners", ["key"], :name => "index_portal_learners_on_key", :unique => true
   add_index "portal_learners", ["offering_id"], :name => "index_portal_learners_on_offering_id"
   add_index "portal_learners", ["student_id"], :name => "index_portal_learners_on_student_id"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1267,13 +1267,13 @@ ActiveRecord::Schema.define(:version => 20160115171143) do
     t.datetime "updated_at",                      :null => false
     t.integer  "bundle_logger_id"
     t.integer  "console_logger_id"
-    t.string   "key"
+    t.string   "secure_key"
   end
 
   add_index "portal_learners", ["bundle_logger_id"], :name => "index_portal_learners_on_bundle_logger_id"
   add_index "portal_learners", ["console_logger_id"], :name => "index_portal_learners_on_console_logger_id"
-  add_index "portal_learners", ["key"], :name => "index_portal_learners_on_key", :unique => true
   add_index "portal_learners", ["offering_id"], :name => "index_portal_learners_on_offering_id"
+  add_index "portal_learners", ["secure_key"], :name => "index_portal_learners_on_sec_key", :unique => true
   add_index "portal_learners", ["student_id"], :name => "index_portal_learners_on_student_id"
 
   create_table "portal_nces06_districts", :force => true do |t|

--- a/features/activity_runtime_api/running.feature
+++ b/features/activity_runtime_api/running.feature
@@ -9,7 +9,7 @@ Feature: External Activities can support a REST api
       | domain_uid | 13                       |
       | externalId | 999                      |
       | logging    | false                    |
-      | returnUrl  | http://www.example.com/dataservice/external_activity_data/888 |
+      | returnUrl  | http://www.example.com/dataservice/external_activity_data/key |
     And "activities.com/activity/1/sessions/" GET responds with
       """
       HTTP/1.1 200 OK

--- a/features/step_definitions/activity_runtime_api_steps.rb
+++ b/features/step_definitions/activity_runtime_api_steps.rb
@@ -51,7 +51,7 @@ Given /^"([^"]*)" handles a (POST|GET) with query:$/ do |address, method, table|
   end
   # must use a copy! Cucumber apparently doesn't re-allocate arguments for Background steps
   query_data["externalId"] = query_data["externalId"].sub(/999/,"#{@learner.id}")
-  query_data["returnUrl"] = query_data["returnUrl"].sub(/key/,"#{@learner.key}")
+  query_data["returnUrl"] = query_data["returnUrl"].sub(/key/,"#{@learner.secure_key}")
   stub.with(:query => query_data)
 end
 

--- a/features/step_definitions/activity_runtime_api_steps.rb
+++ b/features/step_definitions/activity_runtime_api_steps.rb
@@ -101,7 +101,7 @@ end
 
 When /^the browser returns the following data to the portal$/ do |string|
   login_as('student')
-  path = external_activity_return_path(@learner)
+  path = @learner.remote_endpoint_path
   Delayed::Job.should_receive(:enqueue)
   page.driver.post(path, :content => string)
   # delayed_job doesn't work in tests, so force running the job

--- a/features/step_definitions/activity_runtime_api_steps.rb
+++ b/features/step_definitions/activity_runtime_api_steps.rb
@@ -51,7 +51,7 @@ Given /^"([^"]*)" handles a (POST|GET) with query:$/ do |address, method, table|
   end
   # must use a copy! Cucumber apparently doesn't re-allocate arguments for Background steps
   query_data["externalId"] = query_data["externalId"].sub(/999/,"#{@learner.id}")
-  query_data["returnUrl"] = query_data["returnUrl"].sub(/888/,"#{@learner.id}")
+  query_data["returnUrl"] = query_data["returnUrl"].sub(/key/,"#{@learner.key}")
   stub.with(:query => query_data)
 end
 


### PR DESCRIPTION
This PR adds support of remote endpoint URLs that use random, long UUID keys instead of IDs. We will use those URLs to identify runs in LARA, so that makes them a bit more secure - it's impossible to guess somebody's endpoint URL and get his answers. If we were using numeric IDs, it would pretty easy to modify ID and get student's data.

The old format (with numeric ID) is still supported, as LARA already stores multiple remote endpoints.

Each new learner will have `key` assigned and his remote endpoint URL will use it. Old learner objects don't have `key`, so they still use ID.

@scytacki, this is based on our discussion, so perhaps it makes sense for you to look at it when you get a chance. Thanks!