### PR TITLE
Log learner data processing times

### DIFF
--- a/app/models/dataservice/v1/process_external_activity_data_job.rb
+++ b/app/models/dataservice/v1/process_external_activity_data_job.rb
@@ -11,7 +11,7 @@ class Dataservice::V1::ProcessExternalActivityDataJob < Dataservice::ProcessExte
   def lara_start
     # this will be nil if there aren't any dirty answers when lara sent the data
     # and we want to leave it that way
-    DateTime.parse(lara_start_str) rescue nil
+    DateTime.parse(JSON.parse(content)['lara_start']) rescue nil
   end
 
   def lara_end

--- a/app/models/dataservice/v1/process_external_activity_data_job.rb
+++ b/app/models/dataservice/v1/process_external_activity_data_job.rb
@@ -9,7 +9,9 @@ class Dataservice::V1::ProcessExternalActivityDataJob < Dataservice::ProcessExte
   end
 
   def lara_start
-    DateTime.parse(JSON.parse(content)['lara_start']) rescue Time.now()
+    # this will be nil if there aren't any dirty answers when lara sent the data
+    # and we want to leave it that way
+    DateTime.parse(lara_start_str) rescue nil
   end
 
   def lara_end
@@ -18,7 +20,8 @@ class Dataservice::V1::ProcessExternalActivityDataJob < Dataservice::ProcessExte
 
   def perform
     super
-    processing_event = LearnerProcessingEvent.build_proccesing_event(learner, lara_start, lara_end, portal_start)
+    processing_event =
+      LearnerProcessingEvent.build_proccesing_event(learner, lara_start, lara_end, portal_start, answers.length)
     processing_event.save
   end
 end

--- a/app/models/learner_processing_event.rb
+++ b/app/models/learner_processing_event.rb
@@ -2,7 +2,8 @@ class LearnerProcessingEvent < ActiveRecord::Base
 
   belongs_to :learner, class_name: Portal::Learner
 
-  attr_accessible :duration, :elapsed_seconds, :lara_end, :lara_start, :login, :portal_end, :portal_start, :teacher, :url
+  attr_accessible :duration, :elapsed_seconds, :lara_end, :lara_start,
+    :login, :portal_end, :portal_start, :teacher, :url
 
 
   # Humanize duration seconds, similar to ActiveSupport's distance_of_time_in_words
@@ -19,26 +20,48 @@ class LearnerProcessingEvent < ActiveRecord::Base
   end
 
 
-  def self.build_proccesing_event(learner, lara_start, lara_end, portal_start)
+  def self.build_proccesing_event(learner, lara_start, lara_end, portal_start, answers_length)
     record = self.new()
     record.learner         = learner
     record.portal_end      = Time.now
 
     record.portal_start    = portal_start || record.portal_end
     record.lara_end        = lara_end     || record.portal_start
-    record.lara_start      = lara_start   || record.lara_end
+    record.lara_start      = lara_start
 
-    record.lara_duration   = record.lara_end   - record.lara_start
+    if record.lara_start
+      record.lara_duration = record.lara_end   - record.lara_start
+    else
+      record.lara_duration = 0
+    end
+
     record.portal_duration = record.portal_end - record.portal_start
-    record.elapsed_seconds = record.portal_end - record.lara_start
+
+    if record.lara_start
+      record.elapsed_seconds = record.portal_end - record.lara_start
+    else
+      record.elapsed_seconds = record.portal_end - record.lara_end
+    end
 
     record.duration        = humanize(record.elapsed_seconds)
     record.login           = (record.learner.student.user.login           rescue 'unknown login').to_s
     record.teacher         = (record.learner.offering.clazz.teacher.name  rescue 'unknown teacher').to_s
     record.url             = (record.learner.offering.runnable.url        rescue 'unknown runnable url').to_s
+    # answers_length is not stored in the database because it is likely that we'll stop storing
+    # this model completely and just log the data
+    record.log_event(answers_length)
     return record
   end
 
+  def log_event(answers_length)
+    # this is structured so CloudWatch can parse it
+    info = "#{elapsed_seconds} #{portal_duration} #{lara_duration} #{answers_length} #{learner_id} #{url}"
+    if lara_start
+      logger.info "LearnerProcessingEventWithLaraStart #{info}"
+    else
+      logger.info "LearnerProcessingEvent #{info}"
+    end
+  end
 
   def self.avg_delay(hours=2)
     self.where("updated_at > ?", hours.hours.ago).average(:elapsed_seconds)
@@ -48,11 +71,12 @@ class LearnerProcessingEvent < ActiveRecord::Base
     self.where("updated_at > ?", hours.hours.ago).maximum(:elapsed_seconds)
   end
 
+  # only include records that have a valid lara_start
   def self.histogram(hours=12)
     hours.times.to_a.reverse.map do |h|
       start_time = (h+1).hours.ago
       end_time   = h.hours.ago
-      range = self.where("updated_at  > ? and updated_at < ?", start_time, end_time)
+      range = self.where("lara_start IS NOT NULL and updated_at  > ? and updated_at < ?", start_time, end_time)
       {
         total: range.average(:elapsed_seconds).to_i,
         lara: range.average(:lara_duration).to_i,

--- a/spec/models/dataservice/v1/process_external_Activity_data_job_spec.rb
+++ b/spec/models/dataservice/v1/process_external_Activity_data_job_spec.rb
@@ -1,0 +1,56 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+
+describe Dataservice::V1::ProcessExternalActivityDataJob do
+  let(:template)     { mock({open_responses: [], multiple_choices: [], image_questions: [], iframes: []}) }
+  let(:runnable)     { mock(template: template) }
+  let(:offering)     { mock(runnable: runnable, id: 23) }
+  let(:report_learner) { mock('last_run=' => true, update_fields: true) }
+  let(:learner)      { mock(offering: offering, report_learner: report_learner) }
+  let(:event)        { mock() }
+  before(:each) do
+    Portal::Learner.stub!(:find => learner)
+  end
+
+  subject { Dataservice::V1::ProcessExternalActivityDataJob.new(23,json_content, Time.now())}
+
+  describe "#perform" do
+    describe "without lara_start" do
+      let(:json_content) do
+        {
+          answers: [
+          ]
+        }.to_json
+      end
+
+      it "should build a LearnerProcessingEvent with a nil lara_start" do
+        LearnerProcessingEvent.should_receive(:build_proccesing_event)
+          .with(learner, nil, an_instance_of(Time), an_instance_of(Time), 0) {
+            event
+          }
+        event.should_receive(:save)
+        subject.perform
+      end
+    end
+
+    describe "with lara_start" do
+      let(:lara_start) { DateTime.new(1976,2,23) }
+      let(:json_content) do
+        {
+          lara_start: lara_start.to_s,
+          answers: [
+          ]
+        }.to_json
+      end
+
+      it "the create a LearnerProcessingEvent with lara_start" do
+        LearnerProcessingEvent.should_receive(:build_proccesing_event)
+          .with(learner, lara_start, an_instance_of(Time), an_instance_of(Time), 0) {
+            event
+          }
+        event.should_receive(:save)
+        subject.perform
+      end
+    end
+
+  end
+end

--- a/spec/models/learner_processing_event_spec.rb
+++ b/spec/models/learner_processing_event_spec.rb
@@ -8,7 +8,11 @@ describe LearnerProcessingEvent do
   let(:lara_start)               { 10.minutes.ago }
   let(:lara_end)                 { 5.minutes.ago  }
   let(:portal_start)             { 2.minutes.ago  }
-  let(:record)                   { LearnerProcessingEvent.build_proccesing_event(learner, lara_start, lara_end, portal_start)}
+  let(:answers_length)           { 1 }
+  let(:record)                   {
+    LearnerProcessingEvent.build_proccesing_event(
+      learner, lara_start, lara_end, portal_start, answers_length)
+  }
   before(:each) do
 
   end


### PR DESCRIPTION
This also adds the answer count to the log message.
In additional it handles a new case where lara_start is nil
lara_start will be nil if there aren't any 'dirty' or modified answers in the data sent from LARA.

If the logging mechanism works with CloudWatch then I'm going to consider
not storing these events in the database and removing the web routes to access the data.
I won't really know how it works out until we get this on staging and I can try setting up the CloudWatch metrics.

https://www.pivotaltracker.com/story/show/157824597