### PR TITLE
Saveables provide their own 'embeddable' method.

### DIFF
--- a/app/models/saveable/image_question.rb
+++ b/app/models/saveable/image_question.rb
@@ -13,6 +13,10 @@ class Saveable::ImageQuestion < ActiveRecord::Base
 
   include Saveable::Saveable
 
+  def embeddable
+    image_question
+  end
+
   def submitted_answer
     if submitted?
       answers.last.answer

--- a/app/models/saveable/multiple_choice.rb
+++ b/app/models/saveable/multiple_choice.rb
@@ -17,6 +17,10 @@ class Saveable::MultipleChoice < ActiveRecord::Base
 
   include Saveable::Saveable
 
+  def embeddable
+    multiple_choice
+  end
+
   # TODO:  We shouldn't need to special case this. But we do.
   # We should use saveable.rb#answer, but because we are sending
   # an array of answers, it doesn't work.

--- a/app/models/saveable/open_response.rb
+++ b/app/models/saveable/open_response.rb
@@ -16,6 +16,10 @@ class Saveable::OpenResponse < ActiveRecord::Base
 
   include Saveable::Saveable
 
+  def embeddable
+    open_response
+  end
+
   def submitted_answer
     if submitted?
       answers.last.answer

--- a/app/models/saveable/saveable.rb
+++ b/app/models/saveable/saveable.rb
@@ -1,37 +1,14 @@
 module Saveable::Saveable
 
-  def self.included(base)
-    base.extend(ClassMethods)
-  end
-
-  module ClassMethods
-    def possible_types
-      @possible_types ||= get_possible_types
-    end
-    def embeddable_type(instance)
-      @embeddable_type ||= get_embeddable_type(instance)
-    end
-    def get_possible_types
-      @possible_types = ResponseTypes.reportable_types.map{ |t|  {:klass => t, :str => t.to_s.demodulize.underscore} }
-      @possible_types
-    end
-    def get_embeddable_type(instance)
-      @embeddable_type = possible_types.detect {|type| instance.respond_to? type[:str]}
-      @embeddable_type
-    end
-  end
-
-  def embeddable
-    # guard against answers where the embeddables are null...
-    return nil unless self.class.embeddable_type(self)
-    self.send(self.class.embeddable_type(self)[:str])
-  end
+  # Required methods in classes mixing in `Saveable::Saveable`:
+  # * `embeddable`
+  # * `asnwers`
 
   def submitted?
     # Note that we consider regular questions (not required) as submitted when
     # they have any answer available. Required questions have to have the last
     # answer explicitly marked as final (submitted).
-    if embeddable.is_required
+    if embeddable.respond_to?(:is_required) && embeddable.is_required
       answered? && answers.last.is_final
     else
       answered?

--- a/factories/embeddable_iframes.rb
+++ b/factories/embeddable_iframes.rb
@@ -1,0 +1,2 @@
+Factory.define :embeddable_iframe, class: Embeddable::Iframe do |f|
+end

--- a/factories/saveable_external_links.rb
+++ b/factories/saveable_external_links.rb
@@ -1,0 +1,5 @@
+Factory.define :saveable_external_link, :class => Saveable::ExternalLink do |f|
+  f.association :learner, :factory => :full_portal_learner
+  f.association :embeddable, :factory => :embeddable_iframe
+  f.association :offering, :factory => :portal_offering
+end

--- a/spec/models/saveable/external_link_spec.rb
+++ b/spec/models/saveable/external_link_spec.rb
@@ -1,0 +1,5 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+describe Saveable::ExternalLink do
+  it_should_behave_like 'a saveable'
+end


### PR DESCRIPTION
Removes complicated and buggy dynamic method lookup in the saveable module. We now expect that saveables bring their own 'embeddable' method.

This fixes a regression that causes student reports to fail when reporting on interactives with external reporting links.

PT Story: https://www.pivotaltracker.com/n/projects/736901/stories/129909019