### PR TITLE
Remove two unused view helper methods for learner_stats.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -512,20 +512,6 @@ module ApplicationHelper
     end
   end
 
-  def open_response_learner_stat(learner)
-    reportUtil = Report::Util.factory(learner.offering)
-    answered = reportUtil.saveables(:answered => true, :learner => learner, :type => Embeddable::OpenResponse).size
-    total = reportUtil.embeddables(:type => Embeddable::OpenRespose).size
-    " Open Response: #{answered}/#{total} "
-  end
-
-  def multiple_choice_learner_stat(learner)
-    reportUtil = Report::Util.factory(learner.offering)
-    answered = reportUtil.saveables(:answered => true, :learner => learner, :type => Embeddable::MultipleChoice).size
-    correct = reportUtil.saveables(:answered => true, :correct => true, :learner => learner, :type => Embeddable::MultipleChoice).size
-    total = reportUtil.embeddables(:type => Embeddable::MultipleChoice).size
-    " Multiple Choice: #{answered}/#{correct}/#{total} "
-  end
 
   def sessions_learner_stat(learner)
     sessions = learner.bundle_logger.bundle_contents.count


### PR DESCRIPTION
@scytacki  I found these methods that are not used while hunting for references to `Embeddable::*`.

`open_response_learner_stat` and `multiple_choice_learner_stat` are not found anywhere in the source
except in these definitions.

`open_response_learner_stat` looks for an `Embeddable::OpenRespose`  which would trigger a runtime error because no such class exists elsewhere in the source.