### PR TITLE
Fix edge case related to school selection in sign up form

### DIFF
--- a/app/assets/javascripts/components/signup/school_input.js.coffee
+++ b/app/assets/javascripts/components/signup/school_input.js.coffee
@@ -22,6 +22,8 @@ modulejs.define 'components/signup/school_input', [], () ->
       {country, zipcode} = @props
       # Update options if country is changed or zipcode input is changed.
       if prevProps.country != country || prevProps.zipcode != zipcode
+        # Reset current school if country or zipcode is changed and download a new list of schools.
+        @setValue ''
         @updateOptions()
 
     newSchoolLink: ->
@@ -43,8 +45,6 @@ modulejs.define 'components/signup/school_input', [], () ->
           options = data.map (school) -> label: school.name, value: school.id
           options.push {label: @newSchoolLink(), disabled: true}
           @setState options: options, isLoading: false
-          # Reset selected option when we download a new list of schools.
-          @setValue ''
       , TIMEOUT
 
     render: ->

--- a/app/assets/stylesheets/components/signup.scss
+++ b/app/assets/stylesheets/components/signup.scss
@@ -94,6 +94,10 @@
       color: #d0d0d0;
     }
 
+    .Select-input > input {
+      padding: 10px 0 12px !important;
+    }
+
     &.valid {
       .Select-control {
         background: #f6fff5;

--- a/app/assets/stylesheets/modal.scss
+++ b/app/assets/stylesheets/modal.scss
@@ -19,7 +19,6 @@
   left: 50%;
   height: auto;
   margin: -250px 0 0 -336px;
-  min-height: 500px;
   padding: 1em;
   top: 400px;
   width: 640px;


### PR DESCRIPTION
Fixes an issue found by @eireland:
> 1. Sign up as a new teacher
> 2. When asked to enter a zip code, entered a valid zip code and selected a school. Do not hit enter after this step.
> 3.Change the zip code (I changed it to another valid zip code. Will have to try with an invalid one.)
> 4. Hit Enter on the keyboard.
> 5. The Teacher is now registered at a zip code with a high school that doesn't exist in that zip code.

We use ZIP code only to download a list of schools, so this problem wasn't causing any inconsistency in DB. But definitely makes sense to fix it.