### PR TITLE
Changed Firebase JWT uid to use a hash [#154440024]

### DIFF
--- a/app/controllers/api/v1/jwt_controller.rb
+++ b/app/controllers/api/v1/jwt_controller.rb
@@ -1,5 +1,7 @@
 class API::V1::JwtController < API::APIController
 
+  require 'digest/md5'
+
   def portal
     user, role = check_for_auth_token()
     return if !user
@@ -87,8 +89,11 @@ class API::V1::JwtController < API::APIController
       }
     end
 
+    # the firebase uid must be between 1-36 characters and unique across all portals, MD5 yields a 32 byte string
+    uid = Digest::MD5.hexdigest(url_for(user))
+
     begin
-      render status: 201, json: {token: SignedJWT::create_firebase_token(user, params[:firebase_app], 3600, claims)}
+      render status: 201, json: {token: SignedJWT::create_firebase_token(uid, params[:firebase_app], 3600, claims)}
     rescue Exception => e
       error(e.message, 500)
     end

--- a/lib/signed_jwt.rb
+++ b/lib/signed_jwt.rb
@@ -31,7 +31,7 @@ module SignedJWT
     {data: decoded[0], header: decoded[1]}
   end
 
-  def self.create_firebase_token(user, firebase_app_name, expires_in=3600, claims={})
+  def self.create_firebase_token(uid, firebase_app_name, expires_in=3600, claims={})
     app = FirebaseApp.find_by_name(firebase_app_name)
     raise SignedJWT::Error.new("Unknown firebase app name: #{firebase_app_name}") if app.nil?
 
@@ -43,7 +43,7 @@ module SignedJWT
       aud: 'https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit',
       iat: now,
       exp: now + expires_in,
-      uid: user.id
+      uid: uid
     }
 
     begin


### PR DESCRIPTION
Previously it used user.id but this is not unique across portals obviously so it was changed to a md5 hash of the user's url.  md5 was used because Firebase expects the uid to have a limit of 36 characters and md5 generates a 32 byte hex string.