### PR TITLE
Add token auth for jwt

### DIFF
--- a/app/controllers/api/v1/jwt_controller.rb
+++ b/app/controllers/api/v1/jwt_controller.rb
@@ -3,7 +3,7 @@ class API::V1::JwtController < API::APIController
   # POST api/v1/jwt/firebase
   def firebase
     return error('You must be logged in to use this endpoint') if !current_user
-    return error('Missing firebase_app parameter') if params[:firebase_app].empty?
+    return error('Missing firebase_app parameter') if params[:firebase_app].blank?
 
     begin
       render status: 201, json: {token: SignedJWT::create_firebase_token(current_user, params[:firebase_app])}

--- a/app/controllers/api/v1/jwt_controller.rb
+++ b/app/controllers/api/v1/jwt_controller.rb
@@ -1,12 +1,26 @@
 class API::V1::JwtController < API::APIController
 
-  # POST api/v1/jwt/firebase
+  # POST api/v1/jwt/firebase as a logged in user, or
+  # GET  api/v1/jwt/firebase?firebase_app=abc with a valid bearer token
   def firebase
-    return error('You must be logged in to use this endpoint') if !current_user
+    header = request.headers["Authorization"]
+    if header && header =~ /^Bearer (.*)$/
+      token = $1
+      grant = AccessGrant.find_by_access_token(token)
+
+      return error('Cannot find AccessGrant for token #{token}') if !grant
+      return error('AccessGrant has expired') if grant.access_token_expires_at < Time.now
+
+      user = grant.user
+    else
+      return error('You must be logged in to use this endpoint') if current_visitor.anonymous?
+      user = current_visitor
+    end
+
     return error('Missing firebase_app parameter') if params[:firebase_app].blank?
 
     begin
-      render status: 201, json: {token: SignedJWT::create_firebase_token(current_user, params[:firebase_app])}
+      render status: 201, json: {token: SignedJWT::create_firebase_token(user, params[:firebase_app])}
     rescue Exception => e
       error(e.message, 500)
     end

--- a/app/controllers/api/v1/jwt_controller.rb
+++ b/app/controllers/api/v1/jwt_controller.rb
@@ -13,8 +13,8 @@ class API::V1::JwtController < API::APIController
 
       user = grant.user
     else
-      return error('You must be logged in to use this endpoint') if current_visitor.anonymous?
-      user = current_visitor
+      return error('You must be logged in to use this endpoint') if !current_user
+      user = current_user
     end
 
     return error('Missing firebase_app parameter') if params[:firebase_app].blank?

--- a/app/models/external_activity.rb
+++ b/app/models/external_activity.rb
@@ -152,6 +152,7 @@ class ExternalActivity < ActiveRecord::Base
         append_query(uri, "learner=#{learner.id}") if append_learner_id_to_url
         append_query(uri, "c=#{learner.user.id}") if append_survey_monkey_uid
         if append_auth_token
+          AccessGrant.prune!
           token = learner.user.create_access_token_valid_for(3.minutes)
           append_query(uri, "token=#{token}")
         end

--- a/app/models/external_activity.rb
+++ b/app/models/external_activity.rb
@@ -1,7 +1,7 @@
 require 'uri'
 class ExternalActivity < ActiveRecord::Base
 
-  # 
+  #
   # see https://github.com/sunspot/sunspot/blob/master/README.md
   #
   searchable do
@@ -151,6 +151,10 @@ class ExternalActivity < ActiveRecord::Base
       if learner
         append_query(uri, "learner=#{learner.id}") if append_learner_id_to_url
         append_query(uri, "c=#{learner.user.id}") if append_survey_monkey_uid
+        if append_auth_token
+          token = learner.user.create_access_token_valid_for(3.minutes)
+          append_query(uri, "token=#{token}")
+        end
       end
       return uri.to_sc
     rescue

--- a/app/views/external_activities/_form.html.haml
+++ b/app/views/external_activities/_form.html.haml
@@ -66,6 +66,9 @@
         = f.check_box :append_survey_monkey_uid
         Append a unique Survey Monkey user id to the url (e.g. http://www.surveymonkey.com/s/H2Y9H27?c=00001)
       .config
+        = f.check_box :append_auth_token
+        Append a short-lived authentication token
+      .config
         = f.check_box :is_official
         Designate this as an "official" Concord activity in lists
       .config

--- a/config/application.rb
+++ b/config/application.rb
@@ -126,6 +126,7 @@ module RailsPortal
         resource '/api/v1/offerings/*', :headers => :any, :methods => [:get, :put]
         resource '/api/v1/offering/*', :headers => :any, :methods => [:get, :put]
         resource '/api/v1/classes/*', :headers => :any, :methods => [:get]
+        resource '/api/v1/jwt/*', :headers => :any, :methods => [:get]
       end
 
       # Set up custom CORS, if the environment variable PORTAL_FEATURES includes "allow_cors".

--- a/db/migrate/20170829144925_add_append_auth_token_to_external_activity.rb
+++ b/db/migrate/20170829144925_add_append_auth_token_to_external_activity.rb
@@ -1,0 +1,9 @@
+class AddAppendAuthTokenToExternalActivity < ActiveRecord::Migration
+  def self.up
+    add_column :external_activities, :append_auth_token, :boolean
+  end
+
+  def self.down
+    remove_column :external_activities, :append_auth_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -864,6 +864,7 @@ ActiveRecord::Schema.define(:version => 20170830191912) do
     t.string   "credits"
     t.string   "license_code"
     t.boolean  "enable_sharing",                               :default => true
+    t.boolean  "append_auth_token"
   end
 
   add_index "external_activities", ["is_featured", "publication_status"], :name => "featured_public", :length => {"is_featured"=>nil, "publication_status"=>191}


### PR DESCRIPTION
@scytacki or @dougmartin Do you want to take a look at the PR?

It adds an optional 3-minute authentication token to an external activity's url, and if an external site calls the JWT API route with the token in the header, it will find the appropriate user and then return a JWT for that user.

This uses a similar pattern as the token for the external reports.

I'm not sure what the CORS settings are for the portal right now. This would be expecting that we can make a GET request to `/api/v1/jwt/firebase`.