### PR TITLE
Do not include Prototype.js 1.7.0

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -3,7 +3,6 @@
  // package (mange_classes,instructional_materials, &etc.)
 
 = require 'portal-namespace'
-= require 'prototype'
 = require 'prototype-ui/prototype-ui'
 = require 'globals'
 = require 'effects'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -25,7 +25,7 @@
     / TODO: if themes need their own print CSS make a themed link here:
     != stylesheet_link_tag 'print', {'media' => 'print'}
 
-    %script{ :src=> "https://ajax.googleapis.com/ajax/libs/prototype/1.7.0.0/prototype.js", :type => "text/javascript"}
+    != javascript_include_tag 'prototype'
     %script{ :src=> "https://ajax.googleapis.com/ajax/libs/scriptaculous/1.8.3/scriptaculous.js", :type => "text/javascript"}
 
     / Include scripts that are based on rails data and need to be generated dynamically. They cannot be precompiled.

--- a/app/views/layouts/minimal.html.haml
+++ b/app/views/layouts/minimal.html.haml
@@ -25,7 +25,7 @@
     / TODO: if themes need their own print CSS make a themed link here:
     != stylesheet_link_tag 'print', {'media' => 'print'}
 
-    %script{ :src=> "https://ajax.googleapis.com/ajax/libs/prototype/1.7.0.0/prototype.js", :type => "text/javascript"}
+    != javascript_include_tag 'prototype'
     %script{ :src=> "https://ajax.googleapis.com/ajax/libs/scriptaculous/1.8.3/scriptaculous.js", :type => "text/javascript"}
 
     / Include scripts that are based on rails data and need to be generated dynamically. They cannot be precompiled.

--- a/app/views/layouts/report.html.haml
+++ b/app/views/layouts/report.html.haml
@@ -9,7 +9,7 @@
     %meta{ :name => "resource-type", :content => "document" }
     %meta{ :name => "MSSmartTagsPreventParsing", :content => "true" }
     %link{ :href => path_to_image('favicon.ico'), :rel => "shortcut icon"}/
-    %script{ :src=> "https://ajax.googleapis.com/ajax/libs/prototype/1.7.0.0/prototype.js", :type => "text/javascript"}
+    != javascript_include_tag 'prototype'
 
     != theme_stylesheet_link_tag 'application', {'media' => 'screen, presentation'}
     != stylesheet_link_tag 'print', {'media' => 'print'}

--- a/app/views/layouts/run.run_html.haml
+++ b/app/views/layouts/run.run_html.haml
@@ -9,7 +9,7 @@
     %meta{ :name => "resource-type", :content => "document" }
     %meta{ :name => "MSSmartTagsPreventParsing", :content => "true" }
     %link{ :href => path_to_image('favicon.ico'), :rel => "shortcut icon"}/
-    %script{ :src=> "https://ajax.googleapis.com/ajax/libs/prototype/1.7.0.0/prototype.js", :type => "text/javascript"}
+    != javascript_include_tag 'prototype'
     %script{ :src=> "https://ajax.googleapis.com/ajax/libs/scriptaculous/1.8.3/scriptaculous.js", :type => "text/javascript"}
 
 


### PR DESCRIPTION
Looks simple but it was causing some really weird errors.
Prorotype 1.7.0 is really old. It was replacing some Array functions (e.g. `.filter`). And its own `Array.filter` implementation wasn't compatible with ES5 specs.

We already updated Prototype to 1.7.3 which fixed that. But 1.7.0 was still included in haml file and causing these issues.

I could totally remove this script tag and leave require 'prototype' in application.js, but there's one script tag below that includes:
https://ajax.googleapis.com/ajax/libs/scriptaculous/1.8.3/scriptaculous.js
It's this awesome library: http://script.aculo.us/ (hasn't been updated since 2010) and it depends on Prototype. Has anyone idea what is it used for by any chance? Might be nice to get rid of it too.