### PR TITLE
Print activities

### DIFF
--- a/app/assets/javascripts/components/search/material_info.js.coffee
+++ b/app/assets/javascripts/components/search/material_info.js.coffee
@@ -8,6 +8,7 @@ window.SMaterialInfoClass = React.createClass
 
     links = []
     links.push material.links.preview           if material.links.preview
+    links.push material.links.print_url         if material.links.print_url
     if material.lara_activity_or_sequence
       links.push material.links.external_lara_edit if material.links.external_lara_edit
     else

--- a/db/migrate/20160701193035_add_more_urls_to_external_activity.rb
+++ b/db/migrate/20160701193035_add_more_urls_to_external_activity.rb
@@ -1,0 +1,6 @@
+class AddMoreUrlsToExternalActivity < ActiveRecord::Migration
+  def change
+    add_column :external_activities, :author_url, :string
+    add_column :external_activities, :print_url, :string
+  end
+end

--- a/db/migrate/20160705205130_modify_external_activity_urls.rb
+++ b/db/migrate/20160705205130_modify_external_activity_urls.rb
@@ -1,0 +1,11 @@
+class ModifyExternalActivityUrls < ActiveRecord::Migration
+  def up
+    change_column :external_activities, :author_url, :text
+    change_column :external_activities, :print_url, :text
+  end
+
+  def down
+    change_column :external_activities, :author_url, :string
+    change_column :external_activities, :print_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160517214328) do
+ActiveRecord::Schema.define(:version => 20160701193035) do
 
   create_table "access_grants", :force => true do |t|
     t.string   "code"
@@ -857,6 +857,8 @@ ActiveRecord::Schema.define(:version => 20160517214328) do
     t.boolean  "logging",                  :default => false
     t.boolean  "is_assessment_item",       :default => false
     t.integer  "external_report_id"
+    t.string   "author_url"
+    t.string   "print_url"
   end
 
   add_index "external_activities", ["is_featured", "publication_status"], :name => "featured_public"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160701193035) do
+ActiveRecord::Schema.define(:version => 20160705205130) do
 
   create_table "access_grants", :force => true do |t|
     t.string   "code"
@@ -857,8 +857,8 @@ ActiveRecord::Schema.define(:version => 20160701193035) do
     t.boolean  "logging",                  :default => false
     t.boolean  "is_assessment_item",       :default => false
     t.integer  "external_report_id"
-    t.string   "author_url"
-    t.string   "print_url"
+    t.text     "author_url"
+    t.text     "print_url"
   end
 
   add_index "external_activities", ["is_featured", "publication_status"], :name => "featured_public"

--- a/features/activity_runtime_api/publish.feature
+++ b/features/activity_runtime_api/publish.feature
@@ -7,6 +7,8 @@ Feature: External Activities can support a REST publishing api
         "name": "Cool Activity",
         "url": "http://activity.com/activity/1",
         "launch_url": "http://activity.com/activity/1/sessions/",
+        "author_url": "http://activity.com/activity/1/edit",
+        "print_url": "http://activity.com/activity/1/print_blank",
         "description": "This activity does fun stuff.",
         "sections": [
           {
@@ -55,6 +57,8 @@ Feature: External Activities can support a REST publishing api
         "name": "Cool Activity",
         "url": "http://activity.com/activity/1",
         "launch_url": "http://activity.com/activity/1/sessions/",
+        "author_url": "http://activity.com/activity/1/edit_new",
+        "print_url": "http://activity.com/activity/1/print_blank_new",
         "sections": [
           {
             "name": "Cool Activity Section 1",
@@ -103,6 +107,8 @@ Feature: External Activities can support a REST publishing api
         "description": "Several activities together in a sequence",
         "url": "http://activity.com/sequence/1",
         "launch_url": "http://activity.com/sequence/1",
+        "author_url": "http://activity.com/sequence/1/edit",
+        "print_url": "http://activity.com/sequence/1/print_blank",
         "abstract": "This is the abstract",
         "activities": [
           {
@@ -110,6 +116,8 @@ Feature: External Activities can support a REST publishing api
             "name": "Cool Activity",
             "url": "http://activity.com/activity/1",
             "launch_url": "http://activity.com/activity/1/sessions/",
+            "author_url": "http://activity.com/activity/1/edit",
+            "print_url": "http://activity.com/activity/1/print_blank",
             "description": "This activity does fun stuff.",
             "abstract": "This is the abstract.",
             "sections": [
@@ -208,12 +216,16 @@ Feature: External Activities can support a REST publishing api
         "abstract": "The abstract was also changed",
         "url": "http://activity.com/sequence/1",
         "launch_url": "http://activity.com/sequence/1",
+        "author_url": "http://activity.com/sequence/1/edit_new",
+        "print_url": "http://activity.com/sequence/1/print_blank_new",
         "activities": [
           {
             "type": "Activity",
             "name": "Cool Activity",
             "url": "http://activity.com/activity/1",
             "launch_url": "http://activity.com/activity/1/sessions/",
+            "author_url": "http://activity.com/activity/1/edit_new",
+            "print_url": "http://activity.com/activity/1/print_blank_new",
             "description": "This activity does fun stuff.",
             "sections": [
               {
@@ -310,7 +322,9 @@ Feature: External Activities can support a REST publishing api
     And the portal should create an external activity with the following attributes:
       | name            | Cool Activity |
       | url             | http://activity.com/activity/1 |
-      | launch_url | http://activity.com/activity/1/sessions/ |
+      | launch_url      | http://activity.com/activity/1/sessions/ |
+      | author_url      | http://activity.com/activity/1/edit |
+      | print_url       | http://activity.com/activity/1/print_blank |
       | description     | This activity does fun stuff. |
     And the external activity should have a template
     And the portal should create an activity with the following attributes:
@@ -328,11 +342,19 @@ Feature: External Activities can support a REST publishing api
       | external_id              | 456789 |
       | choices                  | [{"external_id": "97", "choice": "red"},{"external_id": "98", "choice": "blue", "is_correct": "true"},{"external_id": "99", "choice": "green"}] |
 
+
   @mechanize
   Scenario: External REST activity is published the second time
     Given the external runtime published the activity "Fun Stuff" before
     When the external runtime publishes the activity "Fun Stuff" again
     Then the published activity "Fun Stuff" should be correctly modified by the API
+    And the portal should create an external activity with the following attributes:
+      | name            | Cool Activity |
+      | url             | http://activity.com/activity/1 |
+      | launch_url      | http://activity.com/activity/1/sessions/ |
+      | author_url      | http://activity.com/activity/1/edit_new |
+      | print_url       | http://activity.com/activity/1/print_blank_new |
+      | description     | This activity does fun stuff. |
 
   @mechanize
   Scenario: External REST sequence is published the first time
@@ -342,6 +364,8 @@ Feature: External Activities can support a REST publishing api
       | name            | Many fun things |
       | url             | http://activity.com/sequence/1 |
       | launch_url      | http://activity.com/sequence/1 |
+      | author_url      | http://activity.com/sequence/1/edit |
+      | print_url       | http://activity.com/sequence/1/print_blank |
       | description     | Several activities together in a sequence |
       | abstract        | This is the abstract |
     And the external activity should have a template
@@ -367,4 +391,8 @@ Feature: External Activities can support a REST publishing api
     Given the external runtime published the sequence "Many fun things" before
     When the external runtime publishes the sequence "Many fun things" again
     Then the published activity "Many fun things" should be correctly modified by the API
-
+    And the portal should create an external activity with the following attributes:
+      | name            | Many fun things |
+      | launch_url      | http://activity.com/sequence/1 |
+      | author_url      | http://activity.com/sequence/1/edit_new |
+      | print_url       | http://activity.com/sequence/1/print_blank_new |

--- a/lib/activity_runtime_api.rb
+++ b/lib/activity_runtime_api.rb
@@ -48,7 +48,9 @@ class ActivityRuntimeAPI
         :abstract         => hash["abstract"],
         :url              => hash["url"],
         :thumbnail_url    => hash["thumbnail_url"],
-        :launch_url  => hash["launch_url"] || hash["create_url"],
+        :launch_url       => hash["launch_url"] || hash["create_url"],
+        :author_url       => hash["author_url"],
+        :print_url        => hash["print_url"],
         :template         => activity,
         :publication_status => "published",
         :user => user,
@@ -89,7 +91,7 @@ class ActivityRuntimeAPI
       end
     end
 
-    ['author_email', 'is_locked'].each do |attribute|
+    ['author_email', 'is_locked', 'print_url', 'author_url'].each do |attribute|
       external_activity.update_attribute(attribute,hash[attribute])
     end
     
@@ -148,6 +150,8 @@ class ActivityRuntimeAPI
         :url              => hash["url"],
         :thumbnail_url    => hash["thumbnail_url"],
         :launch_url       => hash["launch_url"] || hash["create_url"],
+        :author_url       => hash["author_url"],
+        :print_url        => hash["print_url"],
         :template         => investigation,
         :publication_status => "published",
         :user => user,

--- a/lib/materials/data_helpers.rb
+++ b/lib/materials/data_helpers.rb
@@ -194,6 +194,14 @@ module Materials
         end
       end
 
+      if material.respond_to?(:print_url) && material.print_url.present?
+        links[:print_url] = {
+            text: "Print",
+            target: "_blank",
+            url: material.print_url
+        }
+      end
+
       if material.respond_to?(:teacher_guide_url) && !material.teacher_guide_url.blank?
         if current_visitor.portal_teacher || current_visitor.has_role?('admin','manager')
           links[:teacher_guide] = {


### PR DESCRIPTION
"A teacher can print a blank hardcopy of an investigation"

* External activities display a print link if the 'print_url' is present.
* Activity publication now supports `print_url` and `author_url` attributes.

In support of this [PT story](https://www.pivotaltracker.com/story/show/102391640).


