### PR TITLE
Disable CSRF token check on log in

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,13 @@
+class SessionsController < Devise::SessionsController
+  # With Rails 3 and Devise there doesn't seem to be a good way to handle an invalid
+  # token. The session is cleared and then the login actually continues, but with
+  # mostly empty session.  In more recent Rails the authenticity token can be setup to
+  # throw an exception. If it through that exception then the login should stop and the
+  # the user could see an error message.
+  # In the meantime we'll disable the authenticity token check on login.
+  skip_before_filter :verify_authenticity_token, :only => [:create]
+
+  def new
+    super
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,7 +2,7 @@ class SessionsController < Devise::SessionsController
   # With Rails 3 and Devise there doesn't seem to be a good way to handle an invalid
   # token. The session is cleared and then the login actually continues, but with
   # mostly empty session.  In more recent Rails the authenticity token can be setup to
-  # throw an exception. If it through that exception then the login should stop and the
+  # throw an exception. If it threw that exception then the login should stop and the
   # the user could see an error message.
   # In the meantime we'll disable the authenticity token check on login.
   skip_before_filter :verify_authenticity_token, :only => [:create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 RailsPortal::Application.routes.draw do
 
-  devise_for :users, :controllers => { :registrations => 'registrations', :confirmations => 'confirmations', :omniauth_callbacks => "authentications" }
+  devise_for :users, :controllers => {
+    :registrations => 'registrations',
+    :confirmations => 'confirmations',
+    :omniauth_callbacks => 'authentications',
+    :sessions =>  'sessions'}
 
   # Client stuff
   match '/auth/:provider/check' => 'misc#auth_check', method: :get, as: 'auth_check'


### PR DESCRIPTION
With the CSRF check enabled on log in, a failed CSRF token causes strange behavior.
The session gets cleared by the failed check, but then the login continues as normal.
The result is that the user sees a flash message saying the login was successful, and they are redirected to the page they would normally see. But the user isn’t actually logged in.
So the page is typically blank and there is a login form in the top right.

The solution here is to just disable the CSRF token check on login. Since we had no CSRF check before this isn't a regression.  Once we've upgraded Rails I think this case will be handled better, because we'll have the option of throwing an exception when the check fails. 

[#143357307]