### PR TITLE
add PORTAL_FEATURES support, simplify dev image

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -7,16 +7,9 @@ WORKDIR $APP_HOME
 # use a mounted volume so the gems don't need to be rebundled each time
 ENV BUNDLE_PATH /bundle
 
-ADD Gemfile* $APP_HOME/
-
 ENV BUNDLE_GEMFILE=$APP_HOME/Gemfile \
   BUNDLE_JOBS=2 \
   BUNDLE_PATH=/bundle
-
-ADD . $APP_HOME
-
-RUN cp config/database.sample.yml config/database.yml && \
-    cp config/app_environment_variables.sample.rb config/app_environment_variables.rb
 
 ENV RAILS_ENV=development
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       DB_PASSWORD: master
       SOLR_HOST: solr
       SOLR_PORT: 8983
+      PORTAL_FEATURES:
     # no ports are published, see below for details
     volumes:
       - .:/rigse


### PR DESCRIPTION
PORTAL_FEATURES can now be set by a developers .env file.

The image simplification is so there isn’t confusion when using unison.
With the basic image Rails will not start because there is no source code.
The source folder needs to be mounted into the container.