### PR TITLE
Center light box when editing. Its hard to find on the screen.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,6 +30,7 @@
 * =require web/report_learner
 * =require web/bad_browser
 * =require web/material_collections
+* =require web/matedit
 * =require components/materials_bin
 * =require chosen
 * =require select2

--- a/app/assets/stylesheets/web/matedit.scss
+++ b/app/assets/stylesheets/web/matedit.scss
@@ -1,0 +1,15 @@
+#iframe_container.matedit  {
+  height: 80%;
+  position: absolute;
+  width: 960px;
+  overflow: hidden;
+  margin: 0px;
+  padding: 0px;
+  iframe {
+    margin: 0px;
+    padding: 0px;
+    border: 0;
+    width: 100%;
+    position: relative;
+  }
+}

--- a/app/views/external_activities/matedit.html.haml
+++ b/app/views/external_activities/matedit.html.haml
@@ -9,21 +9,26 @@
       = link_to "Assign To Class", "javascript:void(0)",:onclick=>"get_Assign_To_Class_Popup(#{@external_activity.id}, '#{@external_activity.class.to_s}', null, true)", :class=>"button"
       = link_to "Edit Resource Options", "javascript:void(0)",:onclick=>"get_edit_resource_popup(#{@external_activity.id}, {use_short_form: true, content_height: 400})", :class=>"button"
   -#messgeedit This is edit lara activity page
-  #iframe_container
-    %iframe{:id => "Edit_in_Lara",:src =>"#{@uri}",:width => "1000",:height => "800",:style => "border :0;"}
+  #iframe_container.matedit
+    %iframe{:id => "Edit_in_Lara",:src =>"#{@uri}",:width => "1000",:height => "100%"}
 
   :javascript
-    var $iframe = jQuery("#Edit_in_Lara");
-    $iframe.on('load', function () {
-
-      // tell the iframe site manager we need the poller
-      $iframe[0].contentWindow.postMessage({iframed_site_manager: {need_height_poller: true}}, '*');
-
-      // listen for iframe site manager messages
-      jQuery(window).on('message', function (e) {
-        var data = e.originalEvent.data ? e.originalEvent.data.iframed_site_manager : null;
-        if (data && data.iframe_height) {
-          $iframe.css('height', data.iframe_height + 'px');
-        }
-      })
-    });
+    (function() {
+      var $ = jQuery;
+      var resizeIframe = function() {
+        var iframe = $("#Edit_in_Lara ");
+        var parent = $("#iframe_container");
+        var height = parent.height();
+        var offset = 150;
+        var newHeight = offset + height;
+        iframe.css('height', newHeight + "px");
+        iframe.css('top', "-" + offset + "px");
+      };
+      var registerResizeHandler = function() {
+        $(window).resize(resizeIframe);
+      };
+      $(document).ready(function() {
+        resizeIframe();
+        registerResizeHandler();
+      });
+    })();

--- a/app/views/external_activities/matedit.html.haml
+++ b/app/views/external_activities/matedit.html.haml
@@ -13,9 +13,61 @@
     %iframe{:id => "Edit_in_Lara",:src =>"#{@uri}",:width => "1000",:height => "100%"}
 
   :javascript
+
     (function() {
       var $ = jQuery;
+      var actionMenuPosition= "static";
+      var actionMenuLeft  = 0;
+      var actionMenuWidth = 0;
+      var actionMenuTop   = 0;
+
+
+      var pinActionMenu = function() {
+        var bodyScroll = $(window).scrollTop();
+
+        var saveActionMenu = function() {
+          actionMenuPosition =  $('.action_menu').css('position');
+          actionMenuWidth  =  $('.action_menu').css('width');
+          actionMenuLeft =  $('.action_menu').offset().left + "px";
+        };
+
+        var restoreActionMenu = function() {
+          $('.action_menu').css('position', actionMenuPosition || "static");
+          $('.action_menu').css('top', null);
+          $('.action_menu').css('left', null);
+          $('.action_menu').css('z-index',null);
+          $('.action_menu').css('width', actionMenuWidth);
+        };
+
+        if( $('.action_menu').css('position') != 'fixed') {
+          actionMenuTop = $('.action_menu').offset().top;
+          saveActionMenu();
+        }
+
+        if (bodyScroll > actionMenuTop) {
+          $('.action_menu').css('top', '0px');
+          $('.action_menu').css('position', 'fixed');
+          $('.action_menu').css('left', actionMenuLeft);
+          $('.action_menu').css('width', actionMenuWidth);
+          $('.action_menu').css('z-index', 10);
+        }
+        else {
+          restoreActionMenu();
+        }
+      };
+
+      var adjustIframeContainer = function() {
+        var footerHeight = $("#footer").height();
+        var headerHeight = $("#lead").height();
+        var visiblePort = window.innerHeight;
+        var miniFrameContainer = 200;
+        var computedSize = visiblePort - (footerHeight);
+        computedSize = Math.max(computedSize,miniFrameContainer);
+        $("#iframe_container").css('height', computedSize + "px");
+      };
+
       var resizeIframe = function() {
+        adjustIframeContainer();
         var iframe = $("#Edit_in_Lara ");
         var parent = $("#iframe_container");
         var height = parent.height();
@@ -24,11 +76,16 @@
         iframe.css('height', newHeight + "px");
         iframe.css('top', "-" + offset + "px");
       };
-      var registerResizeHandler = function() {
+
+      var registerListeners = function() {
         $(window).resize(resizeIframe);
+        $(window).scroll(pinActionMenu);
       };
+
       $(document).ready(function() {
+        $("#wrapper").css("min-height", null);
         resizeIframe();
-        registerResizeHandler();
+        registerListeners();
       });
+
     })();


### PR DESCRIPTION
When a teacher is editing a single-page activity and a pop-up box comes up for image or link editing, the light box is hard to find on the screen.

The fix we discussed for this was having the iframe scroll instead of automatically resizing to the size of the page.

[#112067555]
https://www.pivotaltracker.com/story/show/112067555