### PR TITLE
update user listing: badges, and hidden buttons

### DIFF
--- a/app/assets/stylesheets/web/app.scss
+++ b/app/assets/stylesheets/web/app.scss
@@ -1881,3 +1881,12 @@ p.school_description {
     background-color: #ccc;
   }
 }
+
+span.badge {
+  font-size: 10px;
+  padding: 0.2em;
+  color: white;
+  margin-left: 0.2em;
+  text-transform: lowercase;
+  background-color: #479492;
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -582,15 +582,15 @@ class User < ActiveRecord::Base
   end
 
   def cohorts
-    teacher_cohorts || student_cohorts
+    teacher_cohorts | student_cohorts
   end
 
   def cohort_projects
-    teacher_cohort_projects || student_cohort_projects
+    teacher_cohort_projects | student_cohort_projects
   end
 
   def projects
-    (cohort_projects + admin_for_projects + researcher_for_projects).flatten.uniq || []
+    cohort_projects | admin_for_projects | researcher_for_projects
   end
 
   def changeable?(user)

--- a/app/policies/portal/student_policy.rb
+++ b/app/policies/portal/student_policy.rb
@@ -1,2 +1,5 @@
 class Portal::StudentPolicy < ApplicationPolicy
+  def show?
+    owner? || admin?
+  end
 end

--- a/app/policies/portal/teacher_policy.rb
+++ b/app/policies/portal/teacher_policy.rb
@@ -19,4 +19,8 @@ class Portal::TeacherPolicy < ApplicationPolicy
     end
   end
 
+  def show?
+    owner? || admin?
+  end
+
 end

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -7,12 +7,16 @@
         - if imported_user
           %span.tiny{:style=>"font-weight:normal"}
             (Imported)
+        - if user.portal_teacher
+          %span.badge= "Teacher"
+        - if user.portal_student
+          %span.badge= "Student"
       %div.action_menu_header_right
         %ul.menu
           - if (user.changeable?(current_visitor))
-            - if user.portal_teacher
-              %li.menu=link_to 'Teacher Page', portal_teacher_path(user.portal_teacher)
-            - if portal_student = user.portal_student
+            - if (portal_teacher = user.portal_teacher) && policy(portal_teacher).show?
+              %li.menu=link_to 'Teacher Page', portal_teacher_path(portal_teacher)
+            - if (portal_student = user.portal_student) && policy(portal_student).show?
               %li.menu=link_to 'Student Page', portal_student_path(portal_student)
             - if user.has_role?("admin") && !current_visitor.has_role?("admin")
               %li.menu=link_to 'edit', edit_by_project_admin_user_path(user)


### PR DESCRIPTION
if the current_user is a project_admin they cannot see the teacher or
student pages for users. This is just because there isn’t time to
fix those pages to support project_admins right now.
For consistency now there is a ‘student’ and/or ‘teacher’ badge next
to the user.
This code also fixes an issue with the `users#cohorts` method. Previously
it was returning an empty array for students because in ruby [] is true