### PR TITLE
Don’t redirect students back to project pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -204,10 +204,12 @@ class ApplicationController < ActionController::Base
 
   def after_sign_in_path_for(resource)
     redirect_path = root_path
-    if params[:after_sign_in_path]
+    if current_user.portal_student
+      redirect_path = my_classes_path
+    elsif params[:after_sign_in_path]
       redirect_path = params[:after_sign_in_path]
-    elsif APP_CONFIG[:recent_activity_on_login] && current_visitor.portal_teacher
-      if current_visitor.has_active_classes?
+    elsif APP_CONFIG[:recent_activity_on_login] && current_user.portal_teacher
+      if current_user.has_active_classes?
         # Teachers with active classes are redirected to the "Recent Activity" page
         redirect_path = recent_activity_path
       else

--- a/spec/integration/sign_in_redirect_spec.rb
+++ b/spec/integration/sign_in_redirect_spec.rb
@@ -8,4 +8,13 @@ describe "when user signs in and 'after_sign_in_path' parameter is provided" do
     post "/users/sign_in", user: {login: user.login, password: user.password}, after_sign_in_path: custom_url
     expect(response).to redirect_to(custom_url)
   end
+
+  describe "and user is student" do
+    let(:user) { Factory.create(:full_portal_student).user }
+
+    it "user is sent to my classes" do
+      post "/users/sign_in", user: {login: user.login, password: user.password}, after_sign_in_path: custom_url
+      expect(response).to redirect_to(my_classes_url)
+    end
+  end
 end


### PR DESCRIPTION
Dan noticed students running into this problem. The student would sign in on the project page and then they would see the 'preview' buttons for the materials on the project page. If the student runs a material like that then their work is not saved back to the portal.

https://www.pivotaltracker.com/story/show/130556765