### PR TITLE
Upgrade pry and add pry-byebug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -215,6 +215,7 @@ group :test, :cucumber, :development do
   gem "remarkable_activerecord",  "~> 3.1.13", :require => nil
   gem "launchy",           "~> 2.0.5"
   gem "pry"
+  gem 'pry-byebug'
 end
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,7 @@ GEM
     bullet (4.14.0)
       activesupport (>= 3.0.0)
       uniform_notifier (>= 1.6.0)
+    byebug (10.0.2)
     capistrano (2.14.1)
       highline
       net-scp (>= 1.0.0)
@@ -180,7 +181,7 @@ GEM
     ci_reporter (1.7.0)
       builder (>= 2.1.2)
     cocaine (0.4.2)
-    coderay (1.1.0)
+    coderay (1.1.2)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     coffee-rails (3.2.2)
@@ -347,7 +348,7 @@ GEM
       nokogiri (~> 1.4)
       ntlm-http (~> 0.1, >= 0.1.1)
       webrobots (>= 0.0.9, < 0.2)
-    method_source (0.8.2)
+    method_source (0.9.0)
     mime-types (1.25.1)
     mini_portile2 (2.1.0)
     momentjs-rails (2.17.1)
@@ -416,10 +417,12 @@ GEM
     prawn_rails (0.0.8)
       prawn (>= 0.11.1)
       rails (>= 3.0.0)
-    pry (0.10.3)
+    pry (0.11.3)
       coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
+      method_source (~> 0.9.0)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
     pundit (1.0.1)
       activesupport (>= 3.0.0)
     rack (1.4.7)
@@ -524,7 +527,6 @@ GEM
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
-    slop (3.6.0)
     spoon (0.0.1)
     spring (1.7.2)
     spring-commands-cucumber (1.0.1)
@@ -688,6 +690,7 @@ DEPENDENCIES
   prawn_rails (~> 0.0.6)
   prototype-rails!
   pry
+  pry-byebug
   pundit
   rack-cors
   rack-mini-profiler


### PR DESCRIPTION
This PR upgrade the `pry` gem to its latest version. Also adds the `pry-byebug` gem which is a tool we (Hint) commonly use. If you prefer not to commit it, I'll pull it out of this PR. Let me know.