### PR TITLE
Generic interactive state

### DIFF
--- a/app/models/api/v1/report.rb
+++ b/app/models/api/v1/report.rb
@@ -262,6 +262,7 @@ class API::V1::Report
     hash[:answers].select { |a| a[:answer].present? }.each do |answer|
       # Pass these properties to answer too.
       answer[:display_in_iframe] = embeddable.display_in_iframe
+      answer[:url] = embeddable.url
       answer[:width] = embeddable.width
       answer[:height] = embeddable.height
     end

--- a/app/models/dataservice/process_external_activity_data_job.rb
+++ b/app/models/dataservice/process_external_activity_data_job.rb
@@ -41,6 +41,11 @@ class Dataservice::ProcessExternalActivityDataJob
             embeddable = template.iframes.detect {|e| e.external_id == student_response["question_id"]}
             internal_process_external_link(student_response, embeddable)
           end
+        when "interactive"
+          if student_response["question_type"] == "iframe interactive"
+            embeddable = template.iframes.detect {|e| e.external_id == student_response["question_id"]}
+            internal_process_interactive(student_response, embeddable)
+          end
         else
           raise UnknownRespose.new("type: #{student_response["type"]}\nContent: #{content}")
         end
@@ -74,6 +79,11 @@ class Dataservice::ProcessExternalActivityDataJob
   def internal_process_external_link(data,embeddable)
     saveable_external_link = Saveable::ExternalLink.find_or_create_by_learner_id_and_offering_id_and_embeddable_type_and_embeddable_id(@learner_id, @offering_id, embeddable.class.name, embeddable.id)
     saveable_external_link.answers.create(url: data["answer"], is_final: data["is_final"])
+  end
+
+  def internal_process_interactive(data,embeddable)
+    saveable_interactive = Saveable::Interactive.find_or_create_by_learner_id_and_offering_id_and_embeddable_type_and_embeddable_id(@learner_id, @offering_id, embeddable.class.name, embeddable.id)
+    saveable_interactive.answers.create(state: data["answer"], is_final: data["is_final"])
   end
 
   # stub id method, for SaveableExtraction compatibility

--- a/app/models/dataservice/process_external_activity_data_job.rb
+++ b/app/models/dataservice/process_external_activity_data_job.rb
@@ -42,10 +42,8 @@ class Dataservice::ProcessExternalActivityDataJob
             internal_process_external_link(student_response, embeddable)
           end
         when "interactive"
-          if student_response["question_type"] == "iframe interactive"
-            embeddable = template.iframes.detect {|e| e.external_id == student_response["question_id"]}
-            internal_process_interactive(student_response, embeddable)
-          end
+          embeddable = template.iframes.detect {|e| e.external_id == student_response["question_id"]}
+          internal_process_interactive(student_response, embeddable)
         else
           raise UnknownRespose.new("type: #{student_response["type"]}\nContent: #{content}")
         end

--- a/app/models/dataservice/process_external_activity_data_job.rb
+++ b/app/models/dataservice/process_external_activity_data_job.rb
@@ -80,7 +80,7 @@ class Dataservice::ProcessExternalActivityDataJob
   end
 
   def internal_process_interactive(data,embeddable)
-    saveable_interactive = Saveable::Interactive.find_or_create_by_learner_id_and_offering_id_and_embeddable_type_and_embeddable_id(@learner_id, @offering_id, embeddable.class.name, embeddable.id)
+    saveable_interactive = Saveable::Interactive.find_or_create_by_learner_id_and_offering_id_and_iframe_id(@learner_id, @offering_id, embeddable.id)
     saveable_interactive.answers.create(state: data["answer"], is_final: data["is_final"])
   end
 

--- a/app/models/portal/learner.rb
+++ b/app/models/portal/learner.rb
@@ -45,6 +45,12 @@ class Portal::Learner < ActiveRecord::Base
     end
   end
 
+  has_many :interactives, :dependent => :destroy , :class_name => "Saveable::Interactive" do
+    def answered
+      find(:all).select { |question| question.answered? }
+    end
+  end
+
   has_one :report_learner, :dependent => :destroy, :class_name => "Report::Learner",
     :foreign_key => "learner_id", :inverse_of => :learner
 

--- a/app/models/report/learner.rb
+++ b/app/models/report/learner.rb
@@ -118,7 +118,7 @@ class Report::Learner < ActiveRecord::Base
       # feedbacks = s.answers.map do |ans|
       # TOOD: Eventually we want all answers.... Or answers with feedback...
       # this has been simplified here because for performance reasons.
-        feedbacks = [s.answers.last].compact.map do |ans|
+      feedbacks = [s.answers.last].compact.map do |ans|
         {
             answer: serialize_blob_answer(ans.answer),
             answer_key: Report::Learner.encode_answer_key(ans),
@@ -129,6 +129,7 @@ class Report::Learner < ActiveRecord::Base
       end
       hash = {
           answer: serialize_blob_answer(s.answer),
+          answer_type: s.answer_type,
           feedbacks: feedbacks,
           answered: s.answered?,
           submitted: s.submitted?,

--- a/app/models/report/util_learner.rb
+++ b/app/models/report/util_learner.rb
@@ -22,6 +22,7 @@ class Report::UtilLearner
     @saveables += Saveable::MultipleChoice.find_all_by_learner_id(learner.id)
     @saveables += Saveable::ImageQuestion.find_all_by_learner_id(learner.id)
     @saveables += Saveable::ExternalLink.find_all_by_learner_id(learner.id)
+    @saveables += Saveable::Interactive.find_all_by_learner_id(learner.id)
 
     # ResponseTypes.saveable_types.each do |type|
     #   all = type.find_all_by_learner_id(learner.id)

--- a/app/models/saveable/interactive.rb
+++ b/app/models/saveable/interactive.rb
@@ -10,7 +10,7 @@ class Saveable::Interactive < ActiveRecord::Base
 
   delegate :name, :to => :embeddable
 
-  # External link can be displayed in an iframe in teacher report.
+  # Interactive can be displayed in an iframe in teacher report.
   delegate :display_in_iframe, :to => :embeddable
   delegate :width, :to => :embeddable
   delegate :height, :to => :embeddable

--- a/app/models/saveable/interactive.rb
+++ b/app/models/saveable/interactive.rb
@@ -4,18 +4,22 @@ class Saveable::Interactive < ActiveRecord::Base
   belongs_to :learner,     :class_name => 'Portal::Learner'
   belongs_to :offering,    :class_name => 'Portal::Offering'
 
-  belongs_to :embeddable,  :polymorphic => true
+  belongs_to :iframe,  :class_name => 'Embeddable::Iframe'
 
   has_many :answers, :dependent => :destroy ,:order => :position, :class_name => "Saveable::InteractiveState"
 
-  delegate :name, :to => :embeddable
+  delegate :name, :to => :iframe
 
   # Interactive can be displayed in an iframe in teacher report.
-  delegate :display_in_iframe, :to => :embeddable
-  delegate :width, :to => :embeddable
-  delegate :height, :to => :embeddable
+  delegate :display_in_iframe, :to => :iframe
+  delegate :width, :to => :iframe
+  delegate :height, :to => :iframe
 
   include Saveable::Saveable
+
+  def embeddable
+    iframe
+  end
 
   def submitted_answer
     if submitted?

--- a/app/models/saveable/interactive.rb
+++ b/app/models/saveable/interactive.rb
@@ -1,5 +1,5 @@
 class Saveable::Interactive < ActiveRecord::Base
-  self.table_name = "saveable_interactive"
+  self.table_name = "saveable_interactives"
 
   belongs_to :learner,     :class_name => 'Portal::Learner'
   belongs_to :offering,    :class_name => 'Portal::Offering'

--- a/app/models/saveable/interactive.rb
+++ b/app/models/saveable/interactive.rb
@@ -1,0 +1,33 @@
+class Saveable::Interactive < ActiveRecord::Base
+  self.table_name = "saveable_interactive"
+
+  belongs_to :learner,     :class_name => 'Portal::Learner'
+  belongs_to :offering,    :class_name => 'Portal::Offering'
+
+  belongs_to :embeddable,  :polymorphic => true
+
+  has_many :answers, :dependent => :destroy ,:order => :position, :class_name => "Saveable::InteractiveState"
+
+  delegate :name, :to => :embeddable
+
+  # External link can be displayed in an iframe in teacher report.
+  delegate :display_in_iframe, :to => :embeddable
+  delegate :width, :to => :embeddable
+  delegate :height, :to => :embeddable
+
+  include Saveable::Saveable
+
+  def submitted_answer
+    if submitted?
+      answers.last.answer
+    elsif answered?
+      'not submitted'
+    else
+      'not answered'
+    end
+  end
+
+  def submitted?
+    true
+  end
+end

--- a/app/models/saveable/interactive_state.rb
+++ b/app/models/saveable/interactive_state.rb
@@ -4,7 +4,7 @@ class Saveable::InteractiveState < ActiveRecord::Base
   belongs_to :interactive,  :class_name => 'Saveable::Interactive', :counter_cache => :response_count
   belongs_to :bundle_content, :class_name => 'Dataservice::BundleContent'
 
-  acts_as_list :scope => :interactive_state_id
+  acts_as_list :scope => :interactive_id
 
   delegate :learner, to: :interactive, allow_nil: :true
 

--- a/app/models/saveable/interactive_state.rb
+++ b/app/models/saveable/interactive_state.rb
@@ -1,0 +1,18 @@
+class Saveable::InteractiveState < ActiveRecord::Base
+  self.table_name = "saveable_interactive_states"
+
+  belongs_to :interactive,  :class_name => 'Saveable::Interactive', :counter_cache => :response_count
+  belongs_to :bundle_content, :class_name => 'Dataservice::BundleContent'
+
+  acts_as_list :scope => :interactive_state_id
+
+  delegate :learner, to: :interactive, allow_nil: :true
+
+  def answer
+    state
+  end
+
+  def answer=(ans)
+    state = ans
+  end
+end

--- a/app/models/saveable/saveable.rb
+++ b/app/models/saveable/saveable.rb
@@ -23,10 +23,17 @@ module Saveable::Saveable
     end
   end
 
+  def answer_type
+    if answered?
+      answers.last.class.to_s
+    else
+      nil
+    end
+  end
+
   def answered?
     answers.length > 0
   end
-
 
   def current_feedback
     if answered? && answers.last.respond_to?(:feedback)

--- a/db/migrate/20170307192236_create_saveable_interactives.rb
+++ b/db/migrate/20170307192236_create_saveable_interactives.rb
@@ -1,0 +1,13 @@
+class CreateSaveableInteractives < ActiveRecord::Migration
+  def change
+    create_table :saveable_interactives do |t|
+      t.integer :embeddable_id
+      t.string  :embeddable_type
+      t.integer :learner_id
+      t.integer :offering_id
+      t.integer :response_count
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170307192402_create_saveable_interactive_states.rb
+++ b/db/migrate/20170307192402_create_saveable_interactive_states.rb
@@ -1,0 +1,16 @@
+class CreateSaveableInteractiveStates < ActiveRecord::Migration
+  def change
+    create_table :saveable_interactive_states do |t|
+      t.integer :interactive_id
+      t.integer :bundle_content_id
+      t.integer :position
+      t.text    :state, :limit => 4294967295
+      t.boolean :is_final
+      t.text    :feedback
+      t.boolean :has_been_reviewed, default: false
+      t.integer :score
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170312203545_simplify_saveable_interactives.rb
+++ b/db/migrate/20170312203545_simplify_saveable_interactives.rb
@@ -1,0 +1,13 @@
+class SimplifySaveableInteractives < ActiveRecord::Migration
+  def up
+    add_column :saveable_interactives, :iframe_id, :integer
+    remove_column :saveable_interactives, :embeddable_id
+    remove_column :saveable_interactives, :embeddable_type
+  end
+
+  def down
+    remove_column :saveable_interactives, :iframe_id, :integer
+    add_column :saveable_interactives, :embeddable_id, :integer
+    add_column :saveable_interactives, :embeddable_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20170202190333) do
+ActiveRecord::Schema.define(:version => 20170307192402) do
 
   create_table "access_grants", :force => true do |t|
     t.string   "code"
@@ -2460,6 +2460,29 @@ ActiveRecord::Schema.define(:version => 20170202190333) do
   add_index "saveable_image_questions", ["image_question_id"], :name => "index_saveable_image_questions_on_image_question_id"
   add_index "saveable_image_questions", ["learner_id"], :name => "index_saveable_image_questions_on_learner_id"
   add_index "saveable_image_questions", ["offering_id"], :name => "index_saveable_image_questions_on_offering_id"
+
+  create_table "saveable_interactive_states", :force => true do |t|
+    t.integer  "interactive_id"
+    t.integer  "bundle_content_id"
+    t.integer  "position"
+    t.text     "state",             :limit => 2147483647
+    t.boolean  "is_final"
+    t.text     "feedback"
+    t.boolean  "has_been_reviewed",                       :default => false
+    t.integer  "score"
+    t.datetime "created_at",                                                 :null => false
+    t.datetime "updated_at",                                                 :null => false
+  end
+
+  create_table "saveable_interactives", :force => true do |t|
+    t.integer  "embeddable_id"
+    t.string   "embeddable_type"
+    t.integer  "learner_id"
+    t.integer  "offering_id"
+    t.integer  "response_count"
+    t.datetime "created_at",      :null => false
+    t.datetime "updated_at",      :null => false
+  end
 
   create_table "saveable_multiple_choice_answers", :force => true do |t|
     t.integer  "multiple_choice_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20170307192402) do
+ActiveRecord::Schema.define(:version => 20170312203545) do
 
   create_table "access_grants", :force => true do |t|
     t.string   "code"
@@ -2475,13 +2475,12 @@ ActiveRecord::Schema.define(:version => 20170307192402) do
   end
 
   create_table "saveable_interactives", :force => true do |t|
-    t.integer  "embeddable_id"
-    t.string   "embeddable_type"
     t.integer  "learner_id"
     t.integer  "offering_id"
     t.integer  "response_count"
-    t.datetime "created_at",      :null => false
-    t.datetime "updated_at",      :null => false
+    t.datetime "created_at",     :null => false
+    t.datetime "updated_at",     :null => false
+    t.integer  "iframe_id"
   end
 
   create_table "saveable_multiple_choice_answers", :force => true do |t|

--- a/lib/response_types.rb
+++ b/lib/response_types.rb
@@ -1,6 +1,6 @@
 module ResponseTypes
   def self.saveable_types
-    [ Saveable::OpenResponse, Saveable::MultipleChoice, Saveable::ImageQuestion, Saveable::ExternalLink ]
+    [ Saveable::OpenResponse, Saveable::MultipleChoice, Saveable::ImageQuestion, Saveable::ExternalLink, Saveable::Interactive ]
   end
 
   def saveable_types

--- a/spec/models/dataservice/process_external_activity_data_job_spec.rb
+++ b/spec/models/dataservice/process_external_activity_data_job_spec.rb
@@ -25,6 +25,10 @@ describe Dataservice::ProcessExternalActivityDataJob do
         question_type: "iframe interactive",
         question_id: 4
       },
+      {
+        type: "interactive",
+        question_id: 5
+      }
     ].to_json
   end
 
@@ -49,6 +53,7 @@ describe Dataservice::ProcessExternalActivityDataJob do
     subject.stub!(:internal_process_multiple_choice)
     subject.stub!(:internal_process_image_question)
     subject.stub!(:internal_process_external_link)
+    subject.stub!(:internal_process_interactive)
   end
 
 
@@ -74,6 +79,7 @@ describe Dataservice::ProcessExternalActivityDataJob do
         subject.should_receive :internal_process_multiple_choice
         subject.should_receive :internal_process_image_question
         subject.should_receive :internal_process_external_link
+        subject.should_receive :internal_process_interactive
         subject.perform
       end
     end


### PR DESCRIPTION
This PR adds support of a new answer type - "interactive". It's handled by `Saveable::Interactive` and `Saveable::InteractiveState`. Portal assumes that it's an "answer" to `Embeddable::Iframe`. It's an reportable item, so all the progress bars would count it. Note that `Saveable::ExternalLink` is an older, alternative answer type to this "question type" / embeddable. 

`Saveable::InteractiveState` state keeps it's state in a text field and makes no assumptions about it (although in most cases it would be JSON). This state is passed later to the report app via report API. Also, this API has been updated to provide `answer_type` field, as now one question type can have more than one type of an answer (iframe -> external link or interactive state).
