### PR TITLE
Add env variable to have the report link go to a secondary reporting …

### DIFF
--- a/app/controllers/report/learner_controller.rb
+++ b/app/controllers/report/learner_controller.rb
@@ -23,7 +23,17 @@ class Report::LearnerController < ApplicationController
   end
 
   def index
+    # Anonymous user might try to access this page when a separate portal instance
+    # is used to handle researcher reports. In this case don't follow typical authorization
+    # path, as a confusing alert message would be displayed. Use our nice sign in page
+    # (auth_login_path) instead and redirect to report page later.
+    if current_user.nil?
+      session[:redirect_path_after_signin] = learner_report_path # this action
+      redirect_to auth_login_path
+      return
+    end
     authorize Report::Learner
+    render layout: ENV['RESEARCHER_REPORT_ONLY'] ? "application" : "minimal"
   end
 
   def logs_query

--- a/app/views/home/admin.html.haml
+++ b/app/views/home/admin.html.haml
@@ -8,7 +8,8 @@
   - if current_visitor.has_role?('admin', 'manager', 'researcher', 'author')
     %li.trail=link_to('Authoring', authoring_path)
   - if current_visitor.has_role?('admin', 'manager','researcher') || current_visitor.is_project_admin? || current_visitor.is_project_researcher?
-    %li= link_to 'Reports', learner_report_path
+    %li= link_to 'Reports', "#{ENV['RESEARCHER_REPORT_HOST']}#{learner_report_path}",
+                            target: (ENV['RESEARCHER_REPORT_HOST'] ? "_blank" : "_self")
   - if is_admin_or_manager
     %li= link_to 'Districts', portal_districts_path
     %li= link_to 'Schools', portal_schools_path

--- a/app/views/layouts/minimal.html.haml
+++ b/app/views/layouts/minimal.html.haml
@@ -25,6 +25,11 @@
     / TODO: if themes need their own print CSS make a themed link here:
     != stylesheet_link_tag 'print', {'media' => 'print'}
 
+    / Include museo fonts.
+    %script{ :src => "https://use.typekit.com/hdw8ayt.js"}
+    %script
+      try { Typekit.load(); } catch (e) {}
+
     / Include scripts that are based on rails data and need to be generated dynamically. They cannot be precompiled.
     = render :partial => 'dynamic_scripts/all'
     / TODO: if themes need their own javascript, add theme_ to this:
@@ -49,11 +54,11 @@
     / The boxed conditional comment below is required.
     / Do NOT remove it unless you know what you're doing.
     /[if lt IE 10]
-  = javascript_include_tag("pie/PIE")
+      = javascript_include_tag("pie/PIE")
 
-  - if USING_GOOGLE_ANALYTICS
-    = javascript_tag google_analytics_config
-  = javascript_tag "jQuery(function(){jQuery('input[placeholder], textarea[placeholder]').placeholder();});"
+    - if USING_GOOGLE_ANALYTICS
+      = javascript_tag google_analytics_config
+    = javascript_tag "jQuery(function(){jQuery('input[placeholder], textarea[placeholder]').placeholder();});"
 
   %body{:class => 'blank', :'ng-app' => 'cc-portal'}
     #js_flash{:style=>"display: none;"}

--- a/config/app_environment_variables.sample.rb
+++ b/config/app_environment_variables.sample.rb
@@ -14,6 +14,12 @@ ENV['PORTAL_FEATURES']   ||= ''
 ENV['REPORT_VIEW_URL']   ||= 'https://concord-consortium.github.io/portal-report/'
 ENV['REPORT_DOMAINS']    ||= '*.concord.org concord-consortium.github.io'
 
+# Researcher report link can point to a different portal instance to avoid overloading the main server.
+# ENV['RESEARCHER_REPORT_HOST'] ||= 'https://research-report-portal.concord.org'
+# Portal that is dedicated to the research report should enable option below to disable all the links that could
+# lead researchers to other parts of the portal.
+# ENV['RESEARCHER_REPORT_ONLY'] ||= 'true'
+
 # CORS_ORIGINS:
 # Sets the allowed CORS origins to a specific whitelist. Requires ENV['PORTAL_FEATURES'] ||= 'allow_cors'
 # ENV['CORS_ORIGINS']    ||= "concord.org"

--- a/features/limit_access_to_routes.feature
+++ b/features/limit_access_to_routes.feature
@@ -119,7 +119,7 @@ In NO case should the system allow:
   Scenario Outline: Anonymous user can't access report learner routes:
     Given I am not logged in
     When I visit the route <route>
-    Then I should be on the signin page
+    Then I should be on the new signin page
 
     Examples:
       | route           |

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -127,6 +127,8 @@ module NavigationHelpers
       "/interactives/#{interactive}/edit"
     when /the signin page/
       "/users/sign_in"
+    when /the new signin page/
+      "/auth/login"
     # Add more mappings here.
     # Here is an example that pulls values out of the Regexp:
     #


### PR DESCRIPTION
The main portal should use `ENV['RESEARCHER_REPORT_HOST']`.
Second portal instance should set `ENV['RESEARCHER_REPORT_ONLY'] ||= 'true'` which switches layout to `minimal` on the reports page. It ensures that researches won't access other features of the portal. Researcher would need to sign in first, but our ["pretty sign in page"](https://learn.concord.org/auth/login) would be used and he'll be automatically redirected to reports page after successful login.

I've modified minimal layout a bit to fix some style issues.

