### PR TITLE
Remove default from text column

### DIFF
--- a/db/migrate/20171010220806_create_portal_learner_activity_feedbacks.rb
+++ b/db/migrate/20171010220806_create_portal_learner_activity_feedbacks.rb
@@ -1,7 +1,7 @@
 class CreatePortalLearnerActivityFeedbacks < ActiveRecord::Migration
   def change
     create_table :portal_learner_activity_feedbacks do |t|
-      t.text :text_feedback, default: ""
+      t.text :text_feedback
       t.integer :score, default: 10
       t.boolean :has_been_reviewed, default: false
       t.references :portal_learner


### PR DESCRIPTION
Fixes error on some systems where running migration throws

`Mysql2::Error: BLOB/TEXT column 'text_feedback' can't have a default value`