### PR TITLE
Authentication Clients can be restricted to a set of domains.

### DIFF
--- a/app/controllers/admin/clients_controller.rb
+++ b/app/controllers/admin/clients_controller.rb
@@ -1,0 +1,82 @@
+class Admin::ClientsController < ApplicationController
+
+  rescue_from Pundit::NotAuthorizedError, with: :pundit_user_not_authorized
+
+  private
+  def pundit_user_not_authorized(exception)
+    flash[:notice] = "Please log in as an administrator"
+    redirect_to(:home)
+  end
+
+  public
+
+  # GET /admin/clients
+  def index
+    authorize Client
+    @clients = Client.find(:all).paginate(:per_page => 20, :page => params[:page])
+  end
+
+  # GET /admin/client/1
+  def show
+    authorize Client
+    @client = Client.find(params[:id])
+  end
+
+  # GET /admin/client/new
+  def new
+    authorize Client
+    @client = Client.new
+  end
+
+  # GET /admin/client/1/edit
+  def edit
+    authorize Client
+    @client = Client.find(params[:id])
+    if request.xhr?
+      render :partial => 'remote_form', :locals => { :project => @client }
+    end
+  end
+
+  # POST /admin/client
+  def create
+    authorize Client
+    @client = Client.new(params[:client])
+
+    if @client.save
+      flash[:notice]='Client was successfully created.'
+      redirect_to action: :index
+    else
+      render :action => 'new'
+    end
+  end
+
+  # PUT /admin/client/1
+  def update
+    authorize Client
+    @client = Client.find(params[:id])
+    if request.xhr?
+      if @client.update_attributes(params[:client])
+        render :partial => 'show', :locals => { :project => @client }
+      else
+        render :partial => 'remote_form', :locals => { :project => @client }, :status => 400
+      end
+    else
+      if @client.update_attributes(params[:client])
+        flash[:notice]= 'Client was successfully updated.'
+        redirect_to action: :index
+      else
+        render :action => 'edit'
+      end
+    end
+  end
+
+  # DELETE /admin/client/1
+  def destroy
+    authorize Client
+    @client = Client.find(params[:id])
+    @client.destroy
+    flash[:notice]= 'Client was successfully deleted.'
+    redirect_to action: :index
+  end
+
+end

--- a/app/controllers/admin/clients_controller.rb
+++ b/app/controllers/admin/clients_controller.rb
@@ -26,6 +26,7 @@ class Admin::ClientsController < ApplicationController
   def new
     authorize Client
     @client = Client.new
+    @client.app_secret ||= SecureRandom.uuid()
   end
 
   # GET /admin/client/1/edit

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -1,5 +1,7 @@
 class Client < ActiveRecord::Base
   attr_accessible :app_id, :app_secret, :name, :site_url, :domain_matchers
+  has_many :access_grants, :dependent => :delete_all
+
   def self.authenticate(app_id, app_secret)
     where(["app_id = ? AND app_secret = ?", app_id, app_secret]).first
   end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -1,6 +1,22 @@
 class Client < ActiveRecord::Base
-  attr_accessible :app_id, :app_secret, :name, :site_url
+  attr_accessible :app_id, :app_secret, :name, :site_url, :domain_matchers
   def self.authenticate(app_id, app_secret)
     where(["app_id = ? AND app_secret = ?", app_id, app_secret]).first
+  end
+
+  def valid_from_referer?(referer)
+    return true unless enforce_referrer?
+    domain_matchers.split(/\s+/).each do |matcher|
+      return true if (/^https?:\/\/#{matcher}/ =~ referer)
+    end
+    return false
+  end
+
+  def enforce_referrer?
+    if domain_matchers.blank?
+      false
+    else
+      true
+    end
   end
 end

--- a/app/policies/client_policy.rb
+++ b/app/policies/client_policy.rb
@@ -1,2 +1,42 @@
 class ClientPolicy < ApplicationPolicy
+
+  class Scope < Scope
+    def resolve
+      if user.has_role?('admin')
+        all
+      else
+        none
+      end
+    end
+  end
+
+  def index?
+    is_admin
+  end
+
+  def show?
+    is_admin
+  end
+
+  def create?
+    is_admin
+  end
+
+  def edit?
+    is_admin
+  end
+
+  def update?
+    is_admin
+  end
+
+  def changeable?
+    is_admin
+  end
+
+  private
+  def is_admin
+    has_roles?('admin')
+  end
+
 end

--- a/app/policies/client_policy.rb
+++ b/app/policies/client_policy.rb
@@ -11,32 +11,31 @@ class ClientPolicy < ApplicationPolicy
   end
 
   def index?
-    is_admin
+    admin?
   end
 
   def show?
-    is_admin
+    admin?
   end
 
   def create?
-    is_admin
+    admin?
   end
 
   def edit?
-    is_admin
+    admin?
   end
 
   def update?
-    is_admin
+    admin?
+  end
+
+  def new?
+    admin?
   end
 
   def changeable?
-    is_admin
-  end
-
-  private
-  def is_admin
-    has_roles?('admin')
+    admin?
   end
 
 end

--- a/app/views/admin/clients/_form.html.haml
+++ b/app/views/admin/clients/_form.html.haml
@@ -1,0 +1,26 @@
+.item
+  .content
+    - if client.errors.any?
+      %ul.menu_v.error-explanation
+        %li Client can't be saved, there are errors in form:
+        - client.errors.full_messages.each do |msg|
+          %li= msg
+    %p
+      %ul.menu_v
+        /:app_id, :app_secret, :name, :site_url, :domain_matchers
+        %li
+          Name:
+          = f.text_field :name
+        %li
+          App Id:
+          = f.text_field :app_id
+        %li
+          App Secret:
+          = f.text_field :app_secret
+        %li
+          Site URL:
+          = f.text_field :site_url
+        %li
+          Allowed domains (multiple regex sererated by whitespace):
+          = f.text_area :domain_matchers, class: 'mceNoEditor'
+      = submit_tag

--- a/app/views/admin/clients/_remote_form.html.haml
+++ b/app/views/admin/clients/_remote_form.html.haml
@@ -1,0 +1,3 @@
+= remote_form_for(client, update: { success: dom_id_for(client), failure: dom_id_for(client, :edit)},
+                           html: { id: dom_id_for(client, :edit)}) do |f|
+  = render partial: 'form', locals: { client: client, f: f }

--- a/app/views/admin/clients/_show.html.haml
+++ b/app/views/admin/clients/_show.html.haml
@@ -19,6 +19,9 @@
             App Id:
             = client.app_id
           %li
+            Access Grants:
+            = client.access_grants.count
+          %li
             App Secret:
             = client.app_secret
           %li

--- a/app/views/admin/clients/_show.html.haml
+++ b/app/views/admin/clients/_show.html.haml
@@ -1,0 +1,32 @@
+%div{id: dom_id_for(client), class: 'container_element'}
+  .action_menu
+    .action_menu_header_left
+      %h3= client.name
+    .action_menu_header_right
+      %ul.menu
+        %li
+          %a{href:edit_admin_client_path(client)} edit
+        %li
+          %a{href:url_for(action: :destroy, id:client.id), data: {method: 'delete', confirm: "Delete this client?"} } delete
+  %div{id: dom_id_for(client, :item), class: 'item'}
+    %div{id: dom_id_for(client, :details), class: 'content'}
+      %p
+        %ul.menu_v
+          %li
+            Name:
+            = client.name
+          %li
+            App Id:
+            = client.app_id
+          %li
+            App Secret:
+            = client.app_secret
+          %li
+            Site URL:
+            = client.site_url
+          %li
+            Allowed Domain regexs:
+            - unless client.domain_matchers.blank?
+              %ul
+                - client.domain_matchers.split(/\s+/).each do |dm|
+                  %li= dm

--- a/app/views/admin/clients/edit.html.haml
+++ b/app/views/admin/clients/edit.html.haml
@@ -1,0 +1,2 @@
+= form_for(@client, url: url_for(controller: 'clients', action: 'update')) do |f|
+  = render partial: 'admin/clients/form', locals: { client: @client, f: f }

--- a/app/views/admin/clients/index.html.haml
+++ b/app/views/admin/clients/index.html.haml
@@ -1,0 +1,2 @@
+= render partial: 'shared/collection_menu', locals: { collection: @clients, collection_class: Client }
+= render partial: 'show', collection: @clients, as: :client

--- a/app/views/admin/clients/new.html.haml
+++ b/app/views/admin/clients/new.html.haml
@@ -1,0 +1,2 @@
+= form_for(@client, url: url_for(controller: 'clients', action: 'create')) do |f|
+  = render partial: 'form', locals: { client: @client, f: f }

--- a/app/views/admin/clients/show.html.haml
+++ b/app/views/admin/clients/show.html.haml
@@ -1,0 +1,1 @@
+= render partial: 'show', locals: { client: @client }

--- a/app/views/home/admin.html.haml
+++ b/app/views/home/admin.html.haml
@@ -12,6 +12,7 @@
   - if is_admin_or_manager
     %li= link_to 'Districts', portal_districts_path
     %li= link_to 'Schools', portal_schools_path
+    %li= link_to 'Auth Clients', admin_clients_path
     - if APP_CONFIG[:use_gse]
       %li= link_to 'GSEs', ri_gse_grade_span_expectations_path
   - if is_admin_or_project_admin

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -354,6 +354,7 @@ RailsPortal::Application.routes.draw do
       resources :settings
       resources :tags
       resources :projects
+      resources :clients
       resources :permission_forms do
         member do
           post :update_forms

--- a/db/migrate/20160115171143_add_domain_matchers_to_client.rb
+++ b/db/migrate/20160115171143_add_domain_matchers_to_client.rb
@@ -1,0 +1,5 @@
+class AddDomainMatchersToClient < ActiveRecord::Migration
+  def change
+    add_column :clients, :domain_matchers, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160106034419) do
+ActiveRecord::Schema.define(:version => 20160115171143) do
 
   create_table "access_grants", :force => true do |t|
     t.string   "code"
@@ -238,9 +238,10 @@ ActiveRecord::Schema.define(:version => 20160106034419) do
     t.string   "name"
     t.string   "app_id"
     t.string   "app_secret"
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
+    t.datetime "created_at",      :null => false
+    t.datetime "updated_at",      :null => false
     t.string   "site_url"
+    t.string   "domain_matchers"
   end
 
   create_table "commons_licenses", :id => false, :force => true do |t|

--- a/lib/bearer_token/bearer_token_authenticatable.rb
+++ b/lib/bearer_token/bearer_token_authenticatable.rb
@@ -2,10 +2,11 @@ module BearerTokenAuthenticatable
   class BearerToken < Devise::Strategies::Authenticatable
 
     def valid?
-      !(token_value.nil?)
+      token_valid?()
     end
 
     def authenticate!
+      return fail(:invalid_token) unless token_valid?
       resource = mapping.to.find_for_token_authentication(mapping.to.token_authentication_key => token_value)
       return fail(:invalid_token) unless resource
 
@@ -16,6 +17,18 @@ module BearerTokenAuthenticatable
     end
 
     private
+    def token_valid?
+      token = token_value
+      return false unless token
+      grant = AccessGrant.find_by_access_token(token)
+      return false unless grant && grant.client
+      return false unless grant.client.valid_from_referer?(referer)
+      return true
+    end
+
+    def referer
+      return request.env["HTTP_REFERER"]
+    end
 
     def token_value
       header = request.headers["Authorization"]

--- a/spec/controllers/admin/client_spec.rb
+++ b/spec/controllers/admin/client_spec.rb
@@ -1,0 +1,166 @@
+require 'spec_helper'
+
+describe Admin::ClientsController do
+  let(:admin_user)   { Factory.next(:admin_user)     }
+  let(:simple_user)  { Factory.next(:confirmed_user) }
+  let(:manager_user) { Factory.next(:manager_user)   }
+  let(:client_id)    { 1 }
+
+  describe "anonymous' access" do
+    before (:each) do
+      logout_user
+    end
+
+    describe "GET index" do
+      it "wont alow the index, redirects home" do
+        get :index
+        assert_redirected_to :home
+      end
+    end
+
+    describe "DELETE destroy" do
+      it "wont allow delete, redirects home" do
+        delete :destroy, :id => client_id
+        assert_redirected_to :home
+      end
+    end
+
+    describe "GET show" do
+      it "wont allow show, redirects home" do
+        get :show, :id => client_id
+        assert_redirected_to :home
+      end
+    end
+
+    describe "GET edit" do
+      it "wont allow edit, redirects home" do
+        get :show, :id => client_id
+        assert_redirected_to :home
+      end
+    end
+
+    describe "GET new" do
+      it "wont allow new, redirects home" do
+        get :new
+        assert_redirected_to :home
+      end
+    end
+
+    describe "PUT update" do
+      it "wont allow update, redirects home" do
+        put :update, :id => client_id, :client => {:params => 'params'}
+        assert_redirected_to :home
+      end
+    end
+  end
+
+  describe "manager access" do
+    before (:each) do
+      sign_in manager_user
+    end
+
+    describe "GET index" do
+      it "won't alow the index, redirects home" do
+        get :index
+        assert_redirected_to :home
+      end
+    end
+
+    describe "DELETE destroy" do
+      it "wont allow delete, redirects home" do
+        delete :destroy, :id => client_id
+        assert_redirected_to :home
+      end
+    end
+
+    describe "GET show" do
+      it "wont allow show, redirects home" do
+        get :show, :id => client_id
+        assert_redirected_to :home
+      end
+    end
+
+    describe "GET edit" do
+      it "wont allow edit, redirects home" do
+        get :edit, :id => client_id
+        assert_redirected_to :home
+      end
+    end
+
+    describe "GET new" do
+      it "wont allow new, redirects home" do
+        get :new
+        assert_redirected_to :home
+      end
+    end
+
+    describe "PUT update" do
+      it "wont allow update, redirects home" do
+        put :update, :id => client_id, :client => {:params => 'params'}
+        assert_redirected_to :home
+      end
+    end
+  end
+
+  describe "admin access" do
+    let(:stubs) { {} }
+    let(:mock_client) {
+      mock_model Client, stubs
+    }
+    before (:each) do
+      sign_in admin_user
+    end
+
+    describe "GET index" do
+      it "will render the index" do
+        get :index
+        assert_response 200
+        response.should render_template("index")
+      end
+    end
+
+    describe "DELETE destroy" do
+      it "delete, and redirect back to index" do
+        Client.should_receive(:find).and_return(mock_client)
+        delete :destroy, :id => client_id
+        assert_redirected_to action: :index
+      end
+    end
+
+    describe "GET show" do
+      it "redners the show template" do
+        Client.should_receive(:find).and_return(mock_client)
+        get :show, :id => client_id
+        assigns[:client].should eq mock_client
+        response.should render_template("show")
+      end
+    end
+
+    describe "GET edit" do
+      it "renders the edit template" do
+        Client.should_receive(:find).and_return(mock_client)
+        get :edit, :id => client_id
+        assigns[:client].should eq mock_client
+        response.should render_template("edit")
+      end
+    end
+
+    describe "GET new" do
+      it "renders the new form" do
+        get :new
+        response.should render_template("new")
+        assert_response 200
+      end
+    end
+
+    describe "PUT update" do
+      let(:stubs) {{ update_attributes: true }}
+      it "updates the model, redirects to index" do
+        Client.should_receive(:find).and_return(mock_client)
+        put :update, :id => client_id, :client => {:params => 'params'}
+        assert_redirected_to action: :index
+      end
+    end
+  end
+
+end

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+require 'delorean'
+
+# Test authentication clients
+describe Client do
+  let(:domain_machers) { nil }
+  let(:client) do
+    Client.create(
+      app_id: 'testing-client',
+      app_secret: 'xyzzy',
+      name: 'testing-client',
+      site_url: 'http://localhost:8080/',
+      domain_matchers: domain_machers
+    )
+  end
+  context "a client that isn't restricted to various domains" do
+    it "should validate from any domain" do
+      client.should be_valid_from_referer("http://blargonaut.com/")
+      client.should be_valid_from_referer("http://foo.com/blarg.html")
+    end
+  end
+  context "a client that has domains matchers set to whitespace" do
+    let(:domain_matchers) { "    \t\n   " }
+    it "should validate from any domain" do
+      client.should be_valid_from_referer("http://blargonaut.com/")
+      client.should be_valid_from_referer("http://foo.com/blarg.html")
+    end
+  end
+  context "a client that only works for foo.com or baz.com domains" do
+    let(:domain_machers) { "foo.com baz.com" }
+    it "should not validate for referers of blargonaut" do
+      client.valid_from_referer?("http://blargonaut.com/").should be_false
+      client.valid_from_referer?("http://blargonaut.com/foo.com").should be_false
+      client.valid_from_referer?("http://blargonaut.com/baz.com").should be_false
+    end
+    it "should not validate if HTTP_REFERER is missing" do
+      client.valid_from_referer?("").should be_false
+    end
+    it "should validate for referers of foo.com" do
+      client.valid_from_referer?("http://foo.com").should be_true
+      client.valid_from_referer?("https://foo.com/").should be_true
+      client.valid_from_referer?("https://foo.com/index.html").should be_true
+    end
+    it "should validate for referers of baz.com" do
+      client.valid_from_referer?("http://baz.com").should be_true
+      client.valid_from_referer?("https://baz.com/").should be_true
+      client.valid_from_referer?("https://baz.com/index.html").should be_true
+    end
+  end
+end

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -47,4 +47,26 @@ describe Client do
       client.valid_from_referer?("https://baz.com/index.html").should be_true
     end
   end
+  describe "a client with an access_grant" do
+    let(:user)  { FactoryGirl.create(:user) }
+    before(:each) do
+      user.access_grants.create(client_id: client.id )
+      user.reload
+      client.reload
+    end
+    it "should a valid access_grant" do
+      client.access_grants.should have(1).grant
+      user.access_grants.should have(1).grant
+    end
+
+    describe "deting the client" do
+      before(:each) do
+        client.destroy
+        user.reload
+      end
+      it "should remove the grants from the users" do
+        user.access_grants.should have(0).grant
+      end
+    end
+  end
 end


### PR DESCRIPTION
Not a huge set of changes.

Right now only the bearer token uses the Client domain matching restrictions.

Have a look @scytacki ?