### PR TITLE
Redirect teachers to the page where they started sign up

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,6 +4,7 @@
 
 = require 'modulejs'
 = require 'portal-namespace'
+= require 'modal'
 = require 'prototype-ui/prototype-ui'
 = require 'globals'
 = require 'effects'

--- a/app/assets/javascripts/components/signup/signup.js.coffee
+++ b/app/assets/javascripts/components/signup/signup.js.coffee
@@ -35,6 +35,8 @@ modulejs.define 'components/signup/signup',
       anonymous: Portal.currentUser.isAnonymous
 
     onBasicDataSubmit: (data) ->
+      # Save the current path. Backed can use that information to redirect user to this page the first time he logs in.
+      data.sign_up_path = location.pathname
       @setState basicData: data
 
     onStudentRegistration: (data) ->

--- a/app/assets/javascripts/components/signup/signup.js.coffee
+++ b/app/assets/javascripts/components/signup/signup.js.coffee
@@ -35,7 +35,7 @@ modulejs.define 'components/signup/signup',
       anonymous: Portal.currentUser.isAnonymous
 
     onBasicDataSubmit: (data) ->
-      # Save the current path. Backed can use that information to redirect user to this page the first time he logs in.
+      # Save the current path. Backend can use that information to redirect user to this page the first time he logs in.
       data.sign_up_path = location.pathname
       @setState basicData: data
 

--- a/app/assets/javascripts/components/signup/signup_modal.js.coffee
+++ b/app/assets/javascripts/components/signup/signup_modal.js.coffee
@@ -1,0 +1,38 @@
+{div, p, ul, li} = React.DOM
+
+modulejs.define 'components/signup/signup_modal',
+[
+  'components/signup/signup'
+],
+(
+  SignupClass
+) ->
+  Signup = React.createFactory SignupClass
+
+  React.createClass
+    render: ->
+      (div {className: 'signup-default-modal-content'},
+        (Signup {})
+        (div {className: 'side-info'},
+          (div {className: 'side-info-header'}, 'Why sign up?')
+          (p {}, 'It\'s free and you get access to several key features:')
+          (ul {}, 
+            (li {}, 'Create classes for your students and assign them activities')
+            (li {}, 'Save student work')
+            (li {}, 'Track student progress through activities')
+          )
+        )
+      )
+
+Portal.openSignupModal = ->
+  modalContainerId = 'signup-default-modal'
+  modalContainerSelector = '#' + modalContainerId
+  modalContainer = jQuery(modalContainerSelector)
+  if modalContainer.length == 0
+    modalContainer = jQuery("<div id='#{modalContainerId}'>").appendTo('body')
+  # Always remove and re-render modal again. It makes sure that user always starts with a clean form.
+  ReactDOM.unmountComponentAtNode(modalContainer[0])
+  SignupModal = React.createFactory modulejs.require('components/signup/signup_modal')
+  ReactDOM.render SignupModal({}), modalContainer[0]
+  # Finally, show modal using simple Portal library (see modal.js).
+  Portal.showModal(modalContainerSelector)

--- a/app/assets/javascripts/modal.js
+++ b/app/assets/javascripts/modal.js
@@ -1,0 +1,31 @@
+// Simple library that can be used to create a modal dialog.
+// Requires no setup. Just create HTML container:
+// <div id="my-modal" class="modal">Content</div>
+// and then call:
+// Portal.showModal("#my-modal");
+// Close button and overlay will be automatically added.
+// Related styles are in modal.scss file.
+
+Portal.showModal = function(modalId, specialMsg) {
+  jQuery('.modal').hide();
+  jQuery(modalId).addClass('modal');
+  if (jQuery('#modal-overlay').length === 0) {
+    jQuery('body').append('<div id="modal-overlay"></div>');
+    jQuery('#modal-overlay').click(Portal.hideModal);
+  }
+  if (jQuery(modalId + ' .close').length === 0) {
+    jQuery(modalId).append('<a class="close">x</a>');
+    jQuery(modalId + ' .close').click(Portal.hideModal);
+  }
+  if (specialMsg != null) {
+    jQuery(modalId + ' .special-msg').text(specialMsg).show();
+  }
+  jQuery('#modal-overlay').css({'height': jQuery(document).height() + 'px'}).fadeIn('fast');
+  jQuery(modalId).fadeIn('slow');
+};
+
+Portal.hideModal = function() {
+  jQuery('.modal').fadeOut('fast');
+  jQuery('#modal-overlay').fadeOut('slow');
+  jQuery('.special-msg').text('').hide();
+};

--- a/app/assets/javascripts/search_materials.js.erb
+++ b/app/assets/javascripts/search_materials.js.erb
@@ -373,7 +373,7 @@ function setPopupHeight()
 
 
 function msgPopupDescriptionText() {
-    var popupMessage = "Please log-in or <a href='/pick_signup'>register</a> as a teacher to assign this material.";
+    var popupMessage = "Please log-in or <a href='javascript:Portal.openSignupModal();'>register</a> as a teacher to assign this material.";
     getMessagePopup(popupMessage);
 }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,7 +30,8 @@
 * =require web/bad_browser
 * =require web/material_collections
 * =require web/matedit
-*= require react-select
+* =require modal
+* =require react-select
 * =require components/materials_bin
 * =require components/signup
 * =require chosen

--- a/app/assets/stylesheets/components/signup.scss
+++ b/app/assets/stylesheets/components/signup.scss
@@ -1,4 +1,5 @@
 .signup-form {
+  font-family: museo-sans, verdana, helvetica, sans-serif;
   font-size: 13px;
   padding: 3px;
   
@@ -51,6 +52,7 @@
     margin: 8px 0;
     width: 100%;
     input {
+      box-sizing: border-box;
       width: 100%;
     }
     &.error, &.required {
@@ -173,6 +175,40 @@
     }
     p {
       margin: 6px;
+    }
+  }
+}
+
+.signup-default-modal-content {
+  .signup-form {
+    display: inline-block;
+    width: 46%;
+    font-size: 1.1em;
+
+    .first_name, .last_name {
+      width: 100%;
+      display: block;
+    }
+    .last_name {
+      margin-bottom: 1.5em;
+    }
+  }
+
+  .side-info {
+    display: inline-block;
+    background: #f9eec1;
+    border-radius: 12px;
+    float: right;
+    margin-top: 10px;
+    padding: 3.5% 4% 5% !important;
+    width: 42%;
+    font: 1.2em museo-sans;
+    line-height: 1.3;
+
+    .side-info-header {
+      color: #3f3f3f;
+      font: 1.5em museo;
+      margin-bottom: .25em;
     }
   }
 }

--- a/app/assets/stylesheets/modal.scss
+++ b/app/assets/stylesheets/modal.scss
@@ -1,0 +1,50 @@
+#modal-overlay, .modal {
+  display: none;
+  position: absolute;
+}
+
+#modal-overlay {
+  background: #000;
+  height: 100%;
+  left: 0;
+  opacity: .6;
+  top: 0;
+  width: 100%;
+  z-index: 101;
+}
+
+.modal {
+  background: #fff;
+  box-shadow: 0 5px 10px rgba(51, 51, 51, .5);
+  left: 50%;
+  height: auto;
+  margin: -250px 0 0 -336px;
+  min-height: 500px;
+  padding: 1em;
+  top: 400px;
+  width: 640px;
+  z-index: 110;
+
+  .close {
+    background: #222;
+    border: 2px solid #eee;
+    border-radius: 50%;
+    box-shadow: 0 1.25px 2.5px rgba(51, 51, 51, .5);
+    color: #ddd;
+    display: block;
+    font: 14px verdana, helvetica, sans-serif;
+    padding: 0 5px 2px;
+    position: absolute;
+    right: -15px;
+    text-decoration: none !important;
+    top: -15px;
+    z-index: 25;
+    cursor: pointer;
+  }
+
+  p.special-msg {
+    color: #e16a3e;
+    display: none;
+    margin-bottom: 1em;
+  }
+}

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,0 +1,9 @@
+class ConfirmationsController < Devise::ConfirmationsController
+
+  def after_confirmation_path_for(resource_name, resource)
+    # resource = user
+    # Redirect teacher back to the page where he signed up.
+    resource.portal_teacher && resource.sign_up_path || home_path
+  end
+
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1263,7 +1263,7 @@ module ApplicationHelper
       end
       message += link_to opts[:login], login_path
       message += " / "
-      message += link_to opts[:signup], pick_signup_path
+      message += link_to opts[:signup], 'javascript:Portal.openSignupModal();'
     else
       message += "#{opts[:welcome]} #{current_visitor.send(opts[:name_method])} &nbsp;"
       message += link_to opts[:prefs],  preferences_user_path(current_visitor)

--- a/app/models/api/v1/user_registration.rb
+++ b/app/models/api/v1/user_registration.rb
@@ -11,6 +11,7 @@ class API::V1::UserRegistration
   attribute :password_confirmation, String
   attribute :email,                 String
   attribute :login,                 String
+  attribute :sign_up_path,          String
   attribute :asked_age,             Boolean, :default => false
   attribute :have_consent,          Boolean, :default => false
 
@@ -33,7 +34,7 @@ class API::V1::UserRegistration
   end
 
   def user_params
-    valid_keys = [:first_name, :last_name, :password, :password_confirmation, :email, :login, :asked_age, :have_consent]
+    valid_keys = [:first_name, :last_name, :password, :password_confirmation, :email, :login, :sign_up_path, :asked_age, :have_consent]
     self.attributes.select { |k,v| valid_keys.include? k }
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -266,7 +266,7 @@ class User < ActiveRecord::Base
   # HACK HACK HACK -- how to do attr_accessible from here?
   # prevents a user from submitting a crafted form that bypasses activation
   # anything else you want your user to change should be added here.
-  attr_accessible :login, :email, :first_name, :last_name, :password, :password_confirmation, :remember_me,
+  attr_accessible :login, :email, :first_name, :last_name, :password, :password_confirmation, :sign_up_path, :remember_me,
                   :vendor_interface_id, :external_id, :of_consenting_age, :have_consent,:confirmation_token,:confirmed_at,:state, :require_password_reset
 
   # Authenticates a user by their login name and unencrypted password.  Returns the user or nil.

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -26,7 +26,12 @@
     != stylesheet_link_tag 'print', {'media' => 'print'}
 
     != javascript_include_tag 'prototype'
-    %script{ :src=> "https://ajax.googleapis.com/ajax/libs/scriptaculous/1.8.3/scriptaculous.js", :type => "text/javascript"}
+    %script{ :src => "https://ajax.googleapis.com/ajax/libs/scriptaculous/1.8.3/scriptaculous.js", :type => "text/javascript"}
+
+    / Include museo fonts.
+    %script{ :src => "https://use.typekit.com/hdw8ayt.js"}
+    %script
+      try { Typekit.load(); } catch (e) {}
 
     / Include scripts that are based on rails data and need to be generated dynamically. They cannot be precompiled.
     = render :partial => 'dynamic_scripts/all'

--- a/app/views/shared/_header_login_box.html.haml
+++ b/app/views/shared/_header_login_box.html.haml
@@ -19,10 +19,10 @@
       .login-buttons
         %span.login-links
           %span.segmented.first
-            =link_to "Can't log in?",forgot_password_path, :id=>"link_forgot_password"
+            = link_to "Can't log in?",forgot_password_path, :id=>"link_forgot_password"
           - unless defined? @hide_signup_link
             %span.segmented
-              =link_to 'Sign Up', home_path
+              = link_to "Sign Up", "javascript:Portal.openSignupModal();"
         %span.segmented
           = f.submit "Log In", :id=>"LoginSubmitButtonHeader"
         - Devise.omniauth_providers.each do |provider|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 RailsPortal::Application.routes.draw do
 
-  devise_for :users, :controllers => { :registrations => 'registrations', :omniauth_callbacks => "authentications" }
+  devise_for :users, :controllers => { :registrations => 'registrations', :confirmations => 'confirmations', :omniauth_callbacks => "authentications" }
 
   # Client stuff
   match '/auth/:provider/check' => 'misc#auth_check', method: :get, as: 'auth_check'

--- a/db/migrate/20160708124448_add_sign_up_path_to_users.rb
+++ b/db/migrate/20160708124448_add_sign_up_path_to_users.rb
@@ -1,0 +1,5 @@
+class AddSignUpPathToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :sign_up_path, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160705205130) do
+ActiveRecord::Schema.define(:version => 20160708124448) do
 
   create_table "access_grants", :force => true do |t|
     t.string   "code"
@@ -2625,6 +2625,7 @@ ActiveRecord::Schema.define(:version => 20160705205130) do
     t.string   "unconfirmed_email"
     t.datetime "confirmation_sent_at"
     t.boolean  "require_portal_user_type",                :default => false
+    t.string   "sign_up_path"
   end
 
   add_index "users", ["confirmation_token"], :name => "index_users_on_confirmation_token", :unique => true

--- a/features/teacher_views_materials_preview_page.feature
+++ b/features/teacher_views_materials_preview_page.feature
@@ -50,14 +50,14 @@ Feature: Teacher can search and assign instructional materials to a class
     Then I should see "Please log-in" within the lightbox in focus
     And I should see "as a teacher to assign this material." within the lightbox in focus
     And I follow "register" within the lightbox in focus
-    Then I should be on the pick signup page
+    Then I should see "Sign Up for Rails Portal"
     And I am on the the preview investigation page for the investigation "Mechanics"
     And I uncheck "Fluid Mechanics" from the investigation preview page
     And I follow "Assign Individual Activities"
     Then I should see "Please log-in" within the lightbox in focus
     And I should see "as a teacher to assign this material." within the lightbox in focus
     And I follow "register" within the lightbox in focus
-    Then I should be on the pick signup page
+    Then I should see "Sign Up for Rails Portal"
     
     
   Scenario: Teacher should be able to see different properties of materials

--- a/themes/sglight/views/layouts/application.html.haml
+++ b/themes/sglight/views/layouts/application.html.haml
@@ -58,7 +58,7 @@
             - else
               = link_to 'Login', login_path
               \/
-              = link_to 'Sign Up', pick_signup_path
+              = link_to 'Sign Up', 'javascript:Portal.openSignupModal();'
             - if @original_user.has_role?('admin', 'manager')
               \/
               = link_to 'Switch', switch_user_path(current_visitor)


### PR DESCRIPTION
- Redirects teachers to the page where they started sign up
- Adds `Portal.openSignupModal()` function, so Ethan can use it on landing pages
- Fixes some "Sign Up" and "regiter" links, they should open modal with sign up form now

Makes sense to review when https://github.com/concord-consortium/rigse/pull/241 is merged, as it's based on it.
