### PR TITLE
Remove MaterialsCollectionItems that are not templates

### DIFF
--- a/db/migrate/20180612151521_remove_non_template_materials_collection_items.rb
+++ b/db/migrate/20180612151521_remove_non_template_materials_collection_items.rb
@@ -1,0 +1,11 @@
+class RemoveNonTemplateMaterialsCollectionItems < ActiveRecord::Migration
+  class MaterialsCollectionItem < ActiveRecord::Base
+  end
+
+  def up
+    MaterialsCollectionItem.where("material_type <> 'ExternalActivity'").destroy_all
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20180514200133) do
+ActiveRecord::Schema.define(:version => 20180612151521) do
 
   create_table "access_grants", :force => true do |t|
     t.string   "code"


### PR DESCRIPTION
This fixes a bug where the material collections index page was not loading.
These items are not needed anymore, they wouldn't run anyhow.

[#158164024]