### PR TITLE
Fix getting started pages

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -117,7 +117,7 @@ en:
   RosterRemoveStudentLong: "Remove Student %{name} from %{clazz}"
   RosterChangePassword: "Change password for %{name}"
 
-  UserBadName: "cannot be empty, must include letter characters and cannot use non-printing characters or %{restricted_characters}." 
+  UserBadName: "cannot be empty, must include letter characters and cannot use non-printing characters or %{restricted_characters}."
 
   HomePage:
     MyClassesNav: My Classes
@@ -169,57 +169,6 @@ en:
         Instructions: |
           To get started, click the logo in the top left to view all lessons.
           You can set up a class by clicking the “Add a New Class” link on the left
-
-'en-NEXTGEN':
-  activerecord:
-    models:
-      ExternalActivity : Activity
-      external_activity:
-        zero: activities
-        one: activity
-        other: activities
-  will_paginate:
-    models:
-      external_activity:
-        zero: activities
-        one: activity
-        other: activities
-'en-INTERACTIONS':
-  investigation: investigation
-  activerecord:
-    models:
-      investigation: Investigation
-
-'en-RITES':
-  activerecord:
-    models:
-      investigation: Investigation
-  investigation: investigation
-  will_paginate:
-    investigation:
-      page_entries_info:
-        single_page:
-          zero: "No investigations found"
-          one: "Showing 1 investigation"
-          other: "Showing all %{count} investigations"
-        single_page_html:
-          zero: "No investigations found"
-          one: "Showing 1 investigation"
-          other: "Showing all %{count} investigations"
-        multi_page: "Displaying investigations %{from} - %{to} of %{count} in total"
-        multi_page_html: "Displaying investigations %{from} - %{to} of %{count} in total"
-'en-GENIVERSE':
-  recent_activity:
-    no_offerings: ''
-    no_students:  ''
-    no_activity:  'This area is active only when materials additional to Geniverse in use. At the present time, no other materials are available.'
-  offerings_for_class:
-    no_materials: "This area is active only when materials additional to Geniverse in use. At the present time, no other materials are available."
-  class_full_status:
-    no_students: "This area is active only when materials additional to Geniverse in use. At the present time, no other materials are available."
-    no_assignments: "This area is active only when materials additional to Geniverse in use. At the present time, no other materials are available."
-  class_materials:
-    no_assignments: "Currently, this class is engaged in Geniverse."
 
 'en-ITSI-LEARN':
   material: activity

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -133,8 +133,9 @@ en:
       GettingStarted:
         Heading: Getting Started
         Instructions: |
-          To get started, you can view available activities by clicking on the “Search” link in the menu
-          above. Or set up a class by clicking the “Create a Class” button on the left.
+          To get started, click the Concord Consortium logo in the upper left to search all resources
+          or view curated Collections of resources by clicking the link above. You can set up a class
+          by clicking the “Add a New Class” link on the left
 
   search:
     only_mine: Show only materials authored by me
@@ -160,6 +161,15 @@ en:
         zero: activities
         one: activity
         other: activities
+  HomePage:
+    Teacher:
+      Intro: |
+        Welcome to the High Adventure Science portal.
+      GettingStarted:
+        Instructions: |
+          To get started, click the logo in the top left to view all lessons.
+          You can set up a class by clicking the “Add a New Class” link on the left
+
 'en-NEXTGEN':
   activerecord:
     models:
@@ -220,3 +230,25 @@ en:
     no_assignments: "No activities assigned to this class."
   class_materials:
     no_assignments: "No activities assigned to this class."
+  HomePage:
+    Teacher:
+      Intro: |
+        The Innovative Technology in Science Inquiry project engages students in STEM activities through
+        the integrated use of technologies that include modeling, computational thinking, and real-time
+        data acquisition. This comprehensive project will assist teachers in preparing diverse students
+        for STEM careers by engaging them in exciting, inquiry-based science projects.
+      GettingStarted:
+        Instructions: |
+          To get started, click the Activities link on the left to view all activities
+          You can set up a class by clicking the “Add a New Class” link on the left
+
+'en-NGSS-ASSESSMENT':
+  HomePage:
+    Teacher:
+      Intro: |
+        Welcome to the Next Generation Science Assessment portal.
+      GettingStarted:
+        Instructions: |
+          Try setting up a class by clicking the "Add a New Class" link on the left, and
+          then find assessment tasks to assign by clicking the "Collections" link above
+          and selecting "NGSA Task Collections."

--- a/themes/has/views/home/_project_summary.html.haml
+++ b/themes/has/views/home/_project_summary.html.haml
@@ -1,5 +1,14 @@
 %p
   %strong
     HAS: High Adventure Science
-%p 
-  The goal of the High Adventure Science project is to inject contemporary Earth and Space science into the classroom, engaging students in important unanswered questions that scientists around the world are actively exploring. The project is producing three five-day computer-based learning modules focused on specific questions. Students will learn directly from scientists in the field through video clips. They will use computer-based models to investigate aspects of the same research. We do not expect that students will be able to “solve” the problems, but they will gain hands-on experience in doing science the way current scientists approach these questions. They will also gain an appreciation for how much is not yet known about the world around us, that science is not all about textbook facts. 
+%p
+  The goal of the High Adventure Science project is to inject contemporary Earth and Space
+  science into the classroom, engaging students in important unanswered questions that
+  scientists around the world are actively exploring. The project is producing three
+  five-day computer-based learning modules focused on specific questions. Students will
+  learn directly from scientists in the field through video clips. They will use
+  computer-based models to investigate aspects of the same research. We do not expect
+  that students will be able to “solve” the problems, but they will gain hands-on
+  experience in doing science the way current scientists approach these questions. They
+  will also gain an appreciation for how much is not yet known about the world around us,
+  that science is not all about textbook facts. 

--- a/themes/itsi-learn/views/home/_project_info.html.haml
+++ b/themes/itsi-learn/views/home/_project_info.html.haml
@@ -2,7 +2,7 @@
   %h3
     About the Innovative Technology in Science Inquiry Project
   %p
-    The Innovative Technology in Science Inquiry project engages students in STEM activities through the integrated use of technologies that include modeling, computational thinking, and real-time data acquisition. This comprehensive project will assist teachers in preparing diverse students for STEM careers by engaging them in exciting, inquiry-based science projects.
+    = I18n.t('HomePage.Teacher.Intro')
   %p
     This material is based upon work supported by the National Science Foundation under Grants DRL-0624718, DRL-0929540, DRL-1433761, and DRL-1417722. Any opinions, findings, and conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the National Science Foundation.
   %p

--- a/themes/learn/views/home/_project_info.html.haml
+++ b/themes/learn/views/home/_project_info.html.haml
@@ -2,11 +2,7 @@
   %h1
     About the STEM Resource Finder
   %p
-    Since 1994, the Concord Consortium has been developing deeply digital tools and
-    learning activities that capture the power of curiosity and create revolutionary
-    new approaches to science, math, and engineering education. Our STEM Resource Finder
-    is a central repository for our simulations and activities, giving teachers and
-    students access to open educational resources across our projects, past and present.
+    = I18n.t('HomePage.Teacher.Intro')
   %p
     = link_to "Preview the activities.", root_url
   %p


### PR DESCRIPTION
This is still more confusing than I'd like, but it does reduce some redundancy.

For context, the portal supports 'themes'.  There is one theme for each of the 4 portals.
We have setup themes to be able to override rails views, i18n strings, and styles.
Every theme overrides the _project_info partial which is included in about page. This has not changed.

Some themes (learn, and itsi-learn) now include a i18n string (HomePage.Teacher.Intro) in this _project_info partial.  This same string is included in the getting_started page.

The _getting_started partial itself not themed. Instead it includes two i18n strings. This has not changed.  What is new is that now all of the themes have overriden these two i18n strings.
