### PR TITLE
allow project admin to authorize users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -212,9 +212,9 @@ class UsersController < ApplicationController
 
   #Used for activation of users by a manager/admin
   def confirm
-    authorize User
-    user = User.find(params[:id]) unless params[:id].blank?
-    if !params[:id].blank? && user && user.state != "active"
+    user = User.find(params[:id])
+    authorize user
+    if user.state != "active"
       user.confirm!
       user.make_user_a_member
       # assume this type of user just activated someone from somewhere else in the app


### PR DESCRIPTION
This also simplifies the action a bit. It should be an error if the id is not set on the request so throwing a exception in that case seems fine.

This action was not working correctly because the `User` class was being authenticated not the `user` instance.