### PR TITLE
Updates to support production Docker 

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,6 +23,9 @@ RailsPortal::Application.configure do
 
   # Use a different logger for distributed setups
   # config.logger = SyslogLogger.new
+  if ENV['RAILS_STDOUT_LOGGING']
+    config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
+  end
 
   # Use a different cache store in production
   # config.cache_store = :mem_cache_store

--- a/config/initializers/actionmailer.rb
+++ b/config/initializers/actionmailer.rb
@@ -4,7 +4,7 @@ if File.exists?("#{::Rails.root.to_s}/config/mailer.yml") || ::Rails.env == "tes
     puts "Overriding ActionMailer config and setting test mode"
     ActionMailer::Base.delivery_method = :test
   else
-    c = YAML::load(File.open("#{::Rails.root.to_s}/config/mailer.yml"))
+    c = YAML::load(ERB.new(IO.read("#{::Rails.root.to_s}/config/mailer.yml")).result)
     c.each do |key,val|
       if key == :smtp || key == 'smtp'
         key = :smtp_settings


### PR DESCRIPTION
There are two updates here: 
- a fix so logs and exceptions show up in CloudWatch 
- a fix for the mailer so environment variables can be used in mailer.yml

This logging change is how LARA does it. Without this only some initial startup messages are sent to STDOUT. So we were missing the exceptions and the rails request logs in our docker log system (AWS Cloudwatch).

The itsi portal demo running in rancher was having problems sending email, this fixes that.