### PR TITLE
improve the auto show lightboxes from the portal

### DIFF
--- a/app/views/home/home.html.haml
+++ b/app/views/home/home.html.haml
@@ -1,19 +1,5 @@
 = render :partial => "notice"
 
-- if defined?(@auto_show_lightbox_resource) && @auto_show_lightbox_resource
-  #auto_show_lightbox_resource
-  %script{:type=>"text/javascript"}
-    PortalPages.settings.autoShowingLightboxResource = #{raw @lightbox_resource.to_json };
-    :plain
-      var toggleAutoShowLightbox = function () {
-        ReactDOM.unmountComponentAtNode(document.getElementById('auto_show_lightbox_resource'));
-        delete PortalPages.settings.autoShowingLightboxResource;
-      };
-      PortalPages.renderResourceLightbox({
-        toggleLightbox: toggleAutoShowLightbox,
-        resource: PortalPages.settings.autoShowingLightboxResource
-      }, "auto_show_lightbox_resource")
-
 .landing-container
   .home-page-content
     - if custom_content.blank?
@@ -27,3 +13,19 @@
 
 - if show_project_cards
   = render :partial => "project_cards"
+
+- if defined?(@auto_show_lightbox_resource) && @auto_show_lightbox_resource
+  #auto_show_lightbox_resource
+  %script{:type=>"text/javascript"}
+    PortalPages.settings.autoShowingLightboxResource = #{raw @lightbox_resource.to_json };
+    :plain
+      var toggleAutoShowLightbox = function () {
+        ReactDOM.unmountComponentAtNode(document.getElementById('auto_show_lightbox_resource'));
+        delete PortalPages.settings.autoShowingLightboxResource;
+      };
+      PortalPages.renderResourceLightbox({
+        toggleLightbox: toggleAutoShowLightbox,
+        savedUrl: '#{root_url}',
+        savedTitle: '#{APP_CONFIG[:site_name]}',
+        resource: PortalPages.settings.autoShowingLightboxResource
+      }, "auto_show_lightbox_resource")


### PR DESCRIPTION
this moves the lightbox div after the main content so it is rendered on top
it passes the saveUrl and savedTitle to the lightbox so it can update the
URL and title when closed correctly.

This goes along with this merged PR in portal-pages:
https://github.com/concord-consortium/portal-pages/pull/13

And the overall story is here:
https://www.pivotaltracker.com/story/show/150383056