### PR TITLE
155408322 save rubric feedback

### DIFF
--- a/app/models/api/v1/report.rb
+++ b/app/models/api/v1/report.rb
@@ -195,6 +195,8 @@ class API::V1::Report
       enable_text_feedback: activity_feedback.enable_text_feedback,
       score_type: activity_feedback.score_type,
       max_score: activity_feedback.max_score,
+      rubric_url: activity_feedback.rubric_url,
+      use_rubric: activity_feedback.use_rubric || false,
       activity_feedback:  @offering.learners.map { |l| learner_activity_feedback_json(l,activity_feedback) },
       children: sections.map { |s| section_json(s, answers) }
     }
@@ -210,7 +212,8 @@ class API::V1::Report
         {
           score: feedback.score,
           feedback: feedback.text_feedback,
-          has_been_reviewed: feedback.has_been_reviewed
+          has_been_reviewed: feedback.has_been_reviewed,
+          rubric_feedback: feedback.rubric_feedback
         }
       end
     }

--- a/app/models/portal/learner_activity_feedback.rb
+++ b/app/models/portal/learner_activity_feedback.rb
@@ -16,7 +16,12 @@ class Portal::LearnerActivityFeedback < ActiveRecord::Base
   def self._attribute_ids(*attributes)
     results = []
     for attribute in attributes do
-      results.push(attribute.is_a?(Numeric) ? attribute : attribute.id)
+      case attribute
+      when Numeric, String
+        results.push(attribute)
+      else
+        results.push(attribute.id)
+      end
     end
     return results
   end
@@ -34,8 +39,21 @@ class Portal::LearnerActivityFeedback < ActiveRecord::Base
     if results
       return results
     end
-    l = learner.is_a?(Numeric) ? Portal::Learner.find(learner) : learner
-    f = activity_feedback.is_a?(Numeric) ? Portal::OfferingActivityFeedback.find(activity_feedback) : activity_feedback
+
+    case learner
+    when Numeric, String
+      l = Portal::Learner.find(learner)
+    else
+      l = learner
+    end
+
+    case activity_feedback
+    when Numeric, String
+      f = Portal::OfferingActivityFeedback.find(activity_feedback)
+    else
+      f = activity_feedback
+    end
+
     return self.create({portal_learner:l, activity_feedback: f})
   end
 

--- a/app/models/portal/learner_activity_feedback.rb
+++ b/app/models/portal/learner_activity_feedback.rb
@@ -5,10 +5,13 @@ class Portal::LearnerActivityFeedback < ActiveRecord::Base
   attr_accessible :has_been_reviewed,
     :score,
     :text_feedback,
+    :rubric_feedback,
     :activity_feedback,
     :activity_feedback_id,
     :portal_learner,
     :portal_learner_id
+
+  serialize :rubric_feedback, JSON
 
   def self._attribute_ids(*attributes)
     results = []

--- a/app/models/portal/offering_activity_feedback.rb
+++ b/app/models/portal/offering_activity_feedback.rb
@@ -11,7 +11,10 @@ class Portal::OfferingActivityFeedback < ActiveRecord::Base
     :portal_offering,
     :portal_offering_id,
     :activity,
-    :activity_id
+    :activity_id,
+    :use_rubric,
+    :rubric_url,
+    :rubric
 
   belongs_to :portal_offering, class_name: "Portal::Offering"
   belongs_to :activity
@@ -21,6 +24,7 @@ class Portal::OfferingActivityFeedback < ActiveRecord::Base
     params = { portal_offering_id: offering.id, activity_id: activity.id }
     found  = self.where(params).order('created_at desc').first
     unless(found)
+      params[:rubric_url] = offering.runnable.rubric_url
       found= self.create(params)
     end
     return found

--- a/app/models/portal/offering_activity_feedback.rb
+++ b/app/models/portal/offering_activity_feedback.rb
@@ -24,7 +24,9 @@ class Portal::OfferingActivityFeedback < ActiveRecord::Base
     params = { portal_offering_id: offering.id, activity_id: activity.id }
     found  = self.where(params).order('created_at desc').first
     unless(found)
-      params[:rubric_url] = offering.runnable.rubric_url
+      if(offering.runnable.respond_to? :rubric_url)
+        params[:rubric_url] = offering.runnable.rubric_url
+      end
       found= self.create(params)
     end
     return found

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -10,7 +10,7 @@ class Section < ActiveRecord::Base
 
   has_one :investigation, :through => :activity
 
-  has_many :pages, :dependent => :destroy ,:order => :position, :dependent => :destroy do
+  has_many :pages ,:order => :position, :dependent => :destroy do
     def student_only
       find(:all, :conditions => {'teacher_only' => false})
     end

--- a/db/migrate/20180309155235_add_rubric_url_to_portal_offering_feedbacks.rb
+++ b/db/migrate/20180309155235_add_rubric_url_to_portal_offering_feedbacks.rb
@@ -1,0 +1,7 @@
+class AddRubricUrlToPortalOfferingFeedbacks < ActiveRecord::Migration
+  def change
+    add_column :portal_offering_activity_feedbacks, :rubric_url, :string
+    add_column :portal_offering_activity_feedbacks, :use_rubric, :boolean
+    add_column :portal_offering_activity_feedbacks, :rubric, :text
+  end
+end

--- a/db/migrate/20180309155805_add_rubric_feedback_to_portal_learner_activity_feedbacks.rb
+++ b/db/migrate/20180309155805_add_rubric_feedback_to_portal_learner_activity_feedbacks.rb
@@ -1,0 +1,5 @@
+class AddRubricFeedbackToPortalLearnerActivityFeedbacks < ActiveRecord::Migration
+  def change
+    add_column :portal_learner_activity_feedbacks, :rubric_feedback, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20180223203056) do
+ActiveRecord::Schema.define(:version => 20180309155805) do
 
   create_table "access_grants", :force => true do |t|
     t.string   "code"
@@ -1443,6 +1443,7 @@ ActiveRecord::Schema.define(:version => 20180223203056) do
     t.integer  "activity_feedback_id"
     t.datetime "created_at",                              :null => false
     t.datetime "updated_at",                              :null => false
+    t.text     "rubric_feedback"
   end
 
   add_index "portal_learner_activity_feedbacks", ["activity_feedback_id"], :name => "index_portal_learner_activity_feedbacks_on_activity_feedback_id"
@@ -2157,6 +2158,9 @@ ActiveRecord::Schema.define(:version => 20180223203056) do
     t.integer  "portal_offering_id"
     t.datetime "created_at",                               :null => false
     t.datetime "updated_at",                               :null => false
+    t.string   "rubric_url"
+    t.boolean  "use_rubric"
+    t.text     "rubric"
   end
 
   create_table "portal_offering_embeddable_metadata", :force => true do |t|

--- a/spec/models/api/v1/report_spec.rb
+++ b/spec/models/api/v1/report_spec.rb
@@ -2,7 +2,10 @@
 require 'spec_helper'
 
 describe API::V1::Report do
-  let(:offering)          { FactoryGirl.create(:portal_offering) }
+  let(:investigation)      { FactoryGirl.create(:investigation) }
+  let(:external_activity)  { FactoryGirl.create(:external_activity, template: investigation) }
+  let(:runnable)           { investigation }
+  let(:offering)           { FactoryGirl.create(:portal_offering, runnable: runnable) }
 
   describe "class methods" do
     # def self.update_feedback_settings(offering, embeddable, feedback_settings)
@@ -278,12 +281,14 @@ describe API::V1::Report do
         let(:score)                { nil }
         let(:text_feedback)        { nil }
         let(:has_been_reviewed)    { nil }
+        let(:rubric_feedback)      { nil }
         let(:feedback) do
           {
               'learner_id'           => learner_id,
               'activity_feedback_id' => feedback_id,
               'score'                => score,
               'text_feedback'        => text_feedback,
+              'rubric_feedback'      => rubric_feedback,
               'has_been_reviewed'    => has_been_reviewed
           }
         end
@@ -292,15 +297,17 @@ describe API::V1::Report do
           API::V1::Report.submit_activity_feedback(feedback)
         end
 
-        describe "giving activity level feedback feedback" do
+        describe "giving activity level feedback" do
           let(:learner_feedback) { Portal::LearnerActivityFeedback.for_learner_and_activity_feedback(learner, activity_feedback)}
           describe 'giving feedback without marking complete' do
-            let(:text_feedback) { "good job" }
-            let(:score)         {  10        }
+            let(:text_feedback)   { "good job" }
+            let(:score)           {  10        }
+            let(:rubric_feedback) { {"C1" => {"id"=>"R3"}} }
             subject             { learner_feedback.first }
 
-            its(:score)         { should eql 10 }
-            its(:text_feedback) { should eql "good job" }
+            its(:score)           { should eql 10 }
+            its(:text_feedback)   { should eql "good job" }
+            its(:rubric_feedback) { should eql rubric_feedback }
           end
 
           describe "marking feedback complete" do


### PR DESCRIPTION
This PR has three commits.


4eadc69 :  Introduces a new aspect of activity level feedback called `rubric_feedback`.  Activity level feedback gets a copy of a rubric from the runnable.  `LearnerActivityFeedback` records the rubric feedback for the learner.

214c862 :  Modifies how a learners feedback is searched.  We are more permissive now about using strings or numbers for keys when looking up associations. 

06b87db : Fixes a corrects a typo where a duplicate `:dependant  => :destroy` is specied in `section.rb` It's a non-harmful, and totally unrelated bug. It probably shouldn't be in this PR but it seemed too small to put in its own. PR.

@scytacki  Could you please review?

Thanks!