### PR TITLE
remove the volume from the portal-image test

### DIFF
--- a/docker/portal-image/docker-compose.yml
+++ b/docker/portal-image/docker-compose.yml
@@ -27,8 +27,6 @@ services:
       PORTAL_FEATURES:
     ports:
     - '80'
-    volumes:
-      - code:/rigse
     networks:
       # the portal network allows external connections
       portal:
@@ -43,8 +41,6 @@ services:
       - solr
   solr:
     image: concordconsortium/docker-solr-portal
-    volumes:
-      - code:/rigse
     ports:
     - '8983'
     command: /bin/bash ./start-solr.sh
@@ -57,7 +53,6 @@ services:
       # use a named volume here so the database is preserved after a down and up
       - mysql:/var/lib/mysql
 volumes:
-  code:
   mysql:
 networks:
   # create a portal network so other services such as LARA can be part of this network


### PR DESCRIPTION
This volume was added before the solr image was preconfigured with our Sunspot configuration
The use of this volume causes confusion the second time this setup is used for a new image.
The volume from the first time is preserved, so the second time this volume overrides the
the code from the new image.