### PR TITLE
Publish changes for `external_report_url` from External Activities

### DIFF
--- a/features/activity_runtime_api/publish.feature
+++ b/features/activity_runtime_api/publish.feature
@@ -9,6 +9,7 @@ Feature: External Activities can support a REST publishing api
         "launch_url": "http://activity.com/activity/1/sessions/",
         "author_url": "http://activity.com/activity/1/edit",
         "print_url": "http://activity.com/activity/1/print_blank",
+        "external_report_url": "https://reports.concord.org/act",
         "description": "This activity does fun stuff.",
         "sections": [
           {
@@ -59,6 +60,7 @@ Feature: External Activities can support a REST publishing api
         "launch_url": "http://activity.com/activity/1/sessions/",
         "author_url": "http://activity.com/activity/1/edit_new",
         "print_url": "http://activity.com/activity/1/print_blank_new",
+        "external_report_url": "https://reports.concord.org/act/changed",
         "sections": [
           {
             "name": "Cool Activity Section 1",
@@ -109,6 +111,7 @@ Feature: External Activities can support a REST publishing api
         "launch_url": "http://activity.com/sequence/1",
         "author_url": "http://activity.com/sequence/1/edit",
         "print_url": "http://activity.com/sequence/1/print_blank",
+        "external_report_url": "https://reports.concord.org/seq",
         "abstract": "This is the abstract",
         "activities": [
           {
@@ -218,6 +221,7 @@ Feature: External Activities can support a REST publishing api
         "launch_url": "http://activity.com/sequence/1",
         "author_url": "http://activity.com/sequence/1/edit_new",
         "print_url": "http://activity.com/sequence/1/print_blank_new",
+        "external_report_url": "https://reports.concord.org/seq/changed",
         "activities": [
           {
             "type": "Activity",
@@ -314,6 +318,10 @@ Feature: External Activities can support a REST publishing api
         ]
       }
       """
+    And an external_report with the URL "https://reports.concord.org/act"
+    And an external_report with the URL "https://reports.concord.org/act/changed"
+    And an external_report with the URL "https://reports.concord.org/seq"
+    And an external_report with the URL "https://reports.concord.org/seq/changed"
 
   @mechanize
   Scenario: External REST activity is published the first time
@@ -327,6 +335,7 @@ Feature: External Activities can support a REST publishing api
       | print_url       | http://activity.com/activity/1/print_blank |
       | description     | This activity does fun stuff. |
     And the external activity should have a template
+    And the external activity should have a external report at "https://reports.concord.org/act"
     And the portal should create an activity with the following attributes:
       | name            | Cool Activity |
     And the portal should create a section with the following attributes:
@@ -355,6 +364,7 @@ Feature: External Activities can support a REST publishing api
       | author_url      | http://activity.com/activity/1/edit_new |
       | print_url       | http://activity.com/activity/1/print_blank_new |
       | description     | This activity does fun stuff. |
+    And the external activity should have a external report at "https://reports.concord.org/act/changed"
 
   @mechanize
   Scenario: External REST sequence is published the first time
@@ -369,6 +379,7 @@ Feature: External Activities can support a REST publishing api
       | description     | Several activities together in a sequence |
       | abstract        | This is the abstract |
     And the external activity should have a template
+    And the external activity should have a external report at "https://reports.concord.org/seq"
     And the portal should create an investigation with the following attributes:
       | name            | Many fun things |
     And the portal should create an activity with the following attributes:
@@ -396,3 +407,4 @@ Feature: External Activities can support a REST publishing api
       | launch_url      | http://activity.com/sequence/1 |
       | author_url      | http://activity.com/sequence/1/edit_new |
       | print_url       | http://activity.com/sequence/1/print_blank_new |
+    And the external activity should have a external report at "https://reports.concord.org/seq/changed"

--- a/features/step_definitions/activity_runtime_api_publish_steps.rb
+++ b/features/step_definitions/activity_runtime_api_publish_steps.rb
@@ -136,3 +136,13 @@ Given /^the external runtime published the (activity|sequence) "([^"]*)" before$
     publish_sequence(name, false)
   end
 end
+
+Then(/^the (.*) should have a external report at "(.*)"$/) do |ignored_param, report_url|
+  @external_activity.external_report.should_not be_nil
+  @external_activity.external_report.url.should == report_url
+end
+
+Given(/^an external_report with the URL "(.*?)"$/) do | report_url|
+  ExternalReport.create(url:report_url)
+end
+

--- a/lib/activity_runtime_api.rb
+++ b/lib/activity_runtime_api.rb
@@ -57,6 +57,7 @@ class ActivityRuntimeAPI
         :author_email => hash["author_email"],
         :is_locked => hash["is_locked"]
       )
+      self.update_external_report(external_activity,hash["external_report_url"])
       # update activity so external_activity.template is correctly initialzed
       # otherwise external_activity.template.is_template? won't be true
       activity.reload
@@ -94,7 +95,7 @@ class ActivityRuntimeAPI
     ['author_email', 'is_locked', 'print_url', 'author_url'].each do |attribute|
       external_activity.update_attribute(attribute,hash[attribute])
     end
-    
+    self.update_external_report(external_activity,hash["external_report_url"])
     # save the embeddables
     mc_cache = {}
     or_cache = {}
@@ -158,6 +159,7 @@ class ActivityRuntimeAPI
         :author_email => hash["author_email"],
         :is_locked => hash["is_locked"]
       )
+      self.update_external_report(external_activity, hash["external_report_url"])
       # update investigation so external_activity.template is correctly initialzed
       # otherwise external_activity.template.is_template? won't be true
       investigation.reload
@@ -188,6 +190,7 @@ class ActivityRuntimeAPI
       end
     end
     external_activity.update_attribute('author_email',hash['author_email'])
+    self.update_external_report(external_activity, hash["external_report_url"])
     # save the embeddables
     mc_cache = {}
     or_cache = {}
@@ -448,4 +451,15 @@ class ActivityRuntimeAPI
     filters = template.offerings.map { |offering| offering.report_embeddable_filter }.compact
     filters.each { |filter| filter.clear }
   end
+
+
+  def self.update_external_report(external_activity, report_url)
+    external_report = nil
+    if report_url
+      external_report = ExternalReport.find_by_url(report_url)
+    end
+    external_activity.external_report = external_report
+    external_activity.save
+  end
+
 end


### PR DESCRIPTION
When a LARA author publishes an activity or sequence to the portal, if the activity or sequence has an external report URL, the portal setting for the external report for that activity/sequence is set using the external report URL from the LARA activity/sequence.

see this [PT story](https://www.pivotaltracker.com/story/show/126808601) for more details. 
