### PR TITLE
Fix student progress bar update

### DIFF
--- a/app/assets/javascripts/poll_to_update_student_data_percentages.js.coffee
+++ b/app/assets/javascripts/poll_to_update_student_data_percentages.js.coffee
@@ -12,6 +12,10 @@ window.poll_to_update_student_data_percentages = (options) ->
   poll_interval = DEFAULT_POLL_INTERVAL_IN_SECONDS if isNaN(poll_interval) or poll_interval < 1
   poll_interval *= 1000 if poll_interval < 1000
 
+  # timestamp defines when data has been updated for the last time.
+  # If we send it to server, it can optimize db query and return only updated offerings.
+  data_timestamp = options.data_timestamp
+
   update_percentages = (status) ->
     for report_learner in status?.report_learners
       $offering = jQuery(".offering_for_student[data-offering_id='#{report_learner.offering_id}']")
@@ -27,8 +31,11 @@ window.poll_to_update_student_data_percentages = (options) ->
   # poll for percentage updates
   poll = ->
     jQuery.ajax options.poll_url,
+      data:
+        offerings_updated_after: data_timestamp
       success: (status) ->
         update_percentages status
+        data_timestamp = status.timestamp
         setTimeout poll, poll_interval
 
   # wait for the initial poll

--- a/app/assets/javascripts/poll_to_update_student_data_percentages.js.coffee
+++ b/app/assets/javascripts/poll_to_update_student_data_percentages.js.coffee
@@ -18,7 +18,10 @@ window.poll_to_update_student_data_percentages = (options) ->
       if $offering and report_learner.last_run
         $offering.find('.last_run').html(report_learner.last_run)
         $offering.find('.status_graphs .not_run').hide()
-        $offering.find('.status_graphs .progress').css({width: "#{report_learner.percentage}%"})
+        $offering.find('.status_graphs .summary .progress').css({width: "#{report_learner.complete_percent}%"})
+        $offering.find('.status_graphs .details .progress').each((idx) ->
+          jQuery(this).css({width: "#{report_learner.subsection_complete_percent[idx]}%"})
+        )
         $offering.find('.status_graphs .run_graph').show()
 
   # poll for percentage updates

--- a/app/controllers/portal/students_controller.rb
+++ b/app/controllers/portal/students_controller.rb
@@ -14,7 +14,7 @@ class Portal::StudentsController < ApplicationController
     # authorize @student
     # authorize Portal::Student, :new_or_create?
     # authorize @student, :update_edit_or_destroy?
-    result = Portal::Student.find(params[:id]).status
+    result = Portal::Student.find(params[:id]).status(params[:offerings_updated_after] || 0)
     respond_to do |format|
       format.xml { render :xml => result }
       format.json { render :json => result }

--- a/app/models/portal/learner.rb
+++ b/app/models/portal/learner.rb
@@ -3,7 +3,7 @@ class Portal::Learner < ActiveRecord::Base
 
   self.table_name = :portal_learners
   
-  default_scope :order => 'student_id ASC'
+  default_scope :order => 'portal_learners.student_id ASC'
   
   acts_as_replicatable
   

--- a/app/models/portal/student.rb
+++ b/app/models/portal/student.rb
@@ -65,11 +65,18 @@ class Portal::Student < ActiveRecord::Base
   end
 
   def status
-    report_learners = Report::Learner.where(:student_id => self.id).map do |learner|
+    report_learners = Portal::Learner.where(:student_id => self.id).map do |learner|
+      student_status = Report::OfferingStudentStatus.new
+      student_status.student = self
+      student_status.learner = learner
+      student_status.offering = learner.offering
       {
-        :offering_id => learner.offering_id,
-        :complete_percent => learner.complete_percent,
-        :last_run => learner.last_run_string
+        :offering_id => student_status.offering.id,
+        :last_run => student_status.last_run_string,
+        :complete_percent => student_status.complete_percent,
+        :subsection_complete_percent => student_status.sub_sections.map do |activity|
+          student_status.activity_complete_percent(activity)
+        end
       }
     end
     {

--- a/app/models/portal/student.rb
+++ b/app/models/portal/student.rb
@@ -65,7 +65,8 @@ class Portal::Student < ActiveRecord::Base
   end
 
   def status
-    report_learners = Portal::Learner.where(:student_id => self.id).map do |learner|
+    report_learners = Portal::Learner.includes({offering: {runnable: :template}}, :report_learner, :learner_activities)
+                                     .where(:student_id => self.id).map do |learner|
       student_status = Report::OfferingStudentStatus.new
       student_status.student = self
       student_status.learner = learner

--- a/app/views/portal/students/_show.html.haml
+++ b/app/views/portal/students/_show.html.haml
@@ -3,8 +3,11 @@
 - unless current_visitor.anonymous?
   %h3 Classes and Offerings:
   = render :partial => 'portal/clazzes/list_for_student', :locals => { :portal_student => portal_student }
-  - poll_options = {poll_url: status_portal_student_url(portal_student.id, :format => :json), poll_interval: ENV['PORTAL_STUDENT_STATUS_UPDATE_POLL_INTERVAL_IN_SECONDS']}
   - # note: there is a default value for the poll interval in the javascript
+  - #       timestamp is generated on server, as it more reliable
+  - poll_options = {poll_url: status_portal_student_url(portal_student.id, :format => :json),
+                    poll_interval: ENV['PORTAL_STUDENT_STATUS_UPDATE_POLL_INTERVAL_IN_SECONDS'],
+                    data_timestamp: Time.now.to_i}
   :javascript
     poll_to_update_student_data_percentages(#{ poll_options.to_json })
 

--- a/app/views/shared/_offering_for_student.html.haml
+++ b/app/views/shared/_offering_for_student.html.haml
@@ -1,5 +1,4 @@
 - offering_status = Report::OfferingStatus.new(offering)
-- offering_statuses = [offering_status]
 - student_status = offering_status.student_status_for(@portal_student)
 / TODO move the above outside of the view.
 .offering_container


### PR DESCRIPTION
Progress bar is dynamically updated now (together with last run date and report link).
Some property names didn't match before and some information was missing (completion of the subsections / activities). I've used `Report::OfferingStudentStatus` for the Ajax update which is used by the regular view code on page (re)load, so hopefully things should be consistent.