### PR TITLE
fix typo in permission form scope

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ before_script:
   - RAILS_ENV=test ./bin/rake sunspot:solr:start &
   - sleep 10 # give SOLR some time to start and init
 
+after_script:
+  - RAILS_ENV=test ./bin/rake sunspot:solr:stop
+
 # uncomment this line if your project needs to run something other than `rake`:
 script: ./bin/rake $TEST_SUITE
 

--- a/app/models/report/learner.rb
+++ b/app/models/report/learner.rb
@@ -18,7 +18,7 @@ class Report::Learner < ActiveRecord::Base
 
   scope :with_permission_ids, lambda { |ids|
     includes(student: :portal_student_permission_forms)
-      .where("portal_student_permission_forms.portal_permission_form_id", ids)
+      .where("portal_student_permission_forms.portal_permission_form_id" => ids)
 
   }
 

--- a/spec/models/report/learner_spec.rb
+++ b/spec/models/report/learner_spec.rb
@@ -226,4 +226,48 @@ describe Report::Learner do
 
   end
 
+  describe "with_permission_ids" do
+    let(:permission_form_a) { FactoryGirl.create(:permission_form) }
+
+    let(:permission_form_b) { FactoryGirl.create(:permission_form) }
+
+    let(:offering) { FactoryGirl.create(:portal_offering) }
+
+    let(:report_learner_a) do
+      student = FactoryGirl.create(:full_portal_student,
+        permission_forms: [permission_form_a]
+      )
+
+      learner = FactoryGirl.create(:portal_learner,
+        offering: offering,
+        student: student)
+
+      Report::Learner.create(:learner => learner)
+    end
+
+    let(:report_learner_b) do
+      student = FactoryGirl.create(:full_portal_student,
+        permission_forms: [permission_form_b]
+      )
+
+      learner = FactoryGirl.create(:portal_learner,
+        offering: offering,
+        student: student)
+
+      Report::Learner.create(:learner => learner)
+    end
+
+    it "should not return a learner without the permission_id" do
+      report_learner_a
+      expect(Report::Learner.with_permission_ids([99999]).count).to eq(0)
+    end
+
+    it "should return a learner with with the correct permission_id" do
+      report_learner_a
+      report_learner_b
+      expect(Report::Learner.with_permission_ids([permission_form_a.id]).count).to eq(1)
+    end
+
+  end
+
 end


### PR DESCRIPTION
The typo in the permission form scope did not cause an error, but it did prevent the scope from working at expected.  I'm not 100% sure but I believe the incorrect scope was a filter of: "if the student has any permission forms, then include them".  

This is the second typo of this form I've found in the last 2 weeks. Here is the other one: https://github.com/concord-consortium/rigse/commit/a68fba9ed474d0a9626727d5f9e1fa118f4e4a82

They are hard to catch because they don't cause errors.

[#131178067]