### PR TITLE
Compose overlay to add unison support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ log
 config/app_environment_variables.rb
 config/environments/local-development.rb
 certs
+.env

--- a/docker-compose-unison.yml
+++ b/docker-compose-unison.yml
@@ -19,7 +19,16 @@ services:
       - unison:/rigse
   unison:
     image: onnimonni/unison:2.48.4
+    environment:
+      # root is used here since the app is running as root so any files it creates
+      # will be owned by root, and then unison should be able to override them
+      - UNISON_UID=0
+      - UNISON_GID=0
+      - UNISON_USER=root
+      - UNISON_GROUP=root
     ports:
+      # a single port number means docker will randomly map this the start-unison
+      # script inspects the container to find what it is mapped to
       - "5000"
     volumes:
       - unison:/data

--- a/docker-compose-unison.yml
+++ b/docker-compose-unison.yml
@@ -1,0 +1,27 @@
+# This is an docker-compose overlay that uses unison for syncing files between the host
+# and containers.  On OS X it is much faster than simple mounting of local files
+# You need to run docker/dev/start-unison.sh to start the sync
+
+# A convient way to overlay it is to add a `.env` file with the contents:
+#  COMPOSE_FILE=docker-compose.yml:docker-compose-unison.yml
+# You can also do it manually when you run docker-compose each time with
+# docker-compose -f docker-compose.yml -f docker-compose-unison.yml
+# if you are making changes to docker-compose.yml or this file it is useful to
+# run `docker-compose config` which shows how the two files get merged together
+
+version: '2'
+services:
+  app:
+    volumes:
+      - unison:/rigse
+  solr:
+    volumes:
+      - unison:/rigse
+  unison:
+    image: onnimonni/unison:2.48.4
+    ports:
+      - "5000"
+    volumes:
+      - unison:/data
+volumes:
+  unison:

--- a/docker/dev/docker-compose-unison.yml
+++ b/docker/dev/docker-compose-unison.yml
@@ -2,10 +2,10 @@
 # and containers.  On OS X it is much faster than simple mounting of local files
 # You need to run docker/dev/start-unison.sh to start the sync
 
-# A convient way to overlay it is to add a `.env` file with the contents:
-#  COMPOSE_FILE=docker-compose.yml:docker-compose-unison.yml
+# A convient way to overlay this file is to add a `.env` file with the contents:
+#  COMPOSE_FILE=docker-compose.yml:docker/dev/docker-compose-unison.yml
 # You can also do it manually when you run docker-compose each time with
-# docker-compose -f docker-compose.yml -f docker-compose-unison.yml
+# docker-compose -f docker-compose.yml -f docker/dev/docker-compose-unison.yml
 # if you are making changes to docker-compose.yml or this file it is useful to
 # run `docker-compose config` which shows how the two files get merged together
 

--- a/docker/dev/start-unison.sh
+++ b/docker/dev/start-unison.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# the first time you use this you probably want to bring up the unison container
+# first by doing `docker-compose up unison` then run this file to start the sync
+# otherwise the source files won't be implace before the application starts up
+
+# to run this on OS X you need to install unison and also install the unox watcher:
+# https://github.com/onnimonni/docker-unison#installing-unison-fsmonitor-on-osx-unox
+
+port=$(docker-compose port unison 5000 | awk -F: '{print $NF}')
+echo Connecting to unison on port: $port
+unison . socket://localhost:$port/ -repeat watch -auto -batch


### PR DESCRIPTION
This makes OS X docker based development more bearable.

If you try this out there are a few caveats:
- the solrdata container spins taking up 100% of a core. It can be be stopped without a problem. I'm not sure why it was written that way. 
- when you first run `docker-compose up` it builds the app image. This build process pulls in all of the source code. The unison volume is then initialized with this source code. So if you stop the containers, delete the unison volume, and then change your local files (perhaps a git pull). Now when the syncing starts up again it will have to reconcile these two different source trees. I haven't experimented with this to see what happens yet.
- the database content is stored in an anonymous volume. This will preserve it during restarts. But if you delete the database container and then recreated it (docker-compose down; docker-compose up) then the data will be gone.  The data will actually be stored in a dangling volume, so you could in theory recover it.
