### PR TITLE
fix un configured provider issue

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -207,7 +207,7 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', :scope => 'user,public_repo'
-  if ENV['SCHOOLOGY_CONSUMER_KEY'] && ENV['SCHOOLOGY_CONSUMER_SECRET']
+  if ENV['SCHOOLOGY_CONSUMER_KEY'].present? && ENV['SCHOOLOGY_CONSUMER_SECRET'].present?
     SETUP_PROC = lambda do |env|
       host = env['rack.session'][:schoology_host]
       if host
@@ -218,9 +218,9 @@ Devise.setup do |config|
   end
 
 
-  if ENV['GOOGLE_CLIENT_KEY'] && ENV['GOOGLE_CLIENT_SECRET']
+  if ENV['GOOGLE_CLIENT_KEY'].present? && ENV['GOOGLE_CLIENT_SECRET'].present?
 
-    config.omniauth :google_oauth2, ENV['GOOGLE_CLIENT_KEY'], ENV['GOOGLE_CLIENT_SECRET'], 
+    config.omniauth :google_oauth2, ENV['GOOGLE_CLIENT_KEY'], ENV['GOOGLE_CLIENT_SECRET'],
     {   :name => "google",
         :scope => [ 'https://www.googleapis.com/auth/userinfo.profile',
                     'https://www.googleapis.com/auth/userinfo.email'    ]


### PR DESCRIPTION
I ran into this after moving HAS to ECS it didn't have Schoology configured, but the button to login in with it was still showing up. I've done a patch to 1.18.x branch to fix it for them.  And here is the corresponding update for the master branch.

[#152401992]