### PR TITLE
Updated generated url for portal offerings with auth tokens appended

### DIFF
--- a/app/controllers/portal/offerings_controller.rb
+++ b/app/controllers/portal/offerings_controller.rb
@@ -70,7 +70,7 @@ class Portal::OfferingsController < ApplicationController
            }.to_query
            redirect_to(uri.to_s)
          else
-           redirect_to(@offering.runnable.url(learner))
+           redirect_to(@offering.runnable.url(learner, root_url))
          end
        }
 

--- a/app/models/external_activity.rb
+++ b/app/models/external_activity.rb
@@ -170,7 +170,7 @@ class ExternalActivity < ActiveRecord::Base
   scope :contributed, where(:is_official => false)
   scope :archived, where(:is_archived => true)
 
-  def url(learner = nil)
+  def url(learner = nil, domain = nil)
     begin
       uri = URI.parse(read_attribute(:url))
       if learner
@@ -180,9 +180,10 @@ class ExternalActivity < ActiveRecord::Base
           AccessGrant.prune!
           token = learner.user.create_access_token_with_learner_valid_for(3.minutes, learner)
           append_query(uri, "token=#{token}")
+          append_query(uri, "domain=#{domain}&domain_uid=#{learner.user.id}") if domain
         end
       end
-      return uri.to_sc
+      return uri.to_s
     rescue
       return read_attribute(:url)
     end

--- a/spec/models/external_activity_spec.rb
+++ b/spec/models/external_activity_spec.rb
@@ -45,7 +45,7 @@ describe ExternalActivity do
       url = "http://www.concord.org/#3"
       activity.append_learner_id_to_url = true
       activity.url = url
-      activity.url(learner).should eql(url + "?learner=34")
+      activity.url(learner).should eql("http://www.concord.org/?learner=34#3")
     end
   end
 


### PR DESCRIPTION
* Changed from uri.to_sc to uri.to_s so that hash part of url is preserved in generated url
* Added domain and domain_uid parameters to generated url