### PR TITLE
Provide link to search resources on HAS landing page.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -177,11 +177,20 @@ en:
   HomePage:
     Teacher:
       Intro: |
-        Welcome to the High Adventure Science portal.
+        Welcome to the High-Adventure Science portal.
       GettingStarted:
         Instructions_html: |
-          To get started, click the logo in the top left to view all lessons.
-          You can set up a class by clicking the “Add a New Class” link on the left
+          <p>
+          To get started, <b>Add a New Class</b> by clicking the link on the left and enter
+          <b>Class Setup Information</b>, including class name, description, and applicable
+          grade level(s). Create a unique class word, which students will use to enroll in
+          this class.
+          </p>
+          <p>
+          <b>You can search High-Adventure Science resources to assign to your class.</b>
+          </p><p>
+          <a href="/search" class="button search">Search resources</a>
+          </p>
 
 'en-ITSI-LEARN':
   material: activity


### PR DESCRIPTION
@scytacki Should be a quick review.

This turned out to be a very simple change.  This string key is only used in `_getting_started.html.haml` -- and you already did the work to mark the HTML as safe in that file: `I18n.t('HomePage.Teacher.GettingStarted.Instructions_html').html_safe`


This work is being done for this PT story: https://www.pivotaltracker.com/story/show/153034715