### PR TITLE
Support of non-LARA external activities

### DIFF
--- a/app/models/api/v1/offering.rb
+++ b/app/models/api/v1/offering.rb
@@ -48,14 +48,14 @@ class API::V1::Offering
       self.endpoint_url = learner ? learner.remote_endpoint_url : nil
       self.total_progress = learner ? learner.report_learner.complete_percent : 0
       self.last_run = learner ? learner.report_learner.last_run : nil
-      self.learner_report_url = learner ? report_portal_learner_url(learner, protocol: protocol, host: host_with_port) : nil
-      if learner
+      self.learner_report_url = learner && learner.reportable? ? report_portal_learner_url(learner, protocol: protocol, host: host_with_port) : nil
+      if learner && learner.learner_activities.count > 0
         self.detailed_progress = learner.learner_activities.map do |la|
           {
               activity_id: la.activity.id,
               activity_name: la.activity.name,
               progress: la.complete_percent,
-              learner_activity_report_url: portal_learners_report_url(learner, la.activity, protocol: protocol, host: host_with_port),
+              learner_activity_report_url: learner.reportable? ? portal_learners_report_url(learner, la.activity, protocol: protocol, host: host_with_port) : nil,
               feedback: feedback_json(learner, activity_feedbacks[la.activity.id])
           }
         end
@@ -123,7 +123,7 @@ class API::V1::Offering
       {
         id: activity.id,
         name: activity.name,
-        activity_report_url: portal_offerings_report_url(offering, activity, protocol: protocol, host: host_with_port),
+        activity_report_url: offering.reportable? ? portal_offerings_report_url(offering, activity, protocol: protocol, host: host_with_port) : nil,
         feedback_options: activity_feedback && {
           score_feedback_enabled: !!activity_feedback.enable_score_feedback,
           text_feedback_enabled: !!activity_feedback.enable_text_feedback,

--- a/app/models/api/v1/offering.rb
+++ b/app/models/api/v1/offering.rb
@@ -87,6 +87,7 @@ class API::V1::Offering
   attribute :material_type, String
   attribute :report_url, String
   attribute :external_report, Hash
+  attribute :reportable, Boolean
   attribute :reportable_activities, Array
   attribute :students, Array[OfferingStudent]
 
@@ -100,7 +101,7 @@ class API::V1::Offering
     self.activity = offering.name
     self.activity_url = runnable.respond_to?(:url) ? runnable.url : nil
     self.material_type = runnable.material_type
-
+    self.reportable = offering.reportable?
     self.report_url = offering.reportable? ? report_portal_offering_url(id: offering.id, protocol: protocol, host: host_with_port) : nil
     if runnable.respond_to?(:external_report) && runnable.external_report
       self.external_report =  {

--- a/app/models/report/learner.rb
+++ b/app/models/report/learner.rb
@@ -201,7 +201,8 @@ class Report::Learner < ActiveRecord::Base
       self.num_answered = 0
       self.num_submitted = 0
       self.num_correct = 0
-      self.complete_percent = 99.9
+      # Offering is not reportable, so return 100% progress, as it's been started. That's the only information available.
+      self.complete_percent = 100
       self.last_run = Time.now
     end
     Rails.logger.debug("Updated Report Learner: #{self.student_name}")

--- a/app/models/report/offering_student_status.rb
+++ b/app/models/report/offering_student_status.rb
@@ -34,10 +34,8 @@ class Report::OfferingStudentStatus
       if offering_reportable?
         learner.report_learner.complete_percent || 0
       else
-        # return 99.99 because all we can tell is whether it is in progress
-        # if we return 100 then the progress bar will indicate it is compelete
-        # 99.99 is enough to fill up the progress bar but keep the in_progress color
-        99.99
+        # Offering is not reportable, but it has been started. Return 100%.
+        100
       end
     else
       0

--- a/spec/models/report/offering_student_status_spec.rb
+++ b/spec/models/report/offering_student_status_spec.rb
@@ -29,7 +29,7 @@ describe Report::OfferingStudentStatus do
           _offering.stub!(:individual_reportable?).and_return(false)
           _offering
         end
-        its(:complete_percent){should == 99.99}
+        its(:complete_percent){should == 100}
       end
       context "when the offering is reportable" do
         let :offering do


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/736901/stories/157700766

1. Offering API: added checks whether the offering is actually reportable before providing report URL.
2. Offering API: changed `activities` list to `reportable_activities`. It's returned only if the offering is reportable.
3. Changed completion percent from 99% to 100% when the offering is not reportable but has been launched.

