### PR TITLE
Add REPORT_DOMAINS env variable to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       SITE_URL:
       RESEARCHER_REPORT_ONLY:
       REPORT_VIEW_URL:
+      REPORT_DOMAINS:
 
       #
       # ASN API key


### PR DESCRIPTION
Simple change, so I can define `REPORT_DOMAINS` in my `.env` file and use local portal-report instance.