### PR TITLE
Enable stem-resources route to handle stem finder filters in URL.

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -206,68 +206,25 @@ class HomeController < ApplicationController
 
 
   #
-  # Valid set of stem finder filter names and values.
-  #
-  @@STEM_FILTER_VALIDATION =
-    {   "subject"       =>  {
-                                "physics-chemistry" => {},
-                                "life-sciences"     => {},
-                                "engineering-tech"  => {},
-                                "earth-space"       => {},
-                                "mathematics"       => {}
-                            },
-        "grade-level"   =>  {
-                                "elementary-school" => {},
-                                "middle-school"     => {},
-                                "high-school"       => {},
-                                "higher-education"  => {}
-                            } 
-    }
-
-
-  #
   #
   # Handle /stem-reources/ routes to either pre-populate stem finder filters
-  # or render an individual resource lightbox.
+  # or render an individual material resource lightbox.
   #
   #
   def stem_resources
 
-    # logger.info("INFO stem_resources called.")
-
-    #
-    # See if we are filtering categories in URL to pass to
-    # stem finder.
-    #
-    if params[:filter_name] && params[:filter_value]
-        filter_name     = params[:filter_name]
-        filter_value    = params[:filter_value]
-
-        # logger.info("INFO filter_name/filter_value #{filter_name} #{filter_value}.")
-
-        if  @@STEM_FILTER_VALIDATION.key?(filter_name) &&
-            @@STEM_FILTER_VALIDATION[filter_name].key?(filter_value)
-        
-            # logger.info("INFO Rendering index...")
-
-            index
-            return
-
-        end
-    end
-
-    # logger.info("INFO Could not match stem finder filters.")
-
-    #
-    # See if we are rendering a specifiec resource in a lightbox
-    #
     case params[:type]
     when "activity", "sequence"
-      @lightbox_resource = ExternalActivity.find_by_id(params[:id])
+      @lightbox_resource = ExternalActivity.find_by_id(params[:id_or_filter_value])
     when "interactive"
-      @lightbox_resource = Interactive.find_by_id(params[:id])
+      @lightbox_resource = Interactive.find_by_id(params[:id_or_filter_value])
     else
-      @lightbox_resource = nil
+      #
+      # Otherwise assume the type is referring to a filter name.
+      # And in this case the id_or_filter_value is a filter value.
+      #
+      index
+      return
     end
 
     if @lightbox_resource

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -204,7 +204,63 @@ class HomeController < ApplicationController
 
   end
 
+
+  #
+  # Valid set of stem finder filter names and values.
+  #
+  @@STEM_FILTER_VALIDATION =
+    {   "subject"       =>  {
+                                "physics-chemistry" => {},
+                                "life-sciences"     => {},
+                                "engineering-tech"  => {},
+                                "earth-space"       => {},
+                                "mathematics"       => {}
+                            },
+        "grade-level"   =>  {
+                                "elementary-school" => {},
+                                "middle-school"     => {},
+                                "high-school"       => {},
+                                "higher-education"  => {}
+                            } 
+    }
+
+
+  #
+  #
+  # Handle /stem-reources/ routes to either pre-populate stem finder filters
+  # or render an individual resource lightbox.
+  #
+  #
   def stem_resources
+
+    # logger.info("INFO stem_resources called.")
+
+    #
+    # See if we are filtering categories in URL to pass to
+    # stem finder.
+    #
+    if params[:filter_name] && params[:filter_value]
+        filter_name     = params[:filter_name]
+        filter_value    = params[:filter_value]
+
+        # logger.info("INFO filter_name/filter_value #{filter_name} #{filter_value}.")
+
+        if  @@STEM_FILTER_VALIDATION.key?(filter_name) &&
+            @@STEM_FILTER_VALIDATION[filter_name].key?(filter_value)
+        
+            # logger.info("INFO Rendering index...")
+
+            index
+            return
+
+        end
+    end
+
+    # logger.info("INFO Could not match stem finder filters.")
+
+    #
+    # See if we are rendering a specifiec resource in a lightbox
+    #
     case params[:type]
     when "activity", "sequence"
       @lightbox_resource = ExternalActivity.find_by_id(params[:id])
@@ -213,6 +269,7 @@ class HomeController < ApplicationController
     else
       @lightbox_resource = nil
     end
+
     if @lightbox_resource
       @lightbox_resource = materials_data([@lightbox_resource], nil, 4).shift()
       @page_title = @lightbox_resource[:name]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -767,6 +767,8 @@ RailsPortal::Application.routes.draw do
 
     match '/stem-resources/:type/:id(/:slug)' => 'home#stem_resources', :as => :stem_resources
 
+    match '/stem-resources/:filter_name/:filter_value' => 'home#stem_resources', :as => :stem_resources
+
     match '/:controller(/:action(/:id))'
 
     root :to => 'home#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -765,9 +765,7 @@ RailsPortal::Application.routes.draw do
     match '/learner_proc' => 'misc#learner_proc', :as => :learner_proc
     post  '/installer_report' => 'misc#installer_report', :as => :installer_report
 
-    match '/stem-resources/:type/:id(/:slug)' => 'home#stem_resources', :as => :stem_resources
-
-    match '/stem-resources/:filter_name/:filter_value' => 'home#stem_resources', :as => :stem_resources
+    match '/stem-resources/:type/:id_or_filter_value(/:slug)' => 'home#stem_resources', :as => :stem_resources
 
     match '/:controller(/:action(/:id))'
 


### PR DESCRIPTION
[#150519376]

This is the backend (route / controller) support for specifying stem finder filters in the /stem-resources/ URL path.

Front end changes are here: https://github.com/concord-consortium/portal-pages/pull/16
