### PR TITLE
Ignore description and abstract values sent from LARA

### DIFF
--- a/features/activity_runtime_api/publish.feature
+++ b/features/activity_runtime_api/publish.feature
@@ -10,7 +10,7 @@ Feature: External Activities can support a REST publishing api
         "author_url": "http://activity.com/activity/1/edit",
         "print_url": "http://activity.com/activity/1/print_blank",
         "external_report_url": "https://reports.concord.org/act",
-        "description": "This activity does fun stuff.",
+        "description": "LARA description which should be ignored by Portal",
         "sections": [
           {
             "name": "Cool Activity Section 1",
@@ -106,13 +106,11 @@ Feature: External Activities can support a REST publishing api
       {
         "type": "Sequence",
         "name": "Many fun things",
-        "description": "Several activities together in a sequence",
         "url": "http://activity.com/sequence/1",
         "launch_url": "http://activity.com/sequence/1",
         "author_url": "http://activity.com/sequence/1/edit",
         "print_url": "http://activity.com/sequence/1/print_blank",
         "external_report_url": "https://reports.concord.org/seq",
-        "abstract": "This is the abstract",
         "activities": [
           {
             "type": "Activity",
@@ -121,8 +119,6 @@ Feature: External Activities can support a REST publishing api
             "launch_url": "http://activity.com/activity/1/sessions/",
             "author_url": "http://activity.com/activity/1/edit",
             "print_url": "http://activity.com/activity/1/print_blank",
-            "description": "This activity does fun stuff.",
-            "abstract": "This is the abstract.",
             "sections": [
               {
                 "name": "Cool Activity Section 1",
@@ -167,7 +163,6 @@ Feature: External Activities can support a REST publishing api
             "name": "Cooler Activity",
             "url": "http://activity.com/activity/2",
             "launch_url": "http://activity.com/activity/2/sessions/",
-            "description": "This activity does even more fun stuff.",
             "sections": [
               {
                 "name": "Cooler Activity Section 1",
@@ -215,8 +210,6 @@ Feature: External Activities can support a REST publishing api
       {
         "type": "Sequence",
         "name": "This has a different name",
-        "description": "All we did was change the name. And the description.",
-        "abstract": "The abstract was also changed",
         "url": "http://activity.com/sequence/1",
         "launch_url": "http://activity.com/sequence/1",
         "author_url": "http://activity.com/sequence/1/edit_new",
@@ -230,7 +223,6 @@ Feature: External Activities can support a REST publishing api
             "launch_url": "http://activity.com/activity/1/sessions/",
             "author_url": "http://activity.com/activity/1/edit_new",
             "print_url": "http://activity.com/activity/1/print_blank_new",
-            "description": "This activity does fun stuff.",
             "sections": [
               {
                 "name": "Cool Activity Section 1",
@@ -275,7 +267,6 @@ Feature: External Activities can support a REST publishing api
             "name": "Cooler Activity",
             "url": "http://activity.com/activity/2",
             "launch_url": "http://activity.com/activity/2/sessions/",
-            "description": "This activity does even more fun stuff.",
             "sections": [
               {
                 "name": "Cooler Activity Section 1",
@@ -333,7 +324,7 @@ Feature: External Activities can support a REST publishing api
       | launch_url      | http://activity.com/activity/1/sessions/ |
       | author_url      | http://activity.com/activity/1/edit |
       | print_url       | http://activity.com/activity/1/print_blank |
-      | description     | This activity does fun stuff. |
+    And the external activity should not have any description set
     And the external activity should have a template
     And the external activity should have a external report at "https://reports.concord.org/act"
     And the portal should create an activity with the following attributes:
@@ -363,8 +354,9 @@ Feature: External Activities can support a REST publishing api
       | launch_url      | http://activity.com/activity/1/sessions/ |
       | author_url      | http://activity.com/activity/1/edit_new |
       | print_url       | http://activity.com/activity/1/print_blank_new |
-      | description     | This activity does fun stuff. |
+      | description     | This description is still provided by LARA but it should be ignored! |
     And the external activity should have a external report at "https://reports.concord.org/act/changed"
+    And the external activity should not have any description set
 
   @mechanize
   Scenario: External REST sequence is published the first time
@@ -376,8 +368,6 @@ Feature: External Activities can support a REST publishing api
       | launch_url      | http://activity.com/sequence/1 |
       | author_url      | http://activity.com/sequence/1/edit |
       | print_url       | http://activity.com/sequence/1/print_blank |
-      | description     | Several activities together in a sequence |
-      | abstract        | This is the abstract |
     And the external activity should have a template
     And the external activity should have a external report at "https://reports.concord.org/seq"
     And the portal should create an investigation with the following attributes:

--- a/features/step_definitions/activity_runtime_api_publish_steps.rb
+++ b/features/step_definitions/activity_runtime_api_publish_steps.rb
@@ -140,6 +140,11 @@ Then(/^the (.*) should have a external report at "(.*)"$/) do |ignored_param, re
   @external_activity.external_report.url.should == report_url
 end
 
+Then(/^the external activity should not have any description set/) do
+  @external_activity.description.should be_nil
+  @external_activity.abstract.should be_nil
+end
+
 Given(/^an external_report with the URL "(.*?)"$/) do | report_url|
   ExternalReport.create(url:report_url)
 end

--- a/lib/activity_runtime_api.rb
+++ b/lib/activity_runtime_api.rb
@@ -139,8 +139,10 @@ class ActivityRuntimeAPI
     external_activity = nil # Why are we initializing this? For the transaction?
     Investigation.transaction do
       investigation = Investigation.create(
-        :name => hash["name"], :description => hash['description'],
-        :abstract => hash['abstract'], :user => user)
+        :name => hash["name"],
+        :abstract => hash['abstract'],
+        :user => user
+      )
       all_student_reports_enabled = true
       hash['activities'].each_with_index do |act, index|
         activity_from_hash(act, investigation, user, index)
@@ -149,7 +151,6 @@ class ActivityRuntimeAPI
       end
       external_activity = ExternalActivity.create(
         :name                   => hash["name"],
-        :description            => hash["description"],
         :abstract               => hash["abstract"],
         :url                    => hash["url"],
         :thumbnail_url          => hash["thumbnail_url"],
@@ -189,8 +190,8 @@ class ActivityRuntimeAPI
 
     # update the simple attributes
     [investigation, external_activity].each do |act|
-      ['name','description','abstract', 'thumbnail_url'].each do |attribute|
-        act.update_attribute(attribute,hash[attribute])
+      ['name', 'abstract', 'thumbnail_url'].each do |attribute|
+        act.update_attribute(attribute, hash[attribute])
       end
     end
 
@@ -260,7 +261,7 @@ class ActivityRuntimeAPI
   end
 
   def self.activity_from_hash(hash, investigation, user, position = nil)
-    # NOTE: It seems like we don't copy description or thumbnail url.
+    # NOTE: It seems like we don't copy thumbnail url.
     # is this the right behavior for the report template?
     activity = Activity.create({
       :name => hash["name"],

--- a/lib/activity_runtime_api.rb
+++ b/lib/activity_runtime_api.rb
@@ -44,7 +44,6 @@ class ActivityRuntimeAPI
       activity = activity_from_hash(hash, investigation, user)
       external_activity = ExternalActivity.create(
         :name                   => hash["name"],
-        :abstract               => hash["abstract"],
         :url                    => hash["url"],
         :thumbnail_url          => hash["thumbnail_url"],
         :launch_url             => hash["launch_url"] || hash["create_url"],
@@ -140,7 +139,6 @@ class ActivityRuntimeAPI
     Investigation.transaction do
       investigation = Investigation.create(
         :name => hash["name"],
-        :abstract => hash['abstract'],
         :user => user
       )
       all_student_reports_enabled = true
@@ -151,7 +149,6 @@ class ActivityRuntimeAPI
       end
       external_activity = ExternalActivity.create(
         :name                   => hash["name"],
-        :abstract               => hash["abstract"],
         :url                    => hash["url"],
         :thumbnail_url          => hash["thumbnail_url"],
         :launch_url             => hash["launch_url"] || hash["create_url"],
@@ -190,7 +187,7 @@ class ActivityRuntimeAPI
 
     # update the simple attributes
     [investigation, external_activity].each do |act|
-      ['name', 'abstract', 'thumbnail_url'].each do |attribute|
+      ['name', 'thumbnail_url'].each do |attribute|
         act.update_attribute(attribute, hash[attribute])
       end
     end

--- a/lib/activity_runtime_api.rb
+++ b/lib/activity_runtime_api.rb
@@ -44,7 +44,6 @@ class ActivityRuntimeAPI
       activity = activity_from_hash(hash, investigation, user)
       external_activity = ExternalActivity.create(
         :name                   => hash["name"],
-        :description            => hash["description"],
         :abstract               => hash["abstract"],
         :url                    => hash["url"],
         :thumbnail_url          => hash["thumbnail_url"],
@@ -88,8 +87,8 @@ class ActivityRuntimeAPI
 
     # update the simple attributes
     [investigation, activity, external_activity].each do |act|
-      ['name','description', 'thumbnail_url'].each do |attribute|
-        act.update_attribute(attribute,hash[attribute])
+      ['name', 'thumbnail_url'].each do |attribute|
+        act.update_attribute(attribute, hash[attribute])
       end
     end
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/158870433
https://www.pivotaltracker.com/story/show/158870340
https://www.pivotaltracker.com/story/show/158870718

I've decided to create one PR for all these properties as changes are small and similar to each other.
"description" and "abstract" props coming from LARA will no longer update Portal models.

Related LARA PR: https://github.com/concord-consortium/lara/pull/313
