### PR TITLE
Revert the automatic redirect to previous page code

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,7 +30,7 @@ class ApplicationController < ActionController::Base
     else
       flash[:alert] = error_message
       fallback_url = current_user.nil? ? root_path : after_sign_in_path_for(current_user)
-      redirect_to_siginin_if_anon_or fallback_url
+      redirect_to fallback_url
     end
   end
 
@@ -196,15 +196,6 @@ class ApplicationController < ActionController::Base
     redirect_to path
   end
 
-  def redirect_to_siginin_if_anon_or(path)
-    if current_user.nil?
-      session[:redirect_path_after_signin] = request.path
-      redirect_to new_user_session_path
-    elsif !path.empty?
-      redirect_to path
-    end
-  end
-
   def session_sensitive_path
     path = request.env['PATH_INFO']
     return path =~ /password|session|sign_in|sign_out|security_questions|consent|help|user_type_selector/i
@@ -272,9 +263,6 @@ class ApplicationController < ActionController::Base
       end
       session[:sso_callback_params] = nil
       session[:sso_application] = nil
-    elsif session[:redirect_path_after_signin]
-      redirect_path = session[:redirect_path_after_signin]
-      session[:redirect_path_after_signin] = nil
     end
     return redirect_path
   end


### PR DESCRIPTION
There is a comment in the PT story below about the reason for the revert.
https://www.pivotaltracker.com/story/show/136965555

A lot of work was done to prepare for this by unifying the behavior when a page is requested that the user doesn’t have permission too.

However we ran out of time to do the log in and redirect well enough that it wouldn’t cause problems. I’m going to revert the initial version of this because of those problems.
Here are issues with the code I’m reverting:

- The sign in page the user is directed to doesn’t look good and doesn’t have the login with schoology button. This button might not work with the redirecting even if it was added to the page.
- When users leave open pages and and different users try to log in, it the behavior is confusing.

Here are a couple of confusing scenarios when users leave open pages:

- User leaves open a page, and their session expires, a new user tries to click something. This will result in the new user being sent to the sign in page with a warning they can’t access that particular link. After signing in the new user sees a second warning that they can’t access that page at the link they tried to click before.
- User leaves open a page, and their session expires. The same user then tries to keep working by clicking on something. They are directed to log in. This user gives up and does not log in, and just closes the browser window. Now a second user comes along and opens a new browser window and logs in. They see a warning about trying to access a page that they know nothing about.

Often in cases like this I'd try to fix the issues myself, but I have a back log of other things to do and don't want to slow down the 1.16 release. 