### PR TITLE
Updated bearer token generation and handling in api

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -39,4 +39,55 @@ class API::APIController < ApplicationController
   def destroy
     error("destroy not configured for this resource")
   end
+
+  def check_for_auth_token
+    header = request.headers["Authorization"]
+    if header && header =~ /^Bearer (.*)$/i
+      token = $1
+      grant = AccessGrant.find_by_access_token(token)
+
+      if !grant
+        error('Cannot find AccessGrant for token #{token}')
+        return
+      end
+      if grant.access_token_expires_at < Time.now
+        error('AccessGrant has expired')
+        return
+      end
+
+      role = {
+        :learner => grant.learner,
+        :teacher => grant.teacher
+      }
+
+      return [grant.user, role]
+    elsif header && header =~ /^Bearer\/JWT (.*)$/i
+      portal_token = $1
+      begin
+        decoded_token = SignedJWT::decode_portal_token(portal_token)
+      rescue Exception => e
+        error(e.message)
+        return
+      end
+      data = decoded_token[:data]
+
+      user = User.find_by_id(data["uid"])
+      if !user
+        error('User in token not found')
+        return
+      end
+
+      role = {
+        :learner => data["user_type"] == "learner" ? Portal::Learner.find_by_id(data["learner_id"]) : nil,
+        :teacher => data["user_type"] == "teacher" ? Portal::Teacher.find_by_id(data["teacher_id"]) : nil
+      }
+
+      return [user, role]
+    elsif !current_user
+      error('You must be logged in to use this endpoint')
+      return
+    else
+      return [current_user, nil]
+    end
+  end
 end

--- a/app/controllers/api/v1/classes_controller.rb
+++ b/app/controllers/api/v1/classes_controller.rb
@@ -2,11 +2,14 @@ class API::V1::ClassesController < API::APIController
 
   # GET api/v1/classes/:id
   def show
-    if current_visitor.anonymous?
+    user, role = check_for_auth_token()
+    return if !user
+
+    if user.anonymous?
       return error('You must be logged in to use this endpoint')
     end
 
-    if !current_visitor.portal_student && !current_visitor.portal_teacher
+    if !user.portal_student && !user.portal_teacher
       error('You must be logged in as a student or teacher to use this endpoint')
     end
 
@@ -15,8 +18,8 @@ class API::V1::ClassesController < API::APIController
       return error('The requested class was not found')
     end
 
-    student_in_class = current_visitor.portal_student && current_visitor.portal_student.has_clazz?(clazz)
-    teacher_in_class = !student_in_class || (current_visitor.portal_teacher && current_visitor.portal_teacher.has_clazz?(clazz))
+    student_in_class = user.portal_student && user.portal_student.has_clazz?(clazz)
+    teacher_in_class = !student_in_class || (user.portal_teacher && user.portal_teacher.has_clazz?(clazz))
 
     if (!student_in_class && !teacher_in_class)
       return error('You are not a student or teacher of the requested class')
@@ -28,11 +31,14 @@ class API::V1::ClassesController < API::APIController
   # GET api/v1/classes/mine
   # lists the users classes
   def mine
-    if current_visitor.anonymous?
+    user, role = check_for_auth_token()
+    return if !user
+
+    if user.anonymous?
       return error('You must be logged in to use this endpoint')
     end
 
-    user_with_clazzes = current_visitor.portal_student || current_visitor.portal_teacher
+    user_with_clazzes = user.portal_student || user.portal_teacher
     if !user_with_clazzes
       error('You must be logged in as a student or teacher to use this endpoint')
     end
@@ -91,6 +97,8 @@ class API::V1::ClassesController < API::APIController
   end
 
   private
+
+
 
   def render_info(clazz)
     state = nil

--- a/app/controllers/api/v1/jwt_controller.rb
+++ b/app/controllers/api/v1/jwt_controller.rb
@@ -1,21 +1,51 @@
 class API::V1::JwtController < API::APIController
 
+  def portal
+    user, role = check_for_auth_token()
+    return if !user
+
+    if role
+      learner = role[:learner]
+      teacher = role[:teacher]
+    end
+
+    claims = {}
+    if learner
+      offering = learner.offering
+      claims = {
+        :domain => root_url,
+        :user_type => "learner",
+        :user_id => url_for(user),
+        :learner_id => learner.id,
+        :class_info_url => offering.clazz.class_info_url(request.protocol, request.host_with_port),
+        :offering_id => offering.id
+      }
+    elsif teacher
+      claims = {
+        :domain => root_url,
+        :user_type => "teacher",
+        :user_id => url_for(user),
+        :teacher_id => teacher.id
+      }
+    end
+
+    begin
+      render status: 201, json: {token: SignedJWT::create_portal_token(user, claims, 3600)}
+    rescue Exception => e
+      error(e.message, 500)
+    end
+  end
+
+
   # POST api/v1/jwt/firebase as a logged in user, or
   # GET  api/v1/jwt/firebase?firebase_app=abc with a valid bearer token
   def firebase
-    header = request.headers["Authorization"]
-    if header && header =~ /^Bearer (.*)$/
-      token = $1
-      grant = AccessGrant.find_by_access_token(token)
+    user, role = check_for_auth_token()
+    return if !user
 
-      return error('Cannot find AccessGrant for token #{token}') if !grant
-      return error('AccessGrant has expired') if grant.access_token_expires_at < Time.now
-
-      user = grant.user
-      learner = grant.learner
-    else
-      return error('You must be logged in to use this endpoint') if !current_user
-      user = current_user
+    if role
+      learner = role[:learner]
+      teacher = role[:teacher]
     end
 
     return error('Missing firebase_app parameter') if params[:firebase_app].blank?
@@ -29,7 +59,31 @@ class API::V1::JwtController < API::APIController
         :returnUrl => learner.remote_endpoint_url,
         :logging => offering.clazz.logging || offering.runnable.logging,
         :domain_uid => user.id,
-        :class_info_url => offering.clazz.class_info_url(request.protocol, request.host_with_port)
+        :class_info_url => offering.clazz.class_info_url(request.protocol, request.host_with_port),
+        :claims => { # need claims sub-namespace for firebase auth rules
+          :user_type => "learner",
+          :user_id => url_for(user),
+          :class_hash => offering.clazz.class_hash,
+          :offering_id => offering.id
+        }
+      }
+    elsif teacher
+      # verify if the optional passed class_hash is valid
+      if params[:class_hash].present?
+        class_hashes = teacher.clazzes.map {|c| c.class_hash}
+        if !class_hashes.include? params[:class_hash]
+          return error('Teacher does not have a class with the requested class_hash')
+        end
+      end
+
+      claims = {
+        :domain => root_url,
+        :domain_uid => user.id,
+        :claims => { # need claims sub-namespace for firebase auth rules
+          :user_type => "teacher",
+          :user_id => url_for(user),
+          :class_hash => params[:class_hash]
+        }
       }
     end
 

--- a/app/models/access_grant.rb
+++ b/app/models/access_grant.rb
@@ -2,9 +2,10 @@ class AccessGrant < ActiveRecord::Base
   belongs_to :user
   belongs_to :client
   belongs_to :learner, :class_name => "Portal::Learner"
+  belongs_to :teacher, :class_name => "Portal::Teacher"
   before_create :generate_tokens
 
-  attr_accessible :access_token, :access_token_expires_at, :client_id, :code, :refresh_token, :state, :user_id, :learner_id
+  attr_accessible :access_token, :access_token_expires_at, :client_id, :code, :refresh_token, :state, :user_id, :learner_id, :teacher_id
   ExpireTime = 1.week
 
   # Returns all access grants valid at given time, ordered by expire date.

--- a/app/models/api/v1/offering.rb
+++ b/app/models/api/v1/offering.rb
@@ -23,6 +23,7 @@ class API::V1::Offering
   attribute :teacher, String
   attribute :clazz, String
   attribute :clazz_id, Integer
+  attribute :clazz_info_url, String
   attribute :activity, String
   attribute :activity_url, String
   attribute :students, Array[OfferingStudent]
@@ -31,6 +32,7 @@ class API::V1::Offering
     self.teacher = offering.clazz.teacher.name
     self.clazz = offering.clazz.name
     self.clazz_id = offering.clazz.id
+    self.clazz_info_url = offering.clazz.class_info_url(protocol, host_with_port)
     self.activity = offering.name
     self.activity_url = offering.runnable.respond_to?(:url) ? offering.runnable.url : nil
     self.students = offering.clazz.students.map { |s| OfferingStudent.new(s, offering, protocol, host_with_port) }

--- a/app/models/external_report.rb
+++ b/app/models/external_report.rb
@@ -38,6 +38,10 @@ class ExternalReport < ActiveRecord::Base
   # and the short-lived bearer token for the user.
   def url_for(offering_id, user, protocol, host)
     grant = client.updated_grant_for(user, ReportTokenValidFor)
+    if user.portal_teacher
+      grant.teacher = user.portal_teacher
+      grant.save!
+    end
     token = grant.access_token
     username = user.login
     "#{url}?offering=#{offering_api_url(offering_id, protocol, host)}&token=#{token}&username=#{username}"

--- a/app/models/portal/teacher.rb
+++ b/app/models/portal/teacher.rb
@@ -156,6 +156,10 @@ class Portal::Teacher < ActiveRecord::Base
     end
   end
 
+  def my_classes_url(protocol, host)
+    Rails.application.routes.url_helpers.api_v1_classes_mine(protocol: protocol, host: host)
+  end
+
   private
 
   def add_to_default_cohort

--- a/db/migrate/20171204200632_add_teacher_id_to_access_grants.rb
+++ b/db/migrate/20171204200632_add_teacher_id_to_access_grants.rb
@@ -1,0 +1,6 @@
+class AddTeacherIdToAccessGrants < ActiveRecord::Migration
+  def change
+    add_column :access_grants, :teacher_id, :integer
+    add_index :access_grants, :teacher_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20171116215453) do
+ActiveRecord::Schema.define(:version => 20171204200632) do
 
   create_table "access_grants", :force => true do |t|
     t.string   "code"
@@ -24,10 +24,12 @@ ActiveRecord::Schema.define(:version => 20171116215453) do
     t.datetime "created_at",              :null => false
     t.datetime "updated_at",              :null => false
     t.integer  "learner_id"
+    t.integer  "teacher_id"
   end
 
   add_index "access_grants", ["client_id"], :name => "index_access_grants_on_client_id"
   add_index "access_grants", ["learner_id"], :name => "index_access_grants_on_learner_id"
+  add_index "access_grants", ["teacher_id"], :name => "index_access_grants_on_teacher_id"
   add_index "access_grants", ["user_id"], :name => "index_access_grants_on_user_id"
 
   create_table "activities", :force => true do |t|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,11 @@ services:
       ROLLBAR_ACCESS_TOKEN:
       ROLLBAR_CLIENT_ACCESS_TOKEN:
 
+      #
+      # Set JWT HMAC secret
+      #
+      JWT_HMAC_SECRET:
+
     # no ports are published, see below for details
     volumes:
       - .:/rigse

--- a/spec/libs/bearer_token/jwt_bearer_token_spec.rb
+++ b/spec/libs/bearer_token/jwt_bearer_token_spec.rb
@@ -48,8 +48,8 @@ describe BearerToken:JwtBearerTokenAuthenticatable do
     end
 
     it 'the token should have the claims embedded' do
-      decoded_token[:data]['claims']['bar'].should eql true
-      decoded_token[:data]['claims']['baz'].should eql 'bam'
+      decoded_token[:data]['bar'].should eql true
+      decoded_token[:data]['baz'].should eql 'bam'
     end
   end
 


### PR DESCRIPTION
1. Added helper function in api_controller to check for both Bearer and Bearer/JWT tokens along with current_user
2. Added teachers to portal auth tokens (like learners were already) so that the context of the token is known
3. Added portal JWT creation endpoint which embeds the learner or teacher info like the auth token does
4. Added the teacher info to the auth token when an external report is run
5. Added class_info_url to the portal offering information so that the CollabSpace dashboard can load the class info
6. Added a my_classes_url method to the teacher's model and embedded it in the portal and JWT teacher tokens
7. Merged the claims in the portal token to the root namespace like the Firebase token creator does
8. Added a "claims" subnamespace to the Firebase claims for both the teachers and learners so that the information can be accessed in the Firebase auth rules.