### PR TITLE
fix User#changeable

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -598,7 +598,9 @@ class User < ActiveRecord::Base
   # The solution is that this logic should be moved to the UserPolicy instead here in the
   # model
   def changeable?(user)
-    if user.has_role?("admin", "manager")
+    if self == user
+      true
+    elsif user.has_role?("admin", "manager")
       true
     elsif user.is_project_admin?
       # A project admin can edit a student or teacher's account if the user is tagged with a cohort from one the project admin's projects

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -43,7 +43,6 @@ class UserPolicy < ApplicationPolicy
   end
 
   def preferences?
-    (user && user == record) || changeable?
+    changeable?
   end
-
 end


### PR DESCRIPTION
this allows all users to change themselves.
this fixes bugs where project admins could not save preferences,
or reset their password, or view their own user record.