### PR TITLE
New unison approach

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,13 +1,19 @@
 FROM concordconsortium/docker-rails-base-ruby-2.2.6
 
-ENV APP_HOME /rigse
-RUN mkdir $APP_HOME
-WORKDIR $APP_HOME
-
 #
 # Install some basic dev tools
 #
 RUN apt-get update && apt-get install -y vim xvfb firefox-esr
+
+#
+# Install wait-for-it to support docker-volume-sync
+WORKDIR /usr/local/bin
+RUN wget https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh && \
+    chmod +x wait-for-it.sh
+
+ENV APP_HOME /rigse
+RUN mkdir $APP_HOME
+WORKDIR $APP_HOME
 
 # use a mounted volume so the gems don't need to be rebundled each time
 ENV BUNDLE_PATH /bundle

--- a/docker/dev/docker-compose-sync.yml
+++ b/docker/dev/docker-compose-sync.yml
@@ -1,28 +1,25 @@
-
-
-# This is an docker-compose overlay that uses unison for syncing files between the host
+# This is a docker-compose overlay that uses unison for syncing files between the host
 # and containers.  On OS X it is much faster than simple mounting of local files
-# You need to run docker/dev/start-unison.sh to start the sync
 
 # A convient way to overlay this file is to add a `.env` file with the contents:
-#  COMPOSE_FILE=docker-compose.yml:docker/dev/docker-compose-unison.yml
-# You can also do it manually when you run docker-compose each time with
-# docker-compose -f docker-compose.yml -f docker/dev/docker-compose-unison.yml
+#  COMPOSE_FILE=docker-compose.yml:docker/dev/docker-compose-sync.yml
 # if you are making changes to docker-compose.yml or this file it is useful to
 # run `docker-compose config` which shows how the two files get merged together
 version: '3'
 services:
   app:
+    entrypoint: [ "/bin/bash", "/usr/local/bin/wait-for-it.sh", "sync:5001", "-s", "-t", "60", "--" ]
     depends_on:
-      - unison
+      - sync
     volumes:
-      - unison2:/rigse
+      - sync-volume:/rigse
+
   solr:
     volumes:
-      - unison2:/rigse
-  unison:
+      - sync-volume:/rigse
+  sync:
     # the version of unison in this container needs to match the verson on your machine
-    image: dockerunison_unison
+    image: concordconsortium/docker-volume-sync
     environment:
       # root is used here since the app is running as root so any files it creates
       # will be owned by root, and then unison should be able to override them
@@ -33,7 +30,7 @@ services:
       UNISON_DIR: /data
       UNISON_HOST_DIR: /host_data
     volumes:
-      - unison2:/data
+      - sync-volume:/data
       - .:/host_data:cached
 volumes:
-  unison2:
+  sync-volume:

--- a/docker/dev/docker-compose-unison2.yml
+++ b/docker/dev/docker-compose-unison2.yml
@@ -1,0 +1,39 @@
+
+
+# This is an docker-compose overlay that uses unison for syncing files between the host
+# and containers.  On OS X it is much faster than simple mounting of local files
+# You need to run docker/dev/start-unison.sh to start the sync
+
+# A convient way to overlay this file is to add a `.env` file with the contents:
+#  COMPOSE_FILE=docker-compose.yml:docker/dev/docker-compose-unison.yml
+# You can also do it manually when you run docker-compose each time with
+# docker-compose -f docker-compose.yml -f docker/dev/docker-compose-unison.yml
+# if you are making changes to docker-compose.yml or this file it is useful to
+# run `docker-compose config` which shows how the two files get merged together
+version: '3'
+services:
+  app:
+    depends_on:
+      - unison
+    volumes:
+      - unison2:/rigse
+  solr:
+    volumes:
+      - unison2:/rigse
+  unison:
+    # the version of unison in this container needs to match the verson on your machine
+    image: dockerunison_unison
+    environment:
+      # root is used here since the app is running as root so any files it creates
+      # will be owned by root, and then unison should be able to override them
+      UNISON_UID: 0
+      UNISON_GID: 0
+      UNISON_USER: root
+      UNISON_GROUP: root
+      UNISON_DIR: /data
+      UNISON_HOST_DIR: /host_data
+    volumes:
+      - unison2:/data
+      - .:/host_data:cached
+volumes:
+  unison2:


### PR DESCRIPTION
this uses unison inside of a container to sync two volumes.  The first volume `UNISON_HOST_DIR` is mounted as a standard docker bind mount.  That `UNISON_HOST_DIR` gets sync'd to the `UNISON_DIR` which is a named volume that is shared with the app container.  This isolation of the two volumes allows the app container to run at full speed.