### PR TITLE
Let project researchers access and modify permission forms

### DIFF
--- a/app/policies/admin/project_policy.rb
+++ b/app/policies/admin/project_policy.rb
@@ -6,6 +6,8 @@ class Admin::ProjectPolicy < ApplicationPolicy
         all
       elsif user.is_project_admin?
         user.admin_for_projects
+      elsif user.is_project_researcher?
+        user.researcher_for_projects
       else
         none
       end

--- a/app/policies/portal/permission_form_policy.rb
+++ b/app/policies/portal/permission_form_policy.rb
@@ -23,18 +23,18 @@ class Portal::PermissionFormPolicy < ApplicationPolicy
   end
 
   def index?
-    manager_or_project_admin?
+    manager_or_researcher_or_project_researcher?
   end
 
   def update_forms?
-    manager_or_project_admin?
+    manager_or_researcher_or_project_researcher?
   end
 
   def create?
-    manager_or_project_admin?
+    manager_or_researcher_or_project_researcher?
   end
 
   def destroy?
-    admin? || (project_admin? && user.projects.include?(record.project))
+    admin? || (manager_or_researcher_or_project_researcher? && user.projects.include?(record.project))
   end
 end

--- a/app/views/home/admin.html.haml
+++ b/app/views/home/admin.html.haml
@@ -4,6 +4,7 @@
 %ul
   - is_admin_or_manager = current_visitor.has_role?('admin', 'manager')
   - is_admin_or_project_admin = is_admin_or_manager || current_visitor.is_project_admin?
+  - is_admin_or_project_admin_or_projet_researcher = is_admin_or_project_admin || current_visitor.is_project_researcher?
 
   - if current_visitor.has_role?('admin', 'manager', 'researcher', 'author')
     %li.trail=link_to('Authoring', authoring_path)
@@ -23,7 +24,7 @@
     %li= link_to 'Tags', admin_tags_path
     %li= link_to 'Settings', admin_settings_path
     %li= link_to 'Notices', admin_site_notices_path
-  - if is_admin_or_project_admin
+  - if is_admin_or_project_admin_or_projet_researcher
     %li= link_to 'Permission Forms', admin_permission_forms_path
   - if is_admin_or_manager
     %li= link_to 'Materials Collections', materials_collections_path

--- a/app/views/home/admin.html.haml
+++ b/app/views/home/admin.html.haml
@@ -4,7 +4,7 @@
 %ul
   - is_admin_or_manager = current_visitor.has_role?('admin', 'manager')
   - is_admin_or_project_admin = is_admin_or_manager || current_visitor.is_project_admin?
-  - is_admin_or_project_admin_or_projet_researcher = is_admin_or_project_admin || current_visitor.is_project_researcher?
+  - is_admin_or_project_admin_or_project_researcher = is_admin_or_project_admin || current_visitor.is_project_researcher?
 
   - if current_visitor.has_role?('admin', 'manager', 'researcher', 'author')
     %li.trail=link_to('Authoring', authoring_path)
@@ -24,7 +24,7 @@
     %li= link_to 'Tags', admin_tags_path
     %li= link_to 'Settings', admin_settings_path
     %li= link_to 'Notices', admin_site_notices_path
-  - if is_admin_or_project_admin_or_projet_researcher
+  - if is_admin_or_project_admin_or_project_researcher
     %li= link_to 'Permission Forms', admin_permission_forms_path
   - if is_admin_or_manager
     %li= link_to 'Materials Collections', materials_collections_path

--- a/spec/controllers/admin/permission_forms_controller_spec.rb
+++ b/spec/controllers/admin/permission_forms_controller_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+
+describe Admin::PermissionFormsController do
+  before(:each) do
+    @cohort1 = Factory.create(:admin_cohort)
+    @cohort2 = Factory.create(:admin_cohort)
+    @project1 = Factory.create(:project)
+    @project1.cohorts << @cohort1
+    @project2 = Factory.create(:project)
+    @project2.cohorts << @cohort2
+    @form1 = Factory.create(:permission_form, project: @project1)
+    @form2 = Factory.create(:permission_form, project: @project2)
+    @teacher1 = Factory.create(:portal_teacher, :user => Factory.create(:user, :login => "teacher1"))
+    @teacher1.cohorts << @cohort1
+    @teacher_view1 = Admin::PermissionFormsController::TeacherView.new(@teacher1)
+    @teacher2 = Factory.create(:portal_teacher, :user => Factory.create(:user, :login => "teacher2"))
+    @teacher_view2 = Admin::PermissionFormsController::TeacherView.new(@teacher2)
+    @teacher2.cohorts << @cohort2
+  end
+
+  # User variable is overwritten by some test cases.
+  let(:user) { Factory.next(:admin_user) }
+  before(:each) { sign_in user }
+
+  describe "GET index" do
+    # It means that we're looking for teachers whose name, last name or *login* is "teacher".
+    let(:index_form_params) do
+      {
+        form: {
+          name: 'teacher'
+        }
+      }
+    end
+
+    describe "when user is an admin" do
+      it "lists all forms, projects and teachers" do
+        get :index, index_form_params
+        expect(assigns(:projects)).to eq([@project1, @project2])
+        expect(assigns(:permission_forms)).to eq([@form1, @form2])
+        expect(assigns(:teachers)).to eq([@teacher_view1, @teacher_view2])
+      end
+    end
+
+    describe "when user is a project admin" do
+      let(:user) do
+        user = Factory.create(:confirmed_user)
+        user.add_role_for_project('admin', @project1)
+        user
+      end
+
+      it "lists forms, projects and teachers that belong to his project" do
+        get :index, index_form_params
+        expect(assigns(:projects)).to eq([@project1])
+        expect(assigns(:permission_forms)).to eq([@form1])
+        expect(assigns(:teachers)).to eq([@teacher_view1])
+      end
+    end
+
+    describe "when user is a project researcher" do
+      let(:user) do
+        user = Factory.create(:confirmed_user)
+        user.add_role_for_project('researcher', @project2)
+        user
+      end
+
+      it "lists forms, projects and teachers that belong to his project" do
+        get :index, index_form_params
+        expect(assigns(:projects)).to eq([@project2])
+        expect(assigns(:permission_forms)).to eq([@form2])
+        expect(assigns(:teachers)).to eq([@teacher_view2])
+      end
+    end
+  end
+
+  describe "POST create" do
+    describe "with valid params" do
+      it "creates a new permission form" do
+        expect {
+          post :create, {
+            portal_permission: {
+              name: 'test',
+              url: 'http://concord.org',
+              project_id: @project1.id
+            }
+          }
+        }.to change(Portal::PermissionForm, :count).by(1)
+        new_form = Portal::PermissionForm.last
+        expect(new_form.name).to eq('test')
+        expect(new_form.url).to eq('http://concord.org')
+        expect(new_form.project).to eq(@project1)
+      end
+    end
+  end
+
+  describe "GET remove_form" do
+    it "destroys the requested permission form" do
+      expect {
+        get :remove_form, {id: @form1}
+      }.to change(Portal::PermissionForm, :count).by(-1)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds logic related to project researchers to the permission form page (and lets them see this page at all).

We're filtering permission forms and teachers depending on user role and the project he is admin or researcher for. There were no tests related to this functionality, so I've added some (focusing on filtering part).