### PR TITLE
Registration fixes 135156275

### DIFF
--- a/app/assets/javascripts/components/signup/basic_data_form.js.coffee
+++ b/app/assets/javascripts/components/signup/basic_data_form.js.coffee
@@ -3,11 +3,11 @@
 PASS_TOO_SHORT = 'Password is too short'
 PASS_NOT_MATCH = 'Passwords do not match'
 
-modulejs.define 'components/signup/basic_data_form', 
+modulejs.define 'components/signup/basic_data_form',
 [
   'components/signup/text_input',
   'components/signup/radio_input'
-], 
+],
 (
   TextInputClass,
   RadioInputClass
@@ -17,6 +17,7 @@ modulejs.define 'components/signup/basic_data_form',
   FormsyForm = React.createFactory Formsy.Form
 
   React.createClass
+    displayName: 'BasicDataForm'
     getInitialState: ->
       canSubmit: false
       password: ''

--- a/app/assets/javascripts/components/signup/privacy_policy.js.coffee
+++ b/app/assets/javascripts/components/signup/privacy_policy.js.coffee
@@ -2,6 +2,7 @@
 
 modulejs.define 'components/signup/privacy_policy', [], () ->
   React.createClass
+    displayName: 'PrivacyPolicy'
     render: ->
       (div {className: 'privacy-policy'},
         'By clicking Sign Up!, you agree to our '

--- a/app/assets/javascripts/components/signup/radio_input.js.coffee
+++ b/app/assets/javascripts/components/signup/radio_input.js.coffee
@@ -2,6 +2,7 @@
 
 modulejs.define 'components/signup/radio_input', [], () ->
   React.createClass
+    displayName: 'RadioInput'
     mixins: [Formsy.Mixin]
 
     # setValue() will set the value of the component, which in

--- a/app/assets/javascripts/components/signup/school_input.js.coffee
+++ b/app/assets/javascripts/components/signup/school_input.js.coffee
@@ -9,6 +9,7 @@ modulejs.define 'components/signup/school_input', [], () ->
     jQuery.get("#{Portal.API_V1.SCHOOLS}?country_id=#{country}&zipcode=#{zipcode}")
 
   React.createClass
+    displayName: 'SchoolInput'
     mixins: [Formsy.Mixin]
 
     getInitialState: ->

--- a/app/assets/javascripts/components/signup/select_input.js.coffee
+++ b/app/assets/javascripts/components/signup/select_input.js.coffee
@@ -5,6 +5,7 @@ modulejs.define 'components/signup/select_input', [], () ->
   SelectAsync = React.createFactory Select.Async
 
   React.createClass
+    displayName: 'SelectInput'
     mixins: [Formsy.Mixin]
 
     # setValue() will set the value of the component, which in

--- a/app/assets/javascripts/components/signup/sideinfo.js.coffee
+++ b/app/assets/javascripts/components/signup/sideinfo.js.coffee
@@ -2,6 +2,7 @@
 
 modulejs.define 'components/signup/sideinfo', [], () ->
   React.createClass
+    displayName: 'SideInfo'
     render: ->
       (div {},
         (div {className: 'side-info-header'}, 'Why sign up?')

--- a/app/assets/javascripts/components/signup/signup.js.coffee
+++ b/app/assets/javascripts/components/signup/signup.js.coffee
@@ -31,6 +31,7 @@ modulejs.define 'components/signup/signup',
   TeacherRegistrationComplete = React.createFactory TeacherRegistrationCompleteClass
 
   React.createClass
+    displayName: 'SignUp'
     getInitialState: ->
       basicData: null
       studentData: null

--- a/app/assets/javascripts/components/signup/signup.js.coffee
+++ b/app/assets/javascripts/components/signup/signup.js.coffee
@@ -42,6 +42,8 @@ modulejs.define 'components/signup/signup',
       # When user is anonymous, we need to ask about all the information (email, login, password).
       # However, sometimes users are using SSO and basic user object can be already created. Then we only
       # need to create Portal-specific models (student or teacher).
+      # Note: if the user loaded the page while they were anonymous, but then logged in in another
+      # tab, this property will be incorrect
       anonymous: Portal.currentUser.isAnonymous
 
     onBasicDataSubmit: (data) ->
@@ -81,7 +83,11 @@ modulejs.define 'components/signup/signup',
         ),
         (div {className: 'side-info'},
           if studentData
-            (StudentRegistrationCompleteSideInfo {})
+            # StudentRegistrationCompleteSideInfo contains a login form
+            # If the student is already logged in because of the SSO path, don't show
+            # this form
+            if anonymous
+              (StudentRegistrationCompleteSideInfo {})
           else if !basicData
             (SideInfo {})
           else if basicData.type == 'student'

--- a/app/assets/javascripts/components/signup/signup.js.coffee
+++ b/app/assets/javascripts/components/signup/signup.js.coffee
@@ -85,7 +85,7 @@ modulejs.define 'components/signup/signup',
           if studentData
             # StudentRegistrationCompleteSideInfo contains a login form
             # If the student is already logged in because of the SSO path, don't show
-            # this form
+            # this form or anything else in the side info section.
             if anonymous
               (StudentRegistrationCompleteSideInfo {})
           else if !basicData

--- a/app/assets/javascripts/components/signup/signup_modal.js.coffee
+++ b/app/assets/javascripts/components/signup/signup_modal.js.coffee
@@ -13,6 +13,7 @@ modulejs.define 'components/signup/signup_modal',
   SideInfo = React.createFactory SideInfoClass
 
   React.createClass
+    displayName: 'SignupModal'
     render: ->
       (div {className: 'signup-default-modal-content'},
         (Signup {})

--- a/app/assets/javascripts/components/signup/student_form.js.coffee
+++ b/app/assets/javascripts/components/signup/student_form.js.coffee
@@ -21,6 +21,7 @@ modulejs.define 'components/signup/student_form',
     jQuery.post Portal.API_V1.STUDENTS, params
 
   React.createClass
+    displayName: 'StudentForm'
     getInitialState: ->
       canSubmit: false
 
@@ -31,7 +32,7 @@ modulejs.define 'components/signup/student_form',
 
     onBasicFormInvalid: ->
       @setState canSubmit: false
-    
+
     submit: (data, resetForm, invalidateForm) ->
       {basicData, onRegistration} = @props
       params = jQuery.extend {}, basicData, data

--- a/app/assets/javascripts/components/signup/student_form_sideinfo.js.coffee
+++ b/app/assets/javascripts/components/signup/student_form_sideinfo.js.coffee
@@ -2,6 +2,7 @@
 
 modulejs.define 'components/signup/student_form_sideinfo', [], () ->
   React.createClass
+    displayName: 'StudentFormSideInfo'
     render: ->
       (div {},
         (p {},

--- a/app/assets/javascripts/components/signup/student_registration_complete.js.coffee
+++ b/app/assets/javascripts/components/signup/student_registration_complete.js.coffee
@@ -2,6 +2,7 @@
 
 modulejs.define 'components/signup/student_registration_complete', [], () ->
   React.createClass
+    displayName: 'StudentRegistrationComplete'
     render: ->
       {anonymous, data} = @props
       {first_name, last_name, login} = data

--- a/app/assets/javascripts/components/signup/student_registration_complete_sideinfo.js.coffee
+++ b/app/assets/javascripts/components/signup/student_registration_complete_sideinfo.js.coffee
@@ -2,6 +2,7 @@
 
 modulejs.define 'components/signup/student_registration_complete_sideinfo', [], () ->
   React.createClass
+    displayName: 'StudentRegistrationCompleteSideInfo'
     componentDidMount: ->
       authToken = jQuery('meta[name="csrf-token"]').attr('content');
       jQuery('form[method="post"]').each () ->

--- a/app/assets/javascripts/components/signup/teacher_form.js.coffee
+++ b/app/assets/javascripts/components/signup/teacher_form.js.coffee
@@ -49,6 +49,7 @@ modulejs.define 'components/signup/teacher_form',
     name == 'United States' || name == 'US' || name == 'USA'
 
   React.createClass
+    displayName: 'TeacherForm'
     getInitialState: ->
       canSubmit: false
       currentCountry: null
@@ -69,7 +70,7 @@ modulejs.define 'components/signup/teacher_form',
 
     onBasicFormInvalid: ->
       @setState canSubmit: false
-    
+
     submit: (data, resetForm, invalidateForm) ->
       {basicData, onRegistration} = @props
       params = jQuery.extend {}, basicData, data

--- a/app/assets/javascripts/components/signup/teacher_registration_complete.js.coffee
+++ b/app/assets/javascripts/components/signup/teacher_registration_complete.js.coffee
@@ -2,6 +2,7 @@
 
 modulejs.define 'components/signup/teacher_registration_complete', [], () ->
   React.createClass
+    displayName: 'TeacherRegistrationComplete'
     render: ->
       {anonymous} = @props
       (div {className: 'registration-complete'},

--- a/app/assets/javascripts/components/signup/text_input.js.coffee
+++ b/app/assets/javascripts/components/signup/text_input.js.coffee
@@ -9,6 +9,7 @@ modulejs.define 'components/signup/text_input',
   AsyncValidationMixin
 ) ->
   React.createClass
+    displayName: 'TextInput'
     mixins: [Formsy.Mixin, AsyncValidationMixin]
 
     getDefaultProps: ->

--- a/app/controllers/api/v1/students_controller.rb
+++ b/app/controllers/api/v1/students_controller.rb
@@ -12,10 +12,10 @@ class API::V1::StudentsController < API::APIController
       # The errors in this case will be passed down to the registration form.
       # The use of class_word is so the error message is shown in the form.
       if current_user.portal_teacher
-        error(class_word: I18n.t('Registration.LoggedInAsTeacher'))
+        error(class_word: I18n.t('Registration.ErrorLoggedInAsTeacher'))
         return
       elsif current_user.portal_student
-        error(class_word: I18n.t('Registration.LoggedInAsStudent'));
+        error(class_word: I18n.t('Registration.ErrorLoggedInAsStudent'));
         return
       else
         registration.set_user current_user

--- a/app/controllers/api/v1/students_controller.rb
+++ b/app/controllers/api/v1/students_controller.rb
@@ -9,7 +9,10 @@ class API::V1::StudentsController < API::APIController
 
     if registration.valid?
       registration.save
-      render :json => registration.attributes
+      attributes = registration.attributes
+      attributes.delete(:password)
+      attributes.delete(:password_confirmation)
+      render :json => attributes
     else
       error(registration.errors)
     end

--- a/app/controllers/api/v1/teachers_controller.rb
+++ b/app/controllers/api/v1/teachers_controller.rb
@@ -5,8 +5,23 @@ class API::V1::TeachersController < API::APIController
   # - 'school_name', 'country_id' and 'zipcode' are provided instead - school may be created in case of need
   def create
     teacher_registration = API::V1::TeacherRegistration.new(params)
-    if !current_visitor.anonymous?
-      teacher_registration.set_user current_visitor
+
+    # This was added to allow for registering after logging in the first time with SSO
+    # But it also occurs if a user is able to access the registration form while being
+    # logged in a different window.
+    if current_user
+      # If the user has a portal_teacher or portal_student, we don't want them re-registering
+      # The errors in this case will be passed down to the registration form.
+      # The use of school_id is so the error message is shown in the form.
+      if current_user.portal_teacher
+        error(school_id: I18n.t('Registration.LoggedInAsTeacher'))
+        return
+      elsif current_user.portal_student
+        error(school_id: I18n.t('Registration.LoggedInAsStudent'))
+        return
+      else
+        teacher_registration.set_user current_user
+      end
     end
 
     if should_create_new_school(teacher_registration)

--- a/app/controllers/api/v1/teachers_controller.rb
+++ b/app/controllers/api/v1/teachers_controller.rb
@@ -14,10 +14,10 @@ class API::V1::TeachersController < API::APIController
       # The errors in this case will be passed down to the registration form.
       # The use of school_id is so the error message is shown in the form.
       if current_user.portal_teacher
-        error(school_id: I18n.t('Registration.LoggedInAsTeacher'))
+        error(school_id: I18n.t('Registration.ErrorLoggedInAsTeacher'))
         return
       elsif current_user.portal_student
-        error(school_id: I18n.t('Registration.LoggedInAsStudent'))
+        error(school_id: I18n.t('Registration.ErrorLoggedInAsStudent'))
         return
       else
         teacher_registration.set_user current_user

--- a/app/controllers/api/v1/teachers_controller.rb
+++ b/app/controllers/api/v1/teachers_controller.rb
@@ -21,7 +21,10 @@ class API::V1::TeachersController < API::APIController
 
     if teacher_registration.valid?
       teacher_registration.save
-      render status: 201, json: teacher_registration.attributes
+      attributes = teacher_registration.attributes
+      attributes.delete(:password)
+      attributes.delete(:password_confirmation)
+      render status: 201, json: attributes
     else
       error(teacher_registration.errors)
     end

--- a/app/models/api/v1/user_registration.rb
+++ b/app/models/api/v1/user_registration.rb
@@ -23,6 +23,10 @@ class API::V1::UserRegistration
   def set_user(user)
     @user = user
     @user_set = true
+    self.login = user.login
+    self.email = user.email
+    self.first_name = user.first_name
+    self.last_name = user.last_name
   end
 
   def set_defaults

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -133,10 +133,10 @@ en:
     only_mine: Show only materials authored by me
     only_archived: Show only archived materials
   Registration:
-    LoggedInAsTeacher: |
+    ErrorLoggedInAsTeacher: |
       You are logged in as a teacher in another window.
       Please log out, and register again.
-    LoggedInAsStudent: |
+    ErrorLoggedInAsStudent: |
       You are logged in as a student in another window.
       Please log out, and register again.
 'en-HAS':

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -132,6 +132,13 @@ en:
   search:
     only_mine: Show only materials authored by me
     only_archived: Show only archived materials
+  Registration:
+    LoggedInAsTeacher: |
+      You are logged in as a teacher in another window.
+      Please log out, and register again.
+    LoggedInAsStudent: |
+      You are logged in as a student in another window.
+      Please log out, and register again.
 'en-HAS':
   activerecord:
     models:


### PR DESCRIPTION
The main goal of this PR is to prevent teachers from ending up with a student account associated with their user. It also includes a few other fixes.

It improves the JSON response from the portal after registering a user:
- remove password from registration response json (it isn't needed and seems bad to send it around like that)
- if the user was already logged in (for example from SSO), then add their info to the response

It fixes the path when a student signs up with SSO. With some recent changes this was showing the student a login form when the student was already logged in.

It adds displayNames to the signup React components to make inspection easier.