### PR TITLE
Endpoint for solr to let the portal know solr is up

### DIFF
--- a/app/controllers/api/v1/reindex_solr_job.rb
+++ b/app/controllers/api/v1/reindex_solr_job.rb
@@ -1,0 +1,10 @@
+require 'rake'
+
+class API::V1::ReindexSolrJob
+  def perform
+    # This needs to be in a background job
+    Rake::Task.clear
+    RailsPortal::Application.load_tasks
+    Rake::Task['sunspot:reindex'].invoke
+  end
+end

--- a/app/controllers/api/v1/reindex_solr_job.rb
+++ b/app/controllers/api/v1/reindex_solr_job.rb
@@ -1,10 +1,19 @@
 require 'rake'
 
 class API::V1::ReindexSolrJob
+
+  # this is an approximation of whether the documents in Solr
+  # match the number of activities in the database
+  def self.is_up_to_date
+    search = Sunspot.search([ExternalActivity])
+    return ExternalActivity.count == search.total
+  end
+
   def perform
-    # This needs to be in a background job
-    Rake::Task.clear
-    RailsPortal::Application.load_tasks
-    Rake::Task['sunspot:reindex'].invoke
+    if ! self.class.is_up_to_date
+      Rake::Task.clear
+      RailsPortal::Application.load_tasks
+      Rake::Task['sunspot:reindex'].invoke
+    end
   end
 end

--- a/app/controllers/api/v1/service_controller.rb
+++ b/app/controllers/api/v1/service_controller.rb
@@ -1,0 +1,21 @@
+
+class API::V1::ServiceController < API::APIController
+
+  def solr_initialized
+    search = Sunspot.search([ExternalActivity])
+
+    if ExternalActivity.count != search.total
+      # FIXME: what about if there is a re-indexing job in process?
+      # if the job itself re-checked if it was necessary to do the re-indexing
+      # that would help a little bit. Especially if there is only one job worker.
+      Delayed::Job.enqueue ReindexSolrJob.new
+      message = "Re-indexing"
+    else
+      message = "Up to date"
+    end
+
+    render json: {message: message},
+           status: 200
+  end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -720,6 +720,10 @@ RailsPortal::Application.routes.draw do
         namespace :jwt do
           post :firebase
         end
+
+        namespace :service do
+          get :solr_initialized        
+        end
       end
     end
 


### PR DESCRIPTION
The idea is make a request that doesn't require authentication to simplify things.
This means the request can't trigger a lot of computation in the normal case.
As far as I understand the amount of computation by this request should be less
than the request to the home page which is also open

To test this locally. Stop your docker-compose stack.
Then run `docker-compose rm solr`
Then run `docker-compose up`
If you go to the search results you should see no search results.
Now visit: http://app.rigse.docker/api/v1/service/solr_initialized

There is still a bit more work to do, to help a little with multiple re-indexes happening at the same time.

[#146043589]