### PR TITLE
Fix regression related to creating or viewing class bookmarks.

### DIFF
--- a/app/views/portal/bookmarks/_show.html.haml
+++ b/app/views/portal/bookmarks/_show.html.haml
@@ -1,7 +1,7 @@
 %div.bookmark_item{ :id => bookmark_dom_item(bookmark), 'data-bookmark-id' => bookmark.id }
   = check_box_tag('is_visible', 'true', bookmark.is_visible, :class => 'visibility', :id => nil)
   %a.control.slide ☰
-  = link_to_remote(fa_icon('trash-o', '', :class => 'control'), { |
+  = link_to_remote(fa_icon('trash-o', class: 'control'), { |
       :confirm => "Delete bookmark to #{bookmark.name}?", |
       :url => portal_delete_bookmark_path(bookmark) }) |
   %a.control.edit ✎


### PR DESCRIPTION
The error was `wrong number of arguments 3 for 0..2`  -- new method signature for fa_icon is something like this  `fa_icon "quote-left 4x", class: "text-muted pull-left"`  -- where we are currently using `fa_icon('trash-o', '', :class => 'control'`  (as in `views/portal/bookmarks/_show.html.haml` line 4 )