### PR TITLE
Make `append_auth_token` backwards-compatible

### DIFF
--- a/app/views/external_activities/_form.html.haml
+++ b/app/views/external_activities/_form.html.haml
@@ -65,9 +65,10 @@
       .config
         = f.check_box :append_survey_monkey_uid
         Append a unique Survey Monkey user id to the url (e.g. http://www.surveymonkey.com/s/H2Y9H27?c=00001)
-      .config
-        = f.check_box :append_auth_token
-        Append a short-lived authentication token
+      - if @external_activity.respond_to?(:append_auth_token)
+        .config
+          = f.check_box :append_auth_token
+          Append a short-lived authentication token
       .config
         = f.check_box :is_official
         Designate this as an "official" Concord activity in lists


### PR DESCRIPTION
This simply checks that an external-activity responds to append_auth_token before showing the checkbox.

The only other place that references append_auth_token, ExternalActivity:url, doesn't need a check.