### PR TITLE
this new base image has bundler 1.16.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM concordconsortium/docker-rails-base-ruby-2.2.6
+FROM concordconsortium/docker-rails-base-ruby-2.2.6:1.1
 
 # install nginx
 RUN apt-get update -qq && apt-get install -qq -y nginx
@@ -49,7 +49,7 @@ RUN cp docker/prod/config/settings.yml config/settings.yml
 EXPOSE 80
 
 # this font is used by imagemagick to add attribution to the images in the image library
-# the DejaVu-Sans font is provided by the docker image this one is built on 
+# the DejaVu-Sans font is provided by the docker image this one is built on
 ENV WATERMARK_FONT=DejaVu-Sans
 
 CMD ./docker/prod/run.sh

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM concordconsortium/docker-rails-base-ruby-2.2.6
+FROM concordconsortium/docker-rails-base-ruby-2.2.6:1.1
 
 #
 # Install some basic dev tools


### PR DESCRIPTION
This is basically just a rebuild and push of docker-rails-base-ruby22.

It does have one other change which is to specify the minor version of rails, and also to do better at cleaning up the old version of bundler:
https://github.com/concord-consortium/docker-rails-base/commit/ebc51976a468771e8e99017e378084d1f343da5a