### PR TITLE
Style changes

### DIFF
--- a/app/assets/javascripts/modal.js
+++ b/app/assets/javascripts/modal.js
@@ -22,7 +22,6 @@ Portal.showOverlay = function(clickHandler,modalId,fixedPosition) {
 };
 
 Portal.showModal = function(modalId, specialMsg, fixedPosition) {
-  jQuery('html, body').css({'overflow': 'hidden'});
   Portal.showOverlay(Portal.hideModal,modalId,fixedPosition);
 
   if (jQuery(modalId + ' .close').length === 0) {
@@ -37,7 +36,6 @@ Portal.showModal = function(modalId, specialMsg, fixedPosition) {
 };
 
 Portal.hideModal = function() {
-  jQuery('html, body').css({'overflow': 'auto'});
   jQuery('.modal').fadeOut('fast');
   jQuery('#modal-overlay').fadeOut('slow');
   jQuery('.special-msg').text('').hide();

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -71,6 +71,7 @@ class HomeController < ApplicationController
   end
 
   def collections
+    render layout: 'minimal'
   end
 
   def requirements

--- a/app/views/home/collections.html.haml
+++ b/app/views/home/collections.html.haml
@@ -1,4 +1,7 @@
+-# This is using the minimal layout, so we need to add the header ourselves
+= render :partial => 'shared/project_header'
+
 #collections-page
 
 %script{:type=>"text/javascript"}
-    PortalPages.renderCollectionsPage({}, 'collections-page');
+  PortalPages.renderCollectionsPage({}, 'collections-page');

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -71,8 +71,8 @@
       / For non-visual user agents:
       #top
         %a.hidden.doNotPrint{ :href => "#primary" } Skip to main content.
+    = render :partial => 'shared/project_header'
     #wrapper.wrapper
-      = render :partial => 'shared/project_header'
       #primary{ :class => @wide_content_layout ? "wide" : nil}
         #content.main_content_colors
           #content_header.main_content_colors

--- a/app/views/shared/_left_menu.html.haml
+++ b/app/views/shared/_left_menu.html.haml
@@ -18,6 +18,11 @@
         %a{:href => preferences_user_path(current_visitor)}
           %i{:class => 'icon-settings'}
           &nbsp;Settings
+      %li
+        %a{:href => favorites_user_path(current_visitor)}
+          %i{:class => 'icon-favorite'}
+          &nbsp;Favorites
+
       - if @original_user != current_visitor
         - switch_user_form_id = "switch_user_id_#{@original_user.id}"
         %a{:href => 'javascript: void(0);', :onclick => "$('#{switch_user_form_id}').submit();"}

--- a/app/views/shared/_left_menu.html.haml
+++ b/app/views/shared/_left_menu.html.haml
@@ -26,13 +26,13 @@
         = form_for @original_user, :url => switch_user_path(@original_user), :html => { :method => :put,:class=> "hidden" ,:id=> switch_user_form_id}  do |form|
           = hidden_field_tag 'user[id]', @original_user.id
           = hidden_field_tag 'commit', 'Switch'
-  - if current_visitor.has_role?('admin', 'manager', 'researcher') || current_visitor.portal_teacher
-    %ul.aux-links
-      - if current_visitor.has_role?('admin', 'manager','researcher') || current_visitor.is_project_admin? || current_visitor.is_project_researcher?
-        %li= link_to 'Admin', admin_path
-      - current_visitor.projects.each do |project|
-        - project.links.each do |link|
-          %li= link_to link.name, link.href
+    - if current_visitor.has_role?('admin', 'manager', 'researcher') || current_visitor.portal_teacher
+      %ul.aux-links
+        - if current_visitor.has_role?('admin', 'manager','researcher') || current_visitor.is_project_admin? || current_visitor.is_project_researcher?
+          %li= link_to 'Admin', admin_path
+        - current_visitor.projects.each do |project|
+          - project.links.each do |link|
+            %li= link_to link.name, link.href
 
   - if top_node
     .padded_content


### PR DESCRIPTION
This fixes:
- the header and collections page so they span the whole width.
- the internal modals don't scroll the page these include confirmation boxes used when archiving materials, and a status box when searching for standards
- the extra links are now in the gray section of the left menu so they are easy to find
