### PR TITLE
Make the site_url configurable in dev environment

### DIFF
--- a/config/settings.sample.yml
+++ b/config/settings.sample.yml
@@ -1,6 +1,6 @@
 development: &non_production_settings
   :site_name: Rails Portal (development)
-  :site_url: http://localhost:3000
+  :site_url: <%= ENV["SITE_URL"] || 'http://localhost:3000' %> 
   :authoring_site_url: //authoring.staging.concord.org
   :codap_url: http://codap.concord.org/releases/latest/
   :log_manager_data_interactive_url: //cc-log-manager.herokuapp.com/di

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       SOLR_HOST: solr
       SOLR_PORT: 8983
       PORTAL_FEATURES:
+      SITE_URL:
       RESEARCHER_REPORT_ONLY:
       TEST_SOLR_HOST: solr-test
       TEST_SOLR_PORT: 8981


### PR DESCRIPTION
This is useful so developers don't need to modify their local settings.yml. Instead they can just put this setting in the .env file.

This is heading towards the direction of checking in settings.yml into source control, and removing the copying of the settings.sample.yml file.