### PR TITLE
Add support of "rubric" score type

### DIFF
--- a/app/models/portal/offering_activity_feedback.rb
+++ b/app/models/portal/offering_activity_feedback.rb
@@ -2,7 +2,8 @@ class Portal::OfferingActivityFeedback < ActiveRecord::Base
   SCORE_AUTO   = "auto"
   SCORE_NONE   = "none"
   SCORE_MANUAL = "manual"
-  SCORE_TYPES = [SCORE_AUTO, SCORE_MANUAL, SCORE_NONE]
+  SCORE_RUBRIC = "rubric"
+  SCORE_TYPES = [SCORE_AUTO, SCORE_MANUAL, SCORE_RUBRIC, SCORE_NONE]
 
   self.table_name = :portal_offering_activity_feedbacks
   attr_accessible :enable_text_feedback,


### PR DESCRIPTION
Portal wasn't updating this field.

I don't think we really need this check here in Portal (why would it care about some values used by Portal Report), but it's kind of the documentation of the expected values, so I don't have strong opinion on that.

https://www.pivotaltracker.com/story/show/157497084
