### PR TITLE
fix bug with anonymous users viewing search pages

### DIFF
--- a/app/policies/external_activity_policy.rb
+++ b/app/policies/external_activity_policy.rb
@@ -30,7 +30,7 @@ class ExternalActivityPolicy < ApplicationPolicy
   end
 
   def copy?
-    ! user.anonymous?
+    user.present?
   end
 
   # the basic edit form lets a user change the publication status, subject areas,
@@ -56,7 +56,7 @@ class ExternalActivityPolicy < ApplicationPolicy
   end
 
   def material_admin?
-    record.projects.detect{ |p| user.is_project_admin? p }
+    user.present? && record.projects.detect{ |p| user.is_project_admin? p }
   end
 
   def admin_or_material_admin?


### PR DESCRIPTION
In the Portal policy objects the user is nil if there is no one logged in. This is analogous to the `current_user`.  We also have `current_visitor` in the portal which has a special 'anonymous' user. We are trying to get away from using `current_vistor` because it is non standard.

This PR fixes a policy that assumed the user would always be available.
[#129076031]