### PR TITLE
handle no recent learner events

### DIFF
--- a/app/models/learner_processing_event.rb
+++ b/app/models/learner_processing_event.rb
@@ -7,6 +7,9 @@ class LearnerProcessingEvent < ActiveRecord::Base
 
   # Humanize duration seconds, similar to ActiveSupport's distance_of_time_in_words
   def self.humanize(secs)
+    if secs.nil?
+      return "N/A"
+    end
     [[60, :seconds], [60, :minutes], [24, :hours], [1000, :days]].map{ |count, name|
       if secs > 0
         secs, n = secs.divmod(count)

--- a/spec/models/learner_processing_event_spec.rb
+++ b/spec/models/learner_processing_event_spec.rb
@@ -36,5 +36,14 @@ describe LearnerProcessingEvent do
       expect(record.duration).to match "2 minutes"
     end
   end
+  describe "The expected average" do
+    it "should be N/A when there is no data" do
+      expect(LearnerProcessingEvent.human_avg(12)).to match "N/A"
+    end
 
+    it "should be a human readable form of the time since the lara_start" do
+      record.save!
+      expect(LearnerProcessingEvent.human_avg(12)).to match "10 minutes 0 seconds"
+    end
+  end
 end


### PR DESCRIPTION
If there were no recent learner events the learner processing time view would throw an exception this patch fixes that.

After merging with master I'll also merge with a v1.5.x branch so this can be released with the 1.5.0 release.