### PR TITLE
Change `children` to `responses` in report api format

### DIFF
--- a/app/models/api/v1/report.rb
+++ b/app/models/api/v1/report.rb
@@ -93,6 +93,7 @@ class API::V1::Report
     # Make naming more consistent, otherwise we would have crazy sequence of [:answers][:answer][:answer] keys.
     hash[:answer] = hash[:answer].map do |a|
       {
+        id: a[:id],
         choice: a[:answer],
         is_correct: a[:correct]
       }

--- a/app/models/api/v1/report.rb
+++ b/app/models/api/v1/report.rb
@@ -173,7 +173,7 @@ class API::V1::Report
     key = embeddable_key(embeddable)
     hash[:key] = key
     hash[:type] = embeddable.class.to_s
-    hash[:children] = answers[key]
+    hash[:answers] = answers[key]
 
     if embeddable.is_a? Embeddable::MultipleChoice
       process_multiple_choice(hash, embeddable)
@@ -196,7 +196,7 @@ class API::V1::Report
 
   def process_iframe(hash, embeddable)
     # Filter out null answers.
-    hash[:children].select { |a| a[:answer].present? }.each do |answer|
+    hash[:answers].select { |a| a[:answer].present? }.each do |answer|
       # Pass these properties to answer too.
       answer[:display_in_iframe] = embeddable.display_in_iframe
       answer[:width] = embeddable.width

--- a/app/models/api/v1/report.rb
+++ b/app/models/api/v1/report.rb
@@ -93,7 +93,7 @@ class API::V1::Report
     # Make naming more consistent, otherwise we would have crazy sequence of [:answers][:answer][:answer] keys.
     hash[:answer] = hash[:answer].map do |a|
       {
-        id: a[:id],
+        id: a[:choice_id],
         choice: a[:answer],
         is_correct: a[:correct]
       }
@@ -174,7 +174,7 @@ class API::V1::Report
     key = embeddable_key(embeddable)
     hash[:key] = key
     hash[:type] = embeddable.class.to_s
-    hash[:answers] = answers[key]
+    hash[:answers] = answers[key] || [] #when no students have answered
 
     if embeddable.is_a? Embeddable::MultipleChoice
       process_multiple_choice(hash, embeddable)

--- a/app/models/saveable/multiple_choice_answer.rb
+++ b/app/models/saveable/multiple_choice_answer.rb
@@ -12,6 +12,7 @@ class Saveable::MultipleChoiceAnswer < ActiveRecord::Base
     if rationale_choices.size > 0
       rationale_choices.compact.select { |rc| rc.choice }.map do |rc|
         data = {
+          :choice_id => rc.choice.id,
           :answer => rc.choice.choice,
           :correct => rc.choice.is_correct
         }

--- a/spec/controllers/portal/offerings_controller_spec.rb
+++ b/spec/controllers/portal/offerings_controller_spec.rb
@@ -159,7 +159,7 @@ describe Portal::OfferingsController do
 
       mc_saveables = Saveable::MultipleChoice.find(:all)
       mc_saveables.size.should == (mc_saveables_size + 1)
-      mc_saveables.last.answer.should == [{:answer => choice.choice, :correct => nil}]
+      mc_saveables.last.answer[0].should include({:choice_id => choice.id, :answer => choice.choice, :correct => nil})
     end
 
     it 'should display previous answers when view again' do

--- a/spec/models/dataservice/bundle_content_saveable_extraction_spec.rb
+++ b/spec/models/dataservice/bundle_content_saveable_extraction_spec.rb
@@ -112,7 +112,8 @@ describe Dataservice::BundleContent do
       end
       learner.multiple_choices.each do |saveable|
         saveable.answers.size.should eql(1)
-        saveable.answers[0].answer.should eql([{:answer => 'someChoice', :correct => nil}])
+        saveable.answers[0].answer[0].should include({:answer => 'someChoice', :correct => nil})
+        saveable.answers[0].answer[0].should have_key(:choice_id)
       end
       learner.image_questions.each do |saveable|
         bundle_content.blobs.include?(saveable.answer[:blob]).should be_true
@@ -295,16 +296,18 @@ Long')
       learner.multiple_choices.size.should eql(4)
       learner.multiple_choices.each do |saveable|
         case saveable.multiple_choice_id
-        when 3897
-          saveable.answer.should eql([{:answer => "someChoice 1", :correct => nil}])
+          when 3897
+          saveable.answer[0].should include({:answer => "someChoice 1", :correct => nil})
         when 3901
           # saveable.answer.should eql("someChoice 13, someChoice 14")
-          saveable.answer.should eql([{:answer => "someChoice 13", :correct => nil},{:answer => "someChoice 14", :correct => nil}])
+          saveable.answer[0].should include({:answer => "someChoice 13", :correct => nil})
+          saveable.answer[1].should include({:answer => "someChoice 14", :correct => nil})
         when 3902
-          saveable.answer.should eql([{:answer => "someChoice 18", :rationale => "Soft feels really nice", :correct => nil}])
+          saveable.answer[0].should include({:answer => "someChoice 18", :rationale => "Soft feels really nice", :correct => nil})
         when 3903
           # saveable.answer.should eql("someChoice 21, someChoice 26")
-          saveable.answer.should eql([{:answer => "someChoice 21", :rationale => "It's cold", :correct => nil},{:answer => "someChoice 26", :rationale => "Are yellow", :correct => nil}])
+          saveable.answer[0].should include({:answer => "someChoice 21", :rationale => "It's cold", :correct => nil})
+          saveable.answer[1].should include({:answer => "someChoice 26", :rationale => "Are yellow", :correct => nil})
         else
           raise "Unexpected multiple choice saveable!"
         end
@@ -388,15 +391,21 @@ Long')
       learner.multiple_choices.each do |saveable|
         case saveable.multiple_choice_id
         when 3897
-          saveable.answer.should eql([{:answer => "someChoice 1", :correct => nil}])
+          saveable.answer[0].should include({:answer => "someChoice 1", :correct => nil})
         when 3901
           # saveable.answer.should eql("someChoice 13, someChoice 14")
-          saveable.answer.should eql([{:answer => "someChoice 13", :correct => nil},{:answer => "someChoice 14", :correct => nil}])
+          saveable.answer[0].should include({:answer => "someChoice 13", :correct => nil})
+          saveable.answer[1].should include({:answer => "someChoice 14", :correct => nil})
         when 3902
-          saveable.answer.should eql([{:answer => "someChoice 18", :rationale => "Soft feels really nice, indeed.", :correct => nil}])
+          saveable.answer[0].should include({:answer => "someChoice 18", :rationale => "Soft feels really nice, indeed.", :correct => nil})
         when 3903
           # saveable.answer.should eql("someChoice 21, someChoice 26")
-          saveable.answer.should eql([{:answer => "someChoice 21", :rationale => "It's cold", :correct => nil},{:answer => "someChoice 22", :rationale => "this is a really long answer that wikll keep going and going until the end of the page and keep scrolling", :correct => nil},{:answer => "someChoice 26", :rationale => "Are yellow", :correct => nil}])
+          saveable.answer[0].should include({:answer => "someChoice 21", :rationale => "It's cold", :correct => nil})
+          saveable.answer[1].should include({
+            :answer => "someChoice 22",
+            :rationale => "this is a really long answer that wikll keep going and going until the end of the page and keep scrolling",
+            :correct => nil})
+          saveable.answer[2].should include({:answer => "someChoice 26", :rationale => "Are yellow", :correct => nil})
         else
           raise "Unexpected multiple choice saveable!"
         end

--- a/spec/models/dataservice/periodic_bundle_content_saveable_extraction_spec.rb
+++ b/spec/models/dataservice/periodic_bundle_content_saveable_extraction_spec.rb
@@ -79,7 +79,7 @@ describe Dataservice::PeriodicBundleContent do
     end
     learner.multiple_choices.each do |saveable|
       saveable.answers.size.should eql(1)
-      saveable.answers[0].answer.should eql([{:answer => 'someChoice', :correct => nil}])
+      saveable.answers[0].answer[0].should include({:answer => 'someChoice', :correct => nil})
     end
     learner.image_questions.each do |saveable|
       bundle_content.blobs.include?(saveable.answer[:blob]).should be_true


### PR DESCRIPTION
This PR is tiny ( cedf9de )  -- But its based on work in the report-link PR, so that work should be reviewed / integrated first.

The Client side changes are in this [portal-report PR](https://github.com/concord-consortium/portal-report/pull/1) which is just a little larger.