### PR TITLE
An Investigation should not be returned by the search api.

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -40,17 +40,10 @@ class Search
   InteractiveMaterial     = "Interactive"
   AllMaterials            = [InvestigationMaterial, ActivityMaterial, InteractiveMaterial]
 
-  #
-  # A constant with all searchable models. 
-  #
-  AllSearchableModels       = [ Investigation, 
-                                Activity, 
-                                ExternalActivity, 
-                                Interactive ]
+  AllSearchableModels       = [ ExternalActivity ]
 
-  DefaultSearchableModels   = [ Investigation, 
-                                Activity, 
-                                ExternalActivity ]
+  DefaultSearchableModels   = [ ExternalActivity ]
+
 
   Newest       = 'Newest'
   Oldest       = 'Oldest'

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -40,9 +40,10 @@ class Search
   InteractiveMaterial     = "Interactive"
   AllMaterials            = [InvestigationMaterial, ActivityMaterial, InteractiveMaterial]
 
-  AllSearchableModels       = [ ExternalActivity ]
+  AllSearchableModels       = [ ExternalActivity, Interactive]
 
   DefaultSearchableModels   = [ ExternalActivity ]
+
 
 
   Newest       = 'Newest'

--- a/spec/controllers/api/v1/search_controller_spec.rb
+++ b/spec/controllers/api/v1/search_controller_spec.rb
@@ -45,14 +45,24 @@ describe API::V1::SearchController do
                                         :is_official => true,
                                         :material_type => 'Activity' ) }
 
-  let(:contributed_activity) { Factory.create(:external_activity, 
-                                        :name => "Copy of external_1", 
-                                        :url => "http://concord.org", 
-                                        :publication_status => 'published', 
+
+  let(:external_activity3)   { Factory.create(:external_activity,
+                                        :name => 'a_study_in_lines_and_curves',
+                                        :url => "http://github.com",
+                                        :publication_status =>
+                                        'published',
+                                        :is_official => true,
+                                        :material_type => 'Investigation' ) }
+
+
+  let(:contributed_activity) { Factory.create(:external_activity,
+                                        :name => "Copy of external_1",
+                                        :url => "http://concord.org",
+                                        :publication_status => 'published',
                                         :is_official => false,
                                         :material_type => 'Activity' ) }
 
-  let(:all_investigations)    { [physics_investigation, chemistry_investigation, biology_investigation, mathematics_investigation, lines]}
+  let(:all_investigations)    { [physics_investigation, chemistry_investigation, biology_investigation, mathematics_investigation, lines, external_activity3]}
   let(:official_activities)   { [laws_of_motion_activity, fluid_mechanics_activity, thermodynamics_activity, parallel_lines, external_activity1, external_activity2]}
   let(:contributed_activities){ [contributed_activity] }
   let(:all_activities)        {  official_activities.concat(contributed_activities) }
@@ -90,15 +100,15 @@ describe API::V1::SearchController do
       end
 
       describe "with no filter parameters" do
-        it "should return search results that show all the materials" do
+        it "should return search results that shows only external activity based materials" do
           assigns[:search].should_not be_nil
           assigns[:search].results[Search::InvestigationMaterial].should_not be_nil
-          assigns[:search].results[Search::InvestigationMaterial].length.should be(5)
+          assigns[:search].results[Search::InvestigationMaterial].length.should be(1)
           assigns[:search].results[Search::InvestigationMaterial].each do |investigation|
             all_investigations.should include(investigation)
           end
           assigns[:search].results[Search::ActivityMaterial].should_not be_nil
-          assigns[:search].results[Search::ActivityMaterial].length.should be(7)
+          assigns[:search].results[Search::ActivityMaterial].length.should be(3)
           assigns[:search].results[Search::ActivityMaterial].each do |activity|
             all_activities.should include(activity)
           end
@@ -109,12 +119,12 @@ describe API::V1::SearchController do
         let(:get_params) { {:include_official => 1} }
         it "should show all official study materials" do
           assigns[:search].results[Search::InvestigationMaterial].should_not be_nil
-          assigns[:search].results[Search::InvestigationMaterial].length.should be(5)
+          assigns[:search].results[Search::InvestigationMaterial].length.should be(1)
           assigns[:search].results[Search::InvestigationMaterial].each do |investigation|
             all_investigations.should include(investigation)
           end
           assigns[:search].results[Search::ActivityMaterial].should_not be_nil
-          assigns[:search].results[Search::ActivityMaterial].length.should be(6)
+          assigns[:search].results[Search::ActivityMaterial].length.should be(2)
           assigns[:search].results[Search::ActivityMaterial].each do |activity|
             official_activities.should include(activity)
           end
@@ -133,7 +143,7 @@ describe API::V1::SearchController do
 
         it "should return all investigations" do
           assigns[:search].results[Search::InvestigationMaterial].should_not be_nil
-          assigns[:search].results[Search::InvestigationMaterial].length.should be(5)
+          assigns[:search].results[Search::InvestigationMaterial].length.should be(1)
         end
 
         it "should not return any activities" do
@@ -149,7 +159,7 @@ describe API::V1::SearchController do
         end
         it "should return all activities" do
           assigns[:search].results[Search::ActivityMaterial].should_not be_nil
-          assigns[:search].results[Search::ActivityMaterial].length.should be(7)
+          assigns[:search].results[Search::ActivityMaterial].length.should be(3)
           assigns[:search].results[Search::ActivityMaterial].each do |activity|
             all_activities.should include(activity)
           end

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -119,15 +119,17 @@ describe Search do
     let(:external_seq) { external_base.merge({ :template => private_investigations.first})}
     let(:external_act) { external_base.merge({ :template => private_activities.first})}
 
+    # Activities and Sequence should no longer show up in search results.
     let(:public_investigations) { collection(:investigation, 2, public_opts) }
     let(:private_investigations){ collection(:investigation, 2, private_opts)}
     let(:public_activities)     { collection(:activity, 2, public_opts)      }
     let(:private_activities)    { collection(:activity, 2, private_opts)     }
+
     let(:public_ext_act)        { collection(:external_activity, 2, external_act.merge(public_opts).merge(official))  }
     let(:private_ext_act)       { collection(:external_activity, 2, external_act.merge(private_opts).merge(official)) }
     let(:public_ext_seq)        { collection(:external_activity, 2, external_seq.merge(public_opts).merge(official))  }
     let(:private_ext_seq)       { collection(:external_activity, 2, external_seq.merge(private_opts).merge(official)) }
-    let(:assessment_activities) { collection(:activity, 2, assessment_opts) }
+    let(:assessment_activities) { collection(:external_activity, 2, assessment_opts) }
     let(:search_opts) { {} }
 
     subject do
@@ -141,7 +143,7 @@ describe Search do
 
       describe "searching for materials with tricky names" do
         let(:funny_name)       { "" }
-        let(:funny_activity)   { FactoryGirl.create(:activity, public_opts.merge(:name=>funny_name)) }
+        let(:funny_activity)   { FactoryGirl.create(:external_activity, public_opts.merge(:name=>funny_name)) }
         let(:search_opts)      { {:search_term => search_term} }
         let(:search_term)      { "" }
         let(:materials)        { [funny_activity] }
@@ -258,10 +260,12 @@ describe Search do
 
       describe "searching public items" do
         let(:search_opts) { {:private => false } }
-        it "results should include 4 public activities and 4 public investigations" do
-          subject.results[:all].should have(8).entries
-          subject.results[Search::InvestigationMaterial].should have(4).entries
-          subject.results[Search::ActivityMaterial].should have(4).entries
+        it "results should include 4 public external_activities" do
+          subject.results[:all].should have(4).entries
+          # Sequence externals
+          subject.results[Search::InvestigationMaterial].should have(2).entries
+          # Actvitiy externals
+          subject.results[Search::ActivityMaterial].should have(2).entries
         end
       end
 
@@ -290,18 +294,17 @@ describe Search do
 
       describe "searching all items" do
         let(:search_opts) { {:private => true, :include_templates => true} }
-        it "results should include 8 activities and 8 investigations" do
-          # subject.results[:all].should have(16).entries
-          subject.results[Search::InvestigationMaterial].should have(8).entries
-          subject.results[Search::ActivityMaterial].should have(8).entries
+        it "results should include 4 external activities and 4 external sequences" do
+          subject.results[Search::InvestigationMaterial].should have(4).entries
+          subject.results[Search::ActivityMaterial].should have(4).entries
         end
       end
 
-      describe "searching only public Investigations" do
+      describe "searching only public Sequences" do
         let(:search_opts) { {:private  => false, :material_types => ["Investigation"]} }
         it "results should include 4 investigations" do
-          subject.results[:all].should have(4).entries
-          subject.results[Search::InvestigationMaterial].should have(4).entries
+          subject.results[:all].should have(2).entries
+          subject.results[Search::InvestigationMaterial].should have(2).entries
         end
       end
 
@@ -367,10 +370,10 @@ describe Search do
 
       describe "searching with user_id" do
         let(:my_id)          { 23 }
-        let(:my_activity)    { FactoryGirl.create(:activity, {:publication_status => "private", :user_id => my_id })}
-        let(:someone_elses)  { FactoryGirl.create(:activity, {:publication_status => "private", :user_id => 777   })}
+        let(:my_activity)    { FactoryGirl.create(:external_activity, {:publication_status => "private", :user_id => my_id })}
+        let(:someone_elses)  { FactoryGirl.create(:external_activity, {:publication_status => "private", :user_id => 777   })}
         let(:private_items)  { [my_activity,someone_elses]}
-        let(:public_items)   { collection(:activity, 2, public_opts)}
+        let(:public_items)   { collection(:external_activity, 2, public_opts)}
         let(:search_opts)     {{ :private => false, :user_id => my_id }}
         before(:each) do
           User.stub!(:find => mock_user)
@@ -414,15 +417,15 @@ describe Search do
             let(:cohort2_opts) {{:publication_status=>'published', :cohorts => [cohort2] }}
             let(:both_opts)    {{:publication_status=>'published', :cohorts => [cohort1, cohort2] }}
 
-            let(:blank_sequence)     { collection(:investigation, 1, public_opts) }
-            let(:cohort1_sequences)  { collection(:investigation, 2, cohort1_opts)}
-            let(:cohort2_sequences)  { collection(:investigation, 2, cohort2_opts)}
-            let(:both_sequences)     { collection(:investigation, 1, both_opts)}
+            let(:blank_sequence)     { collection(:external_activity, 1, external_seq.merge( public_opts)) }
+            let(:cohort1_sequences)  { collection(:external_activity, 2, external_seq.merge(cohort1_opts))}
+            let(:cohort2_sequences)  { collection(:external_activity, 2, external_seq.merge(cohort2_opts))}
+            let(:both_sequences)     { collection(:external_activity, 1, external_seq.merge(both_opts))}
 
-            let(:blank_activity)     { collection(:activity, 1, public_opts) }
-            let(:cohort1_activities) { collection(:activity, 2, cohort1_opts)}
-            let(:cohort2_activities) { collection(:activity, 2, cohort2_opts)}
-            let(:both_activity)      { collection(:activity, 1, both_opts)}
+            let(:blank_activity)     { collection(:external_activity, 1, public_opts) }
+            let(:cohort1_activities) { collection(:external_activity, 2, cohort1_opts)}
+            let(:cohort2_activities) { collection(:external_activity, 2, cohort2_opts)}
+            let(:both_activity)      { collection(:external_activity, 1, both_opts)}
 
             let(:blank_external)     { collection(:external_activity, 1, external_base.merge(official).merge(public_opts).merge({:material_type => 'Activity'}) ) }
             let(:cohort1_externals)  { collection(:external_activity, 2, external_base.merge(official).merge(cohort1_opts).merge({:material_type => 'Activity'})) }


### PR DESCRIPTION
@scytacki -- The search model fix was simple.  

This search model is used by the API search controller.
 
I verified that search works on my local system with public Investigations and published sequences from authoring showing up as 'sequences'.  

The search model spec test was failing, so I adjusted to conform with our new expectations.


[#158042177]

https://www.pivotaltracker.com/story/show/158042177