### PR TITLE
fix anonymous programatic use of the search model

### DIFF
--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -2,7 +2,7 @@ class ApplicationPolicy
   attr_reader :user, :original_user, :request, :params, :record
 
   def initialize(context, record)
-    if context.is_a? User
+    if context.nil? || (context.is_a? User)
       @user = context
       @original_user = context
       @request = nil
@@ -52,7 +52,7 @@ class ApplicationPolicy
     attr_reader :user, :scope
 
     def initialize(context, scope)
-      if context.is_a? User
+      if context.nil? || (context.is_a? User)
         @user = context
       else
         @user = context.user

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -189,7 +189,7 @@ describe Search do
         end
       end
 
-      describe "searching collectiosn that includes assessment items" do
+      describe "searching collections that includes assessment items" do
         let(:materials)     { [public_items, assessment_activities].flatten }
         let(:search_opts)   {{ :user_id => mock_user.id }}
         before(:each) do
@@ -537,6 +537,28 @@ describe Search do
           end
         end
       end
+
+      describe "with projects" do
+        let(:public_projects) { collection(:project, 2) }
+
+        describe "available_projects" do
+          subject { Search.new(search_opts).available_projects }
+
+          describe "when public external activities have public projects" do
+            before(:each) do
+              # add these projects to a public external activity
+              public_ext_act.first.projects = public_projects
+              reindex_all
+            end
+
+            it "should contain both public projects" do
+              expect(subject[0][:id]).to eql public_projects[0].id
+              expect(subject[1][:id]).to eql public_projects[1].id
+            end
+          end
+        end
+      end
+
 
       describe "ordering" do
         describe "by date" do


### PR DESCRIPTION
if the user_id was nil and there were Projects associated with
materials, when the Search model was created then the initialization of
the available_materials would fail because there was no user when it
called Pundit.policy!(user, project)

this was causing the ExternalActivity index page to fail because it uses
Search directly

[#126165359]