### PR TITLE
Only show the edit icons if there really is a launch_url

### DIFF
--- a/lib/materials/data_helpers.rb
+++ b/lib/materials/data_helpers.rb
@@ -323,7 +323,7 @@ module Materials
         target: '_blank'
       }
 
-      if external && material.launch_url
+      if external && material.launch_url.present?
         if policy(material).matedit?
           links[:external_edit] = {
             url: matedit_external_activity_url(material, iFrame: false),


### PR DESCRIPTION
This is still not the best approach because we are using this launch_url to figure out
if a resource is has an external_edit url.  However this is consistent with the rest of
the code. This will prevent some resources from showing broken edit links.

[#151332841]