### PR TITLE
Fix permission_form searching

### DIFF
--- a/app/models/report/learner.rb
+++ b/app/models/report/learner.rb
@@ -7,6 +7,7 @@ class Report::Learner < ActiveRecord::Base
 
   belongs_to   :learner, :class_name => "Portal::Learner", :foreign_key => "learner_id",
     :inverse_of => :report_learner
+  belongs_to   :student, :class_name => "Portal::Student"
   serialize    :answers, Hash
   belongs_to   :runnable, :polymorphic => true
 
@@ -16,8 +17,9 @@ class Report::Learner < ActiveRecord::Base
   scope :in_classes, lambda     { |class_ids|    {:conditions => {:class_id    => class_ids    }}}
 
   scope :with_permission_ids, lambda { |ids|
-    joins(:learner => {:student => :portal_student_permission_forms})
-        .where(:portal_student_permission_forms => { :portal_permission_form_id => ids })
+    includes(student: :portal_student_permission_forms)
+      .where("portal_student_permission_forms.portal_permission_form_id", ids)
+
   }
 
   scope :with_runnables, lambda { |runnables|

--- a/app/models/report/learner.rb
+++ b/app/models/report/learner.rb
@@ -14,10 +14,12 @@ class Report::Learner < ActiveRecord::Base
   scope :before, lambda         { |date|         {:conditions => ["last_run < ?", date]} }
   scope :in_schools, lambda     { |school_ids|   {:conditions => {:school_id   => school_ids   }}}
   scope :in_classes, lambda     { |class_ids|    {:conditions => {:class_id    => class_ids    }}}
-  scope :with_perm_form, lambda { |perm_forms|
-    query = perm_forms.map { |pf| "find_in_set(?,permission_forms)" }.join(" or ")
-    where("(#{query})", *perm_forms)
+
+  scope :with_permission_ids, lambda { |ids|
+    joins(:learner => {:student => :portal_student_permission_forms})
+        .where(:portal_student_permission_forms => { :portal_permission_form_id => ids })
   }
+
   scope :with_runnables, lambda { |runnables|
     where 'CONCAT(runnable_type, "_", runnable_id) IN (?)', runnables.map{|runnable| "#{runnable.class}_#{runnable.id}"}.join(",")}
 

--- a/app/models/report/learner/selector.rb
+++ b/app/models/report/learner/selector.rb
@@ -77,7 +77,7 @@ class Report::Learner::Selector
     @scopes[:with_runnables] = @select_runnables                 unless @select_runnables.blank?
     @scopes[:before]         = Time.parse(@parsed_end_date)      unless @parsed_end_date.blank?
     @scopes[:after]          = Time.parse(@start_date)           unless @start_date.blank?
-    @scopes[:with_perm_form] = @select_perm_form                 unless @select_perm_form.blank?
+    @scopes[:with_permission_ids] = @select_perm_form            unless @select_perm_form.blank?
 
     unless @select_teachers.blank?
       clazzes = @select_teachers.map { |t| t.clazzes }
@@ -91,6 +91,7 @@ class Report::Learner::Selector
       results = policy_scopes[:learners]
       @scopes.each_pair do |k,v|
         results = results.send(k,v)
+        puts "#{k} #{v}"
       end
       @learners = results
     else

--- a/app/models/report/learner/selector.rb
+++ b/app/models/report/learner/selector.rb
@@ -32,7 +32,7 @@ class Report::Learner::Selector
 
     @start_date            = options['start_date']
     @end_date              = options['end_date']
-    @all_perm_forms        = policy_scopes[:perm_forms].map { |p| p.fullname }
+    @all_perm_forms        = policy_scopes[:perm_forms]
     begin
       Time.parse(@start_date)
     rescue
@@ -51,11 +51,12 @@ class Report::Learner::Selector
     @select_runnables      = options['runnables'] || []
     @select_schools        = options['schools']   || []
     @select_teachers       = options['teachers']  || []
-    @select_perm_form      = options['perm_form'] || nil
+    @select_perm_form      = options['perm_form'] || []
 
     # to populate dropdown menus:
     @select_schools   = @select_schools.map      { |s| Portal::School.find(s) }
     @select_teachers  = @select_teachers.map     { |t| Portal::Teacher.find(t) }
+    @select_perm_form = @select_perm_form.map    { |p| Portal::PermissionForm.find(p) }
     @select_runnables = @select_runnables.map    { |r|
       case(r)
       when /^Investigation_(\d+)/
@@ -91,7 +92,6 @@ class Report::Learner::Selector
       results = policy_scopes[:learners]
       @scopes.each_pair do |k,v|
         results = results.send(k,v)
-        puts "#{k} #{v}"
       end
       @learners = results
     else
@@ -106,4 +106,33 @@ class Report::Learner::Selector
       select_runnables
     end
   end
+
+  def options_for_schools
+    [
+      @all_schools.map    { |s| [s.name, s.id] },
+      @select_schools.map { |s|          s.id  }
+    ]
+  end
+
+  def options_for_teachers
+    [
+      @all_teachers.map    { |s| [s.name, s.id] },
+      @select_teachers.map { |s|          s.id  }
+    ]
+  end
+
+  def options_for_runnables
+    [
+        @all_runnables.map    { |r| ["#{r.name}(#{r.class})", "#{r.class}_#{r.id}"] },
+        @select_runnables.map { |r| "#{r.class}_#{r.id}" }
+    ]
+  end
+
+  def options_for_permissions
+    [
+      @all_perm_forms.map   { |p| [p.fullname, p.id] },
+      @select_perm_form.map { |p|              p.id  }
+    ]
+  end
+
 end

--- a/app/models/report/learner/selector.rb
+++ b/app/models/report/learner/selector.rb
@@ -78,7 +78,7 @@ class Report::Learner::Selector
     @scopes[:with_runnables] = @select_runnables                 unless @select_runnables.blank?
     @scopes[:before]         = Time.parse(@parsed_end_date)      unless @parsed_end_date.blank?
     @scopes[:after]          = Time.parse(@start_date)           unless @start_date.blank?
-    @scopes[:with_permission_ids] = @select_perm_form            unless @select_perm_form.blank?
+    @scopes[:with_permission_ids] = @select_perm_form.map(&:id)  unless @select_perm_form.blank?
 
     unless @select_teachers.blank?
       clazzes = @select_teachers.map { |t| t.clazzes }

--- a/app/views/report/learner/index.html.haml
+++ b/app/views/report/learner/index.html.haml
@@ -12,25 +12,26 @@
         %td
           %label Schools:
         %td
-          = select_tag('schools', options_for_select(@learner_selector.all_schools.map {|s| [s.name, s.id]},
-                                                     @learner_selector.select_schools.map {|s| s.id}), { :multiple => true })
+          = select_tag('schools', options_for_select(*@learner_selector.options_for_schools),
+            { :multiple => true })
       %tr
         %td
           %label Teachers:
         %td
-          = select_tag('teachers', options_for_select(@learner_selector.all_teachers.map {|s| [s.name, s.id]},
-                                                      @learner_selector.select_teachers.map {|s| s.id}), { :multiple => true })
+          = select_tag('teachers', options_for_select(*@learner_selector.options_for_teachers),
+            { :multiple => true })
       %tr
         %td
           %label Runnables:
         %td
-          = select_tag('runnables', options_for_select(@learner_selector.all_runnables.map {|r| ["#{r.name}(#{r.class})", "#{r.class}_#{r.id}"]},
-                                                       @learner_selector.select_runnables.map {|r| "#{r.class}_#{r.id}"}), { :multiple => true })
+          = select_tag('runnables', options_for_select(*@learner_selector.options_for_runnables),
+            { :multiple => true })
       %tr
         %td
           %label Permission Forms:
         %td
-          = select_tag('perm_form', options_for_select(@learner_selector.all_perm_forms, @learner_selector.select_perm_form),  { :multiple => true, :class => 'big_selector'})
+          = select_tag('perm_form', options_for_select(*@learner_selector.options_for_permissions),
+            { :multiple => true, :class => 'big_selector'})
       %tr
         %td
           %label Start Date:

--- a/factories/admin_projects.rb
+++ b/factories/admin_projects.rb
@@ -1,0 +1,4 @@
+Factory.define :admin_project, :class => Admin::Project do |f|
+
+end
+

--- a/factories/portal_permission_forms.rb
+++ b/factories/portal_permission_forms.rb
@@ -1,0 +1,3 @@
+Factory.define :permission_form, :class => Portal::PermissionForm do |f|
+end
+

--- a/spec/models/portal/permission_form_spec.rb
+++ b/spec/models/portal/permission_form_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Portal::PermissionForm do
+  let(:permission_form_args) { {name: "permission_a"} }
+  let(:permission_form) { FactoryGirl.create(:permission_form, permission_form_args)}
+
+  it 'should exist' do
+    expect(permission_form).to be_a(Portal::PermissionForm)
+  end
+
+  it 'should have a name' do
+    expect(permission_form.name).to match "permission_a"
+  end
+
+  describe "#fullname" do
+    let(:project) { FactoryGirl.create(:admin_project, name: "project a") }
+    let(:permission_form_args) do
+      {
+          name: "permission_a",
+          project: project
+      }
+    end
+
+    it "should include the projects name" do
+      expect(permission_form.fullname).to match "project a"
+    end
+
+  end
+end

--- a/spec/models/report/learner/selector_spec.rb
+++ b/spec/models/report/learner/selector_spec.rb
@@ -6,7 +6,7 @@ describe Report::Learner::Selector do
 
   # assign the student permission_form_b to complicate the tests …
   before(:each) {
-    learner.student.permission_forms << permission_form_b
+    learner.student.permission_forms << students_p_forms
   }
 
   let(:current_user)        { Factory.next(:admin_user) }
@@ -19,6 +19,7 @@ describe Report::Learner::Selector do
   let(:report_learner)      { learner.report_learner                   }
   let(:selector)            { Report::Learner::Selector.new(selector_opts, current_user )   }
   let(:selector_opts)       { {} }
+  let(:students_p_forms)    { [] }
 
   describe "with no permission form filter selected" do
     it "should return one learner for our student" do
@@ -34,9 +35,7 @@ describe Report::Learner::Selector do
     end
 
     describe "when the student has the selected permission form (a)" do
-      before(:each) {
-        learner.student.permission_forms << permission_form_a
-      }
+      let(:students_p_forms) { [permission_form_a] }
       it "our student should have the required permission form" do
         expect(learner.student.permission_forms).to include permission_form_a
       end
@@ -45,13 +44,53 @@ describe Report::Learner::Selector do
       end
     end
 
-    describe "when the student hasn't given us the permission form we are looking for" do
+    describe "when the student hasn't given us the permission form we are searching for" do
       it "the learner should not have our permission form" do
         expect(learner.student.permission_forms).not_to include permission_form_a
       end
       it "selector should return results without our student" do
-        expect(selector.learners).not_to include report_learner
+         expect(selector.learners).not_to include report_learner
       end
     end
+
+    # Ensure we only return one row per learner, even when
+    # The student has multiple permission forms completed.
+    describe "when searching for two permissions forms" do
+      let(:selector_opts) {{ 'perm_form' => [permission_form_a.id, permission_form_b.id] }}
+      describe "and the student has both of the forms completed" do
+        let(:students_p_forms) { [permission_form_a, permission_form_b ]}
+        it "the user should have both permission forms" do
+          expect(learner.student.permission_forms).to include permission_form_b
+          expect(learner.student.permission_forms).to include permission_form_a
+        end
+        it "selector should only return the one report_learner" do
+          expect(selector.learners).to include report_learner
+          expect(selector.learners.size).to eql(1)
+        end
+      end
+    end
+
+    # Ensure we report each learner for students with multiple
+    # matching a given permission form selection.
+    describe "when the student has multiple learners" do
+      let(:other_learner) do
+        FactoryGirl.create(:full_portal_learner, {:student => learner.student})
+      end
+      let(:other_report_learner) { other_learner.report_learner }
+      describe "when searching for two permissions forms" do
+        let(:selector_opts) {{ 'perm_form' => [permission_form_a.id, permission_form_b.id] }}
+
+        describe "and the student has both of the forms completed" do
+          let(:students_p_forms) {[permission_form_a, permission_form_b] }
+          it "selector should still only return the one report_learner" do
+            other_report_learner # creates the other learner
+            expect(selector.learners).to include report_learner
+            expect(selector.learners).to include other_report_learner
+            expect(selector.learners.size).to eql(2)
+          end
+        end
+      end
+    end
+
   end
 end

--- a/spec/models/report/learner/selector_spec.rb
+++ b/spec/models/report/learner/selector_spec.rb
@@ -29,8 +29,8 @@ describe Report::Learner::Selector do
   describe "when filtering based on permission forms" do
     let(:selector_opts)     {{ 'perm_form' => [permission_form_a.id] }}
 
-    it "expect the selector to specigy our permission form" do
-      expect(selector.select_perm_form).to include permission_form_a.id
+    it "expect the selector to specify our permission form" do
+      expect(selector.select_perm_form).to include permission_form_a
     end
 
     describe "when the student has the selected permission form (a)" do

--- a/spec/models/report/learner/selector_spec.rb
+++ b/spec/models/report/learner/selector_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+include ReportLearnerSpecHelper # defines : saveable_for : answers_for : add_answer : stub_all_reportables
+
+describe Report::Learner::Selector do
+
+  # assign the student permission_form_b to complicate the tests …
+  before(:each) {
+    learner.student.permission_forms << permission_form_b
+  }
+
+  let(:current_user)        { Factory.next(:admin_user) }
+  let(:project_a)           { FactoryGirl.create(:admin_project, name: "project-a") }
+  let(:permission_params_a) { { name: "a", project: project_a } }
+  let(:permission_form_a)   { FactoryGirl.create(:permission_form, permission_params_a) }
+  let(:permission_params_b) { { name: "b" } }
+  let(:permission_form_b)   { FactoryGirl.create(:permission_form, permission_params_b) }
+  let(:learner)             { FactoryGirl.create(:full_portal_learner) }
+  let(:report_learner)      { learner.report_learner                   }
+  let(:selector)            { Report::Learner::Selector.new(selector_opts, current_user )   }
+  let(:selector_opts)       { {} }
+
+  describe "with no permission form filter selected" do
+    it "should return one learner for our student" do
+      expect(selector.learners).to include report_learner
+    end
+  end
+
+  describe "when filtering based on permission forms" do
+    let(:selector_opts)     {{ 'perm_form' => [permission_form_a.id] }}
+
+    it "expect the selector to specigy our permission form" do
+      expect(selector.select_perm_form).to include permission_form_a.id
+    end
+
+    describe "when the student has the selected permission form (a)" do
+      before(:each) {
+        learner.student.permission_forms << permission_form_a
+      }
+      it "our student should have the required permission form" do
+        expect(learner.student.permission_forms).to include permission_form_a
+      end
+      it "selector should filter the results and return our student" do
+        expect(selector.learners).to include report_learner
+      end
+    end
+
+    describe "when the student hasn't given us the permission form we are looking for" do
+      it "the learner should not have our permission form" do
+        expect(learner.student.permission_forms).not_to include permission_form_a
+      end
+      it "selector should return results without our student" do
+        expect(selector.learners).not_to include report_learner
+      end
+    end
+  end
+end


### PR DESCRIPTION
Use permission form IDs when selecting learners in the researcher reports.

As per [131178067](https://www.pivotaltracker.com/story/show/131178067):

The report filtering was searching the `Report::Learner` flattened `permission_forms` field which stored the names of permission forms for the learner.  The original problem was that the permission form storage and searching used different formats for the name (one used the project name as part of the permission form name.)

So instead, we now search on the student model directly, using the ID of the students `permission_forms` .

Some spec tests were added to cover these cases.

