### PR TITLE
Move Navigation to portal pages [#157698255]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
   - secure: fBn66dqLiQa0W1eDAV/ZZKgA4K3OogG9WG/9lyd81csj9YGtHnE91YlzHLH25oyMWg53nGYEcUlLnPYFw7mqdFJ48AJ5sMaplIqmBMmb9OnpUpYc1sds3wvi81TmTAT0ColdBtgdSBCjIPTr2AuieBJgR8dqPpT/uXg30meZg/g=
   - secure: ebGYa+ExFODy1+aVIrppCkyuO/z4RLBHQ8oGE7+h4a3Hdzxx4kSvfRt3nIeklMpTBt0M55hpY/MnZxHt1N0fhSkqfjeJrsYaagatBXezPiW34ZZCbS2E/pJ3pYiL2zzZS3hER30oGGNthYXuU3LI8gjLL8NHXvg5dxrHVaQeD1M=
   - ARTIFACTS_BUCKET=cc-travis-artifacts
-
+  - PORTAL_PAGES_LIBRARY_URL=https://portal-pages.concord.org/branch/157698255-addNavigation/library/
 before_install:
   - "export DISPLAY=:99.0"
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1920x1080x16"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ env:
   - secure: fBn66dqLiQa0W1eDAV/ZZKgA4K3OogG9WG/9lyd81csj9YGtHnE91YlzHLH25oyMWg53nGYEcUlLnPYFw7mqdFJ48AJ5sMaplIqmBMmb9OnpUpYc1sds3wvi81TmTAT0ColdBtgdSBCjIPTr2AuieBJgR8dqPpT/uXg30meZg/g=
   - secure: ebGYa+ExFODy1+aVIrppCkyuO/z4RLBHQ8oGE7+h4a3Hdzxx4kSvfRt3nIeklMpTBt0M55hpY/MnZxHt1N0fhSkqfjeJrsYaagatBXezPiW34ZZCbS2E/pJ3pYiL2zzZS3hER30oGGNthYXuU3LI8gjLL8NHXvg5dxrHVaQeD1M=
   - ARTIFACTS_BUCKET=cc-travis-artifacts
-  - PORTAL_PAGES_LIBRARY_URL=https://portal-pages.concord.org/branch/157698255-addNavigation/library/
 before_install:
   - "export DISPLAY=:99.0"
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1920x1080x16"

--- a/Gemfile
+++ b/Gemfile
@@ -203,6 +203,7 @@ group :test, :cucumber do
   gem "capybara-mechanize", "~> 0.3.0"
   gem 'capybara-screenshot'
   gem "connection_pool"
+  gem "json-schema"
 end
 
 group :test, :cucumber, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -319,6 +319,7 @@ GEM
       railties (>= 3.1)
       sass (>= 3.2)
     json (1.8.6)
+    json-schema (2.4.1)
     jwt (1.5.6)
     kgio (2.10.0)
     launchy (2.0.5)
@@ -667,6 +668,7 @@ DEPENDENCIES
   jasmine (~> 2.3.0)
   jquery-fileupload-rails
   json (~> 1.8.6)
+  json-schema
   jwt
   launchy (~> 2.0.5)
   lol_dba

--- a/app/assets/javascripts/components/materials_bin/material.js.coffee
+++ b/app/assets/javascripts/components/materials_bin/material.js.coffee
@@ -39,11 +39,11 @@ window.MBMaterialClass = React.createClass
         if @props.assignToSpecificClass
           (input {type: 'checkbox', onChange: @assignToSpecificClass, checked: @state.assigned})
         if data.edit_url?
-          (a {className: 'mb-edit', href: data.edit_url, target: '_blank', title: 'Edit this activity'},
+          (a {className: 'mb-edit', href: data.edit_url,  title: 'Edit this activity'},
             (span {className: 'mb-edit-text'}, 'Edit')
           )
         if data.copy_url?
-          (a {className: 'mb-copy', href: data.copy_url, target: '_blank', title: 'Make your own version of this activity'},
+          (a {className: 'mb-copy', href: data.copy_url,  title: 'Make your own version of this activity'},
             (span {className: 'mb-copy-text'}, 'Copy')
           )
         if @hasDescription()
@@ -51,7 +51,7 @@ window.MBMaterialClass = React.createClass
             (span {className: 'mb-toggle-info-text'}, 'Info')
           )
         if data.preview_url?
-          (a {className: 'mb-run', href: data.preview_url, target: '_blank', title: 'Run this activity in the browser'},
+          (a {className: 'mb-run', href: data.preview_url,  title: 'Run this activity in the browser'},
             (span {className: 'mb-run-text'}, 'Run')
           )
         if not @props.assignToSpecificClass and data.assign_to_class_url?

--- a/app/assets/stylesheets/web/app.scss
+++ b/app/assets/stylesheets/web/app.scss
@@ -665,76 +665,6 @@ li.item_selectable {
 
 /* ------- #secondary ------- */
 
-#secondary {
-  background: #ea6d2f;
-  color: #313131;
-  display: inline-block;
-  font: 100 16px museo-sans, verdana, helvetica, arial, sans-serif;
-  height: auto;
-  margin: 20px 0 50px 0;
-  padding: 0 0 30px;
-  vertical-align: top;
-  a {
-    color: #fff;
-    display: inline-block;
-    margin: 0;
-    padding: 0;
-    width: 100%; }
-  a:link { background: transparent; }
-  a:visited { background: transparent; }
-  a:hover { color: #313131; }
-  a:active { color: #313131; }
-  a.selected {
-    color: #313131;
-    font-weight: 500;
-  }
-  h2 {
-    color: #555555;
-    font: bold 1.3em Arial, Helvetica, sans-serif !important;
-    margin: 10px 0 10px 20px; }
-  ul {
-    list-style: none;
-    margin: 20px 0 0;
-    padding: 0; }
-  li {
-    color: #ee864e;
-    list-style: none;
-    margin: 20px;
-    padding: 0;
-    li { font-size: 14px; }
-    strong {
-      display: block;
-      font-weight: normal;
-      padding: 5px 20px; } }
-  ul.create {
-    border-top: none; }
-  #utility-links {
-    background: #f5f5f5;
-    padding: 20px;
-    a {
-      color: #ea6d2f;
-      font-size: 12px;
-      font-weight: 500;
-      padding: 0;
-      text-transform: uppercase;
-    }
-    li {
-      margin: 10px 0;
-    }
-    ul.aux-links {
-      border-top: solid 1px #ccc;
-      margin: 20px 0 0;
-      padding-top: 8px;
-      a {
-        font-weight: 100;
-      }
-    }
-  }
-  .secondary-mobile-menu-toggle {
-    display: none;
-  }
-   }
-
 .user-info-box {
   background: white;
   margin: 10px 10px 20px;
@@ -2133,54 +2063,7 @@ span.badge {
       padding-bottom: 30px;
       }
     }
-  #secondary {
-    padding-bottom: 0;
-
-    #utility-links {
-      padding-bottom: 0;
-
-      ul.aux-links {
-        border: none;
-      }
-    }
-
-    .padded_content {
-      display: none;
-      transition: .2s;
-    }
-    .secondary-mobile-menu-toggle {
-      color: #fff;
-      cursor: pointer;
-      display: block;
-      font-weight: 500;
-      padding: 20px;
-      position: relative;
-
-      &:after {
-        content: "\e905";
-        font-family: "icomoon";
-        font-size: 12px;
-        margin: 5px 0 0 10px;
-        position: absolute;
-        right: 20px;
-        transition: .2s;
-      }
-    }
-
-    &.open {
-      .padded_content {
-        display: block;
-        transition: .2s;
-      }
-      .secondary-mobile-menu-toggle {
-
-        &:after {
-          content: "\e906";
-        }
-      }
-    }
-  }
-
+    
   .classdata {
     td {
       display: block;

--- a/app/assets/stylesheets/web/app.scss
+++ b/app/assets/stylesheets/web/app.scss
@@ -370,8 +370,7 @@ body#tinymce {
 
 #primary {
   display: inline-block;
-  margin: 0px 0px 120px 20px;
-
+  margin: 57px 0 0 125px;
   min-height: 400px;
   overflow: auto;
   padding: 0;
@@ -665,6 +664,76 @@ li.item_selectable {
     list-style: none; } }
 
 /* ------- #secondary ------- */
+
+#secondary {
+  background: #ea6d2f;
+  color: #313131;
+  display: inline-block;
+  font: 100 16px museo-sans, verdana, helvetica, arial, sans-serif;
+  height: auto;
+  margin: 20px 0 50px 0;
+  padding: 0 0 30px;
+  vertical-align: top;
+  a {
+    color: #fff;
+    display: inline-block;
+    margin: 0;
+    padding: 0;
+    width: 100%; }
+  a:link { background: transparent; }
+  a:visited { background: transparent; }
+  a:hover { color: #313131; }
+  a:active { color: #313131; }
+  a.selected {
+    color: #313131;
+    font-weight: 500;
+  }
+  h2 {
+    color: #555555;
+    font: bold 1.3em Arial, Helvetica, sans-serif !important;
+    margin: 10px 0 10px 20px; }
+  ul {
+    list-style: none;
+    margin: 20px 0 0;
+    padding: 0; }
+  li {
+    color: #ee864e;
+    list-style: none;
+    margin: 20px;
+    padding: 0;
+    li { font-size: 14px; }
+    strong {
+      display: block;
+      font-weight: normal;
+      padding: 5px 20px; } }
+  ul.create {
+    border-top: none; }
+  #utility-links {
+    background: #f5f5f5;
+    padding: 20px;
+    a {
+      color: #ea6d2f;
+      font-size: 12px;
+      font-weight: 500;
+      padding: 0;
+      text-transform: uppercase;
+    }
+    li {
+      margin: 10px 0;
+    }
+    ul.aux-links {
+      border-top: solid 1px #ccc;
+      margin: 20px 0 0;
+      padding-top: 8px;
+      a {
+        font-weight: 100;
+      }
+    }
+  }
+  .secondary-mobile-menu-toggle {
+    display: none;
+  }
+   }
 
 .user-info-box {
   background: white;
@@ -2064,7 +2133,54 @@ span.badge {
       padding-bottom: 30px;
       }
     }
-    
+  #secondary {
+    padding-bottom: 0;
+
+    #utility-links {
+      padding-bottom: 0;
+
+      ul.aux-links {
+        border: none;
+      }
+    }
+
+    .padded_content {
+      display: none;
+      transition: .2s;
+    }
+    .secondary-mobile-menu-toggle {
+      color: #fff;
+      cursor: pointer;
+      display: block;
+      font-weight: 500;
+      padding: 20px;
+      position: relative;
+
+      &:after {
+        content: "\e905";
+        font-family: "icomoon";
+        font-size: 12px;
+        margin: 5px 0 0 10px;
+        position: absolute;
+        right: 20px;
+        transition: .2s;
+      }
+    }
+
+    &.open {
+      .padded_content {
+        display: block;
+        transition: .2s;
+      }
+      .secondary-mobile-menu-toggle {
+
+        &:after {
+          content: "\e906";
+        }
+      }
+    }
+  }
+
   .classdata {
     td {
       display: block;

--- a/app/assets/stylesheets/web/app.scss
+++ b/app/assets/stylesheets/web/app.scss
@@ -370,7 +370,8 @@ body#tinymce {
 
 #primary {
   display: inline-block;
-  margin: 57px 0 0 125px;
+  margin: 0px 0px 120px 20px;
+
   min-height: 400px;
   overflow: auto;
   padding: 0;

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -233,7 +233,7 @@ module NavigationHelper
 
   def switch_user_link
     # TODO: Make an API to switch users.
-    {label: "Switch Back", url: "/users/switch" }
+    {label: "Switch Back", id: "switch", url: "/users/switch", sort: 2 }
   end
 
 

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -69,7 +69,8 @@ module NavigationHelper
         id: '/help',
         label: nav_label('Help'),
         url: '/help',
-        popOut: true,
+        small: true,
+        sort: -1,
         iconName:'icon-search',
       }
     else

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -67,7 +67,7 @@ module NavigationHelper
     if show_help_link
       {
         id: '/help',
-        label: nav_label('help'),
+        label: nav_label('Help'),
         url: '/help',
         popOut: true,
         iconName:'icon-search',

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -32,6 +32,7 @@ module NavigationHelper
 
   def help_link_params
     {
+      id: '/help',
       label: 'Help',
       url: '/help',
       popOut: true,
@@ -42,6 +43,7 @@ module NavigationHelper
 
   def preference_link_params
     {
+      id: '/settings',
       label: 'Settings',
       url: preferences_user_path(current_visitor),
       iconName: 'icon-settings'
@@ -50,6 +52,7 @@ module NavigationHelper
 
   def favorite_link_params
     {
+      id: '/favorites',
       label: 'Favorites',
       url: favorites_user_path(current_visitor),
       iconName: 'icon-favorite'
@@ -58,6 +61,7 @@ module NavigationHelper
 
   def admin_link_params
     {
+      id: '/admin',
       label: 'Admin',
       url: admin_path
     }
@@ -73,9 +77,16 @@ module NavigationHelper
 
   def clazz_links_for_student
     clazzes = current_visitor.portal_student.clazzes
-    clazz_links = []
+    clazz_links = [
+      id: "/classes",
+      label: "Classes",
+      type: NavigationService::SECTION_TYPE
+    ]
     clazzes.each do |clazz|
-      clazz_links << {section: "classes", label: clazz_label(clazz), url: url_for(clazz) }
+      clazz_links << {
+        id: "/classes/#{clazz.id}",
+        label: clazz_label(clazz),
+        url: url_for(clazz) }
     end
     clazz_links
   end
@@ -83,37 +94,48 @@ module NavigationHelper
   def clazz_links_for_teacher
     # TODO Omit inactive classes.
     clazzes = current_visitor.portal_teacher.teacher_clazzes.map { |c| c.clazz }
-    clazz_links = []
+    clazz_links = [
+      {
+        id: "/classes",
+        label: "clazz_label(clazz)",
+        type: NavigationService::SECTION_TYPE
+      }
+    ]
     clazzes.each do |clazz|
-      section_name = "Classes/#{clazz_label(clazz)}"
+      section_id = "/classes/#{clazz.id}"
       clazz_links << {
-        section: section_name,
+        id: section_id,
+        label: "#{clazz_label(clazz)}",
+        type: NavigationService::SECTION_TYPE
+      }
+      clazz_links << {
+        id: "#{section_id}/assignments",
         label: "Assignments",
         url: url_for([:materials, clazz])
       }
       clazz_links << {
-        section: section_name,
+        id: "#{section_id}/roster",
         label: "Student Roster",
         url: url_for([:roster, clazz])
       }
       clazz_links << {
-        section: section_name,
+        id: "#{section_id}/setup",
         label: "Class Setup",
         url: url_for([:edit, clazz])
       }
       clazz_links << {
-        section: section_name,
+        id: "#{section_id}/status",
         label: "Full Status",
         url: url_for([:fullstatus, clazz])
       }
       clazz_links << {
-        section: section_name,
+        id: "#{section_id}/links",
         label: "Links",
         url: url_for([clazz, :bookmarks])
       }
     end
     clazz_links << {
-      section: "Classes",
+      id: "/classes/add",
       label: "Add Class",
       url: new_portal_clazz_path
     }
@@ -141,43 +163,43 @@ module NavigationHelper
     section_name = "Resources"
     [
       {
-        section: section_name,
+        id: '/resources/activities',
         label: 'activities',
         url: '/itsi',
         popOut: false
       },
       {
-        section: section_name,
+        id: '/resources/interactives',
         label: 'interactives',
         url: '/interactives',
         popOut: true
       },
       {
-        section: section_name,
+        id: '/resources/images',
         label: 'images',
         url: '/images',
         popOut: true
       },
       {
-        section: section_name,
+        id: '/resources/guides',
         label: 'Teacher Guides',
         url: 'https://guides.itsi.concord.org/',
         popOut: true
       },
       {
-        section: section_name,
+        id: '/resources/careers',
         label: 'Careersight',
         url: 'https://careersight.concord.org/',
         popOut: true
       },
       {
-        section: section_name,
+        id: '/resources/probes',
         label: 'Probesight',
         url: 'https://probesight.concord.org/',
         popOut: true
       },
       {
-        section: section_name,
+        id: '/resources/schoology',
         label: 'Schoology',
         url: 'https://www.schoology.com/',
         popOut: true
@@ -195,26 +217,26 @@ module NavigationHelper
     service =  NavigationService.new(self, params.merge(_params))
 
     if show_help_link
-      service.add_link help_link_params
+      service.add_item help_link_params
     end
 
-    service.add_link preference_link_params
+    service.add_item preference_link_params
 
     if show_favorites_link
-      service.add_link favorite_link_params
+      service.add_item favorite_link_params
     end
 
     if show_admin_links
-      service.add_link admin_link_params
+      service.add_item admin_link_params
     end
 
     if show_switch_user_link
-      service.add_link switch_user_link
+      service.add_item switch_user_link
     end
 
 
-    clazz_links.each {|clazz_link| service.add_link clazz_link}
-    itsi_links.each { |link| service.add_link link}
+    clazz_links.each {|clazz_link| service.add_item clazz_link}
+    itsi_links.each { |link| service.add_item link}
     return service
   end
 

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -1,0 +1,222 @@
+
+module NavigationHelper
+
+  private
+  def show_help_link
+    return false unless current_settings
+    current_settings.help_type == 'external url' || current_settings.help_type == 'help custom html'
+  end
+
+  def show_favorites_link
+    is_teacher
+  end
+
+  def is_student
+    current_visitor.portal_student || false
+  end
+
+  def is_teacher
+    current_visitor.portal_teacher || false
+  end
+
+  def show_admin_links
+    current_visitor.has_role?('admin', 'manager','researcher') ||
+    current_visitor.is_project_admin? ||
+    current_visitor.is_project_researcher?
+  end
+
+  def show_switch_user_link
+    # TODO: @original_user isn't available to us probably...
+    @original_user && @original_user != current_visitor
+  end
+
+  def help_link_params
+    {
+      label: 'Help',
+      url: '/help',
+      popOut: true,
+      iconName:'icon-search',
+      className: 'help-link'
+    }
+  end
+
+  def preference_link_params
+    {
+      label: 'Settings',
+      url: preferences_user_path(current_visitor),
+      iconName: 'icon-settings'
+    }
+  end
+
+  def favorite_link_params
+    {
+      label: 'Favorites',
+      url: favorites_user_path(current_visitor),
+      iconName: 'icon-favorite'
+    }
+  end
+
+  def admin_link_params
+    {
+      label: 'Admin',
+      url: admin_path
+    }
+  end
+
+  def clazz_label(clazz)
+    if clazz.section
+      "#{clazz.name} (#{clazz.section})"
+    else
+      clazz.name
+    end
+  end
+
+  def clazz_links_for_student
+    clazzes = current_visitor.portal_student.clazzes
+    clazz_links = []
+    clazzes.each do |clazz|
+      clazz_links << {section: "classes", label: clazz_label(clazz), url: url_for(clazz) }
+    end
+    clazz_links
+  end
+
+  def clazz_links_for_teacher
+    # TODO Omit inactive classes.
+    clazzes = current_visitor.portal_teacher.teacher_clazzes.map { |c| c.clazz }
+    clazz_links = []
+    clazzes.each do |clazz|
+      section_name = "Classes/#{clazz_label(clazz)}"
+      clazz_links << {
+        section: section_name,
+        label: "Assignments",
+        url: url_for([:materials, clazz])
+      }
+      clazz_links << {
+        section: section_name,
+        label: "Student Roster",
+        url: url_for([:roster, clazz])
+      }
+      clazz_links << {
+        section: section_name,
+        label: "Class Setup",
+        url: url_for([:edit, clazz])
+      }
+      clazz_links << {
+        section: section_name,
+        label: "Full Status",
+        url: url_for([:fullstatus, clazz])
+      }
+      clazz_links << {
+        section: section_name,
+        label: "Links",
+        url: url_for([clazz, :bookmarks])
+      }
+    end
+    clazz_links << {
+      section: "Classes",
+      label: "Add Class",
+      url: new_portal_clazz_path
+    }
+    clazz_links
+  end
+
+  def clazz_links
+    if is_teacher
+      clazz_links_for_teacher
+    elsif is_student
+      clazz_links_for_student
+    else
+      []
+    end
+  end
+
+
+  def switch_user_link
+    # TODO: Make an API to switch users.
+    {label: "Switch Back", url: "userse/switch" }
+  end
+
+
+  def itsi_links
+    section_name = "Resources"
+    [
+      {
+        section: section_name,
+        label: 'activities',
+        url: '/itsi',
+        popOut: false
+      },
+      {
+        section: section_name,
+        label: 'interactives',
+        url: '/interactives',
+        popOut: true
+      },
+      {
+        section: section_name,
+        label: 'images',
+        url: '/images',
+        popOut: true
+      },
+      {
+        section: section_name,
+        label: 'Teacher Guides',
+        url: 'https://guides.itsi.concord.org/',
+        popOut: true
+      },
+      {
+        section: section_name,
+        label: 'Careersight',
+        url: 'https://careersight.concord.org/',
+        popOut: true
+      },
+      {
+        section: section_name,
+        label: 'Probesight',
+        url: 'https://probesight.concord.org/',
+        popOut: true
+      },
+      {
+        section: section_name,
+        label: 'Schoology',
+        url: 'https://www.schoology.com/',
+        popOut: true
+      }
+    ]
+  end
+
+
+  public
+  def navigation_service(params={})
+    _params = {
+      name: current_visitor.name,
+      request_path: request.path,
+    }
+    service =  NavigationService.new(self, params.merge(_params))
+
+    if show_help_link
+      service.add_link help_link_params
+    end
+
+    service.add_link preference_link_params
+
+    if show_favorites_link
+      service.add_link favorite_link_params
+    end
+
+    if show_admin_links
+      service.add_link admin_link_params
+    end
+
+    if show_switch_user_link
+      service.add_link switch_user_link
+    end
+
+
+    clazz_links.each {|clazz_link| service.add_link clazz_link}
+    itsi_links.each { |link| service.add_link link}
+    return service
+  end
+
+
+end

--- a/app/models/admin/project_link.rb
+++ b/app/models/admin/project_link.rb
@@ -1,6 +1,6 @@
 class Admin::ProjectLink < ActiveRecord::Base
   self.table_name = "admin_project_links"
   belongs_to :project, :class_name => 'Admin::Project'
-  attr_accessible :href, :name, :project_id
-  validates :href, :name, :presence => true
+  attr_accessible :href, :name, :project_id, :link_id, :pop_out
+  validates :href, :name, :link_id, :presence => true
 end

--- a/app/services/navigation_service.rb
+++ b/app/services/navigation_service.rb
@@ -93,7 +93,10 @@ class NavigationService
   end
 
   def parent_id_for(id)
-    parent_id = id.split("/")[0...-1].join("/")
+    parent_paths =  id.split("/")
+    if parent_paths.size > 0
+      parent_id = id.split("/")[0...-1].join("/")
+    end
     if(parent_id.blank?)
       parent_id = ROOT_SECTION
     end

--- a/app/services/navigation_service.rb
+++ b/app/services/navigation_service.rb
@@ -1,27 +1,44 @@
-require 'ostruct'
-
-
-class Section
-  attr_accessor :path
+class NavItem
+  attr_accessor :id
   attr_accessor :label
+  attr_accessor :url
+  attr_accessor :type
+  attr_accessor :onClick
+  attr_accessor :popOut
+  attr_accessor :sort
+  attr_accessor :selected
+  attr_accessor :iconName
+  attr_accessor :className
+  attr_accessor :target
   attr_accessor :children
 
-  def sortChildren
-
+  def defaults
+    {
+      type: NavigationService::LINK_TYPE,
+      sort: NavigationService::DEFAULT_SORT
+    }
   end
 
-  def addChild(linkOrSection)
-    children.push linkOrSection
-    self.sortChildren()
+  def initialize(props)
+    attributes = self.defaults.merge(props)
+    attributes.each { |k,v| instance_variable_set("@#{k}", v) }
   end
 
+  def to_h
+    hash = instance_variables.each_with_object({}) {|var,hash| hash[var.to_s.delete("@").to_sym] = instance_variable_get(var) }
+    if @children
+      hash[:children] = @children.map { |c| c.to_h }
+    end
+    hash
+  end
 end
 
 class NavigationService
-  ROOT_SECTION = "__NONE__"
+  ROOT_SECTION = "__ROOT__"
   ROOT_PATH = "/"
   DEFAULT_SORT = 5
   SECTION_TYPE = "SECTION"
+  LINK_TYPE = "LINK"
   SELECTED_LINK_CLASS = "link-selected"
   SELECTED_SECTION_CLASS = "in-selected-section"
   NO_ICON_CLASS = "no-icon"
@@ -30,6 +47,7 @@ class NavigationService
   attr_accessor :greeting
   attr_accessor :selected_section
   attr_accessor :links
+  attr_accessor :sections
 
   def initialize(viewHelper, params={})
     @user = params[:user]
@@ -38,6 +56,15 @@ class NavigationService
     @selected_section = params[:selected_section] || ROOT_SECTION
     @name = params[:name] || default_name
     @help = params[:help] || default_help
+    @root = NavItem.new ({
+      id: ROOT_SECTION,
+      label: "",
+      type: SECTION_TYPE,
+      children: []
+    })
+    @sections = {
+      ROOT_SECTION => @root
+    }
     @links = []
   end
 
@@ -53,10 +80,34 @@ class NavigationService
     {
       label: "help",
       url: "/help",
+      id: "/help",
+      type: LINK_TYPE,
       popOut: true
     }
   end
 
+  def parent_id_for(id)
+    parent_id = id.split("/")[0...-1].join("/")
+    if(parent_id.blank?)
+      parent_id = ROOT_SECTION
+    end
+    parent_id
+  end
+
+  def parent_for(id)
+    return @sections[parent_id_for(id)]
+  end
+
+  def remove_item(id)
+    parent = parent_for(id)
+    if parent
+      parent.children.reject! {|i| i.id == id}
+      parent.children.sort_by! { |a| a.sort }
+    end
+    @sections.delete(id)
+    @links.delete(id)
+    self.guess_selection
+  end
 
   # id: "/",
   # label: ""
@@ -64,63 +115,45 @@ class NavigationService
   # type: "section",
   # children: []
   def add_item(item_spec)
-    item = OpenStruct.new(item_spec)
-    parent_id = item.id.split("/")[0...-1].join("/")
-    if(parent_id.blank?)
-      parent_id = ROOT_SECTION
+    item = NavItem.new(item_spec)
+    unless(item.type)
+      item.type = item.url ? LINK_TYPE : SECTION_TYPE
     end
-    parent = @sections.find { |item| item.id == parent_id }
-    parent ||= add_item({
+    parent = parent_for(item.id)
+    parent_id= parent_id_for(item.id)
+    default_section_params = {
       id: parent_id,
       label: parent_id,
       sort: DEFAULT_SORT,
-      type: SECTION,
+      type: SECTION_TYPE,
       children: []
-    })
+    }
+    if !parent
+      parent = add_item(default_section_params)
+    end
 
     if item.type == SECTION_TYPE
-      item.chidlren ||= []
-      @sections.push item
-      @sections.sort! { |a,b| a.sort <=> b.sort }
+      item.children ||= []
+      @sections[item.id] = item
+    elsif item.url
+      @links.push item
     end
 
     parent.children.push item
-    parent.children.sort! { |a,b| a.sort <=> b.sort }
-
+    parent.children.sort_by! { |a| a.sort }
+    self.guess_selection
     return item
   end
 
-  def add_link(link_spec)
-    link = OpenStruct.new(link_spec)
-    link.section ||= ROOT_SECTION
-    section = find_or_create_parent(link.selection)
-    @links.push link
-    guess_selection
-  end
-
-  def sectionFor(linkHash)
-    return linkHash[:section]
-  end
-
-  def makeSections(links)
-    @sections ||={}
-    @sections.push(ROOT_SECTION => {})
-    sectionPaths = @links.map do |link|
-      section = link.section
-      label = section.split("/")
-      parent_id = section.split("/")[0...-1].join("/")
-
-      OpenStruct.new({
-        id: section,
-        label: label,
-        parent_id: parent_id,
-        ChangeJ2seFieldnameMavenJnlpVersionedJnlp
-      })
+  def item_to_hash(item)
+    return_hash = item.to_h
+    if item.children
+      return_hash[:children] = item.children.map { |c| item_to_hash(c) }
     end
-
-    @links.each do |link|
-
+    if item.url
+      return_hash[:url] = item.url
     end
+    return_hash
   end
 
   def to_hash
@@ -130,9 +163,7 @@ class NavigationService
       greeting: @greeting,
       selected_section: @selected_section,
       request_path: @request_path,
-      links: @links
-        .map { |l| l.to_h }
-        .group_by { |h| self.sectionFor(h)}
+      links: @root.children.map { |section| item_to_hash(section) }
     }
   end
 
@@ -143,7 +174,7 @@ class NavigationService
     @links.each do |link|
       if @request_path =~ %r[#{link.url}$]
         link.selected = true
-        @selected_section = link.section || ROOT_SECTION
+        @selected_section = link.id || ROOT_SECTION
       end
     end
     @links.each do |link|
@@ -153,7 +184,7 @@ class NavigationService
       link.className << " #{NO_ICON_CLASS}" unless link.iconName
       link.className << " #{POPOUT_CLASS}" if link.popOut
       if @selected_section != ROOT_SECTION
-        link.className << " #{SELECTED_SECTION_CLASS}" if link.section == @selected_section
+        link.className << " #{SELECTED_SECTION_CLASS}" if link.id == @selected_section
       end
     end
   end

--- a/app/services/navigation_service.rb
+++ b/app/services/navigation_service.rb
@@ -1,0 +1,165 @@
+require 'ostruct'
+
+
+class Section
+  attr_accessor :path
+  attr_accessor :label
+  attr_accessor :children
+
+  def sortChildren
+
+  end
+
+  def addChild(linkOrSection)
+    children.push linkOrSection
+    self.sortChildren()
+  end
+
+end
+
+class NavigationService
+  ROOT_SECTION = "__NONE__"
+  ROOT_PATH = "/"
+  DEFAULT_SORT = 5
+  SECTION_TYPE = "SECTION"
+  SELECTED_LINK_CLASS = "link-selected"
+  SELECTED_SECTION_CLASS = "in-selected-section"
+  NO_ICON_CLASS = "no-icon"
+  POPOUT_CLASS = "pop-out"
+  attr_accessor :name
+  attr_accessor :greeting
+  attr_accessor :selected_section
+  attr_accessor :links
+
+  def initialize(viewHelper, params={})
+    @user = params[:user]
+    @greeting = params[:greeting] || default_greeting
+    @request_path = params[:request_path] || ROOT_PATH
+    @selected_section = params[:selected_section] || ROOT_SECTION
+    @name = params[:name] || default_name
+    @help = params[:help] || default_help
+    @links = []
+  end
+
+  def default_name
+    "guest"
+  end
+
+  def default_greeting
+    "Welcome,"
+  end
+
+  def default_help
+    {
+      label: "help",
+      url: "/help",
+      popOut: true
+    }
+  end
+
+
+  # id: "/",
+  # label: ""
+  # sort: 1,
+  # type: "section",
+  # children: []
+  def add_item(item_spec)
+    item = OpenStruct.new(item_spec)
+    parent_id = item.id.split("/")[0...-1].join("/")
+    if(parent_id.blank?)
+      parent_id = ROOT_SECTION
+    end
+    parent = @sections.find { |item| item.id == parent_id }
+    parent ||= add_item({
+      id: parent_id,
+      label: parent_id,
+      sort: DEFAULT_SORT,
+      type: SECTION,
+      children: []
+    })
+
+    if item.type == SECTION_TYPE
+      item.chidlren ||= []
+      @sections.push item
+      @sections.sort! { |a,b| a.sort <=> b.sort }
+    end
+
+    parent.children.push item
+    parent.children.sort! { |a,b| a.sort <=> b.sort }
+
+    return item
+  end
+
+  def add_link(link_spec)
+    link = OpenStruct.new(link_spec)
+    link.section ||= ROOT_SECTION
+    section = find_or_create_parent(link.selection)
+    @links.push link
+    guess_selection
+  end
+
+  def sectionFor(linkHash)
+    return linkHash[:section]
+  end
+
+  def makeSections(links)
+    @sections ||={}
+    @sections.push(ROOT_SECTION => {})
+    sectionPaths = @links.map do |link|
+      section = link.section
+      label = section.split("/")
+      parent_id = section.split("/")[0...-1].join("/")
+
+      OpenStruct.new({
+        id: section,
+        label: label,
+        parent_id: parent_id,
+        ChangeJ2seFieldnameMavenJnlpVersionedJnlp
+      })
+    end
+
+    @links.each do |link|
+
+    end
+  end
+
+  def to_hash
+    {
+      name: @name,
+      help: @help,
+      greeting: @greeting,
+      selected_section: @selected_section,
+      request_path: @request_path,
+      links: @links
+        .map { |l| l.to_h }
+        .group_by { |h| self.sectionFor(h)}
+    }
+  end
+
+  def guess_selection
+    if @request_path == ROOT_PATH
+      @selected_section = ROOT_SECTION
+    end
+    @links.each do |link|
+      if @request_path =~ %r[#{link.url}$]
+        link.selected = true
+        @selected_section = link.section || ROOT_SECTION
+      end
+    end
+    @links.each do |link|
+      link.target = '_blank' if link.popOut
+      link.className  = ""
+      link.className << " #{SELECTED_LINK_CLASS}" if link.selected
+      link.className << " #{NO_ICON_CLASS}" unless link.iconName
+      link.className << " #{POPOUT_CLASS}" if link.popOut
+      if @selected_section != ROOT_SECTION
+        link.className << " #{SELECTED_SECTION_CLASS}" if link.section == @selected_section
+      end
+    end
+  end
+
+  def to_json
+    to_hash.to_json
+  end
+
+end

--- a/app/views/admin/projects/_form.html.haml
+++ b/app/views/admin/projects/_form.html.haml
@@ -41,6 +41,14 @@
                   %td URL:
                   %td
                     = link_form.text_field :href
+                %tr
+                  %td ID: (eg: '/resources/help'):
+                  %td
+                    = link_form.text_field :link_id
+                %tr
+                  %td Open link in new window:
+                  %td
+                    = link_form.check_box :pop_out
               = link_form.link_to_remove "Remove this link"
           %li
             = f.link_to_add "Add a link", :links

--- a/app/views/dynamic_scripts/_api_paths.html.haml
+++ b/app/views/dynamic_scripts/_api_paths.html.haml
@@ -1,6 +1,6 @@
 - fake_id = 999
 %script#navigationData{type: "application/json"}
-  = navigation_service({"greeting" => "Hola"}).to_json().html_safe
+  = navigation_service().to_json().html_safe
 
 :javascript
   Portal.API_V1 = {

--- a/app/views/dynamic_scripts/_api_paths.html.haml
+++ b/app/views/dynamic_scripts/_api_paths.html.haml
@@ -1,4 +1,7 @@
 - fake_id = 999
+%script#navigationData{type: "application/json"}
+  = navigation_service({"greeting" => "Hola"}).to_json().html_safe
+
 :javascript
   Portal.API_V1 = {
     FAKE_ID: "#{fake_id}",
@@ -65,7 +68,13 @@
     MATERIALS_GET_FAVORITE:     "#{api_v1_materials_get_favorites_path}",
 
     SEARCH: "#{api_v1_search_search_path}",
-    ASSIGN_MATERIAL_TO_CLASS: "#{api_v1_materials_assign_to_class_path}"
+    ASSIGN_MATERIAL_TO_CLASS: "#{api_v1_materials_assign_to_class_path}",
+
+    // Navigation
+    // NavigationHelper#get_navigation_json  see app/helpers/navigation_helper.rb
+    getNavigation: function() {
+      return JSON.parse(document.getElementById('navigationData').innerHTML)
+    }
   };
 - if current_user.present?
   - if current_user.portal_teacher

--- a/app/views/external_activities/matedit.html.haml
+++ b/app/views/external_activities/matedit.html.haml
@@ -1,11 +1,10 @@
+-# TODO: We could put this whole thing in a Portal Pages %component
 - @wide_content_layout = true
 #Activity_edit_container
-  .action_menu
-    .action_menu_header_left
-      %h3.menu
-        %span.component_title
-        #{@external_activity.name} Editing
-    .action_menu_header_right
+  .top-menu
+    .left
+      #navigation
+    .right
       = link_to t("matedit.archive"),
         archive_external_activity_path(@external_activity),
         class: "button",
@@ -19,6 +18,9 @@
         :onclick=>"get_edit_resource_popup(#{@external_activity.id}, {use_short_form: true, content_height: 400})",
         :class=>"button"
   -#messgeedit This is edit lara activity page
+  %h3.menu
+    %span.component_title
+    Edit #{@external_activity.name}
   #iframe_container.matedit
     %iframe{:id => "Edit_in_Lara",:src =>"#{@uri}",:width => "1000",:height => "100%"}
 
@@ -58,6 +60,11 @@
         $("#wrapper").css("min-height", null);
         resizeIframe();
         registerListeners();
+
       });
 
     })();
+:javascript
+  var navProps=Portal.API_V1.getNavigation();
+  navProps.overlay=true;
+  PortalPages.renderNavigation(navProps, 'navigation');

--- a/app/views/portal/clazzes/_clazzes_list.html.haml
+++ b/app/views/portal/clazzes/_clazzes_list.html.haml
@@ -1,3 +1,4 @@
+/ locals: top_node == nil || portal_teacher || portal_student
 .clazz_list_container#clazz_list_container
   - top_container_id = dom_id_for(top_node, :nav_list)
   - top_controller ||= top_node.class.name.tableize

--- a/app/views/portal/clazzes/_clazzes_list.html.haml
+++ b/app/views/portal/clazzes/_clazzes_list.html.haml
@@ -1,4 +1,4 @@
-/ locals: top_node == nil || portal_teacher || portal_student
+-# locals: top_node == nil || portal_teacher || portal_student
 .clazz_list_container#clazz_list_container
   - top_container_id = dom_id_for(top_node, :nav_list)
   - top_controller ||= top_node.class.name.tableize

--- a/app/views/shared/_left_menu.html.haml
+++ b/app/views/shared/_left_menu.html.haml
@@ -1,5 +1,58 @@
-#clazzes_nav
+/ TODO: possible refactoring to make more clazzes specific.
+/ Clazz navigation: top_node could be course, teacher, student ...
 
-- unless @wide_content_layout
-  :javascript
-    PortalPages.renderNavigation(Portal.API_V1.getNavigation(), 'clazzes_nav')
+/ 2018-07-06 NP: When we get all the blockers fixed, navigtion can use services....
+/ - unless @wide_content_layout
+/  :javascript
+/    PortalPages.renderNavigation(Portal.API_V1.getNavigation(), 'clazzes_nav')
+
+#clazzes_nav
+  #utility-links
+    %p
+      Welcome,
+      %br
+      %strong
+        = "#{current_visitor.name}!"
+    %ul
+      - if current_settings && ((current_settings.help_type == 'external url') || (current_settings.help_type == 'help custom html'))
+        %li
+          %a{:href => '/help', :target => '_blank', :class => 'help-link'}
+            %i{:class => 'icon-search'}
+            &nbsp;Help
+      %li
+        %a{:href => preferences_user_path(current_visitor)}
+          %i{:class => 'icon-settings'}
+          &nbsp;Settings
+      - if current_user && !current_user.portal_student
+        %li
+          %a{:href => favorites_user_path(current_visitor)}
+            %i{:class => 'icon-favorite'}
+            &nbsp;Favorites
+
+      - if @original_user != current_visitor
+        - switch_user_form_id = "switch_user_id_#{@original_user.id}"
+        %a{:href => 'javascript: void(0);', :onclick => "$('#{switch_user_form_id}').submit();"}
+          %i{:class => 'icon-login'}
+          &nbsp;Switch Back
+        = form_for @original_user, :url => switch_user_path(@original_user), :html => { :method => :put,:class=> "hidden" ,:id=> switch_user_form_id}  do |form|
+          = hidden_field_tag 'user[id]', @original_user.id
+          = hidden_field_tag 'commit', 'Switch'
+    - if current_visitor.has_role?('admin', 'manager', 'researcher') || current_visitor.portal_teacher
+      %ul.aux-links
+        - if current_visitor.has_role?('admin', 'manager','researcher') || current_visitor.is_project_admin? || current_visitor.is_project_researcher?
+          %li= link_to 'Admin', admin_path
+        - current_visitor.projects.each do |project|
+          - project.links.each do |link|
+            %li= link_to link.name, link.href
+
+  - if top_node
+    .secondary-mobile-menu-toggle{onclick: "toggleSecondaryMenu()"}
+      Menu
+    .padded_content
+      = render :partial => 'portal/clazzes/clazzes_list', :locals => {:top_node => top_node, :selects => selects}
+      - if top_node.is_a? Portal::Teacher
+        .create{:id=>dom_id_for(top_node, :nav_list_create_class)}
+          .create_link
+            = link_to 'Add a New Class', new_portal_clazz_path, :class=>"pie", :id=>"btn_create_class"
+          .manage_classes_link
+            = link_to 'Manage Classes', manage_portal_clazzes_url, :class=>"pie", :id=>"btn_manage_classes"

--- a/app/views/shared/_left_menu.html.haml
+++ b/app/views/shared/_left_menu.html.haml
@@ -1,22 +1,6 @@
-/ TODO: possible refactoring to make more clazzes specific.
-/ Clazz navigation: top_node could be course, teacher, student ...
-/ locals: top_node == nil || portal_teacher || portal_student
+
 - navigation = navigation_service()
 #clazzes_nav
-  -# #utility-links
-  -#   %p
-  -#     = navigation.greeting
-  -#     %br
-  -#     %strong
-  -#       = "#{navigation.name}!"
-  -#   %ul
-  -#   - navigation.links.each do |link|
-  -#     %li
-  -#       %a{href:link.url, target: link.target}
-  -#         -# - if link_def.iconName
-  -#         %i{:class => link.iconName}
-  -#         &nbsp;
-  -#         = link.label
 
 :javascript
   PortalPages.renderNavigation(Portal.API_V1.getNavigation(), 'clazzes_nav')

--- a/app/views/shared/_left_menu.html.haml
+++ b/app/views/shared/_left_menu.html.haml
@@ -1,53 +1,22 @@
 / TODO: possible refactoring to make more clazzes specific.
 / Clazz navigation: top_node could be course, teacher, student ...
-
+/ locals: top_node == nil || portal_teacher || portal_student
+- navigation = navigation_service()
 #clazzes_nav
-  #utility-links
-    %p
-      Welcome,
-      %br
-      %strong
-        = "#{current_visitor.name}!"
-    %ul
-      - if current_settings && ((current_settings.help_type == 'external url') || (current_settings.help_type == 'help custom html'))
-        %li
-          %a{:href => '/help', :target => '_blank', :class => 'help-link'}
-            %i{:class => 'icon-search'}
-            &nbsp;Help
-      %li
-        %a{:href => preferences_user_path(current_visitor)}
-          %i{:class => 'icon-settings'}
-          &nbsp;Settings
-      - if current_user && !current_user.portal_student
-        %li
-          %a{:href => favorites_user_path(current_visitor)}
-            %i{:class => 'icon-favorite'}
-            &nbsp;Favorites
+  -# #utility-links
+  -#   %p
+  -#     = navigation.greeting
+  -#     %br
+  -#     %strong
+  -#       = "#{navigation.name}!"
+  -#   %ul
+  -#   - navigation.links.each do |link|
+  -#     %li
+  -#       %a{href:link.url, target: link.target}
+  -#         -# - if link_def.iconName
+  -#         %i{:class => link.iconName}
+  -#         &nbsp;
+  -#         = link.label
 
-      - if @original_user != current_visitor
-        - switch_user_form_id = "switch_user_id_#{@original_user.id}"
-        %a{:href => 'javascript: void(0);', :onclick => "$('#{switch_user_form_id}').submit();"}
-          %i{:class => 'icon-login'}
-          &nbsp;Switch Back
-        = form_for @original_user, :url => switch_user_path(@original_user), :html => { :method => :put,:class=> "hidden" ,:id=> switch_user_form_id}  do |form|
-          = hidden_field_tag 'user[id]', @original_user.id
-          = hidden_field_tag 'commit', 'Switch'
-    - if current_visitor.has_role?('admin', 'manager', 'researcher') || current_visitor.portal_teacher
-      %ul.aux-links
-        - if current_visitor.has_role?('admin', 'manager','researcher') || current_visitor.is_project_admin? || current_visitor.is_project_researcher?
-          %li= link_to 'Admin', admin_path
-        - current_visitor.projects.each do |project|
-          - project.links.each do |link|
-            %li= link_to link.name, link.href
-
-  - if top_node
-    .secondary-mobile-menu-toggle{onclick: "toggleSecondaryMenu()"}
-      Menu
-    .padded_content
-      = render :partial => 'portal/clazzes/clazzes_list', :locals => {:top_node => top_node, :selects => selects}
-      - if top_node.is_a? Portal::Teacher
-        .create{:id=>dom_id_for(top_node, :nav_list_create_class)}
-          .create_link
-            = link_to 'Add a New Class', new_portal_clazz_path, :class=>"pie", :id=>"btn_create_class"
-          .manage_classes_link
-            = link_to 'Manage Classes', manage_portal_clazzes_url, :class=>"pie", :id=>"btn_manage_classes"
+:javascript
+  PortalPages.renderNavigation(Portal.API_V1.getNavigation(), 'clazzes_nav')

--- a/app/views/shared/_left_menu.html.haml
+++ b/app/views/shared/_left_menu.html.haml
@@ -1,6 +1,5 @@
-
-- navigation = navigation_service()
 #clazzes_nav
 
-:javascript
-  PortalPages.renderNavigation(Portal.API_V1.getNavigation(), 'clazzes_nav')
+- unless @wide_content_layout
+  :javascript
+    PortalPages.renderNavigation(Portal.API_V1.getNavigation(), 'clazzes_nav')

--- a/app/views/shared/_left_menu.html.haml
+++ b/app/views/shared/_left_menu.html.haml
@@ -1,10 +1,10 @@
-/ TODO: possible refactoring to make more clazzes specific.
-/ Clazz navigation: top_node could be course, teacher, student ...
+-# TODO: possible refactoring to make more clazzes specific.
+-# Clazz navigation: top_node could be course, teacher, student ...
 
-/ 2018-07-06 NP: When we get all the blockers fixed, navigtion can use services....
-/ - unless @wide_content_layout
-/  :javascript
-/    PortalPages.renderNavigation(Portal.API_V1.getNavigation(), 'clazzes_nav')
+-# 2018-07-06 NP: When we get all the blockers fixed, navigtion can use services....
+-# - unless @wide_content_layout
+-#  :javascript
+-#    PortalPages.renderNavigation(Portal.API_V1.getNavigation(), 'clazzes_nav')
 
 #clazzes_nav
   #utility-links

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -145,6 +145,22 @@ en:
     ErrorLoggedInAsStudent: |
       You are logged in as a student in another window.
       Please log out, and register again.
+  Navigation:
+    greeting: Hello,
+    help: Help
+    recent_updates: Recent updates
+    getting_started: Getting Started
+    settings: Settings
+    favorites: Favorites
+    admin: Admin
+    classes: Classes
+    resources: Resources
+    assignments: Assignments
+    student_roster: Student Roster
+    class_setup: Class Setup
+    full_status: Full Status
+    links: Links
+
     ErrorNotAllowed: |
       You are not allowed to perform this function.
 'en-HAS':

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -145,6 +145,9 @@ en:
     ErrorLoggedInAsStudent: |
       You are logged in as a student in another window.
       Please log out, and register again.
+    ErrorNotAllowed: |
+      You are not allowed to perform this function.
+
   Navigation:
     greeting: Hello,
     help: Help
@@ -160,9 +163,6 @@ en:
     class_setup: Class Setup
     full_status: Full Status
     links: Links
-
-    ErrorNotAllowed: |
-      You are not allowed to perform this function.
 'en-HAS':
   activerecord:
     models:

--- a/db/migrate/20180620194214_add_link_idand_pop_out_to_admin_project_links.rb
+++ b/db/migrate/20180620194214_add_link_idand_pop_out_to_admin_project_links.rb
@@ -1,0 +1,6 @@
+class AddLinkIdandPopOutToAdminProjectLinks < ActiveRecord::Migration
+  def change
+    add_column :admin_project_links, :link_id, :string
+    add_column :admin_project_links, :pop_out, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -85,6 +85,8 @@ ActiveRecord::Schema.define(:version => 20180703161820) do
     t.text     "href",       :limit => 16777215
     t.datetime "created_at",                     :null => false
     t.datetime "updated_at",                     :null => false
+    t.string   "link_id"
+    t.boolean  "pop_out"
   end
 
   create_table "admin_project_materials", :force => true do |t|

--- a/features/admin_accesses_special_pages.feature
+++ b/features/admin_accesses_special_pages.feature
@@ -8,14 +8,14 @@ Feature: Admin can access various admin pages
     Given The default settings and jnlp resources exist using factories
     And the database has been seeded
 
-  @enable_gses
+  @enable_gses @javascript
   Scenario: Admin access GSEs
     When I login as an admin
     And I am on the home page
     And I follow "Admin"
     Then I should see "GSEs"
 
-  @disable_gses
+  @disable_gses @javascript
   Scenario: Admin access GSEs
     When I login as an admin
     And I am on the home page

--- a/features/admin_configures_vendor_interfaces.feature
+++ b/features/admin_configures_vendor_interfaces.feature
@@ -55,6 +55,7 @@ Feature: The Project administrator disables certain vendor interfaces
       | Texas Instruments| false   |
       | pasco bluetooth  | true    |
 
+  @javascript
   Scenario: The student user can only select configured interfaces
     Given the following students exist:
       | login          | password            |

--- a/features/admin_views_districts.feature
+++ b/features/admin_views_districts.feature
@@ -13,7 +13,8 @@ Feature: Admin views districts
     When I am on the districts page
     Then I should see the default district
     And I should see "create District"
-    
+
+  @javascript
   Scenario: admin creates a new district
     When I am on the districts page
     And I follow "create District"

--- a/features/admin_work_with_interactives.feature
+++ b/features/admin_work_with_interactives.feature
@@ -8,6 +8,7 @@ Feature: Admin can work with interactives
     Given the database has been seeded
     And I am logged in with the username admin
 
+  @javascript
   Scenario: Admin accesses Materials Collections
     When I am on the home page
     And I follow "Admin"

--- a/features/admin_works_with_materials_collections.feature
+++ b/features/admin_works_with_materials_collections.feature
@@ -9,6 +9,7 @@ Feature: Admin can work with materials collections
     And the database has been seeded
     And I am logged in with the username admin
 
+  @javascript
   Scenario: Admin accesses Materials Collections
     When I am on the home page
     And I follow "Admin"

--- a/features/external_activites_can_be_run_as_offerings.feature
+++ b/features/external_activites_can_be_run_as_offerings.feature
@@ -6,7 +6,8 @@ Feature: External Activities can be run as offerings
   Background:
     Given The default settings and jnlp resources exist using factories
     And the database has been seeded
-    
+
+  @javascript
   Scenario: External Activity offerings are runnable
     When the external activity "My Activity" is assigned to the class "Class_with_no_assignment"
     And I am logged in with the username student

--- a/features/step_definitions/project_links_steps.rb
+++ b/features/step_definitions/project_links_steps.rb
@@ -7,12 +7,14 @@ Given /^the default project links exist using factories$/ do
   Factory(:project_link, {
     :project_id => project.id,
     :name => "Foo Project Link",
-    :href => "http://foo.com"
+    :href => "http://foo.com",
+    :link_id => "/resources/foo"
   })
   Factory(:project_link, {
     :project_id => project.id,
     :name => "Bar Project Link",
-    :href => "http://bar.com"
+    :href => "http://bar.com",
+    :link_id => "/resources/bar"
   })
 end
 

--- a/features/student_should_not_see_project_specific_links.feature
+++ b/features/student_should_not_see_project_specific_links.feature
@@ -10,11 +10,13 @@ Feature: Student cannot see project specific links
     And the default project links exist using factories
     And I am logged in with the username student
 
+  @javascript
   Scenario: Student not in project visits homepage
     When I am on my classes page
     Then I should not see a project link labeled "Foo Project Link"
       And I should not see a project link labeled "Bar Project Link"
 
+  @javascript
   Scenario: Student in project visits homepage
     Given the "student" user is added to the default project
     When I am on my classes page

--- a/features/student_should_see_latest_class_information.feature
+++ b/features/student_should_see_latest_class_information.feature
@@ -20,7 +20,7 @@ Feature: Student should see latest class information
     When I login with username: taylor
     Then I should see "Basic Electronics"
     
-    
+  @javascript
   Scenario: Student should see all the updated information of a class
     When I login with username: taylor
     And I follow "Basic Electronics"

--- a/features/teacher_navigates_classes_using_left_pane.feature
+++ b/features/teacher_navigates_classes_using_left_pane.feature
@@ -9,23 +9,23 @@ Feature: Teacher navigates using left pane
     And the database has been seeded
     And I login with username: teacher
 
-
+  @javascript
   Scenario: Teachers can see their class name
     Then I should see "My Class"
 
-
+  @javascript
   Scenario: Teacher visits Student Roster page
     When I follow "My Class"
     And I follow "Student Roster"
     Then I should be on "Student Roster" page for "My Class"
 
-
+  @javascript
   Scenario: Teacher visits Class Setup page
     When I follow "My Class"
     And I follow "Class Setup"
     Then I should be on the class edit page for "My Class"
 
-
+  @javascript
   Scenario: Teacher visits Materials page
     When I follow "My Class"
     And I follow "Assignments"

--- a/features/teacher_sees_project_specific_links.feature
+++ b/features/teacher_sees_project_specific_links.feature
@@ -10,6 +10,7 @@ Feature: Teacher can see project specific links
     And the default project links exist using factories
     And I am logged in with the username teacher
 
+  @javascript
   Scenario: Teacher not in project visits homepage
     When I am on getting started page
     Then I should not see a project link labeled "Foo Project Link"

--- a/spec/helpers/navigation_helper_spec.rb
+++ b/spec/helpers/navigation_helper_spec.rb
@@ -37,12 +37,11 @@ describe NavigationHelper do
     subject { JSON.pretty_generate(helper.navigation_service(params).to_hash) }
     it "should inlude teacher links" do
       fake_clazzes.each do |clazz|
-        subject.should match %r{"url": "/portal/classes/#{clazz.id}"}
         subject.should match %r{"url": "/portal/classes/#{clazz.id}/materials"}
         subject.should match %r{"url": "/portal/classes/#{clazz.id}/roster"}
         subject.should match %r{"url": "/portal/classes/#{clazz.id}/edit"}
         subject.should match %r{"url": "/portal/classes/#{clazz.id}/fullstatus"}
-        subject.should match %r{"section": "classes/#{clazz.name}"}
+        subject.should match %r{"id": "/classes/#{clazz.id}"}
       end
       subject.should_not match %r{"url": "/admin}
     end
@@ -95,18 +94,21 @@ describe NavigationHelper do
     let(:path) { "/" }
     before(:each) do
       helper.stub_chain(:request, :path).and_return(path)
-      puts path
     end
     let(:fake_visitor) { fake_teacher.user }
     subject { helper.navigation_service() }
     it "should have several links" do
-      subject.links.should have(20).links
+      subject.links.should have(25).links
     end
+    it "should have several sections" do
+      subject.sections.should have(6).sections
+    end
+
     describe "when on the assignment page for the first class" do
       let(:path) { helper.url_for([:materials, clazz]) }
       let(:clazz) { fake_clazzes.first }
       it "should have the correct selected section" do
-        subject.selected_section.should == "classes/#{clazz.name}"
+        subject.selected_section.should == "/classes/#{clazz.id}/assignments"
       end
       it "The selected link should be to the fake first class." do
         subject.links.find { |l| l.selected }.label.should == "Assignments"

--- a/spec/helpers/navigation_helper_spec.rb
+++ b/spec/helpers/navigation_helper_spec.rb
@@ -1,0 +1,116 @@
+require 'spec_helper'
+
+
+
+include ApplicationHelper
+describe NavigationHelper do
+  let(:name) { "fredrique" }
+  let(:fake_clazzes) { FactoryGirl.create_list(:portal_clazz, 3)}
+  let(:fake_teacher_clazzes) { fake_clazzes.map { |c| mock(clazz: c)}}
+  let(:fake_student) { FactoryGirl.create(:full_portal_student) }
+  let(:fake_teacher) { FactoryGirl.create(:portal_teacher) }
+  let(:fake_visitor) { fake_student.user }
+  let(:params)       { {greeting: "bonjour"} }
+  before(:each) do
+    helper.stub(:current_visitor).and_return(fake_visitor)
+    helper.stub(:current_user).and_return(fake_visitor)
+    fake_visitor.stub(:name).and_return(name)
+    fake_teacher.stub(:teacher_clazzes).and_return(fake_teacher_clazzes)
+    fake_student.stub(:clazzes).and_return(fake_clazzes)
+  end
+  describe "get_nav_content" do
+    describe "schema validation" do
+      subject { helper.navigation_service(params).to_json }
+      it { should match_response_schema("navigation") }
+    end
+    describe "values" do
+      subject { helper.navigation_service(params).to_hash }
+      it { should include(name:  name )}
+      it { should include(greeting: "bonjour") }
+      it { should include(:help) }
+      it { should include(:links) }
+      it { should_not include("xxx") }
+    end
+  end
+  describe "teacher links" do
+    let(:fake_visitor) { fake_teacher.user }
+    subject { JSON.pretty_generate(helper.navigation_service(params).to_hash) }
+    it "should inlude teacher links" do
+      fake_clazzes.each do |clazz|
+        subject.should match %r{"url": "/portal/classes/#{clazz.id}"}
+        subject.should match %r{"url": "/portal/classes/#{clazz.id}/materials"}
+        subject.should match %r{"url": "/portal/classes/#{clazz.id}/roster"}
+        subject.should match %r{"url": "/portal/classes/#{clazz.id}/edit"}
+        subject.should match %r{"url": "/portal/classes/#{clazz.id}/fullstatus"}
+        subject.should match %r{"section": "classes/#{clazz.name}"}
+      end
+      subject.should_not match %r{"url": "/admin}
+    end
+
+    describe "teacher that is also a project admin" do
+      before(:each) do
+        fake_visitor.stub(:is_project_admin?).and_return(true)
+      end
+      it "should still include teacher clazz links" do
+        fake_clazzes.each do |clazz|
+          subject.should match %r{"url": "/portal/classes/#{clazz.id}/materials"}
+        end
+      end
+      it "should include admin links" do
+        subject.should match %r{"url": "/admin}
+      end
+      it "should include favorites links" do
+        subject.should match %r{"label": "Favorites"}
+      end
+    end
+  end
+
+  describe "student links" do
+    let(:fake_visitor) { fake_student.user }
+    subject { JSON.pretty_generate(helper.navigation_service(params).to_hash) }
+
+    it "should include class links" do
+      fake_clazzes.each do |clazz|
+        subject.should match %r{"url": "/portal/classes/#{clazz.id}"}
+      end
+    end
+
+    it "should not inlude teacher links" do
+      fake_clazzes.each do |clazz|
+        subject.should_not match %r{"url": "/portal/classes/#{clazz.id}/materials"}
+        subject.should_not match %r{"url": "/portal/classes/#{clazz.id}/roster"}
+        subject.should_not match %r{"url": "/portal/classes/#{clazz.id}/edit"}
+        subject.should_not match %r{"url": "/portal/classes/#{clazz.id}/fullstatus"}
+        subject.should_not match %r{"section": "classes/#{clazz.name}"}
+      end
+      subject.should_not match %r{"url": "/admin}
+    end
+
+    it "should not include favorites links" do
+      subject.should_not match %r{"label": "Favorites"}
+    end
+  end
+
+  describe "selections" do
+    let(:path) { "/" }
+    before(:each) do
+      helper.stub_chain(:request, :path).and_return(path)
+      puts path
+    end
+    let(:fake_visitor) { fake_teacher.user }
+    subject { helper.navigation_service() }
+    it "should have several links" do
+      subject.links.should have(20).links
+    end
+    describe "when on the assignment page for the first class" do
+      let(:path) { helper.url_for([:materials, clazz]) }
+      let(:clazz) { fake_clazzes.first }
+      it "should have the correct selected section" do
+        subject.selected_section.should == "classes/#{clazz.name}"
+      end
+      it "The selected link should be to the fake first class." do
+        subject.links.find { |l| l.selected }.label.should == "Assignments"
+      end
+    end
+  end
+end

--- a/spec/helpers/navigation_helper_spec.rb
+++ b/spec/helpers/navigation_helper_spec.rb
@@ -1,20 +1,32 @@
 require 'spec_helper'
 
-
-
 include ApplicationHelper
 describe NavigationHelper do
   let(:name) { "fredrique" }
+  let(:itsi_links) do
+    [
+      mock(link_id: '/resources/activities', name: 'activities', href: '/itsi', pop_out: false),
+      mock(link_id: '/resources/interactives', name: 'interactives', href: '/interactives', pop_out: true),
+      mock(link_id: '/resources/images', name: 'images', href: '/images', pop_out: true),
+      mock(link_id: '/resources/guides', name: 'Teacher Guides', href: 'https://guides.itsi.concord.org/', pop_out: true),
+      mock(link_id: '/resources/careers', name: 'Careersight', href: 'https://careersight.concord.org/', pop_out: true),
+      mock(link_id: '/resources/probes', name: 'Probesight', href: 'https://probesight.concord.org/', pop_out: true),
+      mock(link_id: '/resources/schoology', name: 'Schoology', href: 'https://www.schoology.com/', pop_out: true)
+    ]
+  end
+  let(:itsi_project) { mock(links: itsi_links)}
   let(:fake_clazzes) { FactoryGirl.create_list(:portal_clazz, 3)}
   let(:fake_teacher_clazzes) { fake_clazzes.map { |c| mock(clazz: c)}}
   let(:fake_student) { FactoryGirl.create(:full_portal_student) }
   let(:fake_teacher) { FactoryGirl.create(:portal_teacher) }
   let(:fake_visitor) { fake_student.user }
   let(:params)       { {greeting: "bonjour"} }
+  let(:projects)     { [itsi_project] }
   before(:each) do
     helper.stub(:current_visitor).and_return(fake_visitor)
     helper.stub(:current_user).and_return(fake_visitor)
     fake_visitor.stub(:name).and_return(name)
+    fake_visitor.stub(:projects).and_return(projects)
     fake_teacher.stub(:teacher_clazzes).and_return(fake_teacher_clazzes)
     fake_student.stub(:clazzes).and_return(fake_clazzes)
   end
@@ -36,11 +48,11 @@ describe NavigationHelper do
     let(:fake_visitor) { fake_teacher.user }
     subject { JSON.pretty_generate(helper.navigation_service(params).to_hash) }
     it "should inlude teacher links" do
+      puts subject
       fake_clazzes.each do |clazz|
         subject.should match %r{"url": "/portal/classes/#{clazz.id}/materials"}
         subject.should match %r{"url": "/portal/classes/#{clazz.id}/roster"}
         subject.should match %r{"url": "/portal/classes/#{clazz.id}/edit"}
-        subject.should match %r{"url": "/portal/classes/#{clazz.id}/fullstatus"}
         subject.should match %r{"id": "/classes/#{clazz.id}"}
       end
       subject.should_not match %r{"url": "/admin}
@@ -92,18 +104,12 @@ describe NavigationHelper do
 
   describe "selections" do
     let(:path) { "/" }
-    before(:each) do
-      helper.stub_chain(:request, :path).and_return(path)
-    end
     let(:fake_visitor) { fake_teacher.user }
     subject { helper.navigation_service() }
-    it "should have several links" do
-      subject.links.should have(25).links
+    before(:each) do
+      helper.stub_chain(:request, :path).and_return(path)
+      subject.update_selection()
     end
-    it "should have several sections" do
-      subject.sections.should have(6).sections
-    end
-
     describe "when on the assignment page for the first class" do
       let(:path) { helper.url_for([:materials, clazz]) }
       let(:clazz) { fake_clazzes.first }
@@ -112,6 +118,38 @@ describe NavigationHelper do
       end
       it "The selected link should be to the fake first class." do
         subject.links.find { |l| l.selected }.label.should == "Assignments"
+      end
+    end
+  end
+
+  describe "Links and sections for a teacher in ITSI" do
+    let(:fake_visitor) { fake_teacher.user }
+    subject { helper.navigation_service() }
+    describe "In the ITSI Project" do
+      let(:projects)     { [itsi_project] }
+
+      it "should have several links" do
+        subject.links.should have(24).links
+      end
+      it "should have several sections" do
+        subject.sections.should have(6).sections
+      end
+      it "should have resources, and classes sections" do
+        subject.sections.keys.should include("/resources", "/classes")
+      end
+    end
+
+    describe "Not in any Projects" do
+      let(:projects)     { [] }
+      it "should have several links" do
+        subject.links.should have(17).links
+      end
+      it "should have several sections" do
+        puts subject.sections.keys
+        subject.sections.should have(6).sections
+      end
+      it "should not have resources sections" do
+        subject.sections.keys.should_not include("/resources")
       end
     end
   end

--- a/spec/helpers/navigation_helper_spec.rb
+++ b/spec/helpers/navigation_helper_spec.rb
@@ -48,7 +48,6 @@ describe NavigationHelper do
     let(:fake_visitor) { fake_teacher.user }
     subject { JSON.pretty_generate(helper.navigation_service(params).to_hash) }
     it "should inlude teacher links" do
-      puts subject
       fake_clazzes.each do |clazz|
         subject.should match %r{"url": "/portal/classes/#{clazz.id}/materials"}
         subject.should match %r{"url": "/portal/classes/#{clazz.id}/roster"}
@@ -145,8 +144,7 @@ describe NavigationHelper do
         subject.links.should have(17).links
       end
       it "should have several sections" do
-        puts subject.sections.keys
-        subject.sections.should have(6).sections
+        subject.sections.should have(5).sections
       end
       it "should not have resources sections" do
         subject.sections.keys.should_not include("/resources")

--- a/spec/models/admin/project_link_spec.rb
+++ b/spec/models/admin/project_link_spec.rb
@@ -2,12 +2,13 @@ require 'spec_helper'
 
 describe Admin::ProjectLink do
 
-  describe "#name and #href" do
+  describe "#name and #href and #link_id" do
     it "should be required" do
-      expect(Admin::ProjectLink.new(name: 'foo', href: 'bar').valid?).to be_true
-      expect(Admin::ProjectLink.new(name: 'foo', href: '').valid?).to be_false
-      expect(Admin::ProjectLink.new(name: '', href: 'bar').valid?).to be_false
-      expect(Admin::ProjectLink.new(name: '', href: '').valid?).to be_false
+      expect(Admin::ProjectLink.new(name: 'foo', href: 'bar', link_id:'/foo/bar').valid?).to be_true
+      expect(Admin::ProjectLink.new(name: 'foo', href: '', link_id: '/foo').valid?).to be_false
+      expect(Admin::ProjectLink.new(name: '', href: 'bar', link_id: '/bar').valid?).to be_false
+      expect(Admin::ProjectLink.new(name: '', href: '', link_id:'/').valid?).to be_false
+      expect(Admin::ProjectLink.new(name: 'foo', href: 'bar', link_id:'').valid?).to be_false
       expect(Admin::ProjectLink.new().valid?).to be_false
     end
   end

--- a/spec/services/navigation_service_spec.rb
+++ b/spec/services/navigation_service_spec.rb
@@ -1,0 +1,130 @@
+require 'spec_helper'
+
+def gather_item_values(obj,key)
+  results = []
+  if obj.respond_to?(:key?) && obj.key?(key)
+    results.push obj[key]
+  elsif obj.respond_to?(:each)
+    obj.select { |*a| results.push gather_item_values(a.last,key) }
+  end
+  results.flatten
+end
+
+describe NavigationService do
+  let(:name)     { "Mad Franky" }
+  let(:greeting) { "Hello"}
+  let(:items) {
+    [
+      {
+        id: "/classes/2",
+        label: "Noahs Class",
+        type: NavigationService::SECTION_TYPE,
+        sort: 1,
+      },
+      {
+        id: "/classes/2/assign",
+        label: "Assign Material",
+        sort: 1,
+        url: "/classes/2/edit"
+      },
+      {
+        id: "/resources/schoology",
+        label: "schoology",
+        sort: 1,
+        url: "http://scologoy.com"
+      },
+    ]
+  }
+  let(:params) {
+    {
+      greeting: greeting,
+      name: name
+    }
+  }
+  let(:nav_service) { NavigationService.new(nil,params) }
+
+  before(:each) do
+    nav_service
+    items.each { |item| nav_service.add_item(item) }
+  end
+
+  describe "basics" do
+    it "should have some sections" do
+      nav_service.sections.should have(4).sections
+    end
+    it "should have 2 links" do
+      nav_service.links.should have(2).links
+    end
+  end
+
+  describe "nested structure" do
+    describe "schema validation" do
+      subject { nav_service.to_json }
+      it { should match_response_schema("navigation")}
+    end
+    describe "values" do
+      let(:greeting) { "bonjour" }
+      subject { nav_service.to_hash }
+      it { should include(name:  name )}
+      it { should include(greeting: "bonjour") }
+      it { should include(:help) }
+      it { should include(:links) }
+      it { should_not include("xxx") }
+      describe "nested links" do
+        it "should have /classes/2/assign link" do
+          subject[:links].first()[:children].first()[:children].first()[:id].should eq("/classes/2/assign")
+        end
+      end
+    end
+  end
+  describe "sort orders" do
+    let(:sort)     { 5 }
+    let(:new_item) {
+      {
+        id: "/classes/2/roster",
+        label: "Class Roster",
+        sort: sort,
+        url: "/classes/2/roster"
+      }
+    }
+    subject { nav_service.to_hash }
+    before(:each) do
+      nav_service.add_item(new_item)
+    end
+    describe "nested links" do
+      describe "with roster using lower sort value" do
+        let(:sort) { 0 }
+        it "should have /classes/2/assign should appear after /casses/2/roster" do
+          subject[:links].first()[:children].first()[:children].first()[:id].should eq("/classes/2/roster")
+        end
+      end
+      describe "with roster using higher sort value" do
+        let(:sort) { 7 }
+        it "should have /classes/2/assign should appear before /casses/2/roster" do
+          subject[:links].first()[:children].first()[:children].first()[:id].should eq("/classes/2/assign")
+        end
+      end
+      describe "supressing items" do
+        let(:supress_path) { "/foo" }
+        before(:each) do
+          nav_service.remove_item(supress_path)
+        end
+        describe "supressing a non existant item" do
+          let(:supress_path) { "/foo" }
+          it "it should still have all sections, such as resources and classes" do
+            gather_item_values(subject[:links], :id).should include("/resources")
+            gather_item_values(subject[:links], :id).should include("/classes")
+          end
+        end
+
+        describe "supressing the resources section" do
+          let(:supress_path) { "/resources" }
+          it "should no longer have a resources section" do
+            gather_item_values(subject[:links], :id).should_not include("/resources")
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/spec/services/navigation_service_spec.rb
+++ b/spec/services/navigation_service_spec.rb
@@ -33,6 +33,12 @@ describe NavigationService do
         sort: 1,
         url: "http://scologoy.com"
       },
+      {
+        id: "google",
+        label: "google",
+        sort: 5,
+        url: "http://google.com"
+      },
     ]
   }
   let(:params) {
@@ -53,7 +59,7 @@ describe NavigationService do
       nav_service.sections.should have(4).sections
     end
     it "should have 2 links" do
-      nav_service.links.should have(2).links
+      nav_service.links.should have(3).links
     end
   end
 

--- a/spec/support/api/schemas/navigation.json
+++ b/spec/support/api/schemas/navigation.json
@@ -12,7 +12,8 @@
         "sort":     { "type": "number"  },
         "selected": { "type": "boolean" },
         "iconName": { "type": "string"  },
-        "className":{ "type": "string"  },
+        "small":    { "type": "boolean" },
+        "divider":  { "type": "boolean" },
         "children": {
           "type": "array",
           "items": {"$ref": "#/definitions/item"}

--- a/spec/support/api/schemas/navigation.json
+++ b/spec/support/api/schemas/navigation.json
@@ -1,0 +1,34 @@
+{
+  "definitions": {
+    "link": {
+      "type": "object",
+      "properties": {
+        "label":    { "type": "string"  },
+        "url":      { "type": "string"  },
+        "onClick":  { "type": "string"  },
+        "popOut":   { "type": "boolean" },
+        "index":    { "type": "string"  },
+        "selected": { "type": "boolean" },
+        "section":  { "type": "string"  },
+        "iconName": { "type": "string"  },
+        "className":{ "type": "string"  }
+      },
+      "required": [ "label", "url"]
+    }
+  },
+  "type": "object",
+  "required": [
+    "name",
+    "greeting",
+    "help"
+  ],
+  "properties": {
+    "greeting": {"type": "string"},
+    "name" : { "type" : "string" },
+    "help" : { "$ref": "#/definitions/link" },
+    "links": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/link"}
+    }
+  }
+}

--- a/spec/support/api/schemas/navigation.json
+++ b/spec/support/api/schemas/navigation.json
@@ -1,19 +1,24 @@
 {
   "definitions": {
-    "link": {
+    "item": {
       "type": "object",
       "properties": {
+        "id":       { "type": "string"  },
         "label":    { "type": "string"  },
         "url":      { "type": "string"  },
+        "type":     { "type": "string"  },
         "onClick":  { "type": "string"  },
         "popOut":   { "type": "boolean" },
-        "index":    { "type": "string"  },
+        "sort":     { "type": "number"  },
         "selected": { "type": "boolean" },
-        "section":  { "type": "string"  },
         "iconName": { "type": "string"  },
-        "className":{ "type": "string"  }
+        "className":{ "type": "string"  },
+        "children": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/item"}
+        }
       },
-      "required": [ "label", "url"]
+      "required": [ "id", "label", "type"]
     }
   },
   "type": "object",
@@ -25,10 +30,10 @@
   "properties": {
     "greeting": {"type": "string"},
     "name" : { "type" : "string" },
-    "help" : { "$ref": "#/definitions/link" },
+    "help" : { "$ref": "#/definitions/item" },
     "links": {
       "type": "array",
-      "items": { "$ref": "#/definitions/link"}
+      "items": { "$ref": "#/definitions/item"}
     }
   }
 }

--- a/spec/support/api_schema_matcher.rb
+++ b/spec/support/api_schema_matcher.rb
@@ -1,0 +1,7 @@
+RSpec::Matchers.define :match_response_schema do |schema|
+  match do |json|
+    schema_directory = "#{Dir.pwd}/spec/support/api/schemas"
+    schema_path = "#{schema_directory}/#{schema}.json"
+    JSON::Validator.validate!(schema_path, json, strict: false)
+  end
+end

--- a/themes/itsi-learn/views/portal/clazzes/materials.html.haml
+++ b/themes/itsi-learn/views/portal/clazzes/materials.html.haml
@@ -1,2 +1,0 @@
-= form_for(@portal_clazz) do |f|
-  = render :partial => 'materials', :locals => { :portal_clazz => @portal_clazz, :f => f, :assign_materials_link => "/itsi?assign_to_class=#{@portal_clazz.id}" }


### PR DESCRIPTION
Removes navigation logic from the portal views.

NavigationHelper can create a NavigationService. These two work in concert to generate a JSON description of navigation links that are available for the current user on the current page.  

The JSON structure is available to scripts in the portal api via `Portal.API_V1.getNavigation()`.

I just noticed a few things I need to cleanup before getting a review.


