### PR TITLE
Added related materials to search results [#147646471]

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -28,7 +28,7 @@ class API::V1::SearchController < API::APIController
     {
       type: type.to_s.pluralize,
       header: view_context.t(type).pluralize.titleize,
-      materials: materials_data(collection),
+      materials: materials_data(collection, nil, params[:include_related] || 0),
       pagination: {
         current_page: collection.current_page,
         total_pages: collection.total_pages,

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -209,7 +209,7 @@ class HomeController < ApplicationController
       @lightbox_resource = nil
     end
     if @lightbox_resource
-      @lightbox_resource = materials_data([@lightbox_resource]).shift()
+      @lightbox_resource = materials_data([@lightbox_resource], nil, 4).shift()
       @page_title = @lightbox_resource[:name]
     else
       @page_title = "Resource not found"


### PR DESCRIPTION
This adds the related_materials to the search results based on the `include_related` query parameter.  It also always adds 4 related materials to the stem_finder routes.

NOTE: This PR depends on https://github.com/concord-consortium/rigse/pull/339 which changed the `include_related` parameter to `materials_data` from a boolean to a numeric.