### PR TITLE
Allow project admins to mark any material with their project

### DIFF
--- a/app/policies/external_activity_policy.rb
+++ b/app/policies/external_activity_policy.rb
@@ -41,11 +41,20 @@ class ExternalActivityPolicy < ApplicationPolicy
   end
 
   # FIMXE: This single update permission is used by all users when they are changing the
-  # settings. The edit_basic and the other fine grained permissions in MaterialSharedPolicy 
-  # only control which fields are visible. So for example it would be possible for an 
+  # settings. The edit_basic and the other fine grained permissions in MaterialSharedPolicy
+  # only control which fields are visible. So for example it would be possible for an
   # owner who is not an admin to change some advanced settings.
   def update?
-    admin_or_material_admin? || owner?
+    # the edit here refers to the edit in material_shared_policy
+    # that edit lets any admin, project_admin, or material_admin to edit the material
+    # admins and material_admins makes sense in this case. project_admins require access
+    # so they can update project and project cohorts of materials they aren't the owner of
+    # and are not part of their project yet
+    # This is needed when there are multiple authors on a project. An non project admin
+    # author creates the material.  Then the project admins needs to find it and mark
+    # configure the advanced configuration options. Otherwise a portal admin needs to
+    # get involved.
+    edit? || owner?
   end
 
   def archive?

--- a/spec/policies/external_activity_policy_spec.rb
+++ b/spec/policies/external_activity_policy_spec.rb
@@ -73,7 +73,7 @@ describe ExternalActivityPolicy do
   end
 
 
-  context "for a project admin" do
+  context "for a material admin" do
     let(:project_a)   { FactoryGirl.create(:project)                                 }
     let(:active_user) { FactoryGirl.create(:user, admin_for_projects: [project_a])   }
     let(:activity)    { FactoryGirl.create(:external_activity, projects: [project_a])}
@@ -89,6 +89,20 @@ describe ExternalActivityPolicy do
     it { should permit(:unarchive)                }
     it { should permit(:duplicate)                }
     it { should permit(:edit_credits)             }
+  end
+
+  context "for an admin of a project that is not one of the material's projects" do
+    let(:project_a)   { FactoryGirl.create(:project)                                 }
+    let(:active_user) { FactoryGirl.create(:user, admin_for_projects: [project_a])   }
+    before(:each) do
+      active_user.add_role_for_project('admin', project_a)
+    end
+    it { should permit(:edit_projects)            }
+    it { should permit(:edit_cohorts)             }
+    it { should permit(:edit)                     }
+    # this type of user needs to be able to update the activity so that it can make a
+    # material part of a project that isn't already part of the project.
+    it { should permit(:update)                   }
   end
 
 end


### PR DESCRIPTION
This was working that way before, but it was broken in this commit:
https://github.com/concord-consortium/rigse/commit/30bd1f8b1143a7ce95a58c67d1841f753d428dd5
I'm not sure why it was changed in that commit.

That change was partially reverted in this commit:
https://github.com/concord-consortium/rigse/commit/241e846211fcfd871c205741be34d42fe4cc447c

[#155376959]
https://www.pivotaltracker.com/story/show/155376959