### PR TITLE
Use site_url when constructing remote_endpoint_url

### DIFF
--- a/app/controllers/portal/offerings_controller.rb
+++ b/app/controllers/portal/offerings_controller.rb
@@ -63,7 +63,7 @@ class Portal::OfferingsController < ApplicationController
            uri.query = {
              :domain => root_url,
              :externalId => learner.id,
-             :returnUrl => learner.remote_endpoint_url(request.protocol, request.host_with_port),
+             :returnUrl => learner.remote_endpoint_url,
              :logging => @offering.clazz.logging || @offering.runnable.logging,
              :domain_uid => current_visitor.id,
              :class_info_url => @offering.clazz.class_info_url(request.protocol, request.host_with_port)

--- a/app/controllers/report/learner_controller.rb
+++ b/app/controllers/report/learner_controller.rb
@@ -29,7 +29,7 @@ class Report::LearnerController < ApplicationController
 
   def logs_query
     authorize Report::Learner
-    @remote_endpoints = @select_learners.map { |l| l.learner.remote_endpoint_url(request.protocol, request.host_with_port) }
+    @remote_endpoints = @select_learners.map { |l| l.learner.remote_endpoint_url }
     render :layout => false
   end
 
@@ -193,7 +193,7 @@ class Report::LearnerController < ApplicationController
 
     @report_url = "#{authoring_sites.first}/c_rater/argumentation_blocks/report"
     @remote_endpoints = learners.map do |learner|
-      learner.learner.remote_endpoint_url(request.protocol, request.host_with_port)
+      learner.learner.remote_endpoint_url
     end
 
     # intentionally leave out student name - results should be semi-anonymized
@@ -203,7 +203,7 @@ class Report::LearnerController < ApplicationController
     rows = learners.map do |learner|
       columns.map do |column|
         # except for remote_endpoint, column names are just names of Report::Learner instance methods
-        column == :remote_endpoint ? learner.learner.remote_endpoint_url(request.protocol, request.host_with_port) : learner.send(column)
+        column == :remote_endpoint ? learner.learner.remote_endpoint_url : learner.send(column)
       end
     end
 

--- a/app/models/api/v1/offering.rb
+++ b/app/models/api/v1/offering.rb
@@ -16,7 +16,7 @@ class API::V1::Offering
       learner = offering.learners.where(student_id: student.id).first
       # Learner object is available only if student has started the activity.
       self.started_activity = learner ? true : false
-      self.endpoint_url = learner ? learner.remote_endpoint_url(protocol, host_with_port) : nil
+      self.endpoint_url = learner ? learner.remote_endpoint_url : nil
     end
   end
 

--- a/app/models/portal/learner.rb
+++ b/app/models/portal/learner.rb
@@ -201,11 +201,11 @@ class Portal::Learner < ActiveRecord::Base
     end
   end
 
-  def remote_endpoint_url(protocol, host_with_port)
+  def remote_endpoint_url
     if secure_key.present?
-      external_activity_return_url(secure_key, protocol: protocol, host: host_with_port)
+      "#{APP_CONFIG[:site_url]}#{external_activity_return_path(secure_key)}"
     else
-      external_activity_return_url(id, protocol: protocol, host: host_with_port)
+      "#{APP_CONFIG[:site_url]}#{external_activity_return_path(id)}"
     end
   end
 end

--- a/app/services/api/v1/show_collaborators_data.rb
+++ b/app/services/api/v1/show_collaborators_data.rb
@@ -27,7 +27,7 @@ class API::V1::ShowCollaboratorsData
         # Not sure why this is needed, but currently LARA expects that value for regular activity run.
         learner_id: learner.id,
         # This URL can be used by external activity system to publish back  student answers.
-        endpoint_url: learner.remote_endpoint_url(self.protocol, self.host_with_port)
+        endpoint_url: learner.remote_endpoint_url
       }
     end
   end

--- a/features/activity_runtime_api/running.feature
+++ b/features/activity_runtime_api/running.feature
@@ -9,7 +9,7 @@ Feature: External Activities can support a REST api
       | domain_uid        | domain_uid of 'student'      |
       | externalId        | 999                          |
       | logging           | false                        |
-      | returnUrl         | http://www.example.com/dataservice/external_activity_data/key |
+      | returnUrl         | site_url/dataservice/external_activity_data/key |
       | class_info_url    | class_info_url of 'My Class' |
     And "activities.com/activity/1/sessions/" GET responds with
       """

--- a/features/step_definitions/activity_runtime_api_steps.rb
+++ b/features/step_definitions/activity_runtime_api_steps.rb
@@ -51,6 +51,7 @@ Given /^"([^"]*)" handles a (POST|GET) with query:$/ do |address, method, table|
   end
   # must use a copy! Cucumber apparently doesn't re-allocate arguments for Background steps
   query_data["externalId"] = query_data["externalId"].sub(/999/,"#{@learner.id}")
+  query_data["returnUrl"] = query_data["returnUrl"].sub(/site_url/,APP_CONFIG[:site_url])
   query_data["returnUrl"] = query_data["returnUrl"].sub(/key/,"#{@learner.secure_key}")
   # replace domain_uid by user id if it has the pattern "domain_uid of 'login'"
   if /domain_uid of '(.*)'/ =~ query_data["domain_uid"]

--- a/lib/reports/url_helpers.rb
+++ b/lib/reports/url_helpers.rb
@@ -5,6 +5,6 @@ class Reports::UrlHelpers
   end
 
   def remote_endpoint_url(portal_learner)
-    portal_learner.remote_endpoint_url(@protocol, @host_with_port)
+    portal_learner.remote_endpoint_url
   end
 end


### PR DESCRIPTION
As far as I can tell, the failing Travis tests on this PR and the other one are not related to the changes.