### PR TITLE
Remove the solrdata container and volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,17 +26,7 @@ services:
       - 8983:8983
     volumes:
       - .:/rigse
-      - data:/opt/solr/server/solr/mycores
-    depends_on:
-      - solrdata
     command: /bin/bash ./start-solr.sh
-  solrdata:
-    image: concordconsortium/docker-solr-portal
-    volumes:
-      - data:/opt/solr/server/solr/mycores
-    user:
-      root
-    command: /bin/bash ./start-volume.sh
   mysql:
     image: mysql:5.6
     environment:
@@ -47,4 +37,3 @@ services:
     command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci
 volumes:
   bundle:
-  data:


### PR DESCRIPTION
It is quick to re-index the solr data especially in a development environment
So the extra complexity of the data container doesn’t seem worth it.

In production it would be better to at least use anonymous volume, because the docker filesystem doesn't clean up files that are deleted. Volumes do not have this clean up problem.
Adding a volume though will require fixing the permissions so the non-root solr user can 
access the volume.  I believe the recent solr images have support for injecting 'init' scripts
which should make this easy to do without needing a solrdata container.


