### PR TITLE
Adress production NoMethodError in report.rb:27 is_teacher?

### DIFF
--- a/app/policies/api/v1/report_policy.rb
+++ b/app/policies/api/v1/report_policy.rb
@@ -16,11 +16,11 @@ class API::V1::ReportPolicy < ApplicationPolicy
   end
 
   def class_teacher?
-    record.is_teacher? user
+    user && (record.is_teacher? user)
   end
 
   def is_the_student?
-    record.is_report_for_student? user
+    user && (record.is_report_for_student? user)
   end
 
   def class_teacher_or_admin?


### PR DESCRIPTION
Added nil guard to report policy to prevent production NoMethodError in app/models/api/v1/report.rb:27:in `is_teacher?'

The problem seems to manifest when, down in the model, a test for is_teacher?(user) has a nil user. We could guard against it there, but backing up a little, this seems to be happening because the reports controller, using Pundit, is performing the "authorize report" function which is succeeding.

Digging further, it looks as if the Pundit policy could be a little smarter and guard against the call to is_teacher? with a nil user. Parallel to this phrase in the policy, is_the_student? looks like it could have the same issue.

Since this version is in production, only the most minimal changes were implemented in this by adding the guards for user being non-nil.

I'm out of time for the day, but it would be really good to add some coverage tests.