### PR TITLE
Display summary info for all students in the class report

### DIFF
--- a/app/models/api/v1/report.rb
+++ b/app/models/api/v1/report.rb
@@ -69,7 +69,7 @@ class API::V1::Report
 
   def provide_no_answer_entries(answers, students_json)
     # Provide "no answer" entries for students who started activity, but didn't respond to given question.
-    default_answer_entries = students_json.select { |s| s[:started_offering] }.map do |s|
+    default_answer_entries = students_json.map do |s|
       {
         student_id: s[:id],
         answer: nil,
@@ -175,7 +175,7 @@ class API::V1::Report
     hash[:key] = key
     hash[:type] = embeddable.class.to_s
     hash[:question_number] = question_number
-    hash[:answers] = answers[key] || [] #when no students have answered
+    hash[:answers] = answers[key] || no_answers(key)
 
     # We want to remove markup from the prompt and name. Even though
     # Markup is stript, HTML entities are preserved, eg `&deg`;
@@ -215,8 +215,18 @@ class API::V1::Report
     end
   end
 
-  # Visibility filter:
+  def no_answers(embeddable_key)
+    @offering.clazz.students.map do |s|
+      {
+          student_id: s.id,
+          answer: nil,
+          type: 'NoAnswer',
+          embeddable_key: embeddable_key
+      }
+    end
+  end
 
+  # Visibility filter:
   def visibility_filter_json(filter)
     {
       active: !filter.ignore,


### PR DESCRIPTION
There has been a change to the report format.

We now want to show 'not answered' for any student in the class who hasn't answered a question, regardless of whether the student (or any student) has started the activity / offering.

Change on line 72:  Even if the student hasn't 'started' the activity, we want to report 'not answered'
Change on line 178:  We don't process an embeddable at all if there isn't a report learner for it, so we end up with null in `answers[key]`.  Instead of assigning an empty array, we assign an array of 'not answered' student answers.

Overall, I think this whole process could be streamlined so that first we generate a map of embeddables with default answers, then fill in the actual answers where we have them.  But since there is more work on this soon, I thought I would post-pone that optimization.

@pjanik @dougmartin  take a look?

[#116769539]

https://www.pivotaltracker.com/story/show/116769539