### PR TITLE
Fix issue with author listing in other activities bin

### DIFF
--- a/app/controllers/api/v1/materials_bin_controller.rb
+++ b/app/controllers/api/v1/materials_bin_controller.rb
@@ -69,9 +69,9 @@ class API::V1::MaterialsBinController < API::APIController
 
   def filtered_materials(materials, user_id = -1)
     materials = materials.where(is_assessment_item: false) unless show_assessment_items
-    materials = materials.reject { |m| m.archived? }
+    materials = materials.where(is_archived: false)
     if current_user.nil? || (current_user.id != user_id.to_i && current_user.does_not_have_role?('admin'))
-      materials = materials.select { |material| material.public? }
+      materials = materials.where(publication_status: 'published')
     end
     materials
   end

--- a/spec/controllers/api/v1/materials_bin_controller_spec.rb
+++ b/spec/controllers/api/v1/materials_bin_controller_spec.rb
@@ -80,8 +80,9 @@ describe API::V1::MaterialsBinController do
     # Make sure that objects are saved to DB.
     cohort_activity.cohorts = [foo_cohort]
     act1; user2_public_activity; official_activity; cohort_activity; user2_private_activity; inv
-    # the order maters here. in the code we are testing if the filters are applied
-    # after the grouping then this user will not show up
+    # the order matters here. in the code we are testing if the filters are applied
+    # after the grouping then only the archived activity will be in the list and this user will not show up
+    # if the code is working correctly then it will find user4_public_activity and the user will show up
     user4_archived_activity; user4_private_activity; user4_public_activity
   end
 

--- a/spec/controllers/api/v1/materials_bin_controller_spec.rb
+++ b/spec/controllers/api/v1/materials_bin_controller_spec.rb
@@ -61,6 +61,7 @@ describe API::V1::MaterialsBinController do
   let(:user1) { t = FactoryGirl.create(:teacher); t.user }
   let(:user2) { t = FactoryGirl.create(:teacher); t.user }
   let(:user3) { t = FactoryGirl.create(:teacher); t.user }
+  let(:user4) { t = FactoryGirl.create(:teacher); t.user }
   let (:act1) { FactoryGirl.create(:external_activity, user: user1, publication_status: 'published') }
   let (:user2_public_activity) { FactoryGirl.create(:external_activity, user: user2, publication_status: 'published', is_assessment_item: true) }
   let (:user2_private_activity) { FactoryGirl.create(:external_activity, user: user2, publication_status: 'private') }
@@ -70,11 +71,18 @@ describe API::V1::MaterialsBinController do
   let (:user3_private_activity) { FactoryGirl.create(:external_activity, user: user3, publication_status: 'private') }
   # investigation is considered to be always official
   let (:inv) { FactoryGirl.create(:investigation, user: user3, publication_status: 'published') }
+  # user with an archived and private activity
+  let (:user4_archived_activity) { FactoryGirl.create(:external_activity, user: user4, is_archived: true) }
+  let (:user4_private_activity) { FactoryGirl.create(:external_activity, user: user4, publication_status: 'private') }
+  let (:user4_public_activity) { FactoryGirl.create(:external_activity, user: user4, publication_status: 'published') }
 
   def populate_example_materials
     # Make sure that objects are saved to DB.
     cohort_activity.cohorts = [foo_cohort]
     act1; user2_public_activity; official_activity; cohort_activity; user2_private_activity; inv
+    # the order maters here. in the code we are testing if the filters are applied
+    # after the grouping then this user will not show up
+    user4_archived_activity; user4_private_activity; user4_public_activity
   end
 
   describe 'GET unofficial_materials_authors' do
@@ -86,10 +94,12 @@ describe API::V1::MaterialsBinController do
         get :unofficial_materials_authors
         expect(response.status).to eql(200)
         results = JSON.parse(response.body)
-        # Only act1 is public, not assigned to any cohort and not an assessment item.
-        expect(results.length).to eql(1)
+        # Only act1 and user4_public_activity is public, not assigned to any cohort and not an assessment item.
+        expect(results.length).to eql(2)
         expect(results[0]['id']).to eql(user1.id)
         expect(results[0]['name']).to eql(user1.name)
+        expect(results[1]['id']).to eql(user4.id)
+        expect(results[1]['name']).to eql(user4.name)
       end
     end
 
@@ -101,10 +111,11 @@ describe API::V1::MaterialsBinController do
         get :unofficial_materials_authors
         expect(response.status).to eql(200)
         results = JSON.parse(response.body)
-        expect(results.length).to eql(3)
+        expect(results.length).to eql(4)
         expect(results.select {|r| r['id'] == user1.id}.length).to eql(1)
         expect(results.select {|r| r['id'] == user2.id}.length).to eql(1)
         expect(results.select {|r| r['id'] == user3.id}.length).to eql(1)
+        expect(results.select {|r| r['id'] == user4.id}.length).to eql(1)
       end
     end
   end


### PR DESCRIPTION
The main issue here was that the filtered_materials method was being called on a active record relation that was grouped by users.  So only the first of the user's materials was in the list.  The way the method was working would then reject any archived or non-published materials (if the user isn't an admin).  So even if a user had valid materials, if their first material did not match the criteria then the user would not be listed. 

[#158570912]