### PR TITLE
Add `rubric_url` field to ExternalActivity

### DIFF
--- a/app/views/external_activities/_form.html.haml
+++ b/app/views/external_activities/_form.html.haml
@@ -45,6 +45,8 @@
       = t('authoring.external_report_description')
     = field_set_tag 'Teacher Guide (URL)' do
       = f.text_field :teacher_guide_url, :size => 60
+    = field_set_tag t('authoring.rubric_url_label') do
+      = f.text_field :rubric_url, :size => 60
     = field_set_tag 'Thumbnail image URL (300 x 250 px)' do
       = f.text_field :thumbnail_url, :size => 60
     = field_set_tag 'Feature On Landing Page' do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,6 +82,7 @@ en:
     external_report_label: External Reporting
     external_report_description: Specify and alternate report link to be shown to teachers in the offering view. Unless you know what you are doing 'none' is recommended.
     report_client: Report Auth Client
+    rubric_url_label: Rubric (URL)
   matedit:
     assign_to_class: Assign To Class
     edit_options: Edit Options

--- a/db/migrate/20180223203056_add_rubric_url_to_external_activity.rb
+++ b/db/migrate/20180223203056_add_rubric_url_to_external_activity.rb
@@ -1,0 +1,5 @@
+class AddRubricUrlToExternalActivity < ActiveRecord::Migration
+  def change
+    add_column :external_activities, :rubric_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20180127143049) do
+ActiveRecord::Schema.define(:version => 20180223203056) do
 
   create_table "access_grants", :force => true do |t|
     t.string   "code"
@@ -877,6 +877,7 @@ ActiveRecord::Schema.define(:version => 20180127143049) do
     t.boolean  "enable_sharing",                               :default => true
     t.boolean  "append_auth_token"
     t.string   "material_type",                                :default => "Activity"
+    t.string   "rubric_url"
   end
 
   add_index "external_activities", ["is_featured", "publication_status"], :name => "featured_public", :length => {"is_featured"=>nil, "publication_status"=>191}
@@ -2443,10 +2444,10 @@ ActiveRecord::Schema.define(:version => 20180127143049) do
     t.integer  "num_answerables"
     t.integer  "num_answered"
     t.integer  "num_correct"
-    t.text     "answers",             :limit => 2147483647
+    t.text     "answers",              :limit => 2147483647
     t.string   "runnable_type"
     t.float    "complete_percent"
-    t.text     "permission_forms",    :limit => 16777215
+    t.text     "permission_forms",     :limit => 16777215
     t.integer  "num_submitted"
     t.string   "teachers_district"
     t.string   "teachers_state"


### PR DESCRIPTION
A rubric URL field is added to the portal settings for an external activity. The content at the URL can be used as an activity level rubric in the portal report feedback system.

[#155403937]

https://www.pivotaltracker.com/story/show/155403937