### PR TITLE
Add limit to number of related resources included in materials json.

### DIFF
--- a/app/controllers/api/v1/materials_controller.rb
+++ b/app/controllers/api/v1/materials_controller.rb
@@ -2,6 +2,11 @@ class API::V1::MaterialsController < API::APIController
   include Materials::DataHelpers
 
   #
+  # Default number of related materials to return
+  #
+  @@DEFAULT_RELATED_MATERIALS_COUNT = 4
+
+  #
   # Map of class types supported material types.
   #
   # Might also consider using "classify" and "constantize" here
@@ -244,7 +249,9 @@ class API::V1::MaterialsController < API::APIController
 
     type            = params[:material_type]
     id              = params[:id]
-    include_related = params[:include_related]
+    include_related = params.has_key?(:include_related)     ? 
+                        params[:include_related].to_i       : 
+                        @@DEFAULT_RELATED_MATERIALS_COUNT
 
     status          = 200
     data            = {}

--- a/app/views/browse/_related.html.haml
+++ b/app/views/browse/_related.html.haml
@@ -16,7 +16,7 @@
   jQuery(document).ready(function() {
 
     var dest    = '.related_materials_list';
-    var apiUrl  = '/api/v1/materials/#{material.class.name.underscore}/#{material.id}?include_related=true';
+    var apiUrl  = '/api/v1/materials/#{material.class.name.underscore}/#{material.id}';
 
     jQuery.ajax({
         dataType: "json",

--- a/lib/materials/data_helpers.rb
+++ b/lib/materials/data_helpers.rb
@@ -13,7 +13,7 @@ module Materials
 
     def materials_data( materials, 
                         assigned_to_class   = nil, 
-                        include_related     = false )
+                        include_related     = 0 )
       data = []
 
       if assigned_to_class
@@ -112,7 +112,7 @@ module Materials
         # Check if we should search for related material
         #
         related_materials = []
-        if include_related
+        if include_related > 0
             
             search = Sunspot.search(Search::SearchableModels) do
 
@@ -124,6 +124,7 @@ module Materials
 
                 without     material
                 order_by    :score, :desc
+                paginate    page: 1, per_page: include_related
             end
 
             related = search.results


### PR DESCRIPTION
[#146043029]

Limit number of related resources to return.
Make default 4 for API clients.
Keep default 0 for internal lib callers.
