### PR TITLE
remove explicit scriptaculous reference

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,6 +4,7 @@
 
 = require 'modulejs'
 = require 'portal-namespace'
+= require 'prototype'
 = require 'modal'
 = require 'prototype-ui/prototype-ui'
 = require 'globals'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -25,9 +25,6 @@
     / TODO: if themes need their own print CSS make a themed link here:
     != stylesheet_link_tag 'print', {'media' => 'print'}
 
-    != javascript_include_tag 'prototype'
-    %script{ :src => "https://ajax.googleapis.com/ajax/libs/scriptaculous/1.8.3/scriptaculous.js", :type => "text/javascript"}
-
     / Include museo fonts.
     %script{ :src => "https://use.typekit.com/hdw8ayt.js"}
     %script

--- a/app/views/layouts/minimal.html.haml
+++ b/app/views/layouts/minimal.html.haml
@@ -25,9 +25,6 @@
     / TODO: if themes need their own print CSS make a themed link here:
     != stylesheet_link_tag 'print', {'media' => 'print'}
 
-    != javascript_include_tag 'prototype'
-    %script{ :src=> "https://ajax.googleapis.com/ajax/libs/scriptaculous/1.8.3/scriptaculous.js", :type => "text/javascript"}
-
     / Include scripts that are based on rails data and need to be generated dynamically. They cannot be precompiled.
     = render :partial => 'dynamic_scripts/all'
     / TODO: if themes need their own javascript, add theme_ to this:

--- a/app/views/layouts/report.html.haml
+++ b/app/views/layouts/report.html.haml
@@ -9,7 +9,6 @@
     %meta{ :name => "resource-type", :content => "document" }
     %meta{ :name => "MSSmartTagsPreventParsing", :content => "true" }
     %link{ :href => path_to_image('favicon.ico'), :rel => "shortcut icon"}/
-    != javascript_include_tag 'prototype'
 
     != theme_stylesheet_link_tag 'application', {'media' => 'screen, presentation'}
     != stylesheet_link_tag 'print', {'media' => 'print'}

--- a/app/views/layouts/run.run_html.haml
+++ b/app/views/layouts/run.run_html.haml
@@ -9,9 +9,6 @@
     %meta{ :name => "resource-type", :content => "document" }
     %meta{ :name => "MSSmartTagsPreventParsing", :content => "true" }
     %link{ :href => path_to_image('favicon.ico'), :rel => "shortcut icon"}/
-    != javascript_include_tag 'prototype'
-    %script{ :src=> "https://ajax.googleapis.com/ajax/libs/scriptaculous/1.8.3/scriptaculous.js", :type => "text/javascript"}
-
 
     != theme_stylesheet_link_tag 'application', {'media' => 'screen, presentation'}
     != stylesheet_link_tag 'print', {'media' => 'print'}

--- a/spec/javascripts/components/materials_bin/material_category_spec.js.coffee
+++ b/spec/javascripts/components/materials_bin/material_category_spec.js.coffee
@@ -1,5 +1,4 @@
 #= require helpers/react_helper
-#= require component
 
 describe 'MBMaterialsCategoryClass', ->
   beforeEach ->

--- a/spec/javascripts/components/materials_bin/material_spec.js.coffee
+++ b/spec/javascripts/components/materials_bin/material_spec.js.coffee
@@ -1,5 +1,4 @@
 #= require helpers/react_helper
-#= require component
 
 describe 'MBMaterialClass', ->
   beforeEach ->

--- a/spec/javascripts/components/search/material_body_spec.js.coffee
+++ b/spec/javascripts/components/search/material_body_spec.js.coffee
@@ -1,5 +1,4 @@
 #= require helpers/react_helper
-#= require components/search/material_body
 
 describe 'SMaterialBodyClass', ->
 

--- a/spec/javascripts/helpers/react_helper.js.coffee
+++ b/spec/javascripts/helpers/react_helper.js.coffee
@@ -1,8 +1,9 @@
 #= require react
+#= require react-server
 
 # helper methods
 window.renderStatic = (reactClass, props={} ) ->
-  ReactDOM.renderToStaticMarkup ((React.createFactory reactClass) props)
+  ReactDOMServer.renderToStaticMarkup ((React.createFactory reactClass) props)
 
 # shortcuts for add-on test utilities (the add-ons are enabled in /config/environments/test.rb)
 window.Simulate = React.addons.TestUtils.Simulate


### PR DESCRIPTION
the various scriptaculous files seem to be loaded through the asset
pipeline such as effects.js

This also fixes a bug where prototype was not part of the asset pipeline
so it was not being precompiled for production.

Currently this has failing jasmine tests. The problem seems to be that these tests were not really running before and now for some reason they have started running. So it is not clear how long they have been broken.