### PR TITLE
change default of images to published

### DIFF
--- a/db/migrate/20160804135541_change_publication_of_image.rb
+++ b/db/migrate/20160804135541_change_publication_of_image.rb
@@ -1,0 +1,9 @@
+class ChangePublicationOfImage < ActiveRecord::Migration
+  def up
+    change_column :images, :publication_status, :string, :default => "published"
+  end
+
+  def down
+    change_column :images, :publication_status, :string, :default => "private"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160708124448) do
+ActiveRecord::Schema.define(:version => 20160804135541) do
 
   create_table "access_grants", :force => true do |t|
     t.string   "code"
@@ -883,9 +883,9 @@ ActiveRecord::Schema.define(:version => 20160708124448) do
     t.integer  "user_id"
     t.string   "name"
     t.text     "attribution"
-    t.string   "publication_status", :default => "private"
     t.datetime "created_at",                                :null => false
     t.datetime "updated_at",                                :null => false
+    t.string   "publication_status", :default => "published"
     t.string   "image_file_name"
     t.string   "image_content_type"
     t.integer  "image_file_size"


### PR DESCRIPTION
The only project using the image library is ITSI now and they’d prefer
images to published by default.
[#127728217]