### PR TITLE
New Report Only Portal features

### DIFF
--- a/app/controllers/report/learner_controller.rb
+++ b/app/controllers/report/learner_controller.rb
@@ -61,6 +61,10 @@ class Report::LearnerController < ApplicationController
     end
   end
 
+  def report_only
+    render layout: "minimal"
+  end
+
   private
 
   def setup

--- a/app/views/report/learner/index.html.haml
+++ b/app/views/report/learner/index.html.haml
@@ -1,4 +1,13 @@
 
+- if ENV['RESEARCHER_REPORT_ONLY']
+  - # in this case we are only showing a minmal layout. So provide the user with a
+  - # simple header
+  %div
+    Welcome
+    = "#{current_visitor.name}"
+    %br
+    = link_to 'Logout', destroy_user_session_path
+
 %div{:style=>"min-height: 400px;"}
   %p
     %h3 You have selected:

--- a/app/views/report/learner/report_only.html.haml
+++ b/app/views/report/learner/report_only.html.haml
@@ -1,0 +1,4 @@
+%div{style: 'font-size: xx-large'}
+  This portal is only for running researcher reports.
+  %br
+  If you are not a researacher please go to the standard portal.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -540,6 +540,7 @@ RailsPortal::Application.routes.draw do
     match '/report/learner' => 'report/learner#index', :as => :learner_report, :method => :get
     match '/report/learner/logs_query' => 'report/learner#logs_query', :as => :learner_logs_query, :method => :get
     match '/report/learner/updated_at/:id' => 'report/learner#updated_at', :as => :learner_updated_at, :method => :get
+    match '/report/learner/report_only' => 'report/learner#report_only', :as => :learner_report_only, :method => :get
     resources :activities do
       member do
         get :duplicate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       SOLR_HOST: solr
       SOLR_PORT: 8983
       PORTAL_FEATURES:
+      RESEARCHER_REPORT_ONLY:
     # no ports are published, see below for details
     volumes:
       - .:/rigse


### PR DESCRIPTION
- Show the user a minimal header in the report only view of the researcher reports.
- Send all users that log into the report only portal to the researcher portal page
- If a user gets an unauthorized error log them out and send them to a page explaining this is a researcher report only portal.

This code changes are spread all over unfortunately. I’m hopefully that we will soon have a better report filtering system. This will change how this report only portal is configured. So it doesn’t seem worthwhile to put in a lot of time to make this more clean.

[#143419001]