### PR TITLE
Migrate test-unit syntax -> rspec syntax

### DIFF
--- a/spec/controllers/admin/client_spec.rb
+++ b/spec/controllers/admin/client_spec.rb
@@ -114,7 +114,7 @@ describe Admin::ClientsController do
     describe "GET index" do
       it "will render the index" do
         get :index
-        assert_response 200
+        expect(response).to be_success
         response.should render_template("index")
       end
     end
@@ -149,7 +149,7 @@ describe Admin::ClientsController do
       it "renders the new form" do
         get :new
         response.should render_template("new")
-        assert_response 200
+        expect(response).to be_success
       end
     end
 

--- a/spec/controllers/admin/client_spec.rb
+++ b/spec/controllers/admin/client_spec.rb
@@ -62,42 +62,42 @@ describe Admin::ClientsController do
     describe "GET index" do
       it "won't alow the index, redirects to manager home" do
         get :index
-        assert_redirected_to :getting_started
+        expect(response).to redirect_to(:getting_started)
       end
     end
 
     describe "DELETE destroy" do
       it "wont allow delete, redirects to manager home" do
         delete :destroy, :id => client_id
-        assert_redirected_to :getting_started
+        expect(response).to redirect_to(:getting_started)
       end
     end
 
     describe "GET show" do
       it "wont allow show, redirects to manager home" do
         get :show, :id => client_id
-        assert_redirected_to :getting_started
+        expect(response).to redirect_to(:getting_started)
       end
     end
 
     describe "GET edit" do
       it "wont allow edit, redirects to manager home" do
         get :edit, :id => client_id
-        assert_redirected_to :getting_started
+        expect(response).to redirect_to(:getting_started)
       end
     end
 
     describe "GET new" do
       it "wont allow new, redirects to manager home" do
         get :new
-        assert_redirected_to :getting_started
+        expect(response).to redirect_to(:getting_started)
       end
     end
 
     describe "PUT update" do
       it "wont allow update, redirects to manager home" do
         put :update, :id => client_id, :client => {:params => 'params'}
-        assert_redirected_to :getting_started
+        expect(response).to redirect_to(:getting_started)
       end
     end
   end
@@ -123,7 +123,7 @@ describe Admin::ClientsController do
       it "delete, and redirect back to index" do
         Client.should_receive(:find).and_return(mock_client)
         delete :destroy, :id => client_id
-        assert_redirected_to action: :index
+        expect(response).to redirect_to(action: :index)
       end
     end
 
@@ -158,7 +158,7 @@ describe Admin::ClientsController do
       it "updates the model, redirects to index" do
         Client.should_receive(:find).and_return(mock_client)
         put :update, :id => client_id, :client => {:params => 'params'}
-        assert_redirected_to action: :index
+        expect(response).to redirect_to(action: :index)
       end
     end
   end

--- a/spec/controllers/admin/external_report_spec.rb
+++ b/spec/controllers/admin/external_report_spec.rb
@@ -62,42 +62,42 @@ describe Admin::ExternalReportsController do
     describe "GET index" do
       it "won't alow the index, redirects to manager home" do
         get :index
-        assert_redirected_to :getting_started
+        expect(response).to redirect_to(:getting_started)
       end
     end
 
     describe "DELETE destroy" do
       it "wont allow delete, redirects to manager home" do
         delete :destroy, :id => report_id
-        assert_redirected_to :getting_started
+        expect(response).to redirect_to(:getting_started)
       end
     end
 
     describe "GET show" do
       it "wont allow show, redirects to manager home" do
         get :show, :id => report_id
-        assert_redirected_to :getting_started
+        expect(response).to redirect_to(:getting_started)
       end
     end
 
     describe "GET edit" do
       it "wont allow edit, redirects to manager home" do
         get :edit, :id => report_id
-        assert_redirected_to :getting_started
+        expect(response).to redirect_to(:getting_started)
       end
     end
 
     describe "GET new" do
       it "wont allow new, redirects to manager home" do
         get :new
-        assert_redirected_to :getting_started
+        expect(response).to redirect_to(:getting_started)
       end
     end
 
     describe "PUT update" do
       it "wont allow update, redirects to manager home" do
         put :update, :id => report_id, :report => {:params => 'params'}
-        assert_redirected_to :getting_started
+        expect(response).to redirect_to(:getting_started)
       end
     end
   end
@@ -123,7 +123,7 @@ describe Admin::ExternalReportsController do
       it "delete, and redirect back to index" do
         ExternalReport.should_receive(:find).and_return(mock_report)
         delete :destroy, :id => report_id
-        assert_redirected_to action: :index
+        expect(response).to redirect_to(action: :index)
       end
     end
 
@@ -158,7 +158,7 @@ describe Admin::ExternalReportsController do
       it "updates the model, redirects to index" do
         ExternalReport.should_receive(:find).and_return(mock_report)
         put :update, :id => report_id, :report => {:params => 'params'}
-        assert_redirected_to action: :index
+        expect(response).to redirect_to(action: :index)
       end
     end
   end

--- a/spec/controllers/admin/external_report_spec.rb
+++ b/spec/controllers/admin/external_report_spec.rb
@@ -114,7 +114,7 @@ describe Admin::ExternalReportsController do
     describe "GET index" do
       it "will render the index" do
         get :index
-        assert_response 200
+        expect(response).to be_success
         response.should render_template("index")
       end
     end
@@ -149,7 +149,7 @@ describe Admin::ExternalReportsController do
       it "renders the new form" do
         get :new
         response.should render_template("new")
-        assert_response 200
+        expect(response).to be_success
       end
     end
 

--- a/spec/controllers/admin/settings_controller_spec.rb
+++ b/spec/controllers/admin/settings_controller_spec.rb
@@ -40,7 +40,7 @@ describe Admin::SettingsController do
       get :index
       
       assert_response :success
-      assert_template :partial => "_show_for_managers"
+      expect(response).to render_template(:partial => "_show_for_managers")
 
       assigns[:admin_settings].size.should be(1)
       assigns[:admin_settings].should include(settings)
@@ -100,7 +100,7 @@ describe Admin::SettingsController do
       get :edit, :id => "37"
 
       assert_response :success
-      assert_template :partial => "_form_for_managers"
+      expect(response).to render_template(:partial => "_form_for_managers")
       
       response.body.should have_selector("*[name='admin_settings[home_page_content]']")
 

--- a/spec/controllers/admin/settings_controller_spec.rb
+++ b/spec/controllers/admin/settings_controller_spec.rb
@@ -23,7 +23,7 @@ describe Admin::SettingsController do
     it "doesn't allow anybody who isn't an admin or manager to access to index" do
       logout_user
       get :index
-      assert_response :redirect
+      expect(response.status).to eq(302)
     end
   end
 
@@ -39,7 +39,7 @@ describe Admin::SettingsController do
       
       get :index
       
-      assert_response :success
+      expect(response).to be_success
       expect(response).to render_template(:partial => "_show_for_managers")
 
       assigns[:admin_settings].size.should be(1)
@@ -99,7 +99,7 @@ describe Admin::SettingsController do
 
       get :edit, :id => "37"
 
-      assert_response :success
+      expect(response).to be_success
       expect(response).to render_template(:partial => "_form_for_managers")
       
       response.body.should have_selector("*[name='admin_settings[home_page_content]']")

--- a/spec/controllers/admin/site_notices_controller_spec.rb
+++ b/spec/controllers/admin/site_notices_controller_spec.rb
@@ -81,20 +81,20 @@ describe Admin::SiteNoticesController do
       @post_params[:notice_html] = ''
       post :create, @post_params
       notice = Admin::SiteNotice.find_by_notice_html(@post_params[:notice_html])
-      assert_nil(notice)
+      expect(notice).to be_nil
       flash[:error].should =~ /Notice text is blank/i
 
       @post_params[:notice_html] = ' '
       post :create, @post_params
       notice = Admin::SiteNotice.find_by_notice_html(@post_params[:notice_html])
-      assert_nil(notice)
+      expect(notice).to be_nil
       flash[:error].should =~ /Notice text is blank/i
     end
     it("should not create a notice if no role is selected") do
       @post_params[:role] = nil
       post :create, @post_params
       notice = Admin::SiteNotice.find_by_notice_html(@post_params[:notice_html])
-      assert_nil(notice)
+      expect(notice).to be_nil
       flash[:error].should =~ /No role is selected/i
     end
   end
@@ -145,20 +145,20 @@ describe Admin::SiteNoticesController do
       @post_params[:notice_html] = ""
       post :update, @post_params
       notice = Admin::SiteNotice.find_by_notice_html(@post_params[:notice_html])
-      assert_nil(notice)
+      expect(notice).to be_nil
       flash[:error].should =~ /Notice text is blank/i
 
       @post_params[:notice_html] = "       "
       post :update, @post_params
       notice = Admin::SiteNotice.find_by_notice_html(@post_params[:notice_html])
-      assert_nil(notice)
+      expect(notice).to be_nil
       flash[:error].should =~ /Notice text is blank/i
     end
     it("should not create a notice if no role is selected") do
       @post_params[:role] = nil
       post :update, @post_params
       notice = Admin::SiteNotice.find_by_notice_html(@post_params[:notice_html])
-      assert_nil(notice)
+      expect(notice).to be_nil
       flash[:error].should =~ /No role is selected/i
     end
   end
@@ -182,9 +182,9 @@ describe Admin::SiteNoticesController do
 
       xhr :post, :remove_notice, @params
       notice = Admin::SiteNotice.find_by_id(@params[:id])
-      assert_nil(notice)
+      expect(notice).to be_nil
       notice_roles = Admin::SiteNoticeRole.find_by_notice_id(@params[:id])
-      assert_nil(notice_roles)
+      expect(notice_roles).to be_nil
       response.should be_success
     end
   end

--- a/spec/controllers/admin/site_notices_controller_spec.rb
+++ b/spec/controllers/admin/site_notices_controller_spec.rb
@@ -69,10 +69,10 @@ describe Admin::SiteNoticesController do
     it("should create a notice with some text and at least one role selected") do
       post :create, @post_params
       notice = Admin::SiteNotice.find_by_notice_html(@post_params[:notice_html])
-      assert_not_nil(notice)
+      expect(notice).not_to be_nil
       notice_id = notice.id
       notice_roles = Admin::SiteNoticeRole.find_all_by_notice_id(notice_id)
-      assert_not_nil(notice_roles)
+      expect(notice_roles).not_to be_nil
       notice_roles.each do |role|
         assert(@post_params[:role].include?(role.role_id))
       end
@@ -133,10 +133,10 @@ describe Admin::SiteNoticesController do
     it("should create a notice if and only if notice contains a non white space character and at least one role is selected") do
       post :update, @post_params
       notice = Admin::SiteNotice.find_by_notice_html(@post_params[:notice_html])
-      assert_not_nil(notice)
+      expect(notice).not_to be_nil
       notice_id = notice.id
       notice_roles = Admin::SiteNoticeUser.find_all_by_notice_id(notice_id)
-      assert_not_nil(notice_roles)
+      expect(notice_roles).not_to be_nil
       notice_roles.each do |role|
         assert(@post_params[:role].include?(role.role_id))
       end
@@ -178,7 +178,7 @@ describe Admin::SiteNoticesController do
 
       # Check the notice exists before checking that it is deleted
       notice = Admin::SiteNotice.find_by_id(@params[:id])
-      assert_not_nil(notice)
+      expect(notice).not_to be_nil
 
       xhr :post, :remove_notice, @params
       notice = Admin::SiteNotice.find_by_id(@params[:id])
@@ -203,7 +203,7 @@ describe Admin::SiteNoticesController do
     it"should dismiss a notice" do
       xhr :post, :dismiss_notice, @params
       dismissed_notice = Admin::SiteNoticeUser.find_by_notice_id_and_user_id(@notice.id, @teacher_user.id)
-      assert_not_nil(dismissed_notice)
+      expect(dismissed_notice).not_to be_nil
       assert(dismissed_notice.notice_dismissed)
       response.should be_success
     end
@@ -220,13 +220,13 @@ describe Admin::SiteNoticesController do
     it"should store collapse time and expand and collapse status" do
       xhr :post, :toggle_notice_display
       toggle_notice_status = Admin::NoticeUserDisplayStatus.find_by_user_id(@teacher_user.id)
-      assert_not_nil(toggle_notice_status)
+      expect(toggle_notice_status).not_to be_nil
       assert(toggle_notice_status.collapsed_status)
       response.should be_success
 
       xhr :post, :toggle_notice_display
       toggle_notice_status.reload
-      assert_not_nil(toggle_notice_status)
+      expect(toggle_notice_status).not_to be_nil
       expect(toggle_notice_status.collapsed_status).to eq(false)
       response.should be_success
     end

--- a/spec/controllers/admin/site_notices_controller_spec.rb
+++ b/spec/controllers/admin/site_notices_controller_spec.rb
@@ -227,7 +227,7 @@ describe Admin::SiteNoticesController do
       xhr :post, :toggle_notice_display
       toggle_notice_status.reload
       assert_not_nil(toggle_notice_status)
-      assert_equal(toggle_notice_status.collapsed_status, false)
+      expect(toggle_notice_status.collapsed_status).to eq(false)
       response.should be_success
     end
   end

--- a/spec/controllers/admin/site_notices_controller_spec.rb
+++ b/spec/controllers/admin/site_notices_controller_spec.rb
@@ -22,12 +22,12 @@ describe Admin::SiteNoticesController do
   describe "GET new" do
     it"doesn't show notice create page to users with roles other than admin and manager" do
       get :new
-      assert_template "new"
+      expect(response).to render_template("new")
 
       sign_out :user
       sign_in @manager_user
       get :new
-      assert_template "new"
+      expect(response).to render_template("new")
 
       sign_out :user
       sign_in @teacher_user
@@ -113,7 +113,7 @@ describe Admin::SiteNoticesController do
     end
     it"should show edit notice form" do
       get :edit, @params
-      assert_template "edit"
+      expect(response).to render_template("edit")
     end
   end
 

--- a/spec/controllers/api/v1/report_learners_es_controller_spec.rb
+++ b/spec/controllers/api/v1/report_learners_es_controller_spec.rb
@@ -96,10 +96,12 @@ describe API::V1::ReportLearnersEsController do
       end
       it "makes a request to ES with the correct body" do
         get :index
-        assert_requested :post, /report_learners\/_search$/,
-          headers: {'Content-Type'=>'application/json'},
-          body: search_body,
-          times: 1
+        expect(WebMock).to have_requested(:post, /report_learners\/_search$/).
+          with(
+            headers: {'Content-Type'=>'application/json'},
+            body: search_body,
+            times: 1
+          )
       end
       it "directly renders the ES response" do
         get :index
@@ -145,10 +147,12 @@ describe API::V1::ReportLearnersEsController do
         restricted_search_body["aggs"]["permission_forms_ids"]["terms"]["include"] =
           [@form1.id]
 
-        assert_requested :post, /report_learners\/_search$/,
-          headers: {'Content-Type'=>'application/json'},
-          body: search_body,
-          times: 1
+        expect(WebMock).to have_requested(:post, /report_learners\/_search$/).
+          with(
+            headers: {'Content-Type'=>'application/json'},
+            body: search_body,
+            times: 1
+          )
       end
     end
   end

--- a/spec/controllers/browse/external_activities_controller_spec.rb
+++ b/spec/controllers/browse/external_activities_controller_spec.rb
@@ -16,11 +16,11 @@ describe Browse::ExternalActivitiesController do
         }
         post :show, @post_params
 
-        assert_equal assigns[:wide_content_layout], true
+        expect(assigns[:wide_content_layout]).to eq(true)
 
         assigns[:back_to_search_url].should match /.*search\?activity_page=1&investigation_page=1&search_term=#{@external_activity.name}$/
         assert_not_nil assigns[:search_material]
-        assert_equal assigns[:search_material].material, @external_activity
+        expect(assigns[:search_material].material).to eq(@external_activity)
       end
     end
 

--- a/spec/controllers/browse/external_activities_controller_spec.rb
+++ b/spec/controllers/browse/external_activities_controller_spec.rb
@@ -19,7 +19,7 @@ describe Browse::ExternalActivitiesController do
         expect(assigns[:wide_content_layout]).to eq(true)
 
         assigns[:back_to_search_url].should match /.*search\?activity_page=1&investigation_page=1&search_term=#{@external_activity.name}$/
-        assert_not_nil assigns[:search_material]
+        expect(assigns[:search_material]).not_to be_nil
         expect(assigns[:search_material].material).to eq(@external_activity)
       end
     end

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -13,7 +13,7 @@ describe HelpController do
     it "should render no help page template when help type is no help" do
       @test_settings.help_type = 'no help'
       get :index
-      assert_template 'help/no_help_page'
+      expect(response).to render_template('help/no_help_page')
     end
     it "should redirect to external url when help type is external url" do
       @test_settings.external_url = 'www.concord.org'
@@ -26,7 +26,7 @@ describe HelpController do
       @test_settings.help_type = 'help custom html'
       get :index
       expect(assigns[:help_page_content]).to eq('<b>Help page</b>')
-      assert_template 'index'
+      expect(response).to render_template('index')
     end
   end
 
@@ -37,7 +37,7 @@ describe HelpController do
         }
       post :preview_help_page, @post_params
       expect(assigns[:help_page_content]).to eq(@post_params[:preview_help_page_from_edit])
-      assert_template 'preview_help_page'
+      expect(response).to render_template('preview_help_page')
     end
     
     it "should render no help page template when help type is no help and preview is from summary page." do
@@ -48,7 +48,7 @@ describe HelpController do
           :preview_help_page_from_summary_page => "#{@test_settings.id}"
         }
       get :preview_help_page, @post_params
-      assert_template 'help/no_help_page'
+      expect(response).to render_template('help/no_help_page')
     end
     
     it "should redirect to external url when help type is external url and preview is from summary page." do
@@ -73,7 +73,7 @@ describe HelpController do
         }
       get :preview_help_page, @post_params
       expect(assigns[:help_page_content]).to eq('<b>Help page</b>')
-      assert_template 'preview_help_page'
+      expect(response).to render_template('preview_help_page')
     end
     
   end

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -25,7 +25,7 @@ describe HelpController do
       @test_settings.custom_help_page_html = '<b>Help page</b>'
       @test_settings.help_type = 'help custom html'
       get :index
-      assert_equal assigns[:help_page_content], '<b>Help page</b>'
+      expect(assigns[:help_page_content]).to eq('<b>Help page</b>')
       assert_template 'index'
     end
   end
@@ -36,7 +36,7 @@ describe HelpController do
           :preview_help_page_from_edit => '<b>help page<b>'
         }
       post :preview_help_page, @post_params
-      assert_equal assigns[:help_page_content], @post_params[:preview_help_page_from_edit]
+      expect(assigns[:help_page_content]).to eq(@post_params[:preview_help_page_from_edit])
       assert_template 'preview_help_page'
     end
     
@@ -72,7 +72,7 @@ describe HelpController do
           :preview_help_page_from_summary_page => "#{@test_settings.id}"
         }
       get :preview_help_page, @post_params
-      assert_equal assigns[:help_page_content], '<b>Help page</b>'
+      expect(assigns[:help_page_content]).to eq('<b>Help page</b>')
       assert_template 'preview_help_page'
     end
     

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -62,7 +62,7 @@ describe HomeController do
         :home_page_preview_content =>"<b>Home page content.</b>",
       }
       post :preview_home_page, @post_params
-      assert_response :success
+      expect(response).to be_success
       response.body.should include(@post_params[:home_page_preview_content])
     end
   end

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -25,7 +25,7 @@ describe PasswordsController do
 
       post :create_by_login, @params
 
-      assert_response :success
+      expect(response).to be_success
       flash[:error].should_not be_nil
     end
 
@@ -34,7 +34,7 @@ describe PasswordsController do
 
       post :create_by_login, @params
 
-      assert_response :success
+      expect(response).to be_success
       flash[:error].should_not be_nil
     end
 
@@ -113,8 +113,7 @@ describe PasswordsController do
         @answers_params[:security_questions][:question2][:id] += 500
 
         post :check_questions, @answers_params
-
-        assert_response :not_found
+        expect(response.status).to eq(404)
       end
     end
   end

--- a/spec/controllers/portal/clazzes_controller_spec.rb
+++ b/spec/controllers/portal/clazzes_controller_spec.rb
@@ -636,27 +636,27 @@ describe Portal::ClazzesController do
       teacher_clazz = Portal::TeacherClazz.find_by_clazz_id_and_teacher_id(@mock_clazz.id, @authorized_teacher.id)
       assert_not_nil(teacher_clazz)
       assert(teacher_clazz.active)
-      assert_equal(teacher_clazz.position, 5)
+      expect(teacher_clazz.position).to eq(5)
 
       teacher_clazz = Portal::TeacherClazz.find_by_clazz_id_and_teacher_id(@mock_clazz_phy.id, @authorized_teacher.id)
       assert_not_nil(teacher_clazz)
       assert(teacher_clazz.active)
-      assert_equal(teacher_clazz.position, 2)
+      expect(teacher_clazz.position).to eq(2)
 
       teacher_clazz = Portal::TeacherClazz.find_by_clazz_id_and_teacher_id(@mock_clazz_chem.id, @authorized_teacher.id)
       assert_not_nil(teacher_clazz)
       assert(teacher_clazz.active == false)
-      assert_equal(teacher_clazz.position, 3)
+      expect(teacher_clazz.position).to eq(3)
 
       teacher_clazz = Portal::TeacherClazz.find_by_clazz_id_and_teacher_id(@mock_clazz_bio.id, @authorized_teacher.id)
       assert_not_nil(teacher_clazz)
       assert(teacher_clazz.active)
-      assert_equal(teacher_clazz.position, 4)
+      expect(teacher_clazz.position).to eq(4)
 
       teacher_clazz = Portal::TeacherClazz.find_by_clazz_id_and_teacher_id(@mock_clazz_math.id, @authorized_teacher.id)
       assert_not_nil(teacher_clazz)
       assert(teacher_clazz.active)
-      assert_equal(teacher_clazz.position, 1)
+      expect(teacher_clazz.position).to eq(1)
 
     end
   end
@@ -694,17 +694,17 @@ describe Portal::ClazzesController do
       @copy_clazz = Portal::Clazz.find_by_name('Concept of physics')
       assert_not_nil(@copy_clazz)
 
-      assert_equal(@copy_clazz.teachers.length, @mock_clazz.teachers.length)
+      expect(@copy_clazz.teachers.length).to eq(@mock_clazz.teachers.length)
       @mock_clazz.teachers.each do |teacher|
         assert_not_nil(@copy_clazz.teachers.find_by_id(teacher.id))
       end
 
-      assert_equal(@copy_clazz.offerings.length, @mock_clazz.offerings.length)
+      expect(@copy_clazz.offerings.length).to eq(@mock_clazz.offerings.length)
       @mock_clazz.offerings.each do |offering|
         assert_not_nil(@copy_clazz.offerings.find_by_runnable_id(offering.runnable_id))
       end
 
-      assert_equal(@copy_clazz.students.length, 0)
+      expect(@copy_clazz.students.length).to eq(0)
 
     end
   end
@@ -773,7 +773,7 @@ describe Portal::ClazzesController do
       xhr :post, :sort_offerings, @params
       offerings = Portal::Offering.where(:id => @params[:clazz_offerings])
       offerings.each do |offering|
-        assert_equal(offering.position , @params[:clazz_offerings].index(offering.id) + 1)
+        expect(offering.position ).to eq(@params[:clazz_offerings].index(offering.id) + 1)
       end
 
       # Update offering positions and verify they have been updated
@@ -781,7 +781,7 @@ describe Portal::ClazzesController do
       xhr :post, :sort_offerings, @params
       offerings = Portal::Offering.where(:id => @params[:clazz_offerings])
       offerings.each do |offering|
-        assert_equal(offering.position , @params[:clazz_offerings].index(offering.id) + 1)
+        expect(offering.position ).to eq(@params[:clazz_offerings].index(offering.id) + 1)
       end
     end
   end
@@ -800,7 +800,7 @@ describe Portal::ClazzesController do
     it "should retrieve the class when user is not anonymous user" do
       sign_in @authorized_teacher_user
       get :fullstatus, @params
-      assert_equal assigns[:portal_clazz], @mock_clazz
+      expect(assigns[:portal_clazz]).to eq(@mock_clazz)
       response.should be_success
       assert_template "fullstatus"
     end

--- a/spec/controllers/portal/clazzes_controller_spec.rb
+++ b/spec/controllers/portal/clazzes_controller_spec.rb
@@ -566,7 +566,7 @@ describe Portal::ClazzesController do
       @post_params[:portal_clazz][:name] = ''
       post :update, @post_params
       @portal_clazz = Portal::Clazz.find_by_id(@post_params[:id])
-      assert_not_equal(@portal_clazz.name , '', 'Class saved with no name.')
+      expect(@portal_clazz.name).not_to eq(''), 'Class saved with no name.'
     end
 
     it "should not save the edited class info if the class word is blank" do
@@ -574,7 +574,7 @@ describe Portal::ClazzesController do
       @post_params[:portal_clazz][:class_word] = ''
       post :update, @post_params
       @portal_clazz = Portal::Clazz.find_by_id(@post_params[:id])
-      assert_not_equal(@portal_clazz.class_word , '', 'Class saved with blank class word.')
+      expect(@portal_clazz.class_word).not_to eq(''), 'Class saved with blank class word.'
     end
   end
 

--- a/spec/controllers/portal/clazzes_controller_spec.rb
+++ b/spec/controllers/portal/clazzes_controller_spec.rb
@@ -802,7 +802,7 @@ describe Portal::ClazzesController do
       get :fullstatus, @params
       expect(assigns[:portal_clazz]).to eq(@mock_clazz)
       response.should be_success
-      assert_template "fullstatus"
+      expect(response).to render_template("fullstatus")
     end
   end
 
@@ -828,7 +828,7 @@ describe Portal::ClazzesController do
       }
       xhr :post, :add_new_student_popup, @params
       response.should be_success
-      assert_template :partial => "portal/students/_form"
+      expect(response).to render_template(:partial => "portal/students/_form")
     end
   end
 

--- a/spec/controllers/portal/clazzes_controller_spec.rb
+++ b/spec/controllers/portal/clazzes_controller_spec.rb
@@ -414,7 +414,7 @@ describe Portal::ClazzesController do
 
       @random_user.reload
 
-      assert_not_nil @random_user.portal_teacher
+      expect(@random_user.portal_teacher).not_to be_nil
       Portal::Teacher.count(:all).should == current_count + 1
     end
 
@@ -588,7 +588,7 @@ describe Portal::ClazzesController do
       }
       post :add_student, post_params
       newStudentInClazz = Portal::StudentClazz.find_by_clazz_id_and_student_id(@mock_clazz.id, @authorized_student.id)
-      assert_not_nil(newStudentInClazz)
+      expect(newStudentInClazz).not_to be_nil
     end
   end
 
@@ -634,27 +634,27 @@ describe Portal::ClazzesController do
       put :manage_classes, @post_params
 
       teacher_clazz = Portal::TeacherClazz.find_by_clazz_id_and_teacher_id(@mock_clazz.id, @authorized_teacher.id)
-      assert_not_nil(teacher_clazz)
+      expect(teacher_clazz).not_to be_nil
       assert(teacher_clazz.active)
       expect(teacher_clazz.position).to eq(5)
 
       teacher_clazz = Portal::TeacherClazz.find_by_clazz_id_and_teacher_id(@mock_clazz_phy.id, @authorized_teacher.id)
-      assert_not_nil(teacher_clazz)
+      expect(teacher_clazz).not_to be_nil
       assert(teacher_clazz.active)
       expect(teacher_clazz.position).to eq(2)
 
       teacher_clazz = Portal::TeacherClazz.find_by_clazz_id_and_teacher_id(@mock_clazz_chem.id, @authorized_teacher.id)
-      assert_not_nil(teacher_clazz)
+      expect(teacher_clazz).not_to be_nil
       assert(teacher_clazz.active == false)
       expect(teacher_clazz.position).to eq(3)
 
       teacher_clazz = Portal::TeacherClazz.find_by_clazz_id_and_teacher_id(@mock_clazz_bio.id, @authorized_teacher.id)
-      assert_not_nil(teacher_clazz)
+      expect(teacher_clazz).not_to be_nil
       assert(teacher_clazz.active)
       expect(teacher_clazz.position).to eq(4)
 
       teacher_clazz = Portal::TeacherClazz.find_by_clazz_id_and_teacher_id(@mock_clazz_math.id, @authorized_teacher.id)
-      assert_not_nil(teacher_clazz)
+      expect(teacher_clazz).not_to be_nil
       assert(teacher_clazz.active)
       expect(teacher_clazz.position).to eq(1)
 
@@ -692,16 +692,16 @@ describe Portal::ClazzesController do
       xhr :post, :copy_class, @post_params
 
       @copy_clazz = Portal::Clazz.find_by_name('Concept of physics')
-      assert_not_nil(@copy_clazz)
+      expect(@copy_clazz).not_to be_nil
 
       expect(@copy_clazz.teachers.length).to eq(@mock_clazz.teachers.length)
       @mock_clazz.teachers.each do |teacher|
-        assert_not_nil(@copy_clazz.teachers.find_by_id(teacher.id))
+        expect(@copy_clazz.teachers.find_by_id(teacher.id)).not_to be_nil
       end
 
       expect(@copy_clazz.offerings.length).to eq(@mock_clazz.offerings.length)
       @mock_clazz.offerings.each do |offering|
-        assert_not_nil(@copy_clazz.offerings.find_by_runnable_id(offering.runnable_id))
+        expect(@copy_clazz.offerings.find_by_runnable_id(offering.runnable_id)).not_to be_nil
       end
 
       expect(@copy_clazz.students.length).to eq(0)

--- a/spec/controllers/portal/clazzes_controller_spec.rb
+++ b/spec/controllers/portal/clazzes_controller_spec.rb
@@ -388,7 +388,7 @@ describe Portal::ClazzesController do
     end
 
     it "should create a new course in the specified school if this class has a unique name" do
-      assert_nil Portal::Course.find_by_name(@post_params[:portal_clazz][:name])
+      expect(Portal::Course.find_by_name(@post_params[:portal_clazz][:name])).to be_nil
 
       sign_in @authorized_teacher_user
 
@@ -405,7 +405,7 @@ describe Portal::ClazzesController do
       @random_user = Factory.create(:confirmed_user, :login => "random_user")
       sign_in @random_user
 
-      assert_nil @random_user.portal_teacher
+      expect(@random_user.portal_teacher).to be_nil
       current_count = Portal::Teacher.count(:all)
 
       @post_params[:portal_clazz][:teacher_id] = nil

--- a/spec/controllers/portal/offerings_controller_spec.rb
+++ b/spec/controllers/portal/offerings_controller_spec.rb
@@ -122,14 +122,14 @@ describe Portal::OfferingsController do
       # after first expand
       xhr :post, :offering_collapsed_status, @params
       portal_teacher_full_status = Portal::TeacherFullStatus.find_by_offering_id_and_teacher_id(@params[:id], @authorized_teacher.id)
-      assert_not_nil(portal_teacher_full_status)
+      expect(portal_teacher_full_status).not_to be_nil
       expect(portal_teacher_full_status.offering_collapsed).to eq(false)
       response.body.should be_blank
 
       #when teacher has collapsed and expanded many times before
       xhr :post, :offering_collapsed_status, @params
       portal_teacher_full_status.reload
-      assert_not_nil(portal_teacher_full_status)
+      expect(portal_teacher_full_status).not_to be_nil
       expect(portal_teacher_full_status.offering_collapsed).to eq(true)
       response.body.should be_blank
     end

--- a/spec/controllers/portal/offerings_controller_spec.rb
+++ b/spec/controllers/portal/offerings_controller_spec.rb
@@ -117,7 +117,7 @@ describe Portal::OfferingsController do
       sign_in @authorized_teacher_user
       #when teacher has never expanded or collapsed before
       portal_teacher_full_status = Portal::TeacherFullStatus.find_by_offering_id_and_teacher_id(@params[:id], @authorized_teacher.id)
-      assert_nil(portal_teacher_full_status)
+      expect(portal_teacher_full_status).to be_nil
 
       # after first expand
       xhr :post, :offering_collapsed_status, @params

--- a/spec/controllers/portal/offerings_controller_spec.rb
+++ b/spec/controllers/portal/offerings_controller_spec.rb
@@ -123,14 +123,14 @@ describe Portal::OfferingsController do
       xhr :post, :offering_collapsed_status, @params
       portal_teacher_full_status = Portal::TeacherFullStatus.find_by_offering_id_and_teacher_id(@params[:id], @authorized_teacher.id)
       assert_not_nil(portal_teacher_full_status)
-      assert_equal(portal_teacher_full_status.offering_collapsed, false)
+      expect(portal_teacher_full_status.offering_collapsed).to eq(false)
       response.body.should be_blank
 
       #when teacher has collapsed and expanded many times before
       xhr :post, :offering_collapsed_status, @params
       portal_teacher_full_status.reload
       assert_not_nil(portal_teacher_full_status)
-      assert_equal(portal_teacher_full_status.offering_collapsed, true)
+      expect(portal_teacher_full_status.offering_collapsed).to eq(true)
       response.body.should be_blank
     end
   end

--- a/spec/controllers/portal/teachers_controller_spec.rb
+++ b/spec/controllers/portal/teachers_controller_spec.rb
@@ -87,7 +87,7 @@ describe Portal::TeachersController do
         expect(Portal::Teacher.count(:all)).to eq(current_teacher_count), "TeachersController#create erroneously created a Portal::Teacher when given invalid POST data"
 
         #expect(flash.now[:error]).not_to be_nil
-        assert_nil flash[:notice]
+        expect(flash[:notice]).to be_nil
         @response.body.should include("must select a school")
         @response.body.should include("Sorry")
       end

--- a/spec/controllers/portal/teachers_controller_spec.rb
+++ b/spec/controllers/portal/teachers_controller_spec.rb
@@ -86,7 +86,7 @@ describe Portal::TeachersController do
         expect(User.count(:all)).to eq(current_user_count), "TeachersController#create erroneously created a User when given invalid POST data"
         expect(Portal::Teacher.count(:all)).to eq(current_teacher_count), "TeachersController#create erroneously created a Portal::Teacher when given invalid POST data"
 
-        #assert_not_nil flash.now[:error]
+        #expect(flash.now[:error]).not_to be_nil
         assert_nil flash[:notice]
         @response.body.should include("must select a school")
         @response.body.should include("Sorry")

--- a/spec/controllers/portal/teachers_controller_spec.rb
+++ b/spec/controllers/portal/teachers_controller_spec.rb
@@ -83,8 +83,9 @@ describe Portal::TeachersController do
         
         post :create, params
         
-        assert_equal User.count(:all), current_user_count, "TeachersController#create erroneously created a User when given invalid POST data"
-        assert_equal Portal::Teacher.count(:all), current_teacher_count, "TeachersController#create erroneously created a Portal::Teacher when given invalid POST data"
+        expect(User.count(:all)).to eq(current_user_count), "TeachersController#create erroneously created a User when given invalid POST data"
+        expect(Portal::Teacher.count(:all)).to eq(current_teacher_count), "TeachersController#create erroneously created a Portal::Teacher when given invalid POST data"
+
         #assert_not_nil flash.now[:error]
         assert_nil flash[:notice]
         @response.body.should include("must select a school")

--- a/spec/controllers/security_questions_controller_spec.rb
+++ b/spec/controllers/security_questions_controller_spec.rb
@@ -79,7 +79,7 @@ describe SecurityQuestionsController do
       put :update, @params_for_update
 
       flash[:error].should include("Wicked bad errors!")
-      assert_template "edit"
+      expect(response).to render_template("edit")
     end
   end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -123,8 +123,8 @@ describe UsersController do
     
     assert_select "*#clazzes_nav", false
     
-    assert_nil flash[:error]
-    assert_nil flash[:notice]
+    expect(flash[:error]).to be_nil
+    expect(flash[:notice]).to be_nil
   end
   
   

--- a/spec/models/admin/site_notice_spec.rb
+++ b/spec/models/admin/site_notice_spec.rb
@@ -20,15 +20,15 @@ describe Admin::SiteNotice do
       Admin::SiteNoticeRole.destroy_all
       Admin::SiteNotice.destroy_all
       notices_hash = Admin::SiteNotice.get_notices_for_user(@admin_user)
-      assert_equal(notices_hash[:notice_display_type] , Admin::SiteNotice.NOTICE_DISPLAY_TYPES[:no_notice])
-      assert_equal(notices_hash[:notices].length , 0)
+      expect(notices_hash[:notice_display_type] ).to eq(Admin::SiteNotice.NOTICE_DISPLAY_TYPES[:no_notice])
+      expect(notices_hash[:notices].length ).to eq(0)
     end
     it"should show uncollapsed notice container if there are recent notices" do
       notices_hash = Admin::SiteNotice.get_notices_for_user(@admin_user)
-      assert_equal(notices_hash[:notice_display_type] , Admin::SiteNotice.NOTICE_DISPLAY_TYPES[:new_notices])
+      expect(notices_hash[:notice_display_type] ).to eq(Admin::SiteNotice.NOTICE_DISPLAY_TYPES[:new_notices])
 
       notice_ids = notices_hash[:notices].map {|n| n.id}
-      assert_equal(notice_ids.length, 3)
+      expect(notice_ids.length).to eq(3)
       assert(notice_ids.include?(@first_notice.id))
       assert(notice_ids.include?(@second_notice.id))
       assert(notice_ids.include?(@third_notice.id))
@@ -36,21 +36,21 @@ describe Admin::SiteNotice do
     it"should not show dismissed notices" do
       Factory.create(:site_notice_user, :notice_id => @first_notice.id,:user_id => @admin_user.id, :notice_dismissed => true)
       notices_hash = Admin::SiteNotice.get_notices_for_user(@admin_user)
-      assert_equal(notices_hash[:notice_display_type] , Admin::SiteNotice.NOTICE_DISPLAY_TYPES[:new_notices])
+      expect(notices_hash[:notice_display_type] ).to eq(Admin::SiteNotice.NOTICE_DISPLAY_TYPES[:new_notices])
 
       notice_ids = notices_hash[:notices].map {|n| n.id}
-      assert_equal(notice_ids.length, 2)
-      assert_equal(notice_ids.include?(@first_notice.id), false)
+      expect(notice_ids.length).to eq(2)
+      expect(notice_ids.include?(@first_notice.id)).to eq(false)
       assert(notice_ids.include?(@second_notice.id))
       assert(notice_ids.include?(@third_notice.id))
     end
     it"should show collapsed notice container if there are no recent notices and user had collapsed the notice container" do
       Factory.create(:notice_user_display_status,:user_id => @admin_user.id,:last_collapsed_at_time => DateTime.now + 1.day, :collapsed_status => true)
       notices_hash = Admin::SiteNotice.get_notices_for_user(@admin_user)
-      assert_equal(notices_hash[:notice_display_type] , Admin::SiteNotice.NOTICE_DISPLAY_TYPES[:collapsed_notices])
+      expect(notices_hash[:notice_display_type] ).to eq(Admin::SiteNotice.NOTICE_DISPLAY_TYPES[:collapsed_notices])
 
       notice_ids = notices_hash[:notices].map {|n| n.id}
-      assert_equal(notice_ids.length, 3)
+      expect(notice_ids.length).to eq(3)
       assert(notice_ids.include?(@first_notice.id))
       assert(notice_ids.include?(@second_notice.id))
       assert(notice_ids.include?(@third_notice.id))

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -26,7 +26,7 @@ describe User do
     it 'starts in pending state' do
       @creating_user.call
       @user.reload
-      assert_equal @user.state, 'pending'
+      expect(@user.state).to eq('pending')
     end
   end
 
@@ -213,16 +213,16 @@ describe User do
 
   it 'registers passive user' do
     user = create_user(:password => nil, :password_confirmation => nil)
-    assert_equal user.state, 'passive'
+    expect(user.state).to eq('passive')
     user.update_attributes({:password => 'new password', :password_confirmation => 'new password'})
     user.save!
     user.reload
-    assert_equal user.state, 'pending'
+    expect(user.state).to eq('pending')
   end
 
   it 'suspends user' do
     users(:quentin).suspend!
-    assert_equal users(:quentin).state, 'suspended'
+    expect(users(:quentin).state).to eq('suspended')
   end
 
   it 'does not authenticate suspended user' do
@@ -234,7 +234,7 @@ describe User do
     users(:quentin).deleted_at.should be_nil
     users(:quentin).delete!
     users(:quentin).deleted_at.should_not be_nil
-    assert_equal users(:quentin).state, 'disabled'
+    expect(users(:quentin).state).to eq('disabled')
   end
 
   describe "being unsuspended" do
@@ -247,13 +247,13 @@ describe User do
 
     it 'reverts to active state' do
       @user.unsuspend!
-      assert_equal @user.state, 'active'
+      expect(@user.state).to eq('active')
     end
 
     it 'reverts to passive state if activation_code and activated_at are nil' do
       User.update_all({:confirmation_token => nil, :confirmed_at => nil})
       @user.reload.unsuspend!
-      assert_equal @user.state, 'passive'
+      expect(@user.state).to eq('passive')
     end
 
     it 'reverts to pending state if activation_code is set and activated_at is nil' do
@@ -265,7 +265,7 @@ describe User do
         user.save!
       end
       @user.reload.unsuspend!
-      assert_equal @user.state, 'pending'
+      expect(@user.state).to eq('pending')
     end
   end
 


### PR DESCRIPTION
Updates the following usage of test-unit syntax.

```
38 | assert_equal
22 | assert_not_nil
16 | assert_redirected_to
14 | assert_nil
13 | assert_template
11 | assert_response
 2 | assert_not_equal
 2 | assert_requested
```