### PR TITLE
Add remote endpoint url to usage and details reports [#116982801]

### DIFF
--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -591,6 +591,7 @@ class InvestigationsController < AuthoringController
     opts = {:verbose => false}
     opts[:runnables] = [@investigation] unless @investigation.id.nil?
     opts[:blobs_url] = dataservice_blobs_url
+    opts[:url_helpers] = Reports::UrlHelpers.new(:protocol => request.protocol, :host_with_port => request.host_with_port)
     rep = nil
     case type
     when :detail

--- a/app/controllers/report/learner_controller.rb
+++ b/app/controllers/report/learner_controller.rb
@@ -106,16 +106,18 @@ class Report::LearnerController < ApplicationController
       @infos[runnable_type.pluralize + ":"] = @select_learners.select{|l| l.runnable_type == runnable_type}.map{|l| l.runnable_id}.uniq.size
     }
 
+    @url_helpers = Reports::UrlHelpers.new(:protocol => request.protocol, :host => request.host_with_port)
+
     if params[:commit] == @button_texts[:usage]
       sio = StringIO.new
       runnables =  @learner_selector.runnables_to_report_on
-      report = Reports::Usage.new(:runnables => runnables, :report_learners => @select_learners, :blobs_url => dataservice_blobs_url, :include_child_usage => params[:include_child_usage])
+      report = Reports::Usage.new(:runnables => runnables, :report_learners => @select_learners, :blobs_url => dataservice_blobs_url, :include_child_usage => params[:include_child_usage], :url_helpers => @url_helpers)
       report.run_report(sio)
       send_data(sio.string, :type => "application/vnd.ms.excel", :filename => "usage.xls" )
     elsif params[:commit] == @button_texts[:details]
       sio = StringIO.new
       runnables =  @learner_selector.runnables_to_report_on
-      report = Reports::Detail.new(:runnables => runnables, :report_learners => @select_learners, :blobs_url => dataservice_blobs_url)
+      report = Reports::Detail.new(:runnables => runnables, :report_learners => @select_learners, :blobs_url => dataservice_blobs_url, :url_helpers => @url_helpers)
       report.run_report(sio)
       send_data(sio.string, :type => "application/vnd.ms.excel", :filename => "detail.xls" )
     elsif params[:commit] == @button_texts[:arg_block]

--- a/app/models/report/learner/selector.rb
+++ b/app/models/report/learner/selector.rb
@@ -12,7 +12,7 @@ class Report::Learner::Selector
 
     policy_scopes = {
       :teachers => Pundit.policy_scope(current_visitor, Portal::Teacher),
-      :learners => Pundit.policy_scope(current_visitor, Report::Learner),
+      :learners => Pundit.policy_scope(current_visitor, Report::Learner).includes(:learner),  # include learner to generate remote endpoint url
       :perm_forms => Pundit.policy_scope(current_visitor, Portal::PermissionForm)
     }
 

--- a/features/researcher_reports.feature
+++ b/features/researcher_reports.feature
@@ -90,7 +90,7 @@ Feature: Investigations can be reported on
     And "student" should have 2 answers for "first investigation" in "My Class"
 
   Scenario: Comprehensive report tests for two investigations and two students
-    Given PENDING yaml dumping on hudson and local machines differ. 
+    Given PENDING yaml dumping on hudson and local machines differ.
     Given the following student answers:
        | student | class       | investigation        | question_prompt | answer |
        | student | My Class    | first investigation  | a               | a      |
@@ -184,6 +184,7 @@ Feature: Investigations can be reported on
         | student | My Class | first investigation | c               | b      |
 
     And a mocked spreadsheet library
+    And a mocked remote endpoint url
 
     And I am logged in with the username researcher
     And I am on the researcher reports page

--- a/features/step_definitions/researcher_report_steps.rb
+++ b/features/step_definitions/researcher_report_steps.rb
@@ -3,7 +3,8 @@ def modified_report_for(investigation)
   report  = Reports::Detail.new(
     :verbose        => false,
     :runnables      => [investigation],
-    :blobs_url      => FAKE_BLOBS_URL
+    :blobs_url      => FAKE_BLOBS_URL,
+    :url_helpers    => Reports::UrlHelpers.new(:protocol => 'https', :host => 'portal.concord.org')
   )
   report.stub!(:learner_id).and_return('learner_id')
   report.stub!(:user_id).and_return('user_id')
@@ -33,7 +34,7 @@ def add_response(learner,prompt_text,answer_text)
   puts "No Question found for #{prompt_text}" if question.nil?
   return if question.nil?
   case question.class.name
-  when "Embeddable::MultipleChoice" 
+  when "Embeddable::MultipleChoice"
     return add_multichoice_answer(learner,question, answer_text)
   when "Embeddable::OpenResponse"
     return add_openresponse_answer(learner,question, answer_text)
@@ -48,7 +49,7 @@ def add_multichoice_answer(learner,question,answer_text)
     :learner => learner,
     :offering => learner.offering,
     :multiple_choice => question
-  ) 
+  )
   saveable_answer = Saveable::MultipleChoiceAnswer.create(
     :multiple_choice => new_answer
   )
@@ -63,7 +64,7 @@ def add_openresponse_answer(learner,question,answer_text)
     :learner => learner,
     :offering => learner.offering,
     :open_repsonse => question
-  ) 
+  )
   saveable_answer = Saveable::OpenResponseAnswer.create(
     :answer          => answer_text
   )
@@ -77,7 +78,7 @@ def add_image_question_answer(learner,question,answer_text)
     :learner => learner,
     :offering => learner.offering,
     :image_question => question
-  ) 
+  )
   # TODO: Maybe slurp in some image and encode it for the blob?
   saveable_answer = Saveable::ImageQuestionAnswer.create(
     :blob => Dataservice::Blob.create(
@@ -234,4 +235,8 @@ Given /^a mocked spreadsheet library$/ do
   workbook = Spreadsheet::Workbook.new
   workbook.stub("write").and_return('')
   Spreadsheet::Workbook.stub(:new).and_return(workbook)
+end
+
+Given /^a mocked remote endpoint url$/ do
+  Reports::UrlHelpers.any_instance.should_receive(:remote_endpoint_url).and_return('https://portal.concord.org/dataservice/external_activity_data/1')
 end

--- a/lib/reports/detail.rb
+++ b/lib/reports/detail.rb
@@ -5,13 +5,15 @@ class Reports::Detail < Reports::Excel
 
     @runnables = opts[:runnables] || Investigation.published
     @report_learners = opts[:report_learners] || report_learners_for_runnables(@runnables)
+    @url_helpers = opts[:url_helpers]
 
     # stud.id, class, school, user.id, username, student name, teachers, completed, %completed, last_run
     @common_columns = common_header + [
-      Reports::ColumnDefinition.new(:title => "# Completed", :width => 10, :left_border => :thin),
-      Reports::ColumnDefinition.new(:title => "% Completed", :width => 10),
-      Reports::ColumnDefinition.new(:title => "# Correct",   :width => 10),
-      Reports::ColumnDefinition.new(:title => "Last run",    :width => 20)
+      Reports::ColumnDefinition.new(:title => "# Completed",     :width => 10, :left_border => :thin),
+      Reports::ColumnDefinition.new(:title => "% Completed",     :width => 10),
+      Reports::ColumnDefinition.new(:title => "# Correct",       :width => 10),
+      Reports::ColumnDefinition.new(:title => "Last run",        :width => 20),
+      Reports::ColumnDefinition.new(:title => "Remote Endpoint", :width => 100)
     ]
 
     @reportable_embeddables = {} # keys will be runnables, and value will be an array of reportables for that runnable, in the correct order
@@ -139,7 +141,8 @@ class Reports::Detail < Reports::Excel
         row = sheet.row(sheet.last_row_index + 1)
         assess_completed = "#{assess_completed}/#{total_assessments}(#{total_by_container})"
         assess_correct = "#{l.num_correct}/#{correctable.size}"
-        row[0, 3] =  report_learner_info_cells([l]) + [assess_completed, assess_percent, assess_correct, last_run]
+        remote_endpoint = @url_helpers.remote_endpoint_url(l.learner)
+        row[0, 3] =  report_learner_info_cells([l]) + [assess_completed, assess_percent, assess_correct, last_run, remote_endpoint]
 
         all_answers = []
         get_containers(runnable).each do |container|

--- a/lib/reports/url_helpers.rb
+++ b/lib/reports/url_helpers.rb
@@ -1,0 +1,10 @@
+class Reports::UrlHelpers
+  def initialize(opts = {})
+    @protocol = opts[:protocol]
+    @host_with_port = opts[:host_with_port]
+  end
+
+  def remote_endpoint_url(portal_learner)
+    portal_learner.remote_endpoint_url(@protocol, @host_with_port)
+  end
+end

--- a/lib/reports/usage.rb
+++ b/lib/reports/usage.rb
@@ -13,6 +13,8 @@ class Reports::Usage < Reports::Excel
     # stud.id, class, school, user.id, username, student name, teachers
     @shared_column_defs = common_header
 
+    @url_helpers = opts[:url_helpers]
+
     @runnable_start_column = {}
     @sheet_defs = [[]]
     @runnables.each do |runnable|
@@ -21,6 +23,7 @@ class Reports::Usage < Reports::Excel
       col_defs << Reports::ColumnDefinition.new(:title => "#{runnable.name} (#{runnable.class}_#{runnable.id})\nAssessments Completed", :width => 25, :height => 2, :left_border => :thin)
       col_defs << Reports::ColumnDefinition.new(:title => "% Completed", :width => 4)
       col_defs << Reports::ColumnDefinition.new(:title => "Last run",    :width => 20)
+      col_defs << Reports::ColumnDefinition.new(:title => "Remote Endpoint", :width => 100)
       if @include_child_usage
         children = (get_containers(runnable) - [runnable])
         children.each do |child|
@@ -66,7 +69,8 @@ class Reports::Usage < Reports::Excel
           assess_completed =  l.num_submitted
           assess_percent = percent(assess_completed, total_assessments)
           last_run = l.last_run || 'never'
-          row_vals = [assess_completed, assess_percent, last_run]
+          remote_endpoint = @url_helpers.remote_endpoint_url(l.learner)
+          row_vals = [assess_completed, assess_percent, last_run, remote_endpoint]
           if @include_child_usage
             children = (get_containers(runnable) - [runnable])
             children.each do |child|

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -19,7 +19,10 @@ namespace :app do
 
       filename = args[:filename]
       File.new(filename, 'w') do |file|
-        rep = Reports::Detail.new({:verbose => true, :blobs_url => dataservice_blobs_url})
+        rep = Reports::Detail.new({:verbose => true,
+                                   :blobs_url => dataservice_blobs_url,
+                                   :url_helpers => Reports::UrlHelpers.new(:protocol => 'https', :host_with_port => 'portal.concord.org')
+                                   })
         rep.run_report(file)
       end
     end
@@ -32,7 +35,10 @@ namespace :app do
 
       filename = args[:filename]
       File.new(filename, 'w') do |file|
-        rep = Reports::Usage.new({:verbose => true, :blobs_url => dataservice_blobs_url})
+        rep = Reports::Usage.new({:verbose => true,
+                                  :blobs_url => dataservice_blobs_url,
+                                  :url_helpers => Reports::UrlHelpers.new(:protocol => 'https', :host_with_port => 'portal.concord.org')
+                                  })
         rep.run_report(file)
       end
     end
@@ -52,7 +58,9 @@ namespace :app do
                                   :report_learners => Report::Learner.all,
                                   :blobs_url => dataservice_blobs_url,
                                   :include_child_usage => true,
-                                  :verbose => true })
+                                  :verbose => true,
+                                  :url_helpers => Reports::UrlHelpers.new(:protocol => 'https', :host_with_port => 'portal.concord.org')
+                                   })
         rep.run_report(file)
       end
     end


### PR DESCRIPTION
The remote endpoint url is being added so that the biographical data in the usage and details reports can be linked to log manager entries.