### PR TITLE
Fix Offering API, provide ID of template object

### DIFF
--- a/app/models/api/v1/offering.rb
+++ b/app/models/api/v1/offering.rb
@@ -113,6 +113,11 @@ class API::V1::Offering
     # Cache feedback activity objects and pass them to student model.
     activity_feedbacks = {}
     self.activities = (runnable.respond_to?(:activities) && runnable.activities || [ runnable ]).map do |activity|
+      if activity.respond_to?(:template) && activity.template
+        # Use template model for reporting purposes when we're dealing with ExternalActivity.
+        # That's the general assumption in many other places. Reporting code and URL helpers expect template object ID.
+        activity = activity.template
+      end
       activity_feedback = offering.activity_feedbacks.find { |af| af.activity_id == activity.id }
       activity_feedbacks[activity.id] = activity_feedback
       {


### PR DESCRIPTION
@scytacki, it fixes the problem you've noticed on learn.staging.

It was caused by Offering API and a mismatch between ExternalActivity ID and Activity ID (690 vs 898):
<img width="445" alt="screen shot 2018-05-17 at 17 47 01" src="https://user-images.githubusercontent.com/767857/40210757-a79c9c76-59fb-11e8-991c-6880cc681662.png">

I've fixed API to always return template model ID as that's what is expected everywhere else.