### PR TITLE
Fix style of the permission forms listing

### DIFF
--- a/app/assets/stylesheets/web/admin.scss
+++ b/app/assets/stylesheets/web/admin.scss
@@ -59,13 +59,9 @@
   }
   .label {
     font-weight: bold;
-    padding-left: 2em;
   }
   .permission_checkbox {
     padding-left: 2em;
-  }
-  table.admin_students_table {
-    width: 100%;
   }
   label {
     font-weight: bold;
@@ -90,6 +86,12 @@
       white-space: normal;
       .permission_from_item {
         white-space: nowrap;
+        display: block;
+        label {
+          vertical-align: top;
+          display: inline-block;
+          white-space: normal;
+        }
       }
     }
 


### PR DESCRIPTION
Now each permission form is displayed in its own line + other, small style fixes:
<img width="748" alt="screen shot 2017-03-03 at 15 03 59" src="https://cloud.githubusercontent.com/assets/767857/23553816/ae7071be-0022-11e7-80d7-1d2f82d7d05a.png">
