### PR TITLE
Feature:  Save & Load rubric (content) using report API.

### DIFF
--- a/app/models/api/v1/report.rb
+++ b/app/models/api/v1/report.rb
@@ -196,6 +196,7 @@ class API::V1::Report
       score_type: activity_feedback.score_type,
       max_score: activity_feedback.max_score,
       rubric_url: activity_feedback.rubric_url,
+      rubric: activity_feedback.rubric,
       use_rubric: activity_feedback.use_rubric || false,
       activity_feedback:  @offering.learners.map { |l| learner_activity_feedback_json(l,activity_feedback) },
       children: sections.map { |s| section_json(s, answers) }

--- a/app/models/portal/offering_activity_feedback.rb
+++ b/app/models/portal/offering_activity_feedback.rb
@@ -16,6 +16,8 @@ class Portal::OfferingActivityFeedback < ActiveRecord::Base
     :rubric_url,
     :rubric
 
+  serialize :rubric, JSON
+
   belongs_to :portal_offering, class_name: "Portal::Offering"
   belongs_to :activity
   has_many   :learner_activity_feedbacks, class_name: "Portal::LearnerActivityFeedback", foreign_key: "activity_feedback_id"

--- a/spec/models/api/v1/report_spec.rb
+++ b/spec/models/api/v1/report_spec.rb
@@ -234,13 +234,19 @@ describe API::V1::Report do
         let(:enable_text_feedback)   { nil }
         let(:score_type)             { "none" }
         let(:max_score)              { nil }
+        let(:use_rubric)             { nil }
+        let(:rubric_url)             { nil }
+        let(:rubric)                 { nil }
         let(:feedback_settings) do
           {
               'activity_feedback_id' => feedback_id,
               'learner_id' => learner_id,
               'max_score' => max_score,
               'score_type' => score_type,
-              'enable_text_feedback' => enable_text_feedback
+              'enable_text_feedback' => enable_text_feedback,
+              'use_rubric' => use_rubric,
+              'rubric_url' => rubric_url,
+              'rubric' => rubric
           }
         end
 
@@ -273,6 +279,24 @@ describe API::V1::Report do
             its(:max_score)            { should eq 12 }
             its(:enable_text_feedback) { should be true }
             its(:score_type)           { should eq "auto"  }
+          end
+
+          describe "enabling rubric" do
+            let(:use_rubric)   { true }
+
+            its(:use_rubric)   { should be_true }
+          end
+
+          describe "setting the rubric URL" do
+            let(:rubric_url)   { "http://somplace.com/api/blarg.json" }
+
+            its(:rubric_url)   { should eql rubric_url }
+          end
+
+          describe "setting the rubric" do
+            let(:rubric)   { {"version" => "1.0", "timestamp" => Time.now.to_i} }
+
+            its(:rubric)   { should eql rubric }
           end
         end
       end


### PR DESCRIPTION
@scytacki this is the PR that addresses some of your concerns from yesterday.

We serializes the `rubric` field in `offering_activity_feedback.rb` and also send this field to the portal-report client when a report is requested.

Some setup for this (AR Model, migrations) was part of the last PR.

A related pending PR in the portal-report can be found here: xxxx
-----

If a teacher uses a rubric to give feedback, it is copied and locked for them for that assignment, so that it does not change if the author changes it after that point.

[#155368181]

https://www.pivotaltracker.com/story/show/155368181