### PR TITLE
Add a new Portal.currentUser.homePath property

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -240,9 +240,9 @@ class ApplicationController < ActionController::Base
         # be nice.
         #
         # Also if this could be passed in, rather than stored in the
-        # session, that would. 
+        # session, that would.
         #
-        # Otherwise, this is not actually used. 
+        # Otherwise, this is not actually used.
         #
         redirect_to portal_user_type_selector_path(omniauth_origin: session["omniauth.origin"])
 
@@ -282,26 +282,23 @@ class ApplicationController < ActionController::Base
   # a hidden param :after_sign_in_path to the sign in form.
   def after_sign_in_path_for(resource)
 
-    redirect_path = root_path
+    redirect_path = view_context.current_user_home_path
+
     if ENV['RESEARCHER_REPORT_ONLY']
+      # force all users to try to go to the researcher page on a report only portal
       redirect_path = learner_report_path
-    elsif current_user.portal_student
-      redirect_path = my_classes_path
-    elsif params[:after_sign_in_path]
-      # add an extra param to this path we don't go in a loop, see pundit_user_not_authorized
+    elsif !current_user.portal_student && params[:after_sign_in_path].present?
+      # users that aren't student can be redirected to other pages after logging in if
+      # the after_sign_in_path param is provided
+
       redirect_uri = URI.parse(params[:after_sign_in_path])
       query = Rack::Utils.parse_query(redirect_uri.query)
+      # add an extra param to this path, so we don't go in a loop, see pundit_user_not_authorized
       query["redirecting_after_sign_in"] = '1'
       redirect_uri.query = Rack::Utils.build_query(query)
       redirect_path = redirect_uri.to_s
-    elsif APP_CONFIG[:recent_activity_on_login] && current_user.portal_teacher
-      if current_user.has_active_classes?
-        # Teachers with active classes are redirected to the "Recent Activity" page
-        redirect_path = recent_activity_path
-      else
-        redirect_path = getting_started_path
-      end
     end
+
     if session[:sso_callback_params]
       AccessGrant.prune!
       access_grant = current_user.access_grants.create({:client => session[:sso_application], :state => session[:sso_callback_params][:state]}, :without_protection => true)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1367,4 +1367,22 @@ CONFIG
     end
   end
 
+  def current_user_home_path
+    if current_user.nil?
+      # anonymous home is the '/'
+      root_path
+    elsif current_user.portal_student
+      my_classes_path
+    elsif APP_CONFIG[:recent_activity_on_login] &&
+          current_user.portal_teacher &&
+          current_user.has_active_classes?
+      # Teachers with active classes are redirected to the "Recent Activity" page
+      recent_activity_path
+    else
+      # this is a generic logged in user (not teacher or student)
+      # or it is teacher without active classes
+      getting_started_path
+    end
+  end
+
 end

--- a/app/views/dynamic_scripts/_current_user.html.haml
+++ b/app/views/dynamic_scripts/_current_user.html.haml
@@ -34,5 +34,8 @@
     },
     get fullName() {
       return "#{current_visitor.full_name}";
+    },
+    get homePath() {
+      return "#{current_user_home_path}";
     }
   };

--- a/spec/controllers/admin/client_spec.rb
+++ b/spec/controllers/admin/client_spec.rb
@@ -60,44 +60,44 @@ describe Admin::ClientsController do
     end
 
     describe "GET index" do
-      it "won't alow the index, redirects to root" do
+      it "won't alow the index, redirects to manager home" do
         get :index
-        assert_redirected_to :root
+        assert_redirected_to :getting_started
       end
     end
 
     describe "DELETE destroy" do
-      it "wont allow delete, redirects to root" do
+      it "wont allow delete, redirects to manager home" do
         delete :destroy, :id => client_id
-        assert_redirected_to :root
+        assert_redirected_to :getting_started
       end
     end
 
     describe "GET show" do
-      it "wont allow show, redirects to root" do
+      it "wont allow show, redirects to manager home" do
         get :show, :id => client_id
-        assert_redirected_to :root
+        assert_redirected_to :getting_started
       end
     end
 
     describe "GET edit" do
-      it "wont allow edit, redirects to root" do
+      it "wont allow edit, redirects to manager home" do
         get :edit, :id => client_id
-        assert_redirected_to :root
+        assert_redirected_to :getting_started
       end
     end
 
     describe "GET new" do
-      it "wont allow new, redirects to root" do
+      it "wont allow new, redirects to manager home" do
         get :new
-        assert_redirected_to :root
+        assert_redirected_to :getting_started
       end
     end
 
     describe "PUT update" do
-      it "wont allow update, redirects to root" do
+      it "wont allow update, redirects to manager home" do
         put :update, :id => client_id, :client => {:params => 'params'}
-        assert_redirected_to :root
+        assert_redirected_to :getting_started
       end
     end
   end

--- a/spec/controllers/admin/external_report_spec.rb
+++ b/spec/controllers/admin/external_report_spec.rb
@@ -60,44 +60,44 @@ describe Admin::ExternalReportsController do
     end
 
     describe "GET index" do
-      it "won't alow the index, redirects to root" do
+      it "won't alow the index, redirects to manager home" do
         get :index
-        assert_redirected_to :root
+        assert_redirected_to :getting_started
       end
     end
 
     describe "DELETE destroy" do
-      it "wont allow delete, redirects to root" do
+      it "wont allow delete, redirects to manager home" do
         delete :destroy, :id => report_id
-        assert_redirected_to :root
+        assert_redirected_to :getting_started
       end
     end
 
     describe "GET show" do
-      it "wont allow show, redirects to root" do
+      it "wont allow show, redirects to manager home" do
         get :show, :id => report_id
-        assert_redirected_to :root
+        assert_redirected_to :getting_started
       end
     end
 
     describe "GET edit" do
-      it "wont allow edit, redirects to root" do
+      it "wont allow edit, redirects to manager home" do
         get :edit, :id => report_id
-        assert_redirected_to :root
+        assert_redirected_to :getting_started
       end
     end
 
     describe "GET new" do
-      it "wont allow new, redirects to root" do
+      it "wont allow new, redirects to manager home" do
         get :new
-        assert_redirected_to :root
+        assert_redirected_to :getting_started
       end
     end
 
     describe "PUT update" do
-      it "wont allow update, redirects to root" do
+      it "wont allow update, redirects to manager home" do
         put :update, :id => report_id, :report => {:params => 'params'}
-        assert_redirected_to :root
+        assert_redirected_to :getting_started
       end
     end
   end

--- a/spec/controllers/admin/site_notices_controller_spec.rb
+++ b/spec/controllers/admin/site_notices_controller_spec.rb
@@ -38,12 +38,12 @@ describe Admin::SiteNoticesController do
       sign_out :user
       sign_in @researcher_user
       get :new
-      response.should redirect_to("/")
+      response.should redirect_to("/getting_started")
 
       sign_out :user
       sign_in @author_user
       get :new
-      response.should redirect_to("/")
+      response.should redirect_to("/getting_started")
 
       sign_out :user
       sign_in @student_user

--- a/spec/controllers/admin/site_notices_controller_spec.rb
+++ b/spec/controllers/admin/site_notices_controller_spec.rb
@@ -53,7 +53,7 @@ describe Admin::SiteNoticesController do
       sign_out :user
       sign_in @guest_user
       get :new
-      response.should redirect_to("/")
+      response.should redirect_to("/getting_started")
 
     end
   end

--- a/spec/controllers/portal/clazzes_controller_spec.rb
+++ b/spec/controllers/portal/clazzes_controller_spec.rb
@@ -813,11 +813,10 @@ describe Portal::ClazzesController do
         :id => @mock_clazz.id
       }
     end
-    it "should redirect to home page for anonymous user" do
-      sign_in @normal_user
+    it "should not allow access for anonymous user" do
+      sign_out :user
       get :fullstatus, @params
       response.should_not be_success
-      response.should redirect_to root_url
     end
     it "should retrieve the class when user is not anonymous user" do
       sign_in @authorized_teacher_user

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -67,11 +67,11 @@ describe SearchController do
 
   describe "GET index" do
     describe "when its a student visiting" do
-      it "should redirect to root" do
+      it "should redirect to student home" do
         student # Ensure student_user has a PortalStudent
-        controller.stub!(:current_visitor).and_return(student_user)
+        controller.stub!(:current_user).and_return(student_user)
         get :index
-        response.should redirect_to("/")
+        response.should redirect_to("/my_classes")
       end
     end
 


### PR DESCRIPTION
This is used so the home button can point to the correct place for teachers, students, and generic users.

In the process, I refactored after_log_in_path_for. With the side effect that generic users (not teacher or students) have a home_path of getting_started now.  This is useful in the current learn portal since the previous path of '/' was is not useful for generic users.
[#150248271]