### PR TITLE
Restrict project listing API

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -1,8 +1,15 @@
 class API::V1::ProjectsController < API::APIController
 
   def index
-    @projects = Portal::Project.all.map{ |c| {name: c.name, id: c.id, landing_page_slug: c.landing_page_slug, project_card_image_url: c.project_card_image_url, project_card_description: c.project_card_description, public: c.public} }
-    render :json => @projects
+    projects = Admin::Project.select {|p| policy(p).visible?}
+    result = projects.map{ |p| {
+      name: p.name,
+      id: p.id,
+      landing_page_slug: p.landing_page_slug,
+      project_card_image_url: p.project_card_image_url,
+      project_card_description: p.project_card_description,
+      public: p.public} }
+    render :json => result
   end
 
 end


### PR DESCRIPTION
This also fixes a bug where Portal::Project was used instead of 
Admin::Project
[#132944869]