### PR TITLE
add overlay for ssh support

### DIFF
--- a/docker/dev/docker-compose-ssh.yml
+++ b/docker/dev/docker-compose-ssh.yml
@@ -1,0 +1,21 @@
+# This is an docker-compose overlay that adds ssh-agent support
+# you will need to setup the ssh-agent container described here:
+# https://github.com/whilp/ssh-agent
+
+# A convient way to overlay this file is to add a `.env` file with the contents:
+#  COMPOSE_FILE=docker-compose.yml:docker/dev/docker-compose-ssh.yml
+# You can also do it manually when you run docker-compose each time with
+# docker-compose -f docker-compose.yml -f docker/dev/docker-compose-ssh.yml
+# if you are making changes to docker-compose.yml or this file it is useful to
+# run `docker-compose config` which shows how the two files get merged together
+
+version: '2'
+services:
+  app:
+    environment:
+      - SSH_AUTH_SOCK=/ssh/auth/sock
+    volumes:
+      - ssh:/ssh
+volumes:
+  ssh:
+    external: true


### PR DESCRIPTION
This uses https://github.com/whilp/ssh-agent

The idea here is that you run a long running container with ssh-agent and then temporarily mount your home folder to add the keys to ssh-agent container.  Now other containers, like the app container in this project, can connect to this agent in order to encrypt and decrypt data.
This should be more secure than simply mounting your private key into the app container. In that case the app container would have full access to try and crack your private key's passphrase.

I'm not really sure this extra layer of complication is worth it. Hopefully the need to do capistrano deploys from the portal code is short lived. At which point the need for ssh'ing from containers is gone. So it doesn't seem worth perfecting this more.