### PR TITLE
Add header to materials collection React component

### DIFF
--- a/app/assets/javascripts/components/materials_collection/materials_collection.js.coffee
+++ b/app/assets/javascripts/components/materials_collection/materials_collection.js.coffee
@@ -14,13 +14,15 @@ window.MaterialsCollectionClass = React.createClass
     randomize: false
     limit: Infinity
     header: null
+    # Optional callback executed when materials collection is downloaded
+    onDataLoad: null
 
   getInitialState: ->
     materials: []
     truncated: true
 
   componentDidMount: ->
-    {randomize} = @props
+    {randomize, onDataLoad} = @props
     jQuery.ajax
       url: Portal.API_V1.MATERIALS_BIN_COLLECTIONS
       data: id: @props.collection
@@ -28,6 +30,7 @@ window.MaterialsCollectionClass = React.createClass
       success: (data) =>
         materials = data[0].materials
         materials = shuffle(materials) if randomize
+        onDataLoad(materials) if onDataLoad
         @setState materials: materials if @isMounted()
 
   toggle: (e) ->
@@ -60,7 +63,7 @@ window.MaterialsCollectionClass = React.createClass
 
 window.MaterialsCollection = React.createFactory MaterialsCollectionClass
 
-# Supported options: limit, randomize, header
+# Supported options: limit, randomize, header, onDataLoad
 # Keep API backward compatible, so accept either 'limit' option as the last argument or hash.
 Portal.renderMaterialsCollection = (collectionId, selectorOrElement, limitOrOptions = Infinity) ->
   props = if typeof limitOrOptions == 'number'

--- a/app/assets/javascripts/components/materials_collection/materials_collection.js.coffee
+++ b/app/assets/javascripts/components/materials_collection/materials_collection.js.coffee
@@ -1,4 +1,4 @@
-{div, span, a, i} = React.DOM
+{div, span, a, i, h1} = React.DOM
 
 shuffle = (a) ->
   idx = a.length
@@ -10,6 +10,11 @@ shuffle = (a) ->
   a
 
 window.MaterialsCollectionClass = React.createClass
+  getDefaultProps: ->
+    randomize: false
+    limit: Infinity
+    header: null
+
   getInitialState: ->
     materials: []
     truncated: true
@@ -45,18 +50,22 @@ window.MaterialsCollectionClass = React.createClass
     )
 
   render: ->
+    headerVisible = @props.header && @state.materials.length > 0
     (div {},
+      if headerVisible
+        (h1 {className: 'collection-header'}, @props.header)
       (SMaterialsList {materials: @getMaterialsList()})
       @renderTruncationToggle()
     )
 
 window.MaterialsCollection = React.createFactory MaterialsCollectionClass
 
+# Supported options: limit, randomize, header
+# Keep API backward compatible, so accept either 'limit' option as the last argument or hash.
 Portal.renderMaterialsCollection = (collectionId, selectorOrElement, limitOrOptions = Infinity) ->
-  # Keep API backward compatible, so accept either 'limit' option as the last argument or hash.
-  options = if typeof limitOrOptions == 'number'
-              {limit: limitOrOptions}
-            else
-              limitOrOptions
-  ReactDOM.render MaterialsCollection(collection: collectionId, limit: options.limit, randomize: options.randomize),
-    jQuery(selectorOrElement)[0]
+  props = if typeof limitOrOptions == 'number'
+            {limit: limitOrOptions}
+          else
+            limitOrOptions
+  props.collection = collectionId
+  ReactDOM.render MaterialsCollection(props), jQuery(selectorOrElement)[0]


### PR DESCRIPTION
Adds optional header to materials collection component. It will be rendered only if the number of materials in collection is > 0. 

@emcelroy, you would need to modify calls to renderMaterialsCollection:
```
 Portal.renderMaterialsCollection(13, '#collection-1', {limit: 10, header: 'Why do fishermen need forests?'}); 
```
and remove static headers defined in HTML. Header will be rendered as H1 element with class `collection-header`, so it can be additionally styled on the home page.