### PR TITLE
allow authors to edit some of their own settings

### DIFF
--- a/app/policies/external_activity_policy.rb
+++ b/app/policies/external_activity_policy.rb
@@ -33,9 +33,11 @@ class ExternalActivityPolicy < ApplicationPolicy
     true
   end
 
-  # owners can edit some basic settings of external activities
+  # the basic edit form lets a user change the publication status, subject areas,
+  # and grade levels. So if a user can change any of those things then they should
+  # be able to see the basic form
   def edit_basic?
-    edit? || owner?
+    edit_publication_status? || edit_subject_areas? || edit_grade_levels?
   end
 
   # we need to let owners update the settings too

--- a/app/policies/material_shared_policy.rb
+++ b/app/policies/material_shared_policy.rb
@@ -19,6 +19,21 @@ module MaterialSharedPolicy
     admin? || project_admin?
   end
 
+  # owners are allowed to edit the publication status of their materials
+  def edit_publication_status?
+    edit_settings? || owner?
+  end
+
+  # owners are allowed to edit the grade levels of their materials
+  def edit_grade_levels?
+    edit_settings? || owner?
+  end
+
+  # owners are allowed to edit the subject areas of their materials
+  def edit_subject_areas?
+    edit_settings? || owner?
+  end
+
   def edit?
     edit_settings? || edit_projects? || edit_cohorts?
   end

--- a/app/policies/resource_page_policy.rb
+++ b/app/policies/resource_page_policy.rb
@@ -1,4 +1,12 @@
 class ResourcePagePolicy < ApplicationPolicy
+  def edit_grade_levels?
+    admin? || owner?
+  end
+
+  def edit_subject_areas?
+    admin? || owner?
+  end
+
   def edit_cohorts?
     admin?
   end

--- a/app/views/external_activities/_basic_form.html.haml
+++ b/app/views/external_activities/_basic_form.html.haml
@@ -1,8 +1,7 @@
 = remote_form_for(@external_activity, :complete => "close_popup();") do |f|
   = f.error_messages
   = edit_menu_for(@external_activity, f)
-  = field_set_tag 'Publication status' do
-    = f.select :publication_status, ExternalActivity.publication_states.map {|s| s.to_s}
+  = render :partial => 'shared/publication_status_edit', :locals => { :form => f, :object => @external_activity }
   = render :partial => 'shared/grade_levels_edit', :locals => { :object => @external_activity }
   = render :partial => 'shared/subject_areas_edit', :locals => { :object => @external_activity }
   = render :partial => 'shared/sensors_edit', :locals => { :object => @external_activity }

--- a/app/views/external_activities/_form.html.haml
+++ b/app/views/external_activities/_form.html.haml
@@ -21,8 +21,6 @@
       = f.text_field :teacher_guide_url, :size => 60
     = field_set_tag 'Thumbnail image URL (300 x 250 px)' do
       = f.text_field :thumbnail_url, :size => 60
-    = field_set_tag 'Publication status' do
-      = f.select :publication_status, ExternalActivity.publication_states.map {|s| s.to_s}
     = field_set_tag 'Feature On Landing Page' do
       - if current_user.has_role? 'admin','manager'
         = f.check_box :is_featured
@@ -63,11 +61,12 @@
       = f.text_field :save_path
     = render :partial => 'shared/is_assessment_item', :locals => { :form => f }
     = render :partial => 'shared/material_properties_edit', :locals => { :object => @external_activity }
-    = render :partial => 'shared/grade_levels_edit', :locals => { :object => @external_activity }
-    = render :partial => 'shared/subject_areas_edit', :locals => { :object => @external_activity }
-    = render :partial => 'shared/sensors_edit', :locals => { :object => @external_activity }
-  -# Partials below can be available for project admins (separate policy method).
+  -# Partials below can be available for project admins or owners (separate policy methods).
+  = render :partial => 'shared/publication_status_edit', :locals => { :form => f, :object => @external_activity }
   = render :partial => 'shared/projects_edit', :locals => { :object => @external_activity }
   = render :partial => 'shared/cohorts_edit', :locals => { :object => @external_activity }
+  = render :partial => 'shared/grade_levels_edit', :locals => { :object => @external_activity }
+  = render :partial => 'shared/subject_areas_edit', :locals => { :object => @external_activity }
+  = render :partial => 'shared/sensors_edit', :locals => { :object => @external_activity }
 
 = javascript_tag("focus_first_field();");

--- a/app/views/shared/_grade_levels_edit.html.haml
+++ b/app/views/shared/_grade_levels_edit.html.haml
@@ -1,5 +1,5 @@
 -# Expects locals: object
-- if object && object.respond_to?("grade_level_list") && current_visitor.has_role?("admin", "manager")
+- if object && object.respond_to?("grade_level_list") && policy(object).edit_grade_levels?
   = field_set_tag 'Grade Levels' do
     .aligned
       = hidden_field_tag :update_grade_levels, "true"

--- a/app/views/shared/_publication_status_edit.haml
+++ b/app/views/shared/_publication_status_edit.haml
@@ -1,0 +1,7 @@
+-# Expects locals: object
+- if object && object.respond_to?("publication_status") && policy(object).edit_publication_status?
+  = field_set_tag 'Publication Status' do
+    -# FIXME: We need to access the publication states that are
+    -# added by the Publishable module. These are available directly so instead we are
+    -# just pulling them from the ExternalActivity class that includes the Publishable module.
+    = form.select :publication_status, ExternalActivity.publication_states.map {|s| s.to_s}

--- a/app/views/shared/_subject_areas_edit.html.haml
+++ b/app/views/shared/_subject_areas_edit.html.haml
@@ -1,5 +1,5 @@
 -# Expects locals: object
-- if object && object.respond_to?("subject_area_list") && current_visitor.has_role?("admin", "manager")
+- if object && object.respond_to?("subject_area_list") && policy(object).edit_subject_areas?
   = field_set_tag 'Subject Areas' do
     .aligned
       = hidden_field_tag :update_subject_areas, "true"


### PR DESCRIPTION
this was partially enabled in an early PR but it wasn’t working
correctly. Now there are separate policy methods for each of the basic
material settings. These policy methods and partials are used by the External Activity forms, but they are not currently used by other material forms like Interactives, Activities, Investigations, and ResourcePages.