### PR TITLE
Report feedback work part 2

### DIFF
--- a/app/controllers/api/v1/reports_controller.rb
+++ b/app/controllers/api/v1/reports_controller.rb
@@ -38,6 +38,9 @@ class API::V1::ReportsController < API::APIController
     if params[:feedback_opts]
       API::V1::Report.update_feedback_settings(offering, params[:feedback_opts])
     end
+    if params[:feedback]
+      API::V1::Report.submit_feedback(params[:feedback])
+    end
     offering.update_attributes!(report_params)
     head :ok
   end

--- a/app/models/api/v1/report.rb
+++ b/app/models/api/v1/report.rb
@@ -1,7 +1,7 @@
 class API::V1::Report
   include RailsPortal::Application.routes.url_helpers
   REPORT_VERSION = "1.0.1"
-  MAX_REPORT_LEARNER_AGE = 2.hours
+  MAX_REPORT_LEARNER_AGE = 1.seconds
 
   def initialize(options)
     # offering, protocol, host_with_port, student_ids = nil, activity_id=nil)
@@ -78,7 +78,7 @@ class API::V1::Report
   end
 
 
-  def update_report_learners(report_learners)
+  def self.update_report_learners(report_learners)
     report_learners.each do |learner|
       if learner.last_report.nil? or learner.last_report < MAX_REPORT_LEARNER_AGE.ago
         learner.last_report = Time.now
@@ -92,7 +92,7 @@ class API::V1::Report
     # Collect all the student answers for given offering.
     student_ids = @students.map { |s| s.id }
     report_learners = Report::Learner.where(offering_id: @offering.id, student_id: student_ids)
-    update_report_learners(report_learners)
+    API::V1::Report.update_report_learners(report_learners)
 
     answers = report_learners.map do |report_learner|
       student_id = report_learner.student_id

--- a/app/models/api/v1/report.rb
+++ b/app/models/api/v1/report.rb
@@ -1,7 +1,6 @@
 class API::V1::Report
   include RailsPortal::Application.routes.url_helpers
   REPORT_VERSION = "1.0.1"
-  MAX_REPORT_LEARNER_AGE = 3.hours
 
   def initialize(options)
     # offering, protocol, host_with_port, student_ids = nil, activity_id=nil)
@@ -78,21 +77,11 @@ class API::V1::Report
   end
 
 
-  def self.update_report_learners(report_learners)
-    report_learners.each do |learner|
-      if learner.last_report.nil? or learner.last_report < MAX_REPORT_LEARNER_AGE.ago
-        learner.last_report = Time.now
-        learner.update_fields()
-      end
-    end
-  end
-
   # Helpers that provide student answers grouped by embeddable key:
   def get_student_answers
     # Collect all the student answers for given offering.
     student_ids = @students.map { |s| s.id }
     report_learners = Report::Learner.where(offering_id: @offering.id, student_id: student_ids)
-    API::V1::Report.update_report_learners(report_learners)
 
     answers = report_learners.map do |report_learner|
       student_id = report_learner.student_id

--- a/app/models/api/v1/report.rb
+++ b/app/models/api/v1/report.rb
@@ -1,7 +1,7 @@
 class API::V1::Report
   include RailsPortal::Application.routes.url_helpers
   REPORT_VERSION = "1.0.1"
-  MAX_REPORT_LEARNER_AGE = 1.seconds
+  MAX_REPORT_LEARNER_AGE = 3.hours
 
   def initialize(options)
     # offering, protocol, host_with_port, student_ids = nil, activity_id=nil)
@@ -337,6 +337,11 @@ class API::V1::Report
       answer.add_feedback(answer_feedback_hash)
     else # assume answer has feedback columns.
       answer.update_attributes(answer_feedback_hash)
+    end
+    # All answers should delegate learner to their saveables...
+    # We need to update fields, because the answer is serialized in the report learner
+    if answer.respond_to?(:learner) && answer.learner
+      answer.learner.report_learner.update_fields()
     end
 
   end

--- a/app/models/report/learner.rb
+++ b/app/models/report/learner.rb
@@ -111,7 +111,10 @@ class Report::Learner < ActiveRecord::Base
     # AU: We'll use a serialized column to store a hash, for now
     answers_hash = {}
     report_util.saveables.each do |s|
-      feedbacks = s.answers.map do |ans|
+      # feedbacks = s.answers.map do |ans|
+      # TOOD: Eventually we want all answers.... Or answers with feedback...
+      # this has been simplified here because for performance reasons.
+        feedbacks = [s.answers.last].compact.map do |ans|
         {
             answer: serialize_blob_answer(ans.answer),
             answer_key: Report::Learner.encode_answer_key(ans),
@@ -125,10 +128,7 @@ class Report::Learner < ActiveRecord::Base
           feedbacks: feedbacks,
           answered: s.answered?,
           submitted: s.submitted?,
-          question_required: s.embeddable.is_required,
-          needs_review: s.needs_review?,
-          score: s.current_score,       # may be null
-          feedback: s.current_feedback  # may be null
+          question_required: s.embeddable.is_required
       }
       hash[:is_correct] = s.answered_correctly? if s.respond_to?("answered_correctly?")
       answers_hash[ Report::Learner.encode_answer_key(s.embeddable)] = hash

--- a/app/models/report/learner.rb
+++ b/app/models/report/learner.rb
@@ -115,8 +115,8 @@ class Report::Learner < ActiveRecord::Base
         {
             answer: serialize_blob_answer(ans.answer),
             answer_key: Report::Learner.encode_answer_key(ans),
-            score: ans.respond_to?(:score) ? (ans.score || false) : nil,
-            feedback: ans.respond_to?(:feedback) ? (ans.feedback || false): nil,
+            score: ans.respond_to?(:score) ? ans.score  : nil,
+            feedback: ans.respond_to?(:feedback) ? ans.feedback : nil,
             has_been_reviewed: ans.respond_to?(:has_been_reviewed?) ? (ans.has_been_reviewed?||false) : nil
         }
       end
@@ -126,7 +126,9 @@ class Report::Learner < ActiveRecord::Base
           answered: s.answered?,
           submitted: s.submitted?,
           question_required: s.embeddable.is_required,
-          needs_review: s.needs_review?
+          needs_review: s.needs_review?,
+          score: s.current_score,       # may be null
+          feedback: s.current_feedback  # may be null
       }
       hash[:is_correct] = s.answered_correctly? if s.respond_to?("answered_correctly?")
       answers_hash[ Report::Learner.encode_answer_key(s.embeddable)] = hash

--- a/app/models/saveable/image_question_answer.rb
+++ b/app/models/saveable/image_question_answer.rb
@@ -7,7 +7,8 @@ class Saveable::ImageQuestionAnswer < ActiveRecord::Base
   belongs_to :blob, :class_name => 'Dataservice::Blob'
 
   acts_as_list :scope => :image_question_id
-  
+  delegate :learner, to: :image_question, allow_nil: :true
+
   def answer
     if blob || note
       {:blob => blob, :note => note}

--- a/app/models/saveable/multiple_choice_answer.rb
+++ b/app/models/saveable/multiple_choice_answer.rb
@@ -8,6 +8,7 @@ class Saveable::MultipleChoiceAnswer < ActiveRecord::Base
 
   acts_as_list :scope => :multiple_choice_id
 
+  delegate :learner, to: :multiple_choice, allow_nil: :true
   def answer
     if rationale_choices.size > 0
       choices = multiple_choice.choices

--- a/app/models/saveable/open_response_answer.rb
+++ b/app/models/saveable/open_response_answer.rb
@@ -5,5 +5,5 @@ class Saveable::OpenResponseAnswer < ActiveRecord::Base
   belongs_to :bundle_content, :class_name => 'Dataservice::BundleContent'
 
   acts_as_list :scope => :open_response_id
-  
+  delegate :learner, to: :open_response, allow_nil: :true
 end

--- a/app/models/saveable/saveable.rb
+++ b/app/models/saveable/saveable.rb
@@ -22,6 +22,8 @@ module Saveable::Saveable
   end
 
   def embeddable
+    # guard against answers where the embeddables are null...
+    return nil unless self.class.embeddable_type(self)
     self.send(self.class.embeddable_type(self)[:str])
   end
 

--- a/spec/controllers/api/v1/report_spec.rb
+++ b/spec/controllers/api/v1/report_spec.rb
@@ -108,7 +108,7 @@ describe API::V1::ReportsController do
         max_score_should_be 0
         feedback_should_be_enabled
         score_should_be_disabled
-        answers.should include_hash({"answer" => "testing from #{learner_a.student.user.id}", "needs_review" => true})
+        answers.should include_hash({"answer" => "testing from #{learner_a.student.user.id}"})
       end
     end
   end

--- a/spec/models/api/v1/report_spec.rb
+++ b/spec/models/api/v1/report_spec.rb
@@ -81,7 +81,7 @@ describe API::V1::Report do
         end
       end
 
-      describe "when an answer is give" do
+      describe "when an answer is given" do
         before(:each) do
           open_response_answer.answers.create(answer: "this is the answer")
           API::V1::Report.submit_feedback(feedback)

--- a/spec/models/api/v1/report_spec.rb
+++ b/spec/models/api/v1/report_spec.rb
@@ -124,7 +124,6 @@ describe API::V1::Report do
             open_response_answer.current_feedback.should eq text_feedback
           end
         end
-
       end
     end
   end

--- a/spec/models/api/v1/report_spec.rb
+++ b/spec/models/api/v1/report_spec.rb
@@ -71,9 +71,6 @@ describe API::V1::Report do
             'has_been_reviewed' => has_been_reviewed
         }
       end
-      before(:each) do
-        API::V1::Report.submit_feedback(feedback)
-      end
 
       describe "when no feedback or answer has been given yet" do
         it "should indicate that it doesn't need review" do
@@ -119,6 +116,7 @@ describe API::V1::Report do
           end
 
           it "should have the correct score" do
+            open_response_answer.answers.length.should have_at_least(1).answer
             open_response_answer.current_score.should eq score
           end
 

--- a/spec/models/report/learner_spec.rb
+++ b/spec/models/report/learner_spec.rb
@@ -194,14 +194,6 @@ describe Report::Learner do
             end
           end
 
-          it "should indicate that the answers need feedback" do
-            subject.answers.each do |answer|
-              qkey,a = answer
-              a[:needs_review].should be_true
-            end
-          end
-
-
           describe "giving feedback" do
             let(:last_answer)           { learner.answers.last }
             let(:feedback)              {{ feedback: "great job!", score: 4, has_been_reviewed: true}}
@@ -223,9 +215,6 @@ describe Report::Learner do
                 report_learner.update_answers()
               end
 
-              it "should require feedback because there is a new answer" do
-                open_response_saveable[1][:needs_review].should be_true
-              end
             end
 
           end


### PR DESCRIPTION
@scytacki :  If you could review these changes.  These are mostly small fixes.

* Student first and last names are sent so the report can sort answers and feedback.
* Changes that update the report_learner only for users who get new feedback.  (In the previous version we were updating all the report learners every time.)
* Redundant fields were removed from the report API response.
