### PR TITLE
Added peer-to-peer api authentication [#157488572]

### DIFF
--- a/app/controllers/api/v1/classes_controller.rb
+++ b/app/controllers/api/v1/classes_controller.rb
@@ -2,8 +2,11 @@ class API::V1::ClassesController < API::APIController
 
   # GET api/v1/classes/:id
   def show
-    user, role = check_for_auth_token()
-    return if !user
+    begin
+      user, role = check_for_auth_token(params)
+    rescue StandardError => e
+      return error(e.message)
+    end
 
     if user.anonymous?
       return error('You must be logged in to use this endpoint')
@@ -31,8 +34,11 @@ class API::V1::ClassesController < API::APIController
   # GET api/v1/classes/mine
   # lists the users classes
   def mine
-    user, role = check_for_auth_token()
-    return if !user
+    begin
+      user, role = check_for_auth_token(params)
+    rescue StandardError => e
+      return error(e.message)
+    end
 
     if user.anonymous?
       return error('You must be logged in to use this endpoint')

--- a/app/controllers/api/v1/external_activities_controller.rb
+++ b/app/controllers/api/v1/external_activities_controller.rb
@@ -5,8 +5,11 @@ class API::V1::ExternalActivitiesController < API::APIController
   def create
     authorize [:api, :v1, :external_activity]
 
-    user, role = check_for_auth_token()
-    return if !user
+    begin
+      user, role = check_for_auth_token(params)
+    rescue StandardError => e
+      return error(e.message)
+    end
 
     name = params.require(:name)
     url = params.require(:url)

--- a/app/controllers/api/v1/jwt_controller.rb
+++ b/app/controllers/api/v1/jwt_controller.rb
@@ -4,8 +4,11 @@ class API::V1::JwtController < API::APIController
   skip_before_filter :verify_authenticity_token
 
   def portal
-    user, role = check_for_auth_token()
-    return if !user
+    begin
+      user, role = check_for_auth_token(params)
+    rescue StandardError => e
+      return error(e.message)
+    end
 
     if role
       learner = role[:learner]
@@ -34,7 +37,7 @@ class API::V1::JwtController < API::APIController
 
     begin
       render status: 201, json: {token: SignedJWT::create_portal_token(user, claims, 3600)}
-    rescue Exception => e
+    rescue StandardError => e
       return error(e.message, 500)
     end
   end
@@ -43,8 +46,11 @@ class API::V1::JwtController < API::APIController
   # POST api/v1/jwt/firebase as a logged in user, or
   # GET  api/v1/jwt/firebase?firebase_app=abc with a valid bearer token
   def firebase
-    user, role = check_for_auth_token()
-    return if !user
+    begin
+      user, role = check_for_auth_token(params)
+    rescue StandardError => e
+      return error(e.message)
+    end
 
     if role
       learner = role[:learner]
@@ -95,7 +101,7 @@ class API::V1::JwtController < API::APIController
 
     begin
       render status: 201, json: {token: SignedJWT::create_firebase_token(uid, params[:firebase_app], 3600, claims)}
-    rescue Exception => e
+    rescue StandardError => e
       return error(e.message, 500)
     end
   end

--- a/lib/signed_jwt.rb
+++ b/lib/signed_jwt.rb
@@ -17,7 +17,7 @@ module SignedJWT
     payload.merge!(claims) { |key, old, new| fail "Duplicate JWT claim key: #{key}" }
     begin
       JWT.encode payload, self.hmac_secret, self.hmac_algorithm
-    rescue Exception => e
+    rescue StandardError => e
       raise SignedJWT::Error.new(e.message)
     end
   end
@@ -25,7 +25,7 @@ module SignedJWT
   def self.decode_portal_token(token)
     begin
       decoded = JWT.decode token, self.hmac_secret, true, {algorithm: self.hmac_algorithm}
-    rescue Exception => e
+    rescue StandardError => e
       raise SignedJWT::Error.new(e.message)
     end
     {data: decoded[0], header: decoded[1]}
@@ -51,7 +51,7 @@ module SignedJWT
       payload.merge!(claims) { |key, old, new| fail "Duplicate JWT claim key: #{key}" }
       rsa_private = OpenSSL::PKey::RSA.new(app.private_key)
       JWT.encode payload, rsa_private, self.rsa_algorithm
-    rescue Exception => e
+    rescue StandardError => e
       raise SignedJWT::Error.new(e.message)
     end
   end
@@ -64,7 +64,7 @@ module SignedJWT
     begin
       rsa_private = OpenSSL::PKey::RSA.new(app.private_key)
       decoded = JWT.decode token, rsa_private, true, {algorithm: self.rsa_algorithm}
-    rescue Exception => e
+    rescue StandardError => e
       raise SignedJWT::Error.new(e.message)
     end
     {data: decoded[0], header: decoded[1]}


### PR DESCRIPTION
This was added to allow LARA to proxy firebase api calls from javascript clients.

This commit also changes the check_for_auth_token() method so that it
now raises an exception when no valid auth token is found instead of
directly rendering an error.

Finally, the new rescue code and the existing recue code that was
listening for Exception have been changed to listen for StandardError
as listening for Exception also swallows errors such as SyntaxError.