### PR TITLE
collection pages are not the about page

### DIFF
--- a/app/views/admin/projects/landing_page.html.haml
+++ b/app/views/admin/projects/landing_page.html.haml
@@ -1,6 +1,5 @@
 -# This is using the minimal layout, so we need to add the header ourselves
-= render :partial => 'shared/project_header',
-  :locals => { :extra_options => { :isAbout => true } }
+= render :partial => 'shared/project_header'
 
 .landing-page-content
   = raw(@landing_page_content)


### PR DESCRIPTION
[#157487684]
https://www.pivotaltracker.com/story/show/157487684

@emcelroy I'm pretty sure you didn't mean mean for collection pages (project landing pages) to have the About link underlined. This commit fixes that.