### PR TITLE
add role classes to body element in minimal layout

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -62,7 +62,10 @@
 
     = render :partial => 'shared/analytics'
     = javascript_tag "jQuery(function(){jQuery('input[placeholder], textarea[placeholder]').placeholder();});"
-  %body{:class => current_visitor.role_names.map{ |role_name| "#{role_name}-visitor" }.unshift(current_visitor.has_role?('guest') ? 'main-nav-hidden' : '').join(' ').squish, :'ng-app' => 'cc-portal'}
+
+  - role_classes = current_visitor.role_names.map{ |role_name| "#{role_name}-visitor" }
+  - guest_classes = current_user.nil? ? ['main-nav-hidden'] : []
+  %body{:class => (guest_classes + role_classes).join(' ').squish, :'ng-app' => 'cc-portal'}
 
     #note{:style=>"display: none;"}
     = content_for :lightboxes

--- a/app/views/layouts/minimal.html.haml
+++ b/app/views/layouts/minimal.html.haml
@@ -64,8 +64,8 @@
 
     = render :partial => 'shared/analytics'
     = javascript_tag "jQuery(function(){jQuery('input[placeholder], textarea[placeholder]').placeholder();});"
-
-  %body{:class => 'blank', :'ng-app' => 'cc-portal'}
+  - role_classes = current_visitor.role_names.map{ |role_name| "#{role_name}-visitor" }
+  %body{:class => (['blank'] + role_classes).join(' ').squish, :'ng-app' => 'cc-portal'}
     #js_flash{:style=>"display: none;"}
     = render :partial=>"layouts/flashes"
     = content_for :layout

--- a/spec/views/layouts/application.html.haml_spec.rb
+++ b/spec/views/layouts/application.html.haml_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe "rendering application.html.haml" do
+  let(:fake_visitor) { Factory(:user, {id: 101,}) }
+  let(:roles) {['first-role']}
+
+  before do
+    view.stub(:current_visitor).and_return(fake_visitor)
+    view.stub(:current_user).and_return(fake_visitor)
+    view.stub(:calpicker_includes).and_return('')
+    fake_visitor.stub(:authenticate).and_return(true)
+    fake_visitor.stub(:role_names).and_return(roles)
+  end
+
+  it "applies the correct role classes" do
+    assign(:original_user, fake_visitor)
+    render(
+      :text => "nothing",
+      :layout => "layouts/application"
+    )
+    rendered.should have_selector("body.first-role-visitor")
+  end
+end
+


### PR DESCRIPTION
the minimal layout is now used for collection pages and these pages use these role classes
to hide and show content

This has not tests. If you know of a quick way to add tests to for this, if you can point it out I'll add them.

[#157442841]