### PR TITLE
Add authoring specific javascript files to precompile list

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -168,6 +168,8 @@ module RailsPortal
       web/search_materials.css
       readme.css
       print.css
+      import_progress.js
+      import_model_library.js
     )
 
     # pre-compile any fonts in the assets/ directory as well


### PR DESCRIPTION
This should fix the errors on the /authoring page, where it can't load in a couple of javascript assets.
This isn't a problem in development because the assets are complied as needed, but in production they are precompiled. 
I tested it locally by using the image built by docker hub for this branch and it no longer has errors.

Once this is merged in then we can also put it up on the learn-stem.staging site so we can import all of the interactives from the production learn site.

[#147376319]