### PR TITLE
Fix /auth/user -> /auth/login for sso and non-sso auth flows.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,15 +33,6 @@ GIT
       rails (~> 3.2.11)
 
 GIT
-  remote: git://github.com/concord-consortium/contentflow
-  revision: 03b18e3c81abead40614f4a748878c63b6381eac
-  branch: remove-addon-support
-  specs:
-    contentflow (0.0.3)
-      railties (>= 3.0)
-      sass (>= 3.2)
-
-GIT
   remote: git://github.com/concord-consortium/genigames-connector
   revision: d46d31cad789dd806377a8e28feecf387a9020ee
   specs:
@@ -648,7 +639,6 @@ DEPENDENCIES
   compass-blueprint
   compass-rails (~> 2.0.4)
   connection_pool
-  contentflow!
   cucumber (~> 1.3.0)
   cucumber-rails (~> 1.3.0)
   daemons (~> 1.1.8)

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -32,13 +32,9 @@ class AuthController < ApplicationController
         #
         # puts "INFO *** Not calling as SSO provider"
 
-        if session[:omniauth_origin]
-            session[:sso_callback_params] = params
-            session[:sso_application]     = application
-        else
-            session.delete :sso_callback_params
-            session.delete :sso_application
-        end
+        session.delete :sso_callback_params
+        session.delete :sso_application
+
         if current_user.nil?
             redirect_to auth_login_path
         end

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -4,9 +4,16 @@ class AuthController < ApplicationController
   skip_before_filter :verify_authenticity_token, :only => [:access_token]
 
   def verify_logged_in
-    if current_user.nil?
+
+    if session[:omniauth_origin]
       session[:sso_callback_params] = params
-      session[:sso_application] = application
+      session[:sso_application]     = application
+    else
+      session.delete :sso_callback_params
+      session.delete :sso_application
+    end
+
+    if current_user.nil?
       redirect_to auth_login_path
     end
   end
@@ -29,6 +36,11 @@ class AuthController < ApplicationController
       redirect_path = redirect_uri.to_s
 
       redirect_to @after_sign_in_path
+    elsif current_user
+      #
+      # User is signed in but there is no after_sign_in_path
+      #
+      redirect_to view_context.current_user_home_path
     else
       render :layout => false
     end

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -5,17 +5,46 @@ class AuthController < ApplicationController
 
   def verify_logged_in
 
-    if session[:omniauth_origin]
-      session[:sso_callback_params] = params
-      session[:sso_application]     = application
+    action = params[:action]
+
+    if action == 'oauth_authorize'
+
+        #
+        # Calling as SSO provider
+        #
+        # Example params
+        # {"response_type"=>"code", "client_id"=>"localhost", "redirect_uri"=>"http://app.lara.docker/users/auth/cc_portal_localhost/callback", "state"=>"8d300e331c03b2255a4d56269b09fa906f1ff5349e943099", "controller"=>"auth", "action"=>"oauth_authorize"}
+        #
+        #
+        # puts "INFO *** Calling as SSO provider"
+
+        if current_user.nil?
+            session[:sso_callback_params] = params
+            session[:sso_application]     = application
+            redirect_to auth_login_path
+        end
+
     else
-      session.delete :sso_callback_params
-      session.delete :sso_application
+
+        #
+        # Example params
+        # {"controller"=>"auth", "action"=>"user", "format"=>"json"}
+        #
+        # puts "INFO *** Not calling as SSO provider"
+
+        if session[:omniauth_origin]
+            session[:sso_callback_params] = params
+            session[:sso_application]     = application
+        else
+            session.delete :sso_callback_params
+            session.delete :sso_application
+        end
+        if current_user.nil?
+            redirect_to auth_login_path
+        end
+
     end
 
-    if current_user.nil?
-      redirect_to auth_login_path
-    end
   end
 
   def login


### PR DESCRIPTION
[#151296804]

Do not include sso_callback_params for non-sso login.
Redirect away from /auth/login page for users that are already logged in.
