### PR TITLE
Added public and private class hashes [#138853633]

### DIFF
--- a/app/controllers/api/v1/classes_controller.rb
+++ b/app/controllers/api/v1/classes_controller.rb
@@ -1,0 +1,70 @@
+class API::V1::ClassesController < API::APIController
+
+  # GET api/v1/classes/:id
+  def show
+    if current_visitor.anonymous?
+      return error('You must be logged in to use this endpoint')
+    end
+
+    if !current_visitor.portal_student && !current_visitor.portal_teacher
+      error('You must be logged in as a student to use this endpoint')
+    end
+
+    clazz = Portal::Clazz.find_by_id(params[:id])
+    if !clazz
+      return error('The requested class was not found')
+    end
+
+    student_in_class = current_visitor.portal_student && current_visitor.portal_student.has_clazz?(clazz)
+    teacher_in_class = !student_in_class || (current_visitor.portal_teacher && current_visitor.portal_teacher.has_clazz?(clazz))
+
+    if (!student_in_class && !teacher_in_class)
+      return error('You are not a student or teacher of the requested class')
+    end
+
+    render_info clazz
+  end
+
+  # GET api/v1/classes/info?class_word=[class word]
+  def info
+    class_word = params.require(:class_word)
+    clazz = Portal::Clazz.find_by_class_word(class_word)
+    if !clazz
+      return error('The requested class was not found')
+    end
+
+    render_info clazz
+  end
+
+  private
+
+  def render_info(clazz)
+    state = nil
+    if school = clazz.school
+      state = school.state
+    end
+
+    render :json => {
+      :uri => url_for(clazz),
+      :name => clazz.name,
+      :state => state,
+      :class_hash => clazz.class_hash,
+      :teachers => clazz.teachers.includes(:user).map{|teacher|
+        {
+          :id => url_for(teacher.user),
+          :first_name => teacher.user.first_name,
+          :last_name => teacher.user.last_name
+        }
+      },
+      :students => clazz.students.includes(:user).map {|student|
+        {
+          :id => url_for(student.user),
+          :email => student.user.email,
+          :first_name => student.user.first_name,
+          :last_name => student.user.last_name
+        }
+      }
+    }
+  end
+
+end

--- a/app/controllers/portal/offerings_controller.rb
+++ b/app/controllers/portal/offerings_controller.rb
@@ -71,7 +71,8 @@ class Portal::OfferingsController < ApplicationController
              :externalId => learner.id,
              :returnUrl => learner.remote_endpoint_url(request.protocol, request.host_with_port),
              :logging => @offering.clazz.logging || @offering.runnable.logging,
-             :domain_uid => current_visitor.id
+             :domain_uid => current_visitor.id,
+             :class_info_url => @offering.clazz.class_info_url(request.protocol, request.host_with_port)
            }.to_query
            redirect_to(uri.to_s)
          else

--- a/app/models/portal/clazz.rb
+++ b/app/models/portal/clazz.rb
@@ -29,6 +29,8 @@ class Portal::Clazz < ActiveRecord::Base
   validates_uniqueness_of :class_word
   validates_presence_of :name
 
+  before_save :generate_class_hash
+
   include Changeable
 
   # String constants for error messages -- Cantina-CMH 6/2/10
@@ -289,6 +291,14 @@ class Portal::Clazz < ActiveRecord::Base
     self.name = self.name.strip if self.name
     self.description = self.description.strip if self.description
     self.class_word = self.class_word.strip if self.class_word
+  end
+
+  def generate_class_hash
+    self.class_hash = SecureRandom.hex(24) if self.class_hash.nil?
+  end
+
+  def class_info_url(protocol, host)
+    Rails.application.routes.url_helpers.api_v1_class_url(id: self.id, protocol: protocol, host: host)
   end
 
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -125,6 +125,7 @@ module RailsPortal
         resource '/api/v1/reports/*', :headers => :any, :methods => [:get, :put]
         resource '/api/v1/offerings/*', :headers => :any, :methods => [:get, :put]
         resource '/api/v1/offering/*', :headers => :any, :methods => [:get, :put]
+        resource '/api/v1/classes/*', :headers => :any, :methods => [:get]
       end
 
       # Set up custom CORS, if the environment variable PORTAL_FEATURES includes "allow_cors".

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -693,6 +693,11 @@ RailsPortal::Application.routes.draw do
             get :for_teacher
           end
         end
+
+        resources :classes, only: [:show]
+        namespace :classes do
+          get :info
+        end
       end
     end
 

--- a/db/migrate/20170202190333_add_class_hash.rb
+++ b/db/migrate/20170202190333_add_class_hash.rb
@@ -1,0 +1,15 @@
+class AddClassHash < ActiveRecord::Migration
+  def up
+    add_column :portal_clazzes, :class_hash, :string, :limit => 48
+
+    Portal::Clazz.where(class_hash: nil).find_each(batch_size: 100) do |portal_clazz|
+      portal_clazz.generate_class_hash
+      portal_clazz.save!
+    end
+  end
+
+  def down
+    remove_column :portal_clazzes, :class_hash
+  end
+end
+

--- a/features/activity_runtime_api/running.feature
+++ b/features/activity_runtime_api/running.feature
@@ -1,15 +1,16 @@
 Feature: External Activities can support a REST api
   Background:
     Given the following external REST activity:
-      | name             | Cool Thing |
-      | url              | http://activities.com/activity/1 |
+      | name        | Cool Thing |
+      | url         | http://activities.com/activity/1 |
       | launch_url  | http://activities.com/activity/1/sessions/ |
     And "activities.com/activity/1/sessions/" handles a GET with query:
-      | domain     | http://www.example.com/  |
-      | domain_uid | domain_uid of 'student'  |
-      | externalId | 999                      |
-      | logging    | false                    |
-      | returnUrl  | http://www.example.com/dataservice/external_activity_data/key |
+      | domain            | http://www.example.com/      |
+      | domain_uid        | domain_uid of 'student'      |
+      | externalId        | 999                          |
+      | logging           | false                        |
+      | returnUrl         | http://www.example.com/dataservice/external_activity_data/key |
+      | class_info_url    | class_info_url of 'My Class' |
     And "activities.com/activity/1/sessions/" GET responds with
       """
       HTTP/1.1 200 OK

--- a/features/step_definitions/activity_runtime_api_steps.rb
+++ b/features/step_definitions/activity_runtime_api_steps.rb
@@ -56,6 +56,9 @@ Given /^"([^"]*)" handles a (POST|GET) with query:$/ do |address, method, table|
   if /domain_uid of '(.*)'/ =~ query_data["domain_uid"]
     query_data["domain_uid"] = User.find_by_login($~[1]).id.to_s
   end
+  if /class_info_url of '(.*)'/ =~ query_data["class_info_url"]
+    query_data["class_info_url"] = Portal::Clazz.find_by_name($~[1]).class_info_url("http", "www.example.com")
+  end
   stub.with(:query => query_data)
 end
 


### PR DESCRIPTION
Adds a public and private class hash.  The public hash can be used with a new API endpoint at `api/v1/classes/info?public_class_hash=<hash>` to retrieve the class name, the students in the class (email and name) and the private class hash.  The endpoint is secured by a combination of the random public class hash and a check to ensure the user is either a teacher or student in the class.

The private class hash was created to use as part of a class key that Sharinator uses with Firebase.  The Sharinator Dashboard is passed a `class=<base64encode(api/v1/classes/info?public_class_hash=<hash>)>` parameter that it decodes and then calls to get the private class hash.  This allows the Dashboard url to be shared but the data to be protected when the user of the shared url is not a teacher or student of the class.