### PR TITLE
Add learner/offering info to JWT

### DIFF
--- a/app/controllers/api/v1/jwt_controller.rb
+++ b/app/controllers/api/v1/jwt_controller.rb
@@ -12,6 +12,7 @@ class API::V1::JwtController < API::APIController
       return error('AccessGrant has expired') if grant.access_token_expires_at < Time.now
 
       user = grant.user
+      learner = grant.learner
     else
       return error('You must be logged in to use this endpoint') if !current_user
       user = current_user
@@ -19,8 +20,21 @@ class API::V1::JwtController < API::APIController
 
     return error('Missing firebase_app parameter') if params[:firebase_app].blank?
 
+    claims = {}
+    if learner
+      offering = learner.offering
+      claims = {
+        :domain => root_url,
+        :externalId => learner.id,
+        :returnUrl => learner.remote_endpoint_url,
+        :logging => offering.clazz.logging || offering.runnable.logging,
+        :domain_uid => user.id,
+        :class_info_url => offering.clazz.class_info_url(request.protocol, request.host_with_port)
+      }
+    end
+
     begin
-      render status: 201, json: {token: SignedJWT::create_firebase_token(user, params[:firebase_app])}
+      render status: 201, json: {token: SignedJWT::create_firebase_token(user, params[:firebase_app], 3600, claims)}
     rescue Exception => e
       error(e.message, 500)
     end

--- a/app/models/access_grant.rb
+++ b/app/models/access_grant.rb
@@ -1,9 +1,10 @@
 class AccessGrant < ActiveRecord::Base
   belongs_to :user
   belongs_to :client
+  belongs_to :learner, :class_name => "Portal::Learner"
   before_create :generate_tokens
 
-  attr_accessible :access_token, :access_token_expires_at, :client_id, :code, :refresh_token, :state, :user_id
+  attr_accessible :access_token, :access_token_expires_at, :client_id, :code, :refresh_token, :state, :user_id, :learner_id
   ExpireTime = 1.week
 
   # Returns all access grants valid at given time, ordered by expire date.

--- a/app/models/external_activity.rb
+++ b/app/models/external_activity.rb
@@ -178,7 +178,7 @@ class ExternalActivity < ActiveRecord::Base
         append_query(uri, "c=#{learner.user.id}") if append_survey_monkey_uid
         if append_auth_token
           AccessGrant.prune!
-          token = learner.user.create_access_token_valid_for(3.minutes)
+          token = learner.user.create_access_token_with_learner_valid_for(3.minutes, learner)
           append_query(uri, "token=#{token}")
         end
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -322,6 +322,11 @@ class User < ActiveRecord::Base
     return access_grants.create!(access_token_expires_at: time.from_now + 1.second).access_token
   end
 
+  # Creates a new access token valid for given time with an associated learner.
+  def create_access_token_with_learner_valid_for(time, learner)
+    return access_grants.create!(access_token_expires_at: time.from_now + 1.second, learner_id: learner.id).access_token
+  end
+
   def active_for_authentication?
     super && user_active?
   end

--- a/db/migrate/20171024192110_add_learner_id_to_access_grants.rb
+++ b/db/migrate/20171024192110_add_learner_id_to_access_grants.rb
@@ -1,0 +1,6 @@
+class AddLearnerIdToAccessGrants < ActiveRecord::Migration
+  def change
+    add_column :access_grants, :learner_id, :integer
+    add_index :access_grants, :learner_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20171010220806) do
+ActiveRecord::Schema.define(:version => 20171024192110) do
 
   create_table "access_grants", :force => true do |t|
     t.string   "code"
@@ -23,9 +23,11 @@ ActiveRecord::Schema.define(:version => 20171010220806) do
     t.string   "state"
     t.datetime "created_at",              :null => false
     t.datetime "updated_at",              :null => false
+    t.integer  "learner_id"
   end
 
   add_index "access_grants", ["client_id"], :name => "index_access_grants_on_client_id"
+  add_index "access_grants", ["learner_id"], :name => "index_access_grants_on_learner_id"
   add_index "access_grants", ["user_id"], :name => "index_access_grants_on_user_id"
 
   create_table "activities", :force => true do |t|

--- a/docker/dev/run-spec.sh
+++ b/docker/dev/run-spec.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 #
 # Run rspec tests in docker environment:
-#   – Execute like this: `docker-compose run --rm app ./docker/dev/run-rspec.sh`
-#   – Or make an alias `alias dspec='docker-compose run --rm app ./docker/dev/run-rspec.sh'`
+#   – Execute like this: `docker-compose run --rm app ./docker/dev/run-spec.sh`
+#   – Or make an alias `alias dspec='docker-compose run --rm app ./docker/dev/run-spec.sh'`
 #        then type `dspec` to start Continuous Integration Testing.
-#   – Or run from shell in docker (`docker-compose run --rm bash` … ./docker/dev/run-rpsec.sh`)
+#   – Or run from shell in docker (`docker-compose run --rm bash` … ./docker/dev/run-psec.sh`)
 
 #
 # Prepare spec tests

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -232,11 +232,11 @@ image above has instructions on doing this.
 1. Connect to the running docker instance of your "app" service. 
 > `$ docker-compose exec app bash`
 2. Invoke the appropriate `run-<test>.sh` script. This should be one of the following scripts which will be mounted in the `/rigse` directory:
-    * `docker/dev/run-rspec.sh`
+    * `docker/dev/run-spec.sh`
     * `docker/dev/run-cucumber.sh`
 
     E.g. 
-    > `$ /rigse/docker/dev/run-rspec.sh`
+    > `$ ./docker/dev/run-rspec.sh`
 
 
  

--- a/lib/signed_jwt.rb
+++ b/lib/signed_jwt.rb
@@ -39,10 +39,12 @@ module SignedJWT
       aud: 'https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit',
       iat: now,
       exp: now + expires_in,
-      uid: user.id,
-      claims: claims
+      uid: user.id
     }
+
     begin
+      # merge claims into payload, preventing duplicates
+      payload.merge!(claims) { |key, old, new| fail "Duplicate JWT claim key: #{key}" }
       rsa_private = OpenSSL::PKey::RSA.new(app.private_key)
       JWT.encode payload, rsa_private, self.rsa_algorithm
     rescue Exception => e

--- a/spec/controllers/api/v1/jwt_controller.rb
+++ b/spec/controllers/api/v1/jwt_controller.rb
@@ -1,0 +1,128 @@
+# encoding: utf-8
+require 'spec_helper'
+
+def set_auth_token(auth_token)
+  request.env["Authorization"] = "Bearer #{auth_token}"
+end
+
+def addToken(user, client, expires_at)
+  grant = user.access_grants.create({
+      :client => client,
+      :state => nil,
+      :access_token_expires_at => expires_at },
+    :without_protection => true
+  )
+  grant.access_token
+end
+
+def addTokenForLearner(user, client, learner, expires_at)
+  grant = user.access_grants.create({
+      :client => client,
+      :state => nil,
+      :learner => learner,
+      :access_token_expires_at => expires_at },
+    :without_protection => true
+  )
+  grant.access_token
+end
+
+describe API::V1::JwtController do
+
+  let(:expires)         { Time.now + 1000000000.minutes}
+  let(:user_token)      { addToken(user, client, expires) }
+  let(:user)            { FactoryGirl.create(:user) }
+  let(:learner_token)   { addTokenForLearner(user, client, learner, expires) }
+  let(:runnable)        { Factory.create(:activity, runnable_opts)    }
+  let(:offering)        { Factory(:portal_offering, offering_opts)    }
+  let(:clazz)           { Factory(:portal_clazz, teachers: [class_teacher], students:[student], logging: true) }
+  let(:offering_opts)   { {clazz: clazz, runnable: runnable}  }
+  let(:runnable_opts)   { {name: 'the activity'}              }
+  let(:class_teacher)   { Factory.create(:portal_teacher)     }
+  let(:student)         { FactoryGirl.create(:full_portal_student) }
+  let(:learner)         { Portal::Learner.find_or_create_by_offering_id_and_student_id(offering.id, student.id )}
+  let(:domain_matchers) { "http://x.y.z" }   # don't know why this is required
+  let(:client)          { Client.create(
+         :name       => "test_api_client",
+         :app_id     => "test_api_client",
+         :app_secret => SecureRandom.uuid,
+         :domain_matchers => domain_matchers
+  )}
+  let(:firebase_app_name)      { "test app" }
+  let(:firebase_app_attributes) {{
+          :name         =>  firebase_app_name,
+          :client_email =>  "user@example.com",
+          # note: the private key below is just a random key - it is not used anywhere
+          :private_key  => "-----BEGIN RSA PRIVATE KEY-----
+MIIEoQIBAAKCAQEAvdCMEYgVdmohS2w7yqPDxQhwKkK+15zDvOY1LgJNnLPoxxEP
+uqQ++BHbfEaGp0jDsLG/f+CjKY2dCP+EHxOuyaAA0IV6eF5rMX0sz8EythpgZDLd
+3mZnChBmP8EQYVAKvY9c8BTvYJFpuFkacxNzCJNop+PGXGlh5hl4FKC7AjF3KvQj
+JHYhh9rE+DX58eQTs+vjjAq65/6+ep8GeDu644sn9HkjrQRvUiQgZhSOsNFl/01O
+chGxLWlFrLO+YdyPlNHRhlEwonr+yI+BvtUoOfrFCstgcY8vvvApplx+efp5Cd4S
+tGUwdn+zqFieeIKz8hUeM6xE2KX1+kXPd6MA+wIDAQABAoIBAGWQgFIlKa7JzPTp
+ffjItcjo4fOK8Ui3ZfjeiRgMPXEaxvQ1SeBJYDQmgfW2WviJs8QI5/nJviRO1Pbq
+mcxzILRb+/OXaFed1eeOHfswWi0cYfVbTmJhEsNM0RlN+bDIPmb9nfIMkaVvSU1N
+yBxJDOVK0tX6x7nM3YhcmmcXNdlOqJX/8YTK6nuNzw2wHkl+RErvO+KycWMitDCx
+ra6ygcgYf30JisilaQ5CvhhCbFx1I8tdep9ppy+JlaMU4q40PcVda5uKzW9ASF0u
+LGjtW4Q95bPZDuy018nedK0noonxkqFgJ759ir6sW9xkRm3IJHyxS9ZmQ/t3Q1aC
+MKUtfOkCgYEA3pSNyQ+d8KYh/8Jywi3ygU7JGeme3MPPDREI7/DmWNyvWABrW4Jc
+bkSX8kHzNvYb+cn/DcOKZq5sB1oujLp6kTz0IxL++bUoDoEd/3dMN52l+qvf+I9K
+wAXNwiWSNGoDbDeGiqJcn7/8oog7jlyKWspqEQnT7usnxFfp9iIsFJ8CgYEA2lCP
+qRoXGl8Wfp6jOINLm6/X6r3rUsCWZhIBYp32jkFGEGdkJzcd0Za1ERI/fQrGW4m1
+ujQZqkgzu1A7QhYQORHega9r7wh/b9HF50sIkWcnGShYG+0D3I7t9HP50ujmd4X7
+c6stYubj8Ci4N74CzONTAXw016f8Igrb35ZoOiUCf3jaMCH7WMZRbiRwb97/E60i
+Gg73ykoUB1gQ58lgA7I8IPinQaNuJMG6fMYNCQHOn2IBS3stsPgPvJhBXwUKO4Kg
+le51YfwzYIx/jsom/Ds2Xei9ad6L7wpUHGROAhRze2hGvcaIYcJbe9DEJ5IkrPqe
+7PhTXb9b7zusgFwkMcsCgYEAsKNyOV5Uxw+cwcJVSgphiIxUZShZWNFeXyO+Xy50
+KVGDAQ7GqDweMlCAHFnpaKDpMXNQyGITSgW1ZZ9a8vOrGKHuqHtpFzSG99CBEc1S
+F2Og7OgJsj6pWzGCMsILpqyunJKZi1M7G8S5NL2dn+xrk59yr8bxcnQGuvySPmwR
+1MkCgYATo5WUro9o1XgEFVMjpwnzxFRED6n9yE13IcL8WH4mbmoVS7fg805A6Vci
+RseUb0vhcp7NWNl86Tm7zWQW8B4RRDNJX4HiKAVzy55x8Azss1P8dPyf4I3c9hNw
+SHlL1Ceaqm35aMguGMBcTs6T5jRJ36K2OPEXU2ZOiRygxcZhFw==
+-----END RSA PRIVATE KEY-----"
+        } }
+
+  describe "GET #firebase" do
+
+    context "when a valid authentication header token is sent without a learner" do
+      before(:each) {
+        set_auth_token(user_token)
+        FirebaseApp.create!(firebase_app_attributes)
+      }
+
+      it "returns a valid JWT" do
+        get :firebase, {:firebase_app => "test app"}, :format => :json
+        expect(response.status).to eq(201)
+
+        body = JSON.parse(response.body)
+        token = body["token"]
+        decoded_token = SignedJWT::decode_firebase_token(token, firebase_app_name)
+        decoded_token[:data]["uid"].should eql user.id
+      end
+    end
+
+    context "when a valid authentication header token is sent with a learner" do
+      before(:each) {
+        set_auth_token(learner_token)
+        FirebaseApp.create!(firebase_app_attributes)
+      }
+
+      it "returns a valid JWT with learner params" do
+        get :firebase, {:firebase_app => "test app"}, :format => :json
+        expect(response.status).to eq(201)
+
+        body = JSON.parse(response.body)
+        token = body["token"]
+        decoded_token = SignedJWT::decode_firebase_token(token, firebase_app_name)
+
+        decoded_token[:data]["uid"].should eql user.id
+        decoded_token[:data]["domain"].should eql root_url
+        decoded_token[:data]["externalId"].should eql learner.id
+        decoded_token[:data]["returnUrl"].should_not be_nil
+        decoded_token[:data]["logging"].should eql true
+        decoded_token[:data]["domain_uid"].should eql user.id
+        decoded_token[:data]["class_info_url"].should_not be_nil
+      end
+    end
+  end
+
+end

--- a/spec/libs/bearer_token/bearer_token_spec.rb
+++ b/spec/libs/bearer_token/bearer_token_spec.rb
@@ -10,18 +10,39 @@ def addToken(user, client, expires_at)
   grant.access_token
 end
 
+def addTokenForLearner(user, client, learner, expires_at)
+  grant = user.access_grants.create({
+      :client => client,
+      :state => nil,
+      :learner => learner,
+      :access_token_expires_at => expires_at },
+    :without_protection => true
+  )
+  grant.access_token
+end
+
 describe BearerToken:BearerTokenAuthenticatable do
   after(:each) { Delorean.back_to_the_present }
   let(:domain_matchers) { "" }
-  let(:strategy)  { BearerTokenAuthenticatable::BearerToken.new(nil) }
-  let(:request)   { mock('request') }
-  let(:mapping)   { Devise.mappings[:user] }
-  let(:expires)   { Time.now + 10.minutes}
-  let(:token)     { addToken(user, client, expires) }
-  let(:headers)   { {"Authorization" => "Bearer #{token}"} }
-  let(:user)      { FactoryGirl.create(:user) }
-  let(:params)    { {} }
-  let(:client)    { Client.create(
+  let(:strategy)        { BearerTokenAuthenticatable::BearerToken.new(nil) }
+  let(:request)         { mock('request') }
+  let(:mapping)         { Devise.mappings[:user] }
+  let(:expires)         { Time.now + 10.minutes}
+  let(:user_token)      { addToken(user, client, expires) }
+  let(:user_headers)    { {"Authorization" => "Bearer #{user_token}"} }
+  let(:learner_token)   { addTokenForLearner(user, client, learner, expires) }
+  let(:learner_headers) { {"Authorization" => "Bearer #{learner_token}"} }
+  let(:user)            { FactoryGirl.create(:user) }
+  let(:runnable)        { Factory.create(:activity, runnable_opts)    }
+  let(:offering)        { Factory(:portal_offering, offering_opts)    }
+  let(:clazz)           { Factory(:portal_clazz, teachers: [class_teacher], students:[student]) }
+  let(:offering_opts)   { {clazz: clazz, runnable: runnable}  }
+  let(:runnable_opts)   { {name: 'the activity'}              }
+  let(:class_teacher)   { Factory.create(:portal_teacher)     }
+  let(:student)         { FactoryGirl.create(:full_portal_student) }
+  let(:learner)         { Portal::Learner.find_or_create_by_offering_id_and_student_id(offering.id, student.id )}
+  let(:params)          { {} }
+  let(:client)          { Client.create(
          :name       => "test_api_client",
          :app_id     => "test_api_client",
          :app_secret => SecureRandom.uuid,
@@ -29,7 +50,7 @@ describe BearerToken:BearerTokenAuthenticatable do
   )}
   let(:referrer)  { "https://foo.bar.com/some/path.html" }
   before(:each) {
-    request.stub!(:headers).and_return(headers)
+    request.stub!(:headers).and_return(user_headers)
     request.stub!(:env).and_return({'HTTP_REFERER' => referrer})
     request.stub!(:params).and_return(params)
     strategy.stub!(:mapping).and_return(mapping)
@@ -71,16 +92,32 @@ describe BearerToken:BearerTokenAuthenticatable do
     let(:good_token)    { addToken(user, client, Time.now + 10.minutes) }
     let(:expired_token) { addToken(user, client, Time.now - 10.minutes) }
     context 'when sending the good bearer token' do
-      let(:token){ good_token }
+      let(:user_token){ good_token }
       it "should authenticate" do
         strategy.authenticate!.should eql :success
       end
     end
     context 'when sending the expired token' do
-      let(:token){ expired_token }
+      let(:user_token){ expired_token }
       it "authentication should fail" do
         strategy.authenticate!.should eql :failure
       end
+    end
+  end
+
+  context 'a learer with a short-lived authentication token' do
+    before(:each) {
+      request.stub!(:headers).and_return(learner_headers)
+    }
+
+    let(:expires) { Time.now + 10.minutes}
+    it 'should authenticate the learner' do
+      strategy.authenticate!.should eql :success
+    end
+
+    it 'should be able to get the learner from the token' do
+      grant = AccessGrant.find_by_access_token(learner_token)
+      grant.learner.should eql learner
     end
   end
 

--- a/spec/models/firebase_app_spec.rb
+++ b/spec/models/firebase_app_spec.rb
@@ -41,7 +41,22 @@ nC64AqP02IP2yOxnbxZ1uY2TrdI1VcO3AwcngxSEUMo=
     decoded_token[:data]["aud"].should eql "https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit"
   end
 
-  it "should throw an error in a signed JWT when it doesn't exist'" do
+  it "should throw an error in a signed JWT when it doesn't exist" do
     expect { SignedJWT::create_firebase_token(user, @valid_app_name) }.to raise_error(SignedJWT::Error)
   end
+
+  it "should create a valid JWT with claims" do
+    FirebaseApp.create!(@valid_attributes)
+    claims = {foo: "bar"}
+    token = SignedJWT::create_firebase_token(user, @valid_app_name, 3600, claims)
+    decoded_token = SignedJWT::decode_firebase_token(token, @valid_app_name)
+    decoded_token[:data]["foo"].should eql "bar"
+  end
+
+  it "should throw an error when create a JWT with claims if reserved keys are used" do
+    FirebaseApp.create!(@valid_attributes)
+    claims = {sub: "bar"}
+    expect { SignedJWT::create_firebase_token(user, @valid_app_name, 3600, claims) }.to raise_error(SignedJWT::Error)
+  end
+
 end


### PR DESCRIPTION
If we launch an external activity url that has been set to append a bearer token, we now add the learner to the generated access grant.

When we request a JWT using the `jwt/firebase` route with this token, we can see if there is an associated learner, and, if so, add claims to the JWT about the learner and offering. These claims are the same as the params that are typically appended to a lara-style url.

As part of this work, JWT claims have now been moved to the top-level, instead of being nested in `claims`, per the JWT spec.

Add tests both for the JWT claims and for the JWT API.

@dougmartin @scytacki Can either of you take a look?