### PR TITLE
Update selenium-webdriver gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -186,7 +186,7 @@ end
 group :test, :cucumber do
   gem "spring-commands-cucumber"
   gem "spring-commands-rspec"
-  gem "selenium-webdriver", "~> 2.46.2"
+  gem "selenium-webdriver"
   gem "cucumber",           "~> 1.2.0"
   gem "cucumber-rails",     "~> 1.3.0", :require => false
   gem "database_cleaner",   "~> 0.7.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,7 +181,7 @@ GEM
     capybara-screenshot (1.0.9)
       capybara (>= 1.0, < 3)
       launchy
-    childprocess (0.5.6)
+    childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
     chronic (0.6.7)
     chunky_png (1.3.4)
@@ -277,8 +277,8 @@ GEM
       activesupport (>= 3.0.0)
     fakeweb (1.3.0)
     fattr (2.2.1)
-    ffi (1.9.8)
-    ffi (1.9.8-x86-mingw32)
+    ffi (1.9.13)
+    ffi (1.9.13-x86-mingw32)
     font-awesome-sass (4.3.2.1)
       sass (~> 3.2)
     formatador (0.2.5)
@@ -355,7 +355,7 @@ GEM
       webrobots (>= 0.0.9, < 0.2)
     method_source (0.8.2)
     mime-types (1.25.1)
-    multi_json (1.11.2)
+    multi_json (1.12.1)
     multi_xml (0.5.1)
     mysql2 (0.3.15)
     nested_form (0.3.2)
@@ -486,7 +486,7 @@ GEM
     ruby-prof (0.12.1)
     ruby-prof (0.12.1-x86-mingw32)
     ruby-rc4 (0.1.5)
-    rubyzip (1.1.7)
+    rubyzip (1.2.0)
     sanitize (4.0.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.4.4)
@@ -498,9 +498,8 @@ GEM
       tilt (~> 1.3)
     select2-rails (3.5.9)
       thor (~> 0.14)
-    selenium-webdriver (2.46.2)
+    selenium-webdriver (2.53.4)
       childprocess (~> 0.5)
-      multi_json (~> 1.0)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
     session (3.1.0)
@@ -580,7 +579,7 @@ GEM
       addressable (>= 2.2.7)
       crack (>= 0.3.2)
     webrobots (0.1.1)
-    websocket (1.2.2)
+    websocket (1.2.3)
     what_methods (1.0.1)
     will_paginate (3.0.3)
     win32-open3 (0.3.2-x86-mingw32)
@@ -701,7 +700,7 @@ DEPENDENCIES
   sass (~> 3.3.14)
   sass-rails
   select2-rails
-  selenium-webdriver (~> 2.46.2)
+  selenium-webdriver
   sextant
   spreadsheet (~> 0.7.3)
   spring
@@ -726,6 +725,3 @@ DEPENDENCIES
   wirble
   xray-rails (~> 0.1.18)
   yui-compressor
-
-BUNDLED WITH
-   1.11.2


### PR DESCRIPTION
Seems to work on Travis and lets you run cucumber tests locally with the recent versions of Firefox.