### PR TITLE
By default questions should not require feedback.

### DIFF
--- a/db/migrate/20161220154756_change_embeddable_meta_defaults.rb
+++ b/db/migrate/20161220154756_change_embeddable_meta_defaults.rb
@@ -1,0 +1,16 @@
+class ChangeEmbeddableMetaDefaults < ActiveRecord::Migration
+
+  def disable_all_feedback()
+    execute "update portal_offering_embeddable_metadata set enable_text_feedback=false"
+    execute "update portal_offering_embeddable_metadata set enable_score=false"
+  end
+
+  def up
+    change_column :portal_offering_embeddable_metadata, :enable_text_feedback, :boolean, :default => false
+    disable_all_feedback
+  end
+
+  def down
+    change_column :portal_offering_embeddable_metadata, :enable_text_feedback, :boolean, :default => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160921194347) do
+ActiveRecord::Schema.define(:version => 20161220154756) do
 
   create_table "access_grants", :force => true do |t|
     t.string   "code"
@@ -1994,7 +1994,7 @@ ActiveRecord::Schema.define(:version => 20160921194347) do
     t.integer  "max_score"
     t.datetime "created_at",                              :null => false
     t.datetime "updated_at",                              :null => false
-    t.boolean  "enable_text_feedback", :default => true
+    t.boolean  "enable_text_feedback", :default => false
   end
 
   add_index "portal_offering_embeddable_metadata", ["offering_id", "embeddable_id", "embeddable_type"], :name => "index_portal_offering_metadata", :unique => true

--- a/spec/controllers/api/v1/report_spec.rb
+++ b/spec/controllers/api/v1/report_spec.rb
@@ -106,7 +106,7 @@ describe API::V1::ReportsController do
         json_path("report.name").should eql "the activity"
         json_path("class.students").should include_hash({"started_offering"=>true, "name"=>"joe user"})
         max_score_should_be 0
-        feedback_should_be_enabled
+        feedback_should_be_disabled
         score_should_be_disabled
         answers.should include_hash({"answer" => "testing from #{learner_a.student.user.id}"})
       end


### PR DESCRIPTION
@scytacki  small PR for default not-requiring feedback.

[#136190849]
https://www.pivotaltracker.com/story/show/136190849

By default questions should not require feedback.  So there should be no red badges on questions that a teacher hasn't provided any feedback on.