### PR TITLE
Cleanup of Activity and Investigation models (making them non-searchable)

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,7 +1,6 @@
 class Activity < ActiveRecord::Base
   include Cohorts
   include JnlpLaunchable
-  include SearchModelInterface
 
   belongs_to :user
   belongs_to :investigation
@@ -56,61 +55,6 @@ class Activity < ActiveRecord::Base
   include TreeNode
   include Publishable
   include Archiveable
-
-  searchable do
-    text :name
-    string :name
-    text :description
-    text :description_for_teacher
-    text :content do
-      nil
-    end
-
-    text :owner do |act|
-      act.user && act.user.name
-    end
-    integer :user_id
-
-    boolean :published do |act|
-      if act.investigation
-        act.investigation.published?
-      else
-        act.published?
-      end
-    end
-
-    boolean :teacher_only
-
-    integer :offerings_count do |act|
-      total = 0
-      if act.investigation
-        total += act.investigation.offerings_count
-      end
-      total += act.offerings_count
-    end
-    boolean :is_official
-    boolean :is_template
-    boolean :is_assessment_item
-
-    time    :updated_at
-    time    :created_at
-
-    string  :grade_span
-    integer :domain_id
-    string  :material_type
-    string  :material_properties, :multiple => true do
-      material_property_list
-    end
-    string  :cohort_ids, :multiple => true, :references => Admin::Cohort
-    string  :grade_levels, :multiple => true do
-      grade_level_list
-    end
-    string  :subject_areas, :multiple => true do
-      subject_area_list
-    end
-    integer :project_ids, :multiple => true, :references => Admin::Project
-
-  end
 
   send_update_events_to :investigation
   delegate :domain_id, :grade_span, :to => :investigation, :allow_nil => true

--- a/app/models/investigation.rb
+++ b/app/models/investigation.rb
@@ -1,61 +1,8 @@
 # encoding: UTF-8
 class Investigation < ActiveRecord::Base
   include Cohorts
-  include JnlpLaunchable
   include ResponseTypes
-  include SearchModelInterface
   include Archiveable
-
-  # see https://github.com/sunspot/sunspot/blob/master/README.md
-  searchable do
-    text :name
-    string :name
-    text :description
-    text :description_for_teacher
-    text :content do
-      nil
-    end
-
-    text :owner do |inv|
-      inv.user && inv.user.name
-    end
-    integer :user_id
-
-    boolean :published do |inv|
-      inv.publication_status == 'published'
-    end
-
-    boolean :is_archived do |o|
-        o.archived?
-    end
-
-    boolean :teacher_only
-    integer :offerings_count
-    boolean :is_official
-    boolean :is_template
-    boolean :is_assessment_item
-
-    time    :updated_at
-    time    :created_at
-
-    string  :grade_span
-    integer :domain_id
-    string  :material_type
-    string  :material_properties, :multiple => true do
-      material_property_list
-    end
-    string  :cohort_ids, :multiple => true, :references => Admin::Cohort
-    string  :grade_levels, :multiple => true do
-      grade_level_list
-    end
-
-    string  :subject_areas, :multiple => true do
-      subject_area_list
-    end
-
-    integer :project_ids, :multiple => true, :references => Admin::Project
-
-  end
 
   belongs_to :user
   belongs_to :grade_span_expectation, :class_name => 'RiGse::GradeSpanExpectation'

--- a/app/models/materials_collection.rb
+++ b/app/models/materials_collection.rb
@@ -6,7 +6,7 @@ class MaterialsCollection < ActiveRecord::Base
   has_many :materials_collection_items, dependent: :destroy, order: :position
 
   # List all supported material types in this array! It's used by #materials method.
-  MATERIAL_TYPES = [Investigation, Activity, ExternalActivity]
+  MATERIAL_TYPES = [ExternalActivity]
 
   include Changeable
 

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -41,7 +41,7 @@ class Search
   InteractiveMaterial     = "Interactive"
   AllMaterials            = [InvestigationMaterial, ActivityMaterial, InteractiveMaterial]
 
-  AllSearchableModels       = [ ExternalActivity, Interactive]
+  AllSearchableModels       = [ ExternalActivity, Interactive ]
 
   DefaultSearchableModels   = [ ExternalActivity ]
 

--- a/db/migrate/20180713084008_remove_description_fields_from_old_runnable_models.rb
+++ b/db/migrate/20180713084008_remove_description_fields_from_old_runnable_models.rb
@@ -1,0 +1,11 @@
+class RemoveDescriptionFieldsFromOldRunnableModels < ActiveRecord::Migration
+  def up
+    remove_column :activities, :description_for_teacher
+    remove_column :investigations, :description_for_teacher
+  end
+
+  def down
+    add_column :activities, :description_for_teacher, :text
+    add_column :investigations, :description_for_teacher, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -34,24 +34,23 @@ ActiveRecord::Schema.define(:version => 20180713201738) do
 
   create_table "activities", :force => true do |t|
     t.integer  "user_id"
-    t.string   "uuid",                    :limit => 36
+    t.string   "uuid",                   :limit => 36
     t.string   "name"
-    t.text     "description",             :limit => 16777215
-    t.datetime "created_at",                                                     :null => false
-    t.datetime "updated_at",                                                     :null => false
+    t.text     "description",            :limit => 16777215
+    t.datetime "created_at",                                                    :null => false
+    t.datetime "updated_at",                                                    :null => false
     t.integer  "position"
     t.integer  "investigation_id"
     t.integer  "original_id"
-    t.boolean  "teacher_only",                                :default => false
+    t.boolean  "teacher_only",                               :default => false
     t.string   "publication_status"
-    t.integer  "offerings_count",                             :default => 0
-    t.boolean  "student_report_enabled",                      :default => true
-    t.boolean  "show_score",                                  :default => false
-    t.text     "description_for_teacher", :limit => 16777215
+    t.integer  "offerings_count",                            :default => 0
+    t.boolean  "student_report_enabled",                     :default => true
+    t.boolean  "show_score",                                 :default => false
     t.string   "teacher_guide_url"
     t.string   "thumbnail_url"
-    t.boolean  "is_featured",                                 :default => false
-    t.boolean  "is_assessment_item",                          :default => false
+    t.boolean  "is_featured",                                :default => false
+    t.boolean  "is_assessment_item",                         :default => false
   end
 
   add_index "activities", ["investigation_id", "position"], :name => "index_activities_on_investigation_id_and_position"
@@ -158,6 +157,17 @@ ActiveRecord::Schema.define(:version => 20180713201738) do
     t.string   "custom_search_path",                                 :default => "/search"
     t.string   "teacher_home_path",                                  :default => "/getting_started"
   end
+
+  create_table "admin_settings_vendor_interfaces", :force => true do |t|
+    t.integer  "admin_settings_id"
+    t.integer  "probe_vendor_interface_id"
+    t.datetime "created_at",                :null => false
+    t.datetime "updated_at",                :null => false
+  end
+
+  add_index "admin_settings_vendor_interfaces", ["admin_settings_id", "probe_vendor_interface_id"], :name => "adm_proj_interface"
+  add_index "admin_settings_vendor_interfaces", ["admin_settings_id"], :name => "index_admin_project_vendor_interfaces_on_admin_project_id"
+  add_index "admin_settings_vendor_interfaces", ["probe_vendor_interface_id"], :name => "adm_proj_vndr_interfc"
 
   create_table "admin_site_notice_roles", :force => true do |t|
     t.integer  "notice_id"
@@ -773,7 +783,6 @@ ActiveRecord::Schema.define(:version => 20180713201738) do
     t.boolean  "student_report_enabled",                        :default => true
     t.boolean  "allow_activity_assignment",                     :default => true
     t.boolean  "show_score",                                    :default => false
-    t.text     "description_for_teacher",   :limit => 16777215
     t.string   "teacher_guide_url"
     t.string   "thumbnail_url"
     t.boolean  "is_featured",                                   :default => false
@@ -1925,6 +1934,95 @@ ActiveRecord::Schema.define(:version => 20180713201738) do
 
   add_index "portal_teachers", ["user_id"], :name => "index_portal_teachers_on_user_id"
 
+  create_table "probe_calibrations", :force => true do |t|
+    t.integer  "data_filter_id"
+    t.integer  "probe_type_id"
+    t.boolean  "default_calibration"
+    t.integer  "physical_unit_id"
+    t.string   "name"
+    t.text     "description",         :limit => 16777215
+    t.float    "k0"
+    t.float    "k1"
+    t.float    "k2"
+    t.float    "k3"
+    t.string   "uuid"
+    t.datetime "created_at",                              :null => false
+    t.datetime "updated_at",                              :null => false
+    t.integer  "user_id"
+  end
+
+  create_table "probe_data_filters", :force => true do |t|
+    t.integer  "user_id"
+    t.string   "name"
+    t.text     "description",         :limit => 16777215
+    t.string   "otrunk_object_class"
+    t.boolean  "k0_active"
+    t.boolean  "k1_active"
+    t.boolean  "k2_active"
+    t.boolean  "k3_active"
+    t.string   "uuid"
+    t.datetime "created_at",                              :null => false
+    t.datetime "updated_at",                              :null => false
+  end
+
+  create_table "probe_device_configs", :force => true do |t|
+    t.integer  "user_id"
+    t.integer  "vendor_interface_id"
+    t.string   "config_string"
+    t.string   "uuid"
+    t.datetime "created_at",          :null => false
+    t.datetime "updated_at",          :null => false
+  end
+
+  add_index "probe_device_configs", ["user_id"], :name => "index_probe_device_configs_on_user_id"
+  add_index "probe_device_configs", ["vendor_interface_id"], :name => "index_probe_device_configs_on_vendor_interface_id"
+
+  create_table "probe_physical_units", :force => true do |t|
+    t.integer  "user_id"
+    t.string   "name"
+    t.string   "quantity"
+    t.string   "unit_symbol"
+    t.string   "unit_symbol_text"
+    t.text     "description",      :limit => 16777215
+    t.boolean  "si"
+    t.boolean  "base_unit"
+    t.string   "uuid"
+    t.datetime "created_at",                           :null => false
+    t.datetime "updated_at",                           :null => false
+  end
+
+  create_table "probe_probe_types", :force => true do |t|
+    t.integer  "user_id"
+    t.string   "name"
+    t.integer  "ptype"
+    t.float    "step_size"
+    t.integer  "display_precision"
+    t.integer  "port"
+    t.string   "unit"
+    t.float    "min"
+    t.float    "max"
+    t.float    "period"
+    t.string   "uuid"
+    t.datetime "created_at",        :null => false
+    t.datetime "updated_at",        :null => false
+  end
+
+  add_index "probe_probe_types", ["user_id"], :name => "index_probe_probe_types_on_user_id"
+
+  create_table "probe_vendor_interfaces", :force => true do |t|
+    t.integer  "user_id"
+    t.string   "name"
+    t.string   "short_name"
+    t.text     "description",            :limit => 16777215
+    t.string   "communication_protocol"
+    t.string   "image"
+    t.string   "uuid"
+    t.integer  "device_id"
+    t.datetime "created_at",                                 :null => false
+    t.datetime "updated_at",                                 :null => false
+    t.string   "driver_short_name"
+  end
+
   create_table "report_embeddable_filters", :force => true do |t|
     t.integer  "offering_id"
     t.text     "embeddables", :limit => 16777215
@@ -2284,6 +2382,20 @@ ActiveRecord::Schema.define(:version => 20180713201738) do
 
   add_index "sessions", ["session_id"], :name => "index_sessions_on_session_id"
   add_index "sessions", ["updated_at"], :name => "index_sessions_on_updated_at"
+
+  create_table "settings", :force => true do |t|
+    t.integer  "scope_id"
+    t.string   "scope_type"
+    t.string   "name"
+    t.string   "value"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
+
+  add_index "settings", ["name"], :name => "index_settings_on_name"
+  add_index "settings", ["scope_id", "scope_type", "name"], :name => "index_settings_on_scope_id_and_scope_type_and_name"
+  add_index "settings", ["scope_type", "scope_id", "name"], :name => "index_settings_on_scope_type_and_scope_id_and_name"
+  add_index "settings", ["value"], :name => "index_settings_on_value"
 
   create_table "standard_documents", :force => true do |t|
     t.string   "uri"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -158,17 +158,6 @@ ActiveRecord::Schema.define(:version => 20180713201738) do
     t.string   "teacher_home_path",                                  :default => "/getting_started"
   end
 
-  create_table "admin_settings_vendor_interfaces", :force => true do |t|
-    t.integer  "admin_settings_id"
-    t.integer  "probe_vendor_interface_id"
-    t.datetime "created_at",                :null => false
-    t.datetime "updated_at",                :null => false
-  end
-
-  add_index "admin_settings_vendor_interfaces", ["admin_settings_id", "probe_vendor_interface_id"], :name => "adm_proj_interface"
-  add_index "admin_settings_vendor_interfaces", ["admin_settings_id"], :name => "index_admin_project_vendor_interfaces_on_admin_project_id"
-  add_index "admin_settings_vendor_interfaces", ["probe_vendor_interface_id"], :name => "adm_proj_vndr_interfc"
-
   create_table "admin_site_notice_roles", :force => true do |t|
     t.integer  "notice_id"
     t.integer  "role_id"
@@ -1934,95 +1923,6 @@ ActiveRecord::Schema.define(:version => 20180713201738) do
 
   add_index "portal_teachers", ["user_id"], :name => "index_portal_teachers_on_user_id"
 
-  create_table "probe_calibrations", :force => true do |t|
-    t.integer  "data_filter_id"
-    t.integer  "probe_type_id"
-    t.boolean  "default_calibration"
-    t.integer  "physical_unit_id"
-    t.string   "name"
-    t.text     "description",         :limit => 16777215
-    t.float    "k0"
-    t.float    "k1"
-    t.float    "k2"
-    t.float    "k3"
-    t.string   "uuid"
-    t.datetime "created_at",                              :null => false
-    t.datetime "updated_at",                              :null => false
-    t.integer  "user_id"
-  end
-
-  create_table "probe_data_filters", :force => true do |t|
-    t.integer  "user_id"
-    t.string   "name"
-    t.text     "description",         :limit => 16777215
-    t.string   "otrunk_object_class"
-    t.boolean  "k0_active"
-    t.boolean  "k1_active"
-    t.boolean  "k2_active"
-    t.boolean  "k3_active"
-    t.string   "uuid"
-    t.datetime "created_at",                              :null => false
-    t.datetime "updated_at",                              :null => false
-  end
-
-  create_table "probe_device_configs", :force => true do |t|
-    t.integer  "user_id"
-    t.integer  "vendor_interface_id"
-    t.string   "config_string"
-    t.string   "uuid"
-    t.datetime "created_at",          :null => false
-    t.datetime "updated_at",          :null => false
-  end
-
-  add_index "probe_device_configs", ["user_id"], :name => "index_probe_device_configs_on_user_id"
-  add_index "probe_device_configs", ["vendor_interface_id"], :name => "index_probe_device_configs_on_vendor_interface_id"
-
-  create_table "probe_physical_units", :force => true do |t|
-    t.integer  "user_id"
-    t.string   "name"
-    t.string   "quantity"
-    t.string   "unit_symbol"
-    t.string   "unit_symbol_text"
-    t.text     "description",      :limit => 16777215
-    t.boolean  "si"
-    t.boolean  "base_unit"
-    t.string   "uuid"
-    t.datetime "created_at",                           :null => false
-    t.datetime "updated_at",                           :null => false
-  end
-
-  create_table "probe_probe_types", :force => true do |t|
-    t.integer  "user_id"
-    t.string   "name"
-    t.integer  "ptype"
-    t.float    "step_size"
-    t.integer  "display_precision"
-    t.integer  "port"
-    t.string   "unit"
-    t.float    "min"
-    t.float    "max"
-    t.float    "period"
-    t.string   "uuid"
-    t.datetime "created_at",        :null => false
-    t.datetime "updated_at",        :null => false
-  end
-
-  add_index "probe_probe_types", ["user_id"], :name => "index_probe_probe_types_on_user_id"
-
-  create_table "probe_vendor_interfaces", :force => true do |t|
-    t.integer  "user_id"
-    t.string   "name"
-    t.string   "short_name"
-    t.text     "description",            :limit => 16777215
-    t.string   "communication_protocol"
-    t.string   "image"
-    t.string   "uuid"
-    t.integer  "device_id"
-    t.datetime "created_at",                                 :null => false
-    t.datetime "updated_at",                                 :null => false
-    t.string   "driver_short_name"
-  end
-
   create_table "report_embeddable_filters", :force => true do |t|
     t.integer  "offering_id"
     t.text     "embeddables", :limit => 16777215
@@ -2382,20 +2282,6 @@ ActiveRecord::Schema.define(:version => 20180713201738) do
 
   add_index "sessions", ["session_id"], :name => "index_sessions_on_session_id"
   add_index "sessions", ["updated_at"], :name => "index_sessions_on_updated_at"
-
-  create_table "settings", :force => true do |t|
-    t.integer  "scope_id"
-    t.string   "scope_type"
-    t.string   "name"
-    t.string   "value"
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
-  end
-
-  add_index "settings", ["name"], :name => "index_settings_on_name"
-  add_index "settings", ["scope_id", "scope_type", "name"], :name => "index_settings_on_scope_id_and_scope_type_and_name"
-  add_index "settings", ["scope_type", "scope_id", "name"], :name => "index_settings_on_scope_type_and_scope_id_and_name"
-  add_index "settings", ["value"], :name => "index_settings_on_value"
 
   create_table "standard_documents", :force => true do |t|
     t.string   "uri"

--- a/lib/activity_runtime_api.rb
+++ b/lib/activity_runtime_api.rb
@@ -57,17 +57,7 @@ class ActivityRuntimeAPI
         :is_locked              => hash["is_locked"]
       )
       self.update_external_report(external_activity,hash["external_report_url"])
-      # update activity so external_activity.template is correctly initialzed
-      # otherwise external_activity.template.is_template? won't be true
-      activity.reload
-      # then reindex it manually, so Solr has correct value of :is_template attribute
-      Sunspot.index(activity)
-      # exactly the same applies to invesigation template
-      investigation.reload
-      Sunspot.index(investigation)
-      Sunspot.commit
     end
-
     return external_activity
   end
 
@@ -162,14 +152,6 @@ class ActivityRuntimeAPI
         :is_locked              => hash["is_locked"]
       )
       self.update_external_report(external_activity, hash["external_report_url"])
-      # update investigation so external_activity.template is correctly initialzed
-      # otherwise external_activity.template.is_template? won't be true
-      investigation.reload
-      # then reindex it manually, so Solr has correct value of :is_template attribute
-      Sunspot.index(investigation)
-      # exactly the same applies to activities
-      investigation.activities.each { |a| Sunspot.index(a) }
-      Sunspot.commit
     end
     return external_activity
   end

--- a/spec/libs/activity_runtime_api_spec.rb
+++ b/spec/libs/activity_runtime_api_spec.rb
@@ -292,18 +292,6 @@ describe ActivityRuntimeAPI do
         result.template.is_template.should be_true
         result.template.investigation.is_template.should be_true
       end
-
-      it "should cause that parent investigation and activities are indexed in SOLR as templates" do
-        result = ActivityRuntimeAPI.publish_activity(new_hash, user)
-        Activity.search {
-          with :name, result.template.name
-          with :is_template, true
-        }.results.size.should == 1
-        Investigation.search {
-          with :name, result.template.investigation.name
-          with :is_template, true
-        }.results.size.should == 1
-      end
     end
 
     describe "When there is an existing external activity with the same url" do
@@ -532,17 +520,6 @@ describe ActivityRuntimeAPI do
       it "should cause that parent investigation and activities are recognized as templates" do
         result.template.is_template.should be_true
         result.template.activities.map { |a| a.is_template.should be_true }
-      end
-
-      it "should cause that parent investigation and activities are indexed in SOLR as templates" do
-        Investigation.search {
-          with :name, result.template.name
-          with :is_template, true
-        }.results.size.should == 1
-        Activity.search {
-          with :name, result.template.activities.map { |a| a.name }
-          with :is_template, true
-        }.results.size.should == 2
       end
     end
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -11,10 +11,6 @@ describe Activity do
     activity.valid?
   end
 
-  it 'should respond to #material_type' do
-    activity.material_type.should == 'Activity'
-  end
-
   it "should be destroy'able" do
     activity.destroy
   end

--- a/spec/models/materials_collection_spec.rb
+++ b/spec/models/materials_collection_spec.rb
@@ -7,9 +7,7 @@ describe MaterialsCollection do
 
   let(:collection) { FactoryGirl.create(:materials_collection) }
   let(:ext_act) { FactoryGirl.create_list(:external_activity, 3) }
-  let(:act) { FactoryGirl.create_list(:activity, 3) }
-  let(:inv) { FactoryGirl.create_list(:investigation, 3) }
-  let(:materials) { ext_act + act + inv }
+  let(:materials) { ext_act }
 
   before(:each) do
     # Assign all materials to collection.

--- a/spec/models/portal/offering_spec.rb
+++ b/spec/models/portal/offering_spec.rb
@@ -3,7 +3,7 @@ require File.expand_path('../../../spec_helper', __FILE__)
 describe Portal::Offering do
   
   describe "after being created" do
-    let(:runnable) { Factory.create(:investigation) }
+    let(:runnable) { Factory.create(:external_activity) }
     let(:args)     { {runnable: runnable} }
     let(:offering) { Factory.create(:portal_offering, args) }
 


### PR DESCRIPTION
Removes teacher-specific descriptions from model that will no longer use - Activity and Investigation. Also, makes them non-searchable and not supported by `MaterialsCollection`. I left regular `description` field as that's used in many models and seems generic enough not to create some serious confusion. I was struggling quite a bit with some tests due to issues with SOLR reindexing, but it's fine now.