### PR TITLE
Project admin can mark an activity  as CC official.

### DIFF
--- a/app/views/external_activities/_form.html.haml
+++ b/app/views/external_activities/_form.html.haml
@@ -50,11 +50,9 @@
       .config
         = f.check_box :append_survey_monkey_uid
         Append a unique Survey Monkey user id to the url (e.g. http://www.surveymonkey.com/s/H2Y9H27?c=00001)
-      - project_admin = (current_visitor.admin_for_projects & @external_activity.projects).length > 0
-      -if project_admin or current_visitor.has_role? 'admin'
-        .config
-          = f.check_box :is_official
-          Designate this as an "official" Concord activity in lists
+      .config
+        = f.check_box :is_official
+        Designate this as an "official" Concord activity in lists
       .config
         = f.check_box :logging
         Enable logging on this activity (for activities that support it)

--- a/app/views/external_activities/_form.html.haml
+++ b/app/views/external_activities/_form.html.haml
@@ -50,9 +50,11 @@
       .config
         = f.check_box :append_survey_monkey_uid
         Append a unique Survey Monkey user id to the url (e.g. http://www.surveymonkey.com/s/H2Y9H27?c=00001)
-      .config
-        = f.check_box :is_official
-        Designate this as an "official" Concord activity in lists
+      - project_admin = (current_visitor.admin_for_projects & @external_activity.projects).length > 0
+      -if project_admin or current_visitor.has_role? 'admin'
+        .config
+          = f.check_box :is_official
+          Designate this as an "official" Concord activity in lists
       .config
         = f.check_box :logging
         Enable logging on this activity (for activities that support it)

--- a/app/views/external_activities/_form.html.haml
+++ b/app/views/external_activities/_form.html.haml
@@ -50,17 +50,15 @@
       .config
         = f.check_box :append_survey_monkey_uid
         Append a unique Survey Monkey user id to the url (e.g. http://www.surveymonkey.com/s/H2Y9H27?c=00001)
-      - if current_visitor.has_role? 'admin'
-        .config
-          = f.check_box :is_official
-          Designate this as an "official" Concord activity in lists
-        .config
-          = f.check_box :logging
-          Enable logging on this activity (for activities that support it)
-      - if current_visitor.has_role? 'admin'
-        .config
-          = f.check_box :is_locked
-          Do not allow to copy this activity.
+      .config
+        = f.check_box :is_official
+        Designate this as an "official" Concord activity in lists
+      .config
+        = f.check_box :logging
+        Enable logging on this activity (for activities that support it)
+      .config
+        = f.check_box :is_locked
+        Do not allow to copy this activity.
     = field_set_tag 'Save Path' do
       = f.text_field :save_path
     = render :partial => 'shared/is_assessment_item', :locals => { :form => f }

--- a/spec/views/external_activities/edit.html.haml_spec.rb
+++ b/spec/views/external_activities/edit.html.haml_spec.rb
@@ -20,5 +20,15 @@ describe "/external_activities/edit.html.haml" do
     assert_select "input[id=?]", 'external_activity_is_official', false
   end
 
+  it 'should not show the offical checkbox to project admins of the project material' do
+    common_projects = [mock_model(Admin::Project)]
+    auth_user = Factory.next(:author_user)
+    auth_user.stub!(admin_for_projects: common_projects)
+    ext_act.stub!(projects: common_projects)
+    view.stub!(:current_visitor).and_return(Factory.next(:author_user))
+    render
+    assert_select "input[id=?]", 'external_activity_is_official', false
+  end
+
   include_examples 'projects listing'
 end

--- a/spec/views/external_activities/edit.html.haml_spec.rb
+++ b/spec/views/external_activities/edit.html.haml_spec.rb
@@ -5,7 +5,6 @@ describe "/external_activities/edit.html.haml" do
 
   before(:each) do
     assigns[:external_activity] = @external_activity = ext_act
-    view.stub!(:current_visitor).and_return(Factory.next(:admin_user))
     view.stub!(:current_user).and_return(Factory.next(:admin_user))
   end
 
@@ -15,19 +14,19 @@ describe "/external_activities/edit.html.haml" do
   end
 
   it 'should not show the is_official check box to users without permissions' do
-    view.stub!(:current_visitor).and_return(Factory.next(:author_user))
+    view.stub!(:current_user).and_return(Factory.next(:author_user))
     render
     assert_select "input[id=?]", 'external_activity_is_official', false
   end
 
-  it 'should not show the offical checkbox to project admins of the project material' do
-    common_projects = [mock_model(Admin::Project)]
+  it 'should show the offical checkbox to project admins of the project material' do
+    common_projects = [mock_model(Admin::Project, cohorts: [])]
     auth_user = Factory.next(:author_user)
     auth_user.stub!(admin_for_projects: common_projects)
     ext_act.stub!(projects: common_projects)
-    view.stub!(:current_visitor).and_return(Factory.next(:author_user))
+    view.stub!(:current_user).and_return(auth_user)
     render
-    assert_select "input[id=?]", 'external_activity_is_official', false
+    assert_select "input[id=?]", 'external_activity_is_official'
   end
 
   include_examples 'projects listing'


### PR DESCRIPTION
[#113925649]

https://www.pivotaltracker.com/story/show/113925649