### PR TITLE
remove dead code: active classes finder

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -585,17 +585,6 @@ module ApplicationHelper
     end
   end
 
-  def menu_for_school(school, options = { :omit_delete => true, :omit_edit => true, :hide_componenent_name => true })
-    capture_haml do
-      haml_tag :div, :class => 'action_menu' do
-        haml_tag :div, :class => 'action_menu_header_left' do
-          haml_concat title_for_component(school, options)
-          haml_concat "active classes: #{school.clazzes.active.length}"
-        end
-      end
-    end
-  end
-
   def show_menu_for(component, options={})
     is_page_element = (component.respond_to? :embeddable)
     deletable_element = component

--- a/app/models/portal/clazz.rb
+++ b/app/models/portal/clazz.rb
@@ -65,10 +65,6 @@ class Portal::Clazz < ActiveRecord::Base
     def searchable_attributes
       @@searchable_attributes
     end
-
-    def has_offering
-      Portal::Offering.find(:all, :select => 'distinct clazz_id', :include => :clazz).collect {|p| p.clazz}
-    end
   end
 
   def self.find_or_create_by_course_and_section_and_start_date(portal_course,section,start_date)

--- a/app/models/portal/school.rb
+++ b/app/models/portal/school.rb
@@ -16,11 +16,7 @@ class Portal::School < ActiveRecord::Base
   has_many :grades, :through => :grade_levels, :class_name => "Portal::Grade"
   # has_many :clazzes, :through => :courses, :class_name => "Portal::Clazz"
 
-  has_many :clazzes, :dependent => :destroy, :through => :courses, :class_name => "Portal::Clazz" do
-    def active
-      find(:all) & Portal::Clazz.has_offering
-    end
-  end
+  has_many :clazzes, :dependent => :destroy, :through => :courses, :class_name => "Portal::Clazz"
 
   has_many :members, :class_name => "Portal::SchoolMembership", :foreign_key => "school_id"
 

--- a/app/views/portal/schools/_show.html.haml
+++ b/app/views/portal/schools/_show.html.haml
@@ -1,6 +1,4 @@
 - display_name = "#{portal_school.name}"
-- if local_assigns[:show_classes]
-  - display_name += " active classes: #{portal_school.clazzes.active.length}"
 - options = { :hide_componenent_name => true, :display_name => display_name }
 = accordion_for(portal_school, show_menu_for(portal_school, options), 'accordion') do
   %div{:id => dom_id_for(portal_school, :item), :class => 'item'}
@@ -11,7 +9,3 @@
         - if portal_school.ncessch
           NCES ID :
           =link_to "#{portal_school.ncessch}","http://nces.ed.gov/ccd/schoolsearch/school_detail.asp?ID=#{portal_school.ncessch}", {target: "blank"}
-        - if local_assigns[:show_classes]
-          = render :partial => 'shared/classes_for_school', :locals => { :portal_clazzes => portal_school.clazzes.active }
-
-


### PR DESCRIPTION
Dave and I started looking at out dated Active record finders.  We started with one in Portal::Clazz and then figured out that it wasn't actually used anymore.  It was also very in efficient so we just removed it and all of the code associated with it. 

[#158305089]