### PR TITLE
Pass font to imagemagick

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,4 +48,8 @@ RUN cp docker/prod/config/settings.yml config/settings.yml
 
 EXPOSE 80
 
+# this font is used by imagemagick to add attribution to the images in the image library
+# the DejaVu-Sans font is provided by the docker image this one is built on 
+ENV WATERMARK_FONT=DejaVu-Sans
+
 CMD ./docker/prod/run.sh

--- a/lib/paperclip_processors/attributor_overlay.rb
+++ b/lib/paperclip_processors/attributor_overlay.rb
@@ -53,7 +53,11 @@ class AttributorOverlay < Paperclip::Processor
     pointsize = (pointsize*@scale).ceil
     pointsize = 10 if pointsize < 10
 
-    watermark_params = %!-background white -fill black -border #{border} -bordercolor white -pointsize #{pointsize} -size #{(@width-(2*border)).to_i}x -gravity SouthEast caption:"#{escape(@attribution)}" png:#{tofile(wm_dst)}!
+    if ENV['WATERMARK_FONT'].blank?
+      raise "Must define a WATERMARK_FONT environemnt variable to add watermarks to images"
+    end
+
+    watermark_params = %!-background white -font #{ENV['WATERMARK_FONT']} -fill black -border #{border} -bordercolor white -pointsize #{pointsize} -size #{(@width-(2*border)).to_i}x -gravity SouthEast caption:"#{escape(@attribution)}" png:#{tofile(wm_dst)}!
 
     begin
       success = Paperclip.run("convert", watermark_params)


### PR DESCRIPTION
This fixes an issue with adding images to the image library.
I couldn't figure out why this worked before.
My guess is that somehow image magick has some default font of Arial or Times that it is trying to find. And when ITSI was running on a its old server this font had been installed.

https://www.pivotaltracker.com/story/show/150455863
