### PR TITLE
allow user to override portal-pages library

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,6 +1,6 @@
 # This file will NOT be automatically included if you define COMPOSE_FILE in .env
 # You need to explicity include it in the list COMPOSE_FILE files.
-version: '2'
+version: '3'
 services:
   app:
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 # This file is meant for development, in production we use a slightly different
 # configuration
-version: '2'
+version: '3'
 services:
   app:
     build:
@@ -42,7 +42,7 @@ services:
       #
       # portal-pages URLs
       #
-      PORTAL_PAGES_LIBRARY_URL: https://portal-pages.concord.org/library
+      PORTAL_PAGES_LIBRARY_URL: "${PORTAL_PAGES_LIBRARY_URL:-https://portal-pages.concord.org/library}"
       EXTERNAL_CSS_URL:
 
       GOOGLE_ANALYTICS_ACCOUNT:

--- a/docker/dev/docker-compose-external-mysql.yml
+++ b/docker/dev/docker-compose-external-mysql.yml
@@ -13,7 +13,7 @@
 #
 # This external mysql will not work on Docker for Mac without some extra configuration:
 #    https://docs.docker.com/docker-for-mac/networking/#/i-want-to-connect-from-a-container-to-a-service-on-the-host
-version: '2'
+version: '3'
 services:
   app:
     environment:

--- a/docker/dev/docker-compose-mac-volumes.yml
+++ b/docker/dev/docker-compose-mac-volumes.yml
@@ -8,7 +8,7 @@
 # if you are making changes to docker-compose.yml or this file it is useful to
 # run `docker-compose config` which shows how the two files get merged together
 
-version: '2'
+version: '3'
 services:
   app:
     volumes:

--- a/docker/dev/docker-compose-publish-mysql-port.yml
+++ b/docker/dev/docker-compose-publish-mysql-port.yml
@@ -11,7 +11,7 @@
 # if you are making changes to docker-compose.yml or this file it is useful to
 # run `docker-compose config` which shows how the two files get merged together
 
-version: '2'
+version: '3'
 services:
   mysql:
     ports:

--- a/docker/dev/docker-compose-random-ports.yml
+++ b/docker/dev/docker-compose-random-ports.yml
@@ -9,7 +9,7 @@
 # if you are making changes to docker-compose.yml or this file it is useful to
 # run `docker-compose config` which shows how the two files get merged together
 
-version: '2'
+version: '3'
 services:
   app:
     ports:

--- a/docker/dev/docker-compose-ssh.yml
+++ b/docker/dev/docker-compose-ssh.yml
@@ -9,7 +9,7 @@
 # if you are making changes to docker-compose.yml or this file it is useful to
 # run `docker-compose config` which shows how the two files get merged together
 
-version: '2'
+version: '3'
 services:
   app:
     environment:

--- a/docker/dev/docker-compose-unison.yml
+++ b/docker/dev/docker-compose-unison.yml
@@ -9,7 +9,7 @@
 # if you are making changes to docker-compose.yml or this file it is useful to
 # run `docker-compose config` which shows how the two files get merged together
 
-version: '2'
+version: '3'
 services:
   app:
     volumes:


### PR DESCRIPTION
The previous approach made it hard to override.

This change requires an update to the docker-compose files. I opt'd to go all the way to version '3'.  Which is the recommended version and has been supported by several older versions of docker. As far as I could tell the upgrade to '3' would not break anything we were doing.