### PR TITLE
Add tag based sensor filter

### DIFF
--- a/app/assets/javascripts/search_materials.js
+++ b/app/assets/javascripts/search_materials.js
@@ -16,7 +16,7 @@ jQuery(function () {
 
 function setAllProbesSelected(allChecked) {
     var anythingModified = false;
-    $$(".probe_items").each(function(e) {
+    $$(".sensor_filter_item").each(function(e) {
         // Convert values to boolean, as checked attribute may be a string like "checked".
         if (!!e.checked !== !!allChecked) {
             e.checked = allChecked;

--- a/app/assets/stylesheets/web/search_materials.scss
+++ b/app/assets/stylesheets/web/search_materials.scss
@@ -212,14 +212,14 @@ search_materials{
   background-color:white;
 }
 
-.probes_container{
+.sensors_container{
   overflow:auto;
   max-height:190px;
   background-color:white;
   border: 1px solid #CCC;
   padding-left: 5px;
   }
-.probes_label{
+.sensors_label{
   text-transform:none;
 }
 .material_list {

--- a/app/models/external_activity.rb
+++ b/app/models/external_activity.rb
@@ -33,13 +33,6 @@ class ExternalActivity < ActiveRecord::Base
     boolean :is_template do
       false
     end
-    # TODO: Support probes via tags
-    integer :probe_type_ids, :multiple => true do
-      nil
-    end
-    boolean :no_probes do
-      true
-    end
 
     boolean :teacher_only do
       # Useful in Activity and Investigation; stubbed here

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -274,21 +274,6 @@ class Search
   #
   def add_custom_search_filters(search); end
 
-  def params
-    params = {}
-    keys = [:user_id, :material_types, :grade_span, :sensors, :private, :sort_order,
-      :per_page, :include_contributed,:include_mine, :investigation_page, :activity_page, :material_properties,
-      :grade_level_groups, :subject_areas, :project_ids ]
-    keys.each do |key|
-      value = self.send key
-      if value
-        params[key] = value
-      end
-    end
-    # TODO: remove coupled controller concerns from this:
-    params.merge({:controller => 'search', :action => 'index'})
-  end
-
   def types(*types)
     type_names = types.map { |t| t.name                           }
     self.results.select    { |r| type_names.include? r.class_name }
@@ -358,7 +343,6 @@ class Search
   end
 
   def search_by_sensors(search)
-    return if !no_sensors && sensors.blank?
     search.any_of do |s|
       s.with(:sensors, nil) if no_sensors
       s.with(:sensors).any_of(sensors) if sensors.present?

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -358,11 +358,10 @@ class Search
   end
 
   def search_by_sensors(search)
-    if no_sensors
-      search.with(:sensors, nil)
-    elsif sensors.present?
-      # this is a more concise version of way subject areas are doing it
-      search.with(:sensors).any_of(sensors)
+    return if !no_sensors && sensors.blank?
+    search.any_of do |s|
+      s.with(:sensors, nil) if no_sensors
+      s.with(:sensors).any_of(sensors) if sensors.present?
     end
   end
 

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -8,8 +8,6 @@ class Search
   attr_accessor :clean_material_types
   attr_accessor :sort_order
   attr_accessor :private
-  attr_accessor :probe
-  attr_accessor :no_probes
   attr_accessor :grade_span
   attr_accessor :domain_id
   attr_accessor :without_teacher_only
@@ -27,11 +25,14 @@ class Search
   attr_accessor :material_properties
   attr_accessor :grade_level_groups
   attr_accessor :subject_areas
+  attr_accessor :no_sensors
+  attr_accessor :sensors
   attr_accessor :project_ids
 
   attr_accessor :available_subject_areas
   attr_accessor :available_grade_level_groups
   attr_accessor :available_projects
+  attr_accessor :available_sensors
 
   attr_accessor :searchable_models
 
@@ -59,8 +60,7 @@ class Search
     Score        => [:score, :desc]
   }
   NoSearchTerm    = nil
-  NoGradeSpan     = NoDomainID = AnyProbeType =[]
-  NoProbeRequired = ["0"]
+  NoGradeSpan     = NoDomainID =[]
 
   def self.grade_level_groups
     { 'K-2' => ["K","1","2"], '3-4' => ["3","4"], '5-6' => ["5","6"], '7-8' => ["7","8"], '9-12' => ["9","10","11","12"], 'Higher Ed' => ["Higher Ed"] }
@@ -121,21 +121,21 @@ class Search
     self.grade_level_groups          = opts[:grade_level_groups] || []
     self.subject_areas               = opts[:subject_areas] || []
     self.project_ids                 = opts[:project_ids] || []
+    self.sensors                     = opts[:sensors] || []
     self.available_subject_areas     = []
     self.available_projects          = []
+    self.available_sensors           = []
     self.available_grade_level_groups = { 'K-2' => 0,'3-4' => 0,'5-6' => 0,'7-8' => 0,'9-12' => 0, 'Higher Ed' => 0 }
 
     self.results        = {}
     self.hits           = {}
     self.total_entries  = {}
-    self.no_probes      = false
 
     self.user_id        = opts[:user_id]
     self.user           = User.find(self.user_id)  if self.user_id
     self.engine         = opts[:engine]         || Sunspot
     self.grade_span     = opts[:grade_span]     || NoGradeSpan
-    self.probe          = opts[:probe]          || AnyProbeType
-    self.no_probes      = opts[:no_probes]      || false
+    self.no_sensors     = opts[:no_sensors]     || false
     self.private        = opts[:private]        || false
     self.sort_order     = opts[:sort_order]     || Newest
     self.per_page       = opts[:per_page]       || 10
@@ -151,7 +151,7 @@ class Search
     self.include_templates    = opts[:include_templates]   || false
     self.show_archived     = opts[:show_archived]    || false
 
-    self.fetch_available_grade_subject_areas_projects()
+    self.fetch_available_filter_options()
 
     #
     # Allow subclasses to add their own available search parameters
@@ -167,9 +167,10 @@ class Search
   #
   def fetch_custom_search_params; end
 
-  def fetch_available_grade_subject_areas_projects
+  def fetch_available_filter_options
     results = self.engine.search(self.searchable_models) do |s|
       s.facet :subject_areas
+      s.facet :sensors
       s.facet :grade_levels do
         Search.grade_level_groups.each do |key, value|
           row(key) do
@@ -193,6 +194,10 @@ class Search
       end
     end
     available_projects.uniq!
+    results.facet(:sensors).rows.each do |facet|
+      self.available_sensors << facet.value
+    end
+    available_sensors.uniq!
   end
 
   def search
@@ -215,7 +220,7 @@ class Search
         s.with(:domain_id, self.domain_id) unless self.domain_id.empty?
         s.with(:grade_span, self.grade_span) unless self.grade_span.empty?
 
-        search_by_probes(s)
+        search_by_sensors(s)
         search_by_authorship(s)
         search_by_material_properties(s)
         search_by_grade_levels(s)
@@ -271,7 +276,7 @@ class Search
 
   def params
     params = {}
-    keys = [:user_id, :material_types, :grade_span, :probe, :private, :sort_order,
+    keys = [:user_id, :material_types, :grade_span, :sensors, :private, :sort_order,
       :per_page, :include_contributed,:include_mine, :investigation_page, :activity_page, :material_properties,
       :grade_level_groups, :subject_areas, :project_ids ]
     keys.each do |key|
@@ -303,14 +308,6 @@ class Search
 
   def will_show_contributed
     self.include_contributed
-  end
-
-  def search_by_probes(search)
-    return if !self.no_probes && self.probe.empty? # no sensor filter selected, nothing to do.
-    search.any_of do |c|
-      c.with(:no_probes, true) if self.no_probes
-      c.with(:probe_type_ids, self.probe) unless (self.probe.empty?)
-    end
   end
 
   def search_by_authorship(search)
@@ -360,6 +357,15 @@ class Search
     end
   end
 
+  def search_by_sensors(search)
+    if no_sensors
+      search.with(:sensors, nil)
+    elsif sensors.present?
+      # this is a more concise version of way subject areas are doing it
+      search.with(:sensors).any_of(sensors)
+    end
+  end
+
   def search_by_projects(search)
     return if project_ids.size < 1
     search.any_of do |s|
@@ -372,8 +378,6 @@ class Search
   def count; self.hits.size; end
   alias_method :size, :count
   alias_method :len, :count
-
-  alias_method :probe_type, :probe
 
   def investigation_checkedstatus; self.material_types.include? ::Investigation ; end
   def activity_checkedstatus; self.material_types.include? ::Activity ; end

--- a/app/models/search_interactives.rb
+++ b/app/models/search_interactives.rb
@@ -19,6 +19,10 @@ class SearchInteractives < Search
         super(opts)
     end
 
+    def fetch_available_filter_options
+      # none of the standard Search options are needed for interactives so bypass this
+    end
+
     #
     # Set available search params for Interactives
     #

--- a/app/views/search/_filters.html.haml
+++ b/app/views/search/_filters.html.haml
@@ -89,7 +89,7 @@
                     Requires Download
                     %span.tip
                       These materials download a file to your computer, and start using Java Web Start.
-              %td.probescolumn
+              %td
                 = render :partial => "search/sensors_filter"
           - unless current_visitor.anonymous?
             %br

--- a/app/views/search/_filters.html.haml
+++ b/app/views/search/_filters.html.haml
@@ -90,23 +90,7 @@
                     %span.tip
                       These materials download a file to your computer, and start using Java Web Start.
               %td.probescolumn
-                .filterheader
-                  Sensor Use
-                %span
-                  %a{:href => 'javascript: void(0);', :onclick=>"setAllProbesSelected(true);"}check all
-                %span{:style => 'color: #479492'}|
-                %span
-                  %a{:href => 'javascript: void(0);', :onclick=>"setAllProbesSelected(false);"}clear
-                .noprobesrequired
-
-                .probes_container.webkit_scrollbars
-                  .tablecell
-                    = check_box_tag 'no_probes', '1', @form_model.no_probes, :id=>'probe_0', :class=>'probe_items'
-                    = label_tag 'probe_0', 'Sensors Not Necessary', :class=>'probes_label'
-                  - probe_types.each do |probe|
-                    .tablecell
-                      = check_box_tag 'probe[]',"#{probe.id}",(@form_model.probe_type.include?(probe.id.to_s)),:id=>"probe_#{probe.id}",:class=>"probe_items"
-                      = label_tag "probe_#{probe.id}","#{probe.name}",:class=>"probes_label"
+                = render :partial => "search/sensors_filter"
           - unless current_visitor.anonymous?
             %br
             .authored_by_me

--- a/app/views/search/_sensors_filter.html.haml
+++ b/app/views/search/_sensors_filter.html.haml
@@ -1,0 +1,20 @@
+-if @form_model.available_sensors.size > 0
+  .filterheader
+    Sensors
+  %span
+    %a{:href => 'javascript: void(0);', :onclick=>"setAllProbesSelected(true);"}check all
+  %span{:style => 'color: #479492'}|
+  %span
+    %a{:href => 'javascript: void(0);', :onclick=>"setAllProbesSelected(false);"}clear
+  .noprobesrequired
+
+  .probes_container.webkit_scrollbars
+    .tablecell
+      -# TODO: switch up styles and id to 'sensor'
+      = check_box_tag 'no_sensors', '1', @form_model.no_sensors, :id=>'probe_0', :class=>'probe_items'
+      = label_tag 'probe_0', 'Sensors Not Necessary', :class=>'probes_label'
+    - @form_model.available_sensors.uniq.sort_by { |sensor| sensor.downcase }.each do |sensor|
+      .tablecell
+        - id = "sensor_#{sensor.squish.downcase.tr(" ","_")}"
+        = check_box_tag 'sensors[]', sensor,  @form_model.sensors.include?(sensor),:id => id, :class => 'check-box-left-margin'
+        = label_tag id, sensor

--- a/app/views/search/_sensors_filter.html.haml
+++ b/app/views/search/_sensors_filter.html.haml
@@ -6,15 +6,13 @@
   %span{:style => 'color: #479492'}|
   %span
     %a{:href => 'javascript: void(0);', :onclick=>"setAllProbesSelected(false);"}clear
-  .noprobesrequired
 
-  .probes_container.webkit_scrollbars
+  .sensors_container.webkit_scrollbars
     .tablecell
-      -# TODO: switch up styles and id to 'sensor'
-      = check_box_tag 'no_sensors', '1', @form_model.no_sensors, :id=>'probe_0', :class=>'probe_items'
-      = label_tag 'probe_0', 'Sensors Not Necessary', :class=>'probes_label'
+      = check_box_tag 'no_sensors', '1', @form_model.no_sensors, :id=>'sensor_0', :class=>'sensor_filter_item'
+      = label_tag 'sensor_0', 'Sensors Not Necessary', :class=>'sensors_label'
     - @form_model.available_sensors.uniq.sort_by { |sensor| sensor.downcase }.each do |sensor|
       .tablecell
         - id = "sensor_#{sensor.squish.downcase.tr(" ","_")}"
-        = check_box_tag 'sensors[]', sensor,  @form_model.sensors.include?(sensor),:id => id, :class => 'check-box-left-margin'
-        = label_tag id, sensor
+        = check_box_tag 'sensors[]', sensor,  @form_model.sensors.include?(sensor),:id => id, :class => 'check-box-left-margin sensor_filter_item'
+        = label_tag id, sensor, :class =>'sensors_label'

--- a/features/step_definitions/materials_search_steps.rb
+++ b/features/step_definitions/materials_search_steps.rb
@@ -2,3 +2,8 @@ Then /I search for my own materials/ do
   search_mine_string = I18n.translate("Search.only_mine")
   step "I should see #{search_mine_string}"
 end
+
+When /^I wait for the search to be ready$/ do
+  search_result_delay = ENV['SECONDS_BEFORE_TESTING_SEARCH_RESULTS'].presence || 3
+  sleep(seconds.to_i)
+end

--- a/features/step_definitions/materials_search_steps.rb
+++ b/features/step_definitions/materials_search_steps.rb
@@ -5,5 +5,5 @@ end
 
 When /^I wait for the search to be ready$/ do
   search_result_delay = ENV['SECONDS_BEFORE_TESTING_SEARCH_RESULTS'].presence || 3
-  sleep(seconds.to_i)
+  sleep(search_result_delay.to_i)
 end

--- a/features/teacher_filters_instructional_materials.feature
+++ b/features/teacher_filters_instructional_materials.feature
@@ -67,3 +67,58 @@ Feature: Teacher filters instructional materials
     Then I should see "My grade 5 Math Activity"
     And I should not see "My grade 7 Science Activity"
 
+  @javascript @search
+  Scenario: Searching Materials tagged with Sensors
+    Given the following Admin::tag records exist:
+      | scope         | tag         |
+      | sensors       | Temperature |
+      | sensors       | Force       |
+      | sensors       | Motion      |
+
+    # Create a temperature sensor activity:
+    And I am on the new material page
+    Then I should see "(new) /eresources"
+    When I fill in "external_activity[name]" with "My Temperature Sensor Activity"
+    And I check "external_activity[is_official]"
+    And I select "published" from "external_activity[publication_status]"
+    And under "Sensors" I check "Temperature"
+    And I press "Save"
+
+    # Create a force sensor activity:
+    And I am on the new material page
+    Then I should see "(new) /eresources"
+    When I fill in "external_activity[name]" with "My Force Sensor Activity"
+    And I check "external_activity[is_official]"
+    And I select "published" from "external_activity[publication_status]"
+    And under "Sensors" I check "Force"
+    And I press "Save"
+
+    # Create an activity with no sensors:
+    And I am on the new material page
+    Then I should see "(new) /eresources"
+    When I fill in "external_activity[name]" with "My No Sensor Activity"
+    And I check "external_activity[is_official]"
+    And I select "published" from "external_activity[publication_status]"
+    And I press "Save"
+
+    Given I am on the search instructional materials page
+    And I uncheck "Sequence"
+    And I check "Temperature"
+    And I wait 3 seconds
+    Then I should see "My Temperature Sensor Activity"
+    And I should not see "My Force Sensor Activity"
+    And I should not see "My No Sensor Activity"
+
+    When I check "Force"
+    And I wait 3 seconds
+    Then I should see "My Temperature Sensor Activity"
+    And I should see "My Force Sensor Activity"
+    And I should not see "My No Sensor Activity"
+
+    When I uncheck "Temperature"
+    And I uncheck "Force"
+    And I check "Sensors Not Necessary"
+    And I wait 3 seconds
+    Then I should see "My No Sensor Activity"
+    And I should not see "My Force Sensor Activity"
+    And I should not see "My Temperature Sensor Activity"

--- a/features/teacher_filters_instructional_materials.feature
+++ b/features/teacher_filters_instructional_materials.feature
@@ -41,13 +41,13 @@ Feature: Teacher filters instructional materials
     Given I am on the search instructional materials page
     And I uncheck "Sequence"
     And I check "Math"
-    And I wait 3 seconds
+    And I wait for the search to be ready
     Then I should see "My grade 5 Math Activity"
     And  I should not see "My grade 7 Science Activity"
 
     When I check "Science"
     And I uncheck "Math"
-    And I wait 3 seconds
+    And I wait for the search to be ready
 
     Then I should see "My grade 7 Science Activity"
     And I should not see "My grade 5 Math Activity"
@@ -55,14 +55,14 @@ Feature: Teacher filters instructional materials
     When I uncheck "Math"
     And I uncheck "Science"
     And I check "grade_level_7-8"
-    And I wait 3 seconds
+    And I wait for the search to be ready
 
     Then I should not see "My grade 5 Math Activity"
     And I should see "My grade 7 Science Activity"
 
     When I uncheck "grade_level_7-8"
     And I check "grade_level_5-6"
-    And I wait 3 seconds
+    And I wait for the search to be ready
 
     Then I should see "My grade 5 Math Activity"
     And I should not see "My grade 7 Science Activity"
@@ -104,13 +104,13 @@ Feature: Teacher filters instructional materials
     Given I am on the search instructional materials page
     And I uncheck "Sequence"
     And I check "Temperature"
-    And I wait 3 seconds
+    And I wait for the search to be ready
     Then I should see "My Temperature Sensor Activity"
     And I should not see "My Force Sensor Activity"
     And I should not see "My No Sensor Activity"
 
     When I check "Force"
-    And I wait 3 seconds
+    And I wait for the search to be ready
     Then I should see "My Temperature Sensor Activity"
     And I should see "My Force Sensor Activity"
     And I should not see "My No Sensor Activity"
@@ -118,7 +118,7 @@ Feature: Teacher filters instructional materials
     When I uncheck "Temperature"
     And I uncheck "Force"
     And I check "Sensors Not Necessary"
-    And I wait 3 seconds
+    And I wait for the search to be ready
     Then I should see "My No Sensor Activity"
     And I should not see "My Force Sensor Activity"
     And I should not see "My Temperature Sensor Activity"

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -392,7 +392,6 @@ describe Search do
 
 
       describe "With cohort tags" do
-        # TODO: COHORT FIXME
         let(:teacher_cohorts) {[]}
         let(:teacher)    {
           mock_model(Portal::Teacher, :cohorts => teacher_cohorts)
@@ -639,6 +638,49 @@ describe Search do
         end
       end
     end
+
+    context "with sensor tags" do
+      let(:public_with_temperature_sensor) {
+        FactoryGirl.create(:external_activity, :url => 'http://activities.com',
+          :is_official => true, :publication_status => "published",
+          :sensor_list => ['Temperature']
+        )
+      }
+      let(:public_with_force_sensor) {
+        FactoryGirl.create(:external_activity, :url => 'http://activities.com',
+          :is_official => true, :publication_status => "published",
+          :sensor_list => ['Force']
+        )
+      }
+      let(:public_with_force_and_temperature_sensor) {
+        FactoryGirl.create(:external_activity, :url => 'http://activities.com',
+          :is_official => true, :publication_status => "published",
+          :sensor_list => ['Force', 'Temperature']
+        )
+      }
+      let(:materials) { [public_with_temperature_sensor, public_with_force_sensor,
+        public_with_force_and_temperature_sensor, public_ext_act]}
+      it "the temperature activity is returned" do
+        subject.results[:all].should include(public_with_temperature_sensor)
+      end
+      describe "with the temperature sensor selected" do
+        let(:search_opts)      { {:sensors => ["Temperature"]} }
+        it "only returns activities with a temperature sensor" do
+          subject.results[:all].should have(2).entries
+          subject.results[:all].should include(public_with_temperature_sensor)
+          subject.results[:all].should include(public_with_force_and_temperature_sensor)
+        end
+      end
+      describe "with the 'no sensors' option selected" do
+        let(:search_opts)      { {:no_sensors => true} }
+        it "only returns activities without sensors" do
+          subject.results[:all].should_not include(public_with_temperature_sensor)
+          subject.results[:all].should_not include(public_with_force_sensor)
+          subject.results[:all].should_not include(public_with_force_and_temperature_sensor)
+        end
+      end
+    end
+
     describe "#params" do
       before(:each) do
         User.stub!(:find => mock_user)
@@ -653,7 +695,7 @@ describe Search do
           subject.should include(:investigation_page => 1)
           subject.should include(:material_types => [])
           subject.should include(:per_page => 10)
-          subject.should include(:probe => [])
+          subject.should include(:sensors => [])
           subject.should include(:sort_order => "Newest")
         end
       end
@@ -666,7 +708,7 @@ describe Search do
           :material_types => [Search::InvestigationMaterial, Search::ActivityMaterial],
           :domain_id => ['1','2','4'],
           :user_id => '13',
-          :probe => ['0'],
+          :sensors => ['Temperature'],
           :grade_span => ['k','12'],
           :activity_page => 3,
           :investigation_page => 7
@@ -680,7 +722,7 @@ describe Search do
           subject.should include(:material_types => ["Investigation", "Activity"])
           subject.should include(:per_page => 10)
           subject.should include(:private => true)
-          subject.should include(:probe => ["0"])
+          subject.should include(:sensors => ["Temperature"])
           subject.should include(:sort_order => "Newest")
           subject.should include(:user_id => "13")
         end

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -679,6 +679,16 @@ describe Search do
           subject.results[:all].should_not include(public_with_force_and_temperature_sensor)
         end
       end
+      describe "with the 'no sensors' option selected and temperature sensor selected" do
+        let(:search_opts)      { {:no_sensors => true, :sensors => ["Temperature"]} }
+        it "returns activities with sensors and with temperature sensors" do
+          subject.results[:all].should_not include(public_with_force_sensor)
+          subject.results[:all].should include(public_with_temperature_sensor)
+          subject.results[:all].should include(public_with_force_and_temperature_sensor)
+          # include takes an set of params so turn the array into params with '*'
+          subject.results[:all].should include(*public_ext_act)
+        end
+      end
     end
 
     describe "#params" do

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -674,6 +674,8 @@ describe Search do
       describe "with the 'no sensors' option selected" do
         let(:search_opts)      { {:no_sensors => true} }
         it "only returns activities without sensors" do
+          # public_ext_act is an array so we need to turn it into set parameters
+          subject.results[:all].should include(*public_ext_act)
           subject.results[:all].should_not include(public_with_temperature_sensor)
           subject.results[:all].should_not include(public_with_force_sensor)
           subject.results[:all].should_not include(public_with_force_and_temperature_sensor)
@@ -681,60 +683,12 @@ describe Search do
       end
       describe "with the 'no sensors' option selected and temperature sensor selected" do
         let(:search_opts)      { {:no_sensors => true, :sensors => ["Temperature"]} }
-        it "returns activities with sensors and with temperature sensors" do
-          subject.results[:all].should_not include(public_with_force_sensor)
+        it "returns activities with no sensors and with temperature sensors" do
+          # public_ext_act is an array so we need to turn it into set parameters
+          subject.results[:all].should include(*public_ext_act)
           subject.results[:all].should include(public_with_temperature_sensor)
           subject.results[:all].should include(public_with_force_and_temperature_sensor)
-          # include takes an set of params so turn the array into params with '*'
-          subject.results[:all].should include(*public_ext_act)
-        end
-      end
-    end
-
-    describe "#params" do
-      before(:each) do
-        User.stub!(:find => mock_user)
-      end
-      subject { params = Search.new(search_opts).params }
-      describe "with no options" do
-        let(:search_opts) {{}}
-        it "should return a hash containing some default values" do
-          subject.should include(:activity_page => 1)
-          subject.should include(:controller => "search")
-          subject.should include(:grade_span => [])
-          subject.should include(:investigation_page => 1)
-          subject.should include(:material_types => [])
-          subject.should include(:per_page => 10)
-          subject.should include(:sensors => [])
-          subject.should include(:sort_order => "Newest")
-        end
-      end
-      describe "with a whole lot of options" do
-        let(:search_opts) do
-          {
-          :private => true,
-          :sort => Search::Newest,
-          :search_term => "blue",
-          :material_types => [Search::InvestigationMaterial, Search::ActivityMaterial],
-          :domain_id => ['1','2','4'],
-          :user_id => '13',
-          :sensors => ['Temperature'],
-          :grade_span => ['k','12'],
-          :activity_page => 3,
-          :investigation_page => 7
-          }
-        end
-        it "should return a hash containing all of the options in a hash" do
-          subject.should include(:activity_page => 3)
-          subject.should include(:controller => "search")
-          subject.should include(:grade_span => ["k", "12"])
-          subject.should include(:investigation_page => 7)
-          subject.should include(:material_types => ["Investigation", "Activity"])
-          subject.should include(:per_page => 10)
-          subject.should include(:private => true)
-          subject.should include(:sensors => ["Temperature"])
-          subject.should include(:sort_order => "Newest")
-          subject.should include(:user_id => "13")
+          subject.results[:all].should_not include(public_with_force_sensor)
         end
       end
     end


### PR DESCRIPTION
We have had support for tagging activities with sensors for a while, but we never connected it to the search.  This PR finally connects it. Previously the sensor search was based on the outdated probe models, that was removed and never replaced with the tag based approach.

This also replaces all references of 'probe' with 'sensor' in this part of the code. This will make it easier to remove all of the older probe code in a future PR.

The database schema was not changed in this PR. Two probe fields saved into Solr were removed. The sensors tag field was added a while ago, so it will not be necessary to reset Solr after this is released.

PT story: https://www.pivotaltracker.com/story/show/158574697