### PR TITLE
New report API

### DIFF
--- a/app/controllers/api/v1/reports_controller.rb
+++ b/app/controllers/api/v1/reports_controller.rb
@@ -1,0 +1,190 @@
+class API::V1::ReportsController < API::APIController
+  rescue_from Pundit::NotAuthorizedError, with: :pundit_user_not_authorized
+
+  def pundit_user_not_authorized(exception)
+    unauthorized
+  end
+
+  # GET api/v1/reports/offering?id=:id
+  # Example response: https://gist.github.com/pjanik/b831b67f659e709931bf
+  def offering
+    offering = Portal::Offering.find(params[:id])
+    authorize offering, :api_report?
+    render json: response_json(offering)
+  end
+
+  private
+
+  def response_json(offering)
+    answers_hash = get_student_answers(offering)
+    embeddable_filter = offering.report_embeddable_filter
+    visibility_hash  = Hash[embeddable_filter.embeddables.collect { |v| [embeddable_key(v), true] }]
+    {
+      embeddables_filtering_enabled: !embeddable_filter.ignore,
+      # Might be useful e.g. to filter out sections that doesn't make sense in LARA activities context.
+      is_offering_external: offering.runnable.is_a?(ExternalActivity),
+      class: class_json(offering),
+      report: report_json(offering, answers_hash, visibility_hash)
+    }
+  end
+
+  # Helpers that provide class description:
+
+  def class_json(offering)
+    clazz = offering.clazz
+    section = clazz.section && clazz.section.length > 0 ? clazz.section : nil
+    section = section ? " (#{section})" : ""
+    {
+      name: clazz.name + section,
+      students: clazz.students.includes(:user).map { |s| student_json(s, offering) }
+    }
+  end
+
+  def student_json(student, offering)
+    started_offering = student.report_learners.where(offering_id: offering.id).count > 0
+    {
+      id: student.id,
+      name: student.name,
+      started_offering:  started_offering
+    }
+  end
+
+  # Helpers that provide student answers grouped by embeddable key:
+
+  def get_student_answers(offering)
+    # Collect all the student answers for given offering.
+    answers = Report::Learner.where(offering_id: offering.id).map do |report_learner|
+      student_name = report_learner.student_name
+      student_id = report_learner.student_id
+      answers = []
+      report_learner.answers.map do |embeddable_key, answer|
+        answer[:embeddable_key] = embeddable_key
+        answer[:student_id] = student_id
+        answer[:student_name] = student_name
+        # Process some answers type to provide cleaner format, names, etc.
+        question_type = embeddable_type(embeddable_key)
+        if question_type == 'Embeddable::MultipleChoice'
+          process_multiple_choice_answer(answer)
+        elsif question_type == 'Embeddable::ImageQuestion'
+          process_image_question_answer(answer)
+        end
+        answers.push(answer)
+      end
+      answers
+    end
+    # Flatten answers and group them by the embeddable key.
+    answers.flatten.group_by { |a| a[:embeddable_key] }
+  end
+
+  def process_multiple_choice_answer(hash)
+    # Make naming more consistent, otherwise we would have crazy sequence of [:answers][:answer][:answer] keys.
+    hash[:answer] = hash[:answer].map do |a|
+      {
+        choice: a[:answer],
+        is_correct: a[:correct]
+      }
+    end
+  end
+
+  def process_image_question_answer(hash)
+    # Filter out useless Blob description, provide image URL instead (and note / annotation).
+    ans = hash[:answer]
+    if ans[:type] === 'Dataservice::Blob'
+      ans[:image_url] = dataservice_blob_raw_url(id: ans[:id], token: ans[:token])
+      # Skip unnecessary attributes, leave only image url and note.
+      ans.slice!(:image_url, :note)
+    end
+  end
+
+  # Helpers that provide the final structure of an offering plus visibility and related answers for each question:
+
+  def report_json(offering, answers, visibility)
+    runnable = offering.runnable
+    if runnable.is_a?(ExternalActivity) && runnable.template
+      runnable = runnable.template
+    end
+    # Provide chain of associations to load to avoid N+1 queries (values obtained thanks to Bullet gem).
+    associations_to_load = {sections: {pages: [{page_elements: :embeddable}, :section, {inner_page_pages: :inner_page}]}}
+    if runnable.is_a? Investigation
+      investigation_json(runnable, answers, visibility, associations_to_load)
+    elsif runnable.is_a? Activity
+      activity_json(runnable, answers, visibility, associations_to_load[:sections])
+    end
+  end
+
+  def investigation_json(investigation, answers, visibility, associations_to_load=nil)
+    activities = associations_to_load ? investigation.activities.includes(associations_to_load) : investigation.activities
+    {
+      id: investigation.id,
+      type: 'Investigation',
+      name: investigation.name,
+      children: activities.map { |a| activity_json(a, answers, visibility) }
+    }
+  end
+
+  def activity_json(activity, answers, visibility, associations_to_load=nil)
+    sections = associations_to_load ? activity.sections.includes(associations_to_load) : activity.sections
+    {
+      id: activity.id,
+      type: 'Activity',
+      name: activity.name,
+      children: sections.map { |s| section_json(s, answers, visibility) }
+    }
+  end
+
+  def section_json(section, answers, visibility)
+    {
+      id: section.id,
+      type: 'Section',
+      name: section.name,
+      children: section.pages.map { |p| page_json(p, answers, visibility) }
+    }
+  end
+
+  def page_json(page, answers, visibility)
+    {
+      id: page.id,
+      type: 'Page',
+      name: page.name,
+      children: page.page_elements.map { |pe| embeddable_json(pe.embeddable, answers, visibility) }
+    }
+  end
+
+  IGNORED_EMBEDDABLE_KEYS = ['created_at', 'updated_at', 'uuid', 'user_id', 'external_id']
+
+  def embeddable_json(embeddable, answers, visibility)
+    # Provide as much information about embeddable as we can, but skip some attributes
+    # to make results more readable and clean.
+    hash = embeddable.attributes.clone.except(*IGNORED_EMBEDDABLE_KEYS)
+    key = embeddable_key(embeddable)
+    hash[:type] = embeddable.class.to_s
+    hash[:visible_in_report] = visibility.fetch(key, false)
+    hash[:answers] = answers[key]
+    if embeddable.is_a? Embeddable::MultipleChoice
+      process_multiple_choice(hash, embeddable)
+    end
+    hash
+  end
+
+  def process_multiple_choice(hash, embeddable)
+    # Add available choices list.
+    hash[:choices] = embeddable.choices.map do |c|
+      {
+        id: c.id,
+        choice: c.choice,
+        is_correct: c.is_correct
+      }
+    end
+  end
+
+  # Other helpers:
+
+  def embeddable_key(embeddable)
+    "#{embeddable.class.to_s}|#{embeddable.id}"
+  end
+
+  def embeddable_type(embeddable_key)
+    embeddable_key.split('|')[0]
+  end
+
+end

--- a/app/controllers/api/v1/reports_controller.rb
+++ b/app/controllers/api/v1/reports_controller.rb
@@ -5,186 +5,34 @@ class API::V1::ReportsController < API::APIController
     unauthorized
   end
 
-  # GET api/v1/reports/offering?id=:id
-  # Example response: https://gist.github.com/pjanik/b831b67f659e709931bf
-  def offering
+  # GET api/v1/reports/:id
+  def show
     offering = Portal::Offering.find(params[:id])
-    authorize offering, :api_report?
-    render json: response_json(offering)
+    # authorize offering, :api_report?
+    render json: API::V1::Report.new(offering, request.protocol, request.host_with_port).to_json
+  end
+
+  # POST api/v1/reports/:id
+  def update
+    offering = Portal::Offering.find(params[:id])
+    # authorize offering, :api_report?
+    puts params
+    if params[:visibility_filter]
+      update_visibility_filter(offering.report_embeddable_filter, params[:visibility_filter])
+    end
+    offering.update_attributes!(report_params)
+    head :ok
   end
 
   private
 
-  def response_json(offering)
-    answers_hash = get_student_answers(offering)
-    embeddable_filter = offering.report_embeddable_filter
-    visibility_hash  = Hash[embeddable_filter.embeddables.collect { |v| [embeddable_key(v), true] }]
-    {
-      embeddables_filtering_enabled: !embeddable_filter.ignore,
-      # Might be useful e.g. to filter out sections that doesn't make sense in LARA activities context.
-      is_offering_external: offering.runnable.is_a?(ExternalActivity),
-      class: class_json(offering),
-      report: report_json(offering, answers_hash, visibility_hash)
-    }
+  def update_visibility_filter(filter, filter_params)
+    filter.embeddable_keys = filter_params[:questions] unless filter_params[:questions].nil?
+    filter.ignore = !filter_params[:active]            unless filter_params[:active].nil?
+    filter.save!
   end
 
-  # Helpers that provide class description:
-
-  def class_json(offering)
-    clazz = offering.clazz
-    section = clazz.section && clazz.section.length > 0 ? clazz.section : nil
-    section = section ? " (#{section})" : ""
-    {
-      name: clazz.name + section,
-      students: clazz.students.includes(:user).map { |s| student_json(s, offering) }
-    }
+  def report_params
+    params.permit(:anonymous_report)
   end
-
-  def student_json(student, offering)
-    started_offering = student.report_learners.where(offering_id: offering.id).count > 0
-    {
-      id: student.id,
-      name: student.name,
-      started_offering:  started_offering
-    }
-  end
-
-  # Helpers that provide student answers grouped by embeddable key:
-
-  def get_student_answers(offering)
-    # Collect all the student answers for given offering.
-    answers = Report::Learner.where(offering_id: offering.id).map do |report_learner|
-      student_name = report_learner.student_name
-      student_id = report_learner.student_id
-      answers = []
-      report_learner.answers.map do |embeddable_key, answer|
-        answer[:embeddable_key] = embeddable_key
-        answer[:student_id] = student_id
-        answer[:student_name] = student_name
-        # Process some answers type to provide cleaner format, names, etc.
-        question_type = embeddable_type(embeddable_key)
-        if question_type == 'Embeddable::MultipleChoice'
-          process_multiple_choice_answer(answer)
-        elsif question_type == 'Embeddable::ImageQuestion'
-          process_image_question_answer(answer)
-        end
-        answers.push(answer)
-      end
-      answers
-    end
-    # Flatten answers and group them by the embeddable key.
-    answers.flatten.group_by { |a| a[:embeddable_key] }
-  end
-
-  def process_multiple_choice_answer(hash)
-    # Make naming more consistent, otherwise we would have crazy sequence of [:answers][:answer][:answer] keys.
-    hash[:answer] = hash[:answer].map do |a|
-      {
-        choice: a[:answer],
-        is_correct: a[:correct]
-      }
-    end
-  end
-
-  def process_image_question_answer(hash)
-    # Filter out useless Blob description, provide image URL instead (and note / annotation).
-    ans = hash[:answer]
-    if ans[:type] === 'Dataservice::Blob'
-      ans[:image_url] = dataservice_blob_raw_url(id: ans[:id], token: ans[:token])
-      # Skip unnecessary attributes, leave only image url and note.
-      ans.slice!(:image_url, :note)
-    end
-  end
-
-  # Helpers that provide the final structure of an offering plus visibility and related answers for each question:
-
-  def report_json(offering, answers, visibility)
-    runnable = offering.runnable
-    if runnable.is_a?(ExternalActivity) && runnable.template
-      runnable = runnable.template
-    end
-    # Provide chain of associations to load to avoid N+1 queries (values obtained thanks to Bullet gem).
-    associations_to_load = {sections: {pages: [{page_elements: :embeddable}, :section, {inner_page_pages: :inner_page}]}}
-    if runnable.is_a? Investigation
-      investigation_json(runnable, answers, visibility, associations_to_load)
-    elsif runnable.is_a? Activity
-      activity_json(runnable, answers, visibility, associations_to_load[:sections])
-    end
-  end
-
-  def investigation_json(investigation, answers, visibility, associations_to_load=nil)
-    activities = associations_to_load ? investigation.activities.includes(associations_to_load) : investigation.activities
-    {
-      id: investigation.id,
-      type: 'Investigation',
-      name: investigation.name,
-      children: activities.map { |a| activity_json(a, answers, visibility) }
-    }
-  end
-
-  def activity_json(activity, answers, visibility, associations_to_load=nil)
-    sections = associations_to_load ? activity.sections.includes(associations_to_load) : activity.sections
-    {
-      id: activity.id,
-      type: 'Activity',
-      name: activity.name,
-      children: sections.map { |s| section_json(s, answers, visibility) }
-    }
-  end
-
-  def section_json(section, answers, visibility)
-    {
-      id: section.id,
-      type: 'Section',
-      name: section.name,
-      children: section.pages.map { |p| page_json(p, answers, visibility) }
-    }
-  end
-
-  def page_json(page, answers, visibility)
-    {
-      id: page.id,
-      type: 'Page',
-      name: page.name,
-      children: page.page_elements.map { |pe| embeddable_json(pe.embeddable, answers, visibility) }
-    }
-  end
-
-  IGNORED_EMBEDDABLE_KEYS = ['created_at', 'updated_at', 'uuid', 'user_id', 'external_id']
-
-  def embeddable_json(embeddable, answers, visibility)
-    # Provide as much information about embeddable as we can, but skip some attributes
-    # to make results more readable and clean.
-    hash = embeddable.attributes.clone.except(*IGNORED_EMBEDDABLE_KEYS)
-    key = embeddable_key(embeddable)
-    hash[:type] = embeddable.class.to_s
-    hash[:visible_in_report] = visibility.fetch(key, false)
-    hash[:answers] = answers[key]
-    if embeddable.is_a? Embeddable::MultipleChoice
-      process_multiple_choice(hash, embeddable)
-    end
-    hash
-  end
-
-  def process_multiple_choice(hash, embeddable)
-    # Add available choices list.
-    hash[:choices] = embeddable.choices.map do |c|
-      {
-        id: c.id,
-        choice: c.choice,
-        is_correct: c.is_correct
-      }
-    end
-  end
-
-  # Other helpers:
-
-  def embeddable_key(embeddable)
-    "#{embeddable.class.to_s}|#{embeddable.id}"
-  end
-
-  def embeddable_type(embeddable_key)
-    embeddable_key.split('|')[0]
-  end
-
 end

--- a/app/controllers/api/v1/reports_controller.rb
+++ b/app/controllers/api/v1/reports_controller.rb
@@ -12,7 +12,7 @@ class API::V1::ReportsController < API::APIController
     render json: API::V1::Report.new(offering, request.protocol, request.host_with_port).to_json
   end
 
-  # POST api/v1/reports/:id
+  # PUT api/v1/reports/:id
   def update
     offering = Portal::Offering.find(params[:id])
     # authorize offering, :api_report?

--- a/app/controllers/api/v1/reports_controller.rb
+++ b/app/controllers/api/v1/reports_controller.rb
@@ -8,15 +8,14 @@ class API::V1::ReportsController < API::APIController
   # GET api/v1/reports/:id
   def show
     offering = Portal::Offering.find(params[:id])
-    # authorize offering, :api_report?
+    authorize offering, :api_report?
     render json: API::V1::Report.new(offering, request.protocol, request.host_with_port).to_json
   end
 
   # PUT api/v1/reports/:id
   def update
     offering = Portal::Offering.find(params[:id])
-    # authorize offering, :api_report?
-    puts params
+    authorize offering, :api_report?
     if params[:visibility_filter]
       update_visibility_filter(offering.report_embeddable_filter, params[:visibility_filter])
     end
@@ -27,6 +26,8 @@ class API::V1::ReportsController < API::APIController
   private
 
   def update_visibility_filter(filter, filter_params)
+    # In some cases client can send only one parameter, so make sure that the second one won't be affected.
+    # Note that we should accept an empty array, so #present? or #blank? can't be used here.
     filter.embeddable_keys = filter_params[:questions] unless filter_params[:questions].nil?
     filter.ignore = !filter_params[:active]            unless filter_params[:active].nil?
     filter.save!

--- a/app/models/api/v1/report.rb
+++ b/app/models/api/v1/report.rb
@@ -1,0 +1,228 @@
+class API::V1::Report
+  include RailsPortal::Application.routes.url_helpers
+
+  def initialize(offering, protocol, host_with_port)
+    @offering = offering
+    @protocol = protocol
+    @host_with_port = host_with_port
+  end
+
+  def to_json
+    clazz = class_json
+    answers_hash = get_student_answers
+    provide_no_answer_entries(answers_hash, clazz[:students])
+    {
+      # Might be useful e.g. to filter out sections that doesn't make sense in LARA activities context.
+      report: report_json(answers_hash),
+      class: clazz,
+      visibility_filter: visibility_filter_json(@offering.report_embeddable_filter),
+      anonymous_report: @offering.anonymous_report,
+      is_offering_external: @offering.runnable.is_a?(ExternalActivity)
+    }
+  end
+
+  # Helpers that provide class description:
+
+  def class_json
+    clazz = @offering.clazz
+    section = clazz.section && clazz.section.length > 0 ? clazz.section : nil
+    section = section ? " (#{section})" : ""
+    {
+      name: clazz.name + section,
+      students: clazz.students.includes(:user).map { |s| student_json(s) }.sort_by { |s| s[:name] }
+    }
+  end
+
+  def student_json(student)
+    started_offering = student.report_learners.where(offering_id: @offering.id).count > 0
+    {
+      id: student.id,
+      name: student.name,
+      started_offering:  started_offering
+    }
+  end
+
+  # Helpers that provide student answers grouped by embeddable key:
+
+  def get_student_answers
+    # Collect all the student answers for given offering.
+    answers = Report::Learner.where(offering_id: @offering.id).map do |report_learner|
+      student_id = report_learner.student_id
+      student_name = report_learner.student_name
+      answers = []
+      report_learner.answers.map do |embeddable_key, answer|
+        # Process some answers type to provide cleaner format, names, etc.
+        question_type = embeddable_type(embeddable_key)
+        answer[:type] = question_type
+        answer[:embeddable_key] = embeddable_key
+        answer[:student_id] = student_id
+        answer[:student_name] = student_name
+        if question_type == 'Embeddable::MultipleChoice'
+          process_multiple_choice_answer(answer)
+        elsif question_type == 'Embeddable::ImageQuestion'
+          process_image_question_answer(answer)
+        end
+        answers.push(answer)
+      end
+      answers
+    end
+    # Flatten answers and group them by the embeddable key.
+    answers.flatten.sort_by { |s| s[:student_name] }.group_by { |a| a[:embeddable_key] }
+  end
+
+  def provide_no_answer_entries(answers, students_json)
+    # Provide "no answer" entries for students who started activity, but didn't respond to given question.
+    default_answer_entries = students_json.select { |s| s[:started_offering] }.map do |s|
+      {
+        student_id: s[:id],
+        student_name: s[:name],
+        answer: nil,
+        type: 'NoAnswer'
+      }
+    end
+    answers.each do |embeddable_key, embeddable_answers|
+      student_found = {}
+      embeddable_answers.each { |answer| student_found[answer[:student_id]] = true }
+      default_answer_entries.each do |default_answer|
+        unless student_found.fetch(default_answer[:student_id], false)
+          answers[embeddable_key].push(default_answer)
+        end
+      end
+    end
+  end
+
+  def process_multiple_choice_answer(hash)
+    # Make naming more consistent, otherwise we would have crazy sequence of [:answers][:answer][:answer] keys.
+    hash[:answer] = hash[:answer].map do |a|
+      {
+        choice: a[:answer],
+        is_correct: a[:correct]
+      }
+    end
+  end
+
+  def process_image_question_answer(hash)
+    # Filter out useless Blob description, provide image URL instead (and note / annotation).
+    ans = hash[:answer]
+    if ans[:type] === 'Dataservice::Blob'
+      ans[:image_url] = dataservice_blob_raw_url(id: ans[:id], token: ans[:token],
+                                                 protocol: @protocol, host: @host_with_port)
+      # Skip unnecessary attributes, leave only image url and note.
+      ans.slice!(:image_url, :note)
+    end
+  end
+
+  # Helpers that provide the final structure of an offering plus related answers for each question:
+
+  def report_json(answers)
+    runnable = @offering.runnable
+    if runnable.is_a?(ExternalActivity) && runnable.template
+      runnable = runnable.template
+    end
+    # Provide chain of associations to load to avoid N+1 queries (values obtained thanks to Bullet gem).
+    associations_to_load = {sections: {pages: [{page_elements: :embeddable}, :section, {inner_page_pages: :inner_page}]}}
+    if runnable.is_a? Investigation
+      investigation_json(runnable, answers, associations_to_load)
+    elsif runnable.is_a? Activity
+      activity_json(runnable, answers, associations_to_load[:sections])
+    end
+  end
+
+  def investigation_json(investigation, answers, associations_to_load=nil)
+    activities = associations_to_load ? investigation.activities.includes(associations_to_load) : investigation.activities
+    {
+      id: investigation.id,
+      type: 'Investigation',
+      name: investigation.name,
+      children: activities.map { |a| activity_json(a, answers) }
+    }
+  end
+
+  def activity_json(activity, answers, associations_to_load=nil)
+    sections = associations_to_load ? activity.sections.includes(associations_to_load) : activity.sections
+    {
+      id: activity.id,
+      type: 'Activity',
+      name: activity.name,
+      children: sections.map { |s| section_json(s, answers) }
+    }
+  end
+
+  def section_json(section, answers)
+    {
+      id: section.id,
+      type: 'Section',
+      name: section.name,
+      children: section.pages.map { |p| page_json(p, answers) }
+    }
+  end
+
+  def page_json(page, answers)
+    {
+      id: page.id,
+      type: 'Page',
+      name: page.name,
+      children: page.page_elements.map { |pe| embeddable_json(pe.embeddable, answers) }
+    }
+  end
+
+  IGNORED_EMBEDDABLE_KEYS = ['created_at', 'updated_at', 'uuid', 'user_id', 'external_id']
+
+  def embeddable_json(embeddable, answers)
+    # Provide as much information about embeddable as we can, but skip some attributes
+    # to make results more readable and clean.
+    hash = embeddable.attributes.clone.except(*IGNORED_EMBEDDABLE_KEYS)
+    key = embeddable_key(embeddable)
+    hash[:key] = key
+    hash[:type] = embeddable.class.to_s
+    hash[:children] = answers[key]
+
+    if embeddable.is_a? Embeddable::MultipleChoice
+      process_multiple_choice(hash, embeddable)
+    elsif embeddable.is_a? Embeddable::Iframe
+      process_iframe(hash, embeddable)
+    end
+    hash
+  end
+
+  def process_multiple_choice(hash, embeddable)
+    # Add available choices list.
+    hash[:choices] = embeddable.choices.map do |c|
+      {
+        id: c.id,
+        choice: c.choice,
+        is_correct: c.is_correct
+      }
+    end
+  end
+
+  def process_iframe(hash, embeddable)
+    # Filter out null answers.
+    hash[:children].select { |a| a[:answer].present? }.each do |answer|
+      # Pass these properties to answer too.
+      answer[:display_in_iframe] = embeddable.display_in_iframe
+      answer[:width] = embeddable.width
+      answer[:height] = embeddable.height
+    end
+  end
+
+  # Visibility filter:
+
+  def visibility_filter_json(filter)
+    {
+      active: !filter.ignore,
+      questions: filter.embeddable_keys
+    }
+  end
+
+  # Other helpers:
+
+  def embeddable_key(embeddable)
+    "#{embeddable.class.to_s}|#{embeddable.id}"
+  end
+
+  def embeddable_type(embeddable_key)
+    embeddable_key.split('|')[0]
+  end
+
+end

--- a/app/models/portal/student.rb
+++ b/app/models/portal/student.rb
@@ -13,6 +13,7 @@ class Portal::Student < ActiveRecord::Base
   # has_many :schools, :through => :school_memberships, :class_name => "Portal::School"
 
   has_many :learners, :dependent => :destroy , :class_name => "Portal::Learner", :foreign_key => "student_id"
+  has_many :report_learners, :class_name => "Report::Learner"
   has_many :student_clazzes, :dependent => :destroy, :class_name => "Portal::StudentClazz", :foreign_key => "student_id"
 
   has_many :clazzes, :through => :student_clazzes, :class_name => "Portal::Clazz"

--- a/app/models/report/embeddable_filter.rb
+++ b/app/models/report/embeddable_filter.rb
@@ -25,6 +25,19 @@ class Report::EmbeddableFilter < ActiveRecord::Base
     write_attribute(:embeddables, items)
     @embeddables_internal = array
   end
+
+  def embeddable_keys
+    read_attribute(:embeddables).map { |em| "#{em[:type]}|#{em[:id]}" }
+  end
+
+  def embeddable_keys=(array)
+    items = array.map do |key|
+      keyPair = key.split('|')
+      {type: keyPair[0], id: keyPair[1]}
+    end
+    write_attribute(:embeddables, items)
+    @embeddables_internal = nil
+  end
   
   def clear
     self.update_attribute(:embeddables, [])

--- a/app/policies/portal/offering_policy.rb
+++ b/app/policies/portal/offering_policy.rb
@@ -4,6 +4,11 @@ class Portal::OfferingPolicy < ApplicationPolicy
     class_teacher_or_admin?
   end
 
+  # Used by API::V1::ReportsController:
+  def api_report?
+    class_teacher_or_admin?
+  end
+
   # Used by Portal::OfferingsController:
   def show?
     class_teacher_or_admin? || (class_student? && !record.locked)

--- a/config/application.rb
+++ b/config/application.rb
@@ -122,6 +122,7 @@ module RailsPortal
         resource '/interactives/export_model_library', :headers => :any, :methods => :get
         # always allow access to the class#info
         resource '/portal/classes/info', :headers => :any, :methods => :get
+        resource '/api/v1/reports/*', :headers => :any, :methods => [:get, :put]
       end
 
       # Set up custom CORS, if the environment variable PORTAL_FEATURES includes "allow_cors".

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -683,6 +683,9 @@ RailsPortal::Application.routes.draw do
         namespace :answers do
           get :student_answers
         end
+        namespace :reports do
+          get :offering
+        end
         resources :offerings, only: [:show]
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -683,9 +683,7 @@ RailsPortal::Application.routes.draw do
         namespace :answers do
           get :student_answers
         end
-        namespace :reports do
-          get :offering
-        end
+        resources :reports, only: [:show, :update]
         resources :offerings, only: [:show]
       end
     end


### PR DESCRIPTION
`GET api/v1/reports/offering?id=:id`
Example response: https://gist.github.com/pjanik/b831b67f659e709931bf

It provides some basic information, students list and finally the report structure. It's a tree: (investigation) -> activities -> sections -> pages -> questions -> answers. If offering is an activity, the root will be different (activity). It includes filters settings too (`visible_in_report`).

We don't necessarily need to merge it very soon, things might change a few times once I start working on the client side. However some initial feedback, especially regarding structure and general approach, would be useful. 

@scytacki, @knowuh, a few general notes following our discussion on Monday:
I decided not to use Doug's `api/v1/answer_controller`. It provides students answer, but the format wouldn't be really useful for me. Also, it seems to have lots of raw SQL, maybe it makes sense due to performance reasons in this case (as it provides way more data than my single report), but it wouldn't be too easy to customize it. Also, obtaining students answer was actually the easiest part of this work (just read `Report::Learners`). 

I was trying to follow what's going on when we render the current report and base implementation on it, so hopefully things still work in the same way. The old controller itself is actually very simple, but it passes a bunch of objects to view and then the craziness begins. Views call helpers, partials, then some models, then you go back to view, plus there are some weird intermediate objects (Saveables, Standins) and so on. I tried to simplify it as much as I could, provide minimum information which is necessary to generate current report and move rest of the logic to React components. Yes, I might have missed something important, but I feel it's better to test it in practice rather than try to untangle the old code. Once we're sure that it's working, I hope we can get rid of many files, e.g. [report/util.js](https://github.com/concord-consortium/rigse/blob/master/app/models/report/util.rb). I feel the old code is overly complicated as it randomly tries to cache and pre-calculate various things, so views don't hit DB too many times. JSON structure should solve that issue. I tried not to use old helpers at all, even if some methods were useful, and to keep all the logic in this one controller. If it works and we could limit report generation to < 200 lines, it would be great.

Performance should also be way better, probably we can even implement live reload of the report (easy with React).