### PR TITLE
handle published print_url, other Sequence props

### DIFF
--- a/lib/activity_runtime_api.rb
+++ b/lib/activity_runtime_api.rb
@@ -189,7 +189,11 @@ class ActivityRuntimeAPI
         act.update_attribute(attribute,hash[attribute])
       end
     end
-    external_activity.update_attribute('author_email',hash['author_email'])
+
+    ['author_email', 'is_locked', 'print_url', 'author_url'].each do |attribute|
+      external_activity.update_attribute(attribute,hash[attribute]) if hash.has_key?(attribute)
+    end
+
     self.update_external_report(external_activity, hash["external_report_url"])
     # save the embeddables
     mc_cache = {}


### PR DESCRIPTION
print_url, author_url and is_locked were not updated when a external
activity of type Sequence was updated. [#130612517]

Additionally this changes both the Activity and Sequence property publishing logic. If one of the following properties is not provided then the portal's ExternalActivity property is not changed:
print_url, author_url, is_locked, author_email.
This approach is needed to support the fact that LARA doesn't send is_locked for sequences, so that property should not be changed if a user sets it in the portal.  And it seems a generally better approach. This way systems other than LARA can decide if they want to provide these properties or not. And if they don't provide them a portal user can manually setup them.

There is a lot of duplicate code here. I'm trying to get this print_url fix out quickly so I didn't fix it. Here is a tech debt story to fix it up: https://www.pivotaltracker.com/story/show/130635343