### PR TITLE
Hint/upgrade/rspec 3 syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -195,6 +195,7 @@ group :test, :cucumber do
   gem "capybara",           "~> 1.1.2"
   gem "rspec",              "~> 2.99.0"
   gem "rspec-rails",        "~> 2.99.0"
+  gem "rspec-activemodel-mocks"
   gem "email_spec",         "~> 1.2.1"
   gem "fakeweb",            "~> 1.3", :require => false
   gem "ci_reporter",        "~> 1.7.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -488,6 +488,10 @@ GEM
       rspec-core (~> 2.99.0)
       rspec-expectations (~> 2.99.0)
       rspec-mocks (~> 2.99.0)
+    rspec-activemodel-mocks (1.0.3)
+      activemodel (>= 3.0)
+      activesupport (>= 3.0)
+      rspec-mocks (>= 2.99, < 4.0)
     rspec-collection_matchers (1.1.3)
       rspec-expectations (>= 2.99.0.beta1)
     rspec-core (2.99.2)
@@ -712,6 +716,7 @@ DEPENDENCIES
   remarkable_activerecord (~> 3.1.13)
   rollbar
   rspec (~> 2.99.0)
+  rspec-activemodel-mocks
   rspec-rails (~> 2.99.0)
   ruby-debug
   ruby-prof
@@ -747,4 +752,4 @@ DEPENDENCIES
   yui-compressor
 
 BUNDLED WITH
-   1.16.2
+   1.16.3

--- a/spec/controllers/admin/client_spec.rb
+++ b/spec/controllers/admin/client_spec.rb
@@ -115,13 +115,13 @@ describe Admin::ClientsController do
       it "will render the index" do
         get :index
         expect(response).to be_success
-        response.should render_template("index")
+        expect(response).to render_template("index")
       end
     end
 
     describe "DELETE destroy" do
       it "delete, and redirect back to index" do
-        Client.should_receive(:find).and_return(mock_client)
+        expect(Client).to receive(:find).and_return(mock_client)
         delete :destroy, :id => client_id
         expect(response).to redirect_to(action: :index)
       end
@@ -129,26 +129,26 @@ describe Admin::ClientsController do
 
     describe "GET show" do
       it "redners the show template" do
-        Client.should_receive(:find).and_return(mock_client)
+        expect(Client).to receive(:find).and_return(mock_client)
         get :show, :id => client_id
-        assigns[:client].should eq mock_client
-        response.should render_template("show")
+        expect(assigns[:client]).to eq mock_client
+        expect(response).to render_template("show")
       end
     end
 
     describe "GET edit" do
       it "renders the edit template" do
-        Client.should_receive(:find).and_return(mock_client)
+        expect(Client).to receive(:find).and_return(mock_client)
         get :edit, :id => client_id
-        assigns[:client].should eq mock_client
-        response.should render_template("edit")
+        expect(assigns[:client]).to eq mock_client
+        expect(response).to render_template("edit")
       end
     end
 
     describe "GET new" do
       it "renders the new form" do
         get :new
-        response.should render_template("new")
+        expect(response).to render_template("new")
         expect(response).to be_success
       end
     end
@@ -156,7 +156,7 @@ describe Admin::ClientsController do
     describe "PUT update" do
       let(:stubs) {{ update_attributes: true }}
       it "updates the model, redirects to index" do
-        Client.should_receive(:find).and_return(mock_client)
+        expect(Client).to receive(:find).and_return(mock_client)
         put :update, :id => client_id, :client => {:params => 'params'}
         expect(response).to redirect_to(action: :index)
       end

--- a/spec/controllers/admin/external_report_spec.rb
+++ b/spec/controllers/admin/external_report_spec.rb
@@ -115,13 +115,13 @@ describe Admin::ExternalReportsController do
       it "will render the index" do
         get :index
         expect(response).to be_success
-        response.should render_template("index")
+        expect(response).to render_template("index")
       end
     end
 
     describe "DELETE destroy" do
       it "delete, and redirect back to index" do
-        ExternalReport.should_receive(:find).and_return(mock_report)
+        expect(ExternalReport).to receive(:find).and_return(mock_report)
         delete :destroy, :id => report_id
         expect(response).to redirect_to(action: :index)
       end
@@ -129,26 +129,26 @@ describe Admin::ExternalReportsController do
 
     describe "GET show" do
       it "redners the show template" do
-        ExternalReport.should_receive(:find).and_return(mock_report)
+        expect(ExternalReport).to receive(:find).and_return(mock_report)
         get :show, :id => report_id
-        assigns[:report].should eq mock_report
-        response.should render_template("show")
+        expect(assigns[:report]).to eq mock_report
+        expect(response).to render_template("show")
       end
     end
 
     describe "GET edit" do
       it "renders the edit template" do
-        ExternalReport.should_receive(:find).and_return(mock_report)
+        expect(ExternalReport).to receive(:find).and_return(mock_report)
         get :edit, :id => report_id
-        assigns[:report].should eq mock_report
-        response.should render_template("edit")
+        expect(assigns[:report]).to eq mock_report
+        expect(response).to render_template("edit")
       end
     end
 
     describe "GET new" do
       it "renders the new form" do
         get :new
-        response.should render_template("new")
+        expect(response).to render_template("new")
         expect(response).to be_success
       end
     end
@@ -156,7 +156,7 @@ describe Admin::ExternalReportsController do
     describe "PUT update" do
       let(:stubs) {{ update_attributes: true }}
       it "updates the model, redirects to index" do
-        ExternalReport.should_receive(:find).and_return(mock_report)
+        expect(ExternalReport).to receive(:find).and_return(mock_report)
         put :update, :id => report_id, :report => {:params => 'params'}
         expect(response).to redirect_to(action: :index)
       end

--- a/spec/controllers/admin/projects_controller_spec.rb
+++ b/spec/controllers/admin/projects_controller_spec.rb
@@ -31,28 +31,28 @@ describe Admin::ProjectsController do
       it "assigns all projects as @projects" do
         project
         get :index, {}
-        assigns(:projects).to_a.should eq([project])
+        expect(assigns(:projects).to_a).to eq([project])
       end
     end
 
     describe "GET show" do
       it "assigns the requested project as @project" do
         get :show, {:id => project.to_param}
-        assigns(:project).should eq(project)
+        expect(assigns(:project)).to eq(project)
       end
     end
 
     describe "GET new" do
       it "assigns a new project as @project" do
         get :new, {}
-        assigns(:project).should be_a_new(Admin::Project)
+        expect(assigns(:project)).to be_a_new(Admin::Project)
       end
     end
 
     describe "GET edit" do
       it "assigns the requested project as @project" do
         get :edit, {:id => project.to_param}
-        assigns(:project).should eq(project)
+        expect(assigns(:project)).to eq(project)
       end
     end
 
@@ -66,31 +66,31 @@ describe Admin::ProjectsController do
 
         it "assigns a newly created project as @project" do
           post :create, {:admin_project => valid_attributes}
-          assigns(:project).should be_a(Admin::Project)
-          assigns(:project).should be_persisted
+          expect(assigns(:project)).to be_a(Admin::Project)
+          expect(assigns(:project)).to be_persisted
         end
 
         it "redirects to the projects index" do
           post :create, {:admin_project => valid_attributes}
-          response.should redirect_to(admin_projects_url)
+          expect(response).to redirect_to(admin_projects_url)
         end
       end
 
       describe "with invalid params" do
         it "assigns a newly created but unsaved project as @project" do
           # Trigger the behavior that occurs when invalid params are submitted
-          Admin::Project.any_instance.stub(:save).and_return(false)
+          allow_any_instance_of(Admin::Project).to receive(:save).and_return(false)
           post :create, {:admin_project => valid_attributes}
-          assigns(:project).should be_a(Admin::Project)
-          assigns(:project).should_not be_persisted
-          assigns(:project).should be_a_new(Admin::Project)
+          expect(assigns(:project)).to be_a(Admin::Project)
+          expect(assigns(:project)).not_to be_persisted
+          expect(assigns(:project)).to be_a_new(Admin::Project)
         end
 
         it "re-renders the 'new' template" do
           # Trigger the behavior that occurs when invalid params are submitted
-          Admin::Project.any_instance.stub(:save).and_return(false)
+          allow_any_instance_of(Admin::Project).to receive(:save).and_return(false)
           post :create, {:admin_project => valid_attributes}
-          response.should render_template(:new)
+          expect(response).to render_template(:new)
         end
       end
     end
@@ -102,34 +102,34 @@ describe Admin::ProjectsController do
           # specifies that the Admin::Project created on the previous line
           # receives the :update_attributes message with whatever params are
           # submitted in the request.
-          Admin::Project.any_instance.should_receive(:update_attributes).with({'name' => 'new name'})
+          expect_any_instance_of(Admin::Project).to receive(:update_attributes).with({'name' => 'new name'})
           put :update, {:id => project.to_param, :admin_project => {'name' => 'new name'}}
         end
 
         it "assigns the requested project as @project" do
           put :update, {:id => project.to_param, :admin_project => valid_attributes}
-          assigns(:project).should eq(project)
+          expect(assigns(:project)).to eq(project)
         end
 
         it "redirects to the project" do
           put :update, {:id => project.to_param, :admin_project => valid_attributes}
-          response.should redirect_to(project)
+          expect(response).to redirect_to(project)
         end
       end
 
       describe "with invalid params" do
         it "assigns the project as @project" do
           # Trigger the behavior that occurs when invalid params are submitted
-          Admin::Project.any_instance.stub(:save).and_return(false)
+          allow_any_instance_of(Admin::Project).to receive(:save).and_return(false)
           put :update, {:id => project.to_param, :admin_project => valid_attributes}
-          assigns(:project).should eq(project)
+          expect(assigns(:project)).to eq(project)
         end
 
         it "re-renders the 'edit' template" do
           # Trigger the behavior that occurs when invalid params are submitted
-          Admin::Project.any_instance.stub(:save).and_return(false)
+          allow_any_instance_of(Admin::Project).to receive(:save).and_return(false)
           put :update, {:id => project.to_param, :admin_project => valid_attributes}
-          response.should render_template("edit")
+          expect(response).to render_template("edit")
         end
       end
     end
@@ -144,7 +144,7 @@ describe Admin::ProjectsController do
 
       it "redirects to the projects list" do
         delete :destroy, {:id => project.to_param}
-        response.should redirect_to(admin_projects_url)
+        expect(response).to redirect_to(admin_projects_url)
       end
     end
   end

--- a/spec/controllers/admin/settings_controller_spec.rb
+++ b/spec/controllers/admin/settings_controller_spec.rb
@@ -3,7 +3,9 @@ require File.expand_path('../../../spec_helper', __FILE__)
 describe Admin::SettingsController do
 
   def mock_settings(stubs={})
-    @mock_settings.stub!(stubs) unless stubs.empty?
+    stubs.each do |key, value|
+      allow(@mock_settings).to receive(key).and_return(value)
+    end
     @mock_settings
   end
 
@@ -15,9 +17,9 @@ describe Admin::SettingsController do
 
   describe "GET index" do
     it "assigns all admin_settings as @admin_settings" do
-      Admin::Settings.should_receive(:search).with(nil, nil, nil).and_return([mock_settings])
+      expect(Admin::Settings).to receive(:search).with(nil, nil, nil).and_return([mock_settings])
       get :index
-      assigns[:admin_settings].should == [mock_settings]
+      expect(assigns[:admin_settings]).to eq([mock_settings])
     end
 
     it "doesn't allow anybody who isn't an admin or manager to access to index" do
@@ -33,57 +35,57 @@ describe Admin::SettingsController do
     it "only allows managers to edit the current settings and only shows them the information they can change" do
       settings = Factory.create(:admin_settings, :active => true)
       second_settings = Factory.create(:admin_settings)
-      Admin::Settings.stub!(:default_settings).and_return(settings)
+      allow(Admin::Settings).to receive(:default_settings).and_return(settings)
 
       login_manager
-      
+
       get :index
-      
+
       expect(response).to be_success
       expect(response).to render_template(:partial => "_show_for_managers")
 
-      assigns[:admin_settings].size.should be(1)
-      assigns[:admin_settings].should include(settings)
-      assigns[:admin_settings].should_not include(second_settings)
+      expect(assigns[:admin_settings].size).to be(1)
+      expect(assigns[:admin_settings]).to include(settings)
+      expect(assigns[:admin_settings]).not_to include(second_settings)
     end
   end
 
   describe "GET show" do
     it "assigns the requested settings as @settings" do
-      Admin::Settings.should_receive(:find).with("37").and_return(mock_settings)
+      expect(Admin::Settings).to receive(:find).with("37").and_return(mock_settings)
       get :show, :id => "37"
-      assigns[:admin_settings].should equal(mock_settings)
+      expect(assigns[:admin_settings]).to equal(mock_settings)
     end
   end
 
   describe "GET new" do
     it "assigns a new settings as @settings" do
-      Admin::Settings.should_receive(:new).and_return(mock_settings)
+      expect(Admin::Settings).to receive(:new).and_return(mock_settings)
       get :new
-      assigns[:admin_settings].should equal(mock_settings)
+      expect(assigns[:admin_settings]).to equal(mock_settings)
     end
   end
 
   describe "GET edit" do
     before(:each) do
-      mock_settings.stub!(:home_page_content=).and_return("") # Our controller uses this now, to set default content
-      Admin::Settings.should_receive(:find).with("37").and_return(mock_settings)
+      allow(mock_settings).to receive(:home_page_content=).and_return("") # Our controller uses this now, to set default content
+      expect(Admin::Settings).to receive(:find).with("37").and_return(mock_settings)
     end
 
     it "assigns the requested settings as @admin_settings" do
       get :edit, :id => "37"
-      assigns[:admin_settings].should equal(mock_settings)
+      expect(assigns[:admin_settings]).to equal(mock_settings)
     end
 
     it "uses default content if home_page_content is empty" do
-      mock_settings.stub!(:home_page_content).and_return(nil)
-      mock_settings.should_receive(:home_page_content=)
+      allow(mock_settings).to receive(:home_page_content).and_return(nil)
+      expect(mock_settings).to receive(:home_page_content=)
       get :edit, :id => "37"
     end
 
     it "uses the value of home_page_content if it is not empty" do
-      mock_settings.stub!(:home_page_content).and_return("test content")
-      mock_settings.should_not_receive(:home_page_content=)
+      allow(mock_settings).to receive(:home_page_content).and_return("test content")
+      expect(mock_settings).not_to receive(:home_page_content=)
       get :edit, :id => "37"
     end
   end
@@ -93,7 +95,7 @@ describe Admin::SettingsController do
 
     it "renders the _form_for_managers partial" do
       settings = Factory.create(:admin_settings)
-      Admin::Settings.should_receive(:find).with("37").and_return(settings)
+      expect(Admin::Settings).to receive(:find).with("37").and_return(settings)
 
       login_manager
 
@@ -101,11 +103,11 @@ describe Admin::SettingsController do
 
       expect(response).to be_success
       expect(response).to render_template(:partial => "_form_for_managers")
-      
-      response.body.should have_selector("*[name='admin_settings[home_page_content]']")
+
+      expect(response.body).to have_selector("*[name='admin_settings[home_page_content]']")
 
       (settings.attributes.keys - ["home_page_content", "wrap_home_page_content"]).each do |attribute|
-        response.body.should_not have_selector("*[name='admin_settings[#{attribute}]']")
+        expect(response.body).not_to have_selector("*[name='admin_settings[#{attribute}]']")
       end
     end
   end
@@ -114,33 +116,33 @@ describe Admin::SettingsController do
 
     describe "with valid params" do
       it "assigns a newly created settings as @settings" do
-        Admin::Settings.should_receive(:new).with({'these' => 'params'}).and_return(mock_settings(:save => true))
-        mock_settings.should_receive(:save).and_return(mock_settings(:save => true))
+        expect(Admin::Settings).to receive(:new).with({'these' => 'params'}).and_return(mock_settings(:save => true))
+        expect(mock_settings).to receive(:save).and_return(mock_settings(:save => true))
         post :create, :admin_settings => {:these => 'params'}
-        assigns[:admin_settings].should equal(mock_settings)
+        expect(assigns[:admin_settings]).to equal(mock_settings)
       end
 
       it "redirects to the created settings" do
-        Admin::Settings.should_receive(:new).and_return(mock_settings(:save => true))
-        mock_settings.should_receive(:save).and_return(mock_settings(:save => true))
+        expect(Admin::Settings).to receive(:new).and_return(mock_settings(:save => true))
+        expect(mock_settings).to receive(:save).and_return(mock_settings(:save => true))
         post :create, :admin_settings => {}
-        response.should redirect_to(admin_setting_url(mock_settings))
+        expect(response).to redirect_to(admin_setting_url(mock_settings))
       end
     end
 
     describe "with invalid params" do
       it "assigns a newly created but unsaved settings as @settings" do
-        Admin::Settings.should_receive(:new).with({'these' => 'params'}).and_return(mock_settings(:save => false))
-        mock_settings.should_receive(:save).and_return(mock_settings(:save => false))
+        expect(Admin::Settings).to receive(:new).with({'these' => 'params'}).and_return(mock_settings(:save => false))
+        expect(mock_settings).to receive(:save).and_return(mock_settings(:save => false))
         post :create, :admin_settings => {:these => 'params'}
-        assigns[:admin_settings].should equal(mock_settings)
+        expect(assigns[:admin_settings]).to equal(mock_settings)
       end
 
       it "re-renders the 'new' template" do
-        Admin::Settings.should_receive(:new).and_return(mock_settings(:save => false))
-        mock_settings.should_receive(:save).and_return(false)
+        expect(Admin::Settings).to receive(:new).and_return(mock_settings(:save => false))
+        expect(mock_settings).to receive(:save).and_return(false)
         post :create, :admin_settings => {}
-        response.should redirect_to(new_admin_setting_url)
+        expect(response).to redirect_to(new_admin_setting_url)
       end
     end
 
@@ -150,45 +152,45 @@ describe Admin::SettingsController do
 
     describe "with valid params" do
       it "updates the requested settings" do
-        Admin::Settings.should_receive(:find).with("37").and_return(mock_settings)
-        mock_settings.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(Admin::Settings).to receive(:find).with("37").and_return(mock_settings)
+        expect(mock_settings).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :admin_settings => {:these => 'params'}
       end
 
       it "assigns the requested settings as @settings" do
-        Admin::Settings.should_receive(:find).and_return(mock_settings(:update_attributes => true))
-        mock_settings.should_receive(:update_attributes).and_return(mock_settings(:save => true))
+        expect(Admin::Settings).to receive(:find).and_return(mock_settings(:update_attributes => true))
+        expect(mock_settings).to receive(:update_attributes).and_return(mock_settings(:save => true))
         put :update, :id => "1"
-        assigns[:admin_settings].should equal(mock_settings)
+        expect(assigns[:admin_settings]).to equal(mock_settings)
       end
 
       it "redirects to the settings" do
-        Admin::Settings.should_receive(:find).and_return(mock_settings(:update_attributes => true))
-        mock_settings.should_receive(:update_attributes).and_return(mock_settings(:save => true))
+        expect(Admin::Settings).to receive(:find).and_return(mock_settings(:update_attributes => true))
+        expect(mock_settings).to receive(:update_attributes).and_return(mock_settings(:save => true))
         put :update, :id => "1"
-        response.should redirect_to(admin_setting_url(mock_settings))
+        expect(response).to redirect_to(admin_setting_url(mock_settings))
       end
     end
 
     describe "with invalid params" do
       it "updates the requested settings" do
-        Admin::Settings.should_receive(:find).with("37").and_return(mock_settings)
-        mock_settings.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(Admin::Settings).to receive(:find).with("37").and_return(mock_settings)
+        expect(mock_settings).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :admin_settings => {:these => 'params'}
       end
 
       it "assigns the settings as @settings" do
-        Admin::Settings.should_receive(:find).and_return(mock_settings(:update_attributes => false))
-        mock_settings.should_receive(:update_attributes).and_return(mock_settings(:update_attributes => false))
+        expect(Admin::Settings).to receive(:find).and_return(mock_settings(:update_attributes => false))
+        expect(mock_settings).to receive(:update_attributes).and_return(mock_settings(:update_attributes => false))
         put :update, :id => "1"
-        assigns[:admin_settings].should equal(mock_settings)
+        expect(assigns[:admin_settings]).to equal(mock_settings)
       end
 
       it "re-renders the 'edit' template" do
-        Admin::Settings.should_receive(:find).and_return(mock_settings(:update_attributes => false))
-        mock_settings.should_receive(:update_attributes).and_return(mock_settings(:update_attributes => false))
+        expect(Admin::Settings).to receive(:find).and_return(mock_settings(:update_attributes => false))
+        expect(mock_settings).to receive(:update_attributes).and_return(mock_settings(:update_attributes => false))
         put :update, :id => "1"
-        response.should redirect_to(admin_setting_url(mock_settings))
+        expect(response).to redirect_to(admin_setting_url(mock_settings))
       end
     end
 
@@ -196,16 +198,16 @@ describe Admin::SettingsController do
 
   describe "DELETE destroy" do
     it "destroys the requested settings" do
-      Admin::Settings.should_receive(:find).with("37").and_return(mock_settings)
-      mock_settings.should_receive(:destroy)
+      expect(Admin::Settings).to receive(:find).with("37").and_return(mock_settings)
+      expect(mock_settings).to receive(:destroy)
       delete :destroy, :id => "37"
     end
 
     it "redirects to the admin_settings list" do
-      Admin::Settings.should_receive(:find).and_return(mock_settings(:destroy => true))
-      mock_settings.should_receive(:destroy)
+      expect(Admin::Settings).to receive(:find).and_return(mock_settings(:destroy => true))
+      expect(mock_settings).to receive(:destroy)
       delete :destroy, :id => "1"
-      response.should redirect_to(admin_settings_url)
+      expect(response).to redirect_to(admin_settings_url)
     end
   end
 

--- a/spec/controllers/admin/site_notices_controller_spec.rb
+++ b/spec/controllers/admin/site_notices_controller_spec.rb
@@ -32,27 +32,27 @@ describe Admin::SiteNoticesController do
       sign_out :user
       sign_in @teacher_user
       get :new
-      response.should redirect_to("/recent_activity")
+      expect(response).to redirect_to("/recent_activity")
 
       sign_out :user
       sign_in @researcher_user
       get :new
-      response.should redirect_to("/getting_started")
+      expect(response).to redirect_to("/getting_started")
 
       sign_out :user
       sign_in @author_user
       get :new
-      response.should redirect_to("/getting_started")
+      expect(response).to redirect_to("/getting_started")
 
       sign_out :user
       sign_in @student_user
       get :new
-      response.should redirect_to("/my_classes")
+      expect(response).to redirect_to("/my_classes")
 
       sign_out :user
       sign_in @guest_user
       get :new
-      response.should redirect_to("/getting_started")
+      expect(response).to redirect_to("/getting_started")
 
     end
   end
@@ -82,20 +82,20 @@ describe Admin::SiteNoticesController do
       post :create, @post_params
       notice = Admin::SiteNotice.find_by_notice_html(@post_params[:notice_html])
       expect(notice).to be_nil
-      flash[:error].should =~ /Notice text is blank/i
+      expect(flash[:error]).to match(/Notice text is blank/i)
 
       @post_params[:notice_html] = ' '
       post :create, @post_params
       notice = Admin::SiteNotice.find_by_notice_html(@post_params[:notice_html])
       expect(notice).to be_nil
-      flash[:error].should =~ /Notice text is blank/i
+      expect(flash[:error]).to match(/Notice text is blank/i)
     end
     it("should not create a notice if no role is selected") do
       @post_params[:role] = nil
       post :create, @post_params
       notice = Admin::SiteNotice.find_by_notice_html(@post_params[:notice_html])
       expect(notice).to be_nil
-      flash[:error].should =~ /No role is selected/i
+      expect(flash[:error]).to match(/No role is selected/i)
     end
   end
 
@@ -146,20 +146,20 @@ describe Admin::SiteNoticesController do
       post :update, @post_params
       notice = Admin::SiteNotice.find_by_notice_html(@post_params[:notice_html])
       expect(notice).to be_nil
-      flash[:error].should =~ /Notice text is blank/i
+      expect(flash[:error]).to match(/Notice text is blank/i)
 
       @post_params[:notice_html] = "       "
       post :update, @post_params
       notice = Admin::SiteNotice.find_by_notice_html(@post_params[:notice_html])
       expect(notice).to be_nil
-      flash[:error].should =~ /Notice text is blank/i
+      expect(flash[:error]).to match(/Notice text is blank/i)
     end
     it("should not create a notice if no role is selected") do
       @post_params[:role] = nil
       post :update, @post_params
       notice = Admin::SiteNotice.find_by_notice_html(@post_params[:notice_html])
       expect(notice).to be_nil
-      flash[:error].should =~ /No role is selected/i
+      expect(flash[:error]).to match(/No role is selected/i)
     end
   end
 
@@ -185,7 +185,7 @@ describe Admin::SiteNoticesController do
       expect(notice).to be_nil
       notice_roles = Admin::SiteNoticeRole.find_by_notice_id(@params[:id])
       expect(notice_roles).to be_nil
-      response.should be_success
+      expect(response).to be_success
     end
   end
   describe "Dismiss a notice" do
@@ -205,7 +205,7 @@ describe Admin::SiteNoticesController do
       dismissed_notice = Admin::SiteNoticeUser.find_by_notice_id_and_user_id(@notice.id, @teacher_user.id)
       expect(dismissed_notice).not_to be_nil
       assert(dismissed_notice.notice_dismissed)
-      response.should be_success
+      expect(response).to be_success
     end
   end
   describe "toggle_notice_display" do
@@ -222,13 +222,13 @@ describe Admin::SiteNoticesController do
       toggle_notice_status = Admin::NoticeUserDisplayStatus.find_by_user_id(@teacher_user.id)
       expect(toggle_notice_status).not_to be_nil
       assert(toggle_notice_status.collapsed_status)
-      response.should be_success
+      expect(response).to be_success
 
       xhr :post, :toggle_notice_display
       toggle_notice_status.reload
       expect(toggle_notice_status).not_to be_nil
       expect(toggle_notice_status.collapsed_status).to eq(false)
-      response.should be_success
+      expect(response).to be_success
     end
   end
 end

--- a/spec/controllers/admin/tags_controller_spec.rb
+++ b/spec/controllers/admin/tags_controller_spec.rb
@@ -12,33 +12,33 @@ describe Admin::TagsController do
 
   describe "GET index" do
     it "assigns all admin_tags as @admin_tags" do
-      Admin::Tag.stub(:search).with(nil, nil, nil).and_return([mock_tags])
+      allow(Admin::Tag).to receive(:search).with(nil, nil, nil).and_return([mock_tags])
       get :index
-      assigns[:admin_tags].should == [mock_tags]
+      expect(assigns[:admin_tags]).to eq([mock_tags])
     end
   end
 
   describe "GET show" do
     it "assigns the requested tags as @tags" do
-      Admin::Tag.stub(:find).with("37").and_return(mock_tags)
+      allow(Admin::Tag).to receive(:find).with("37").and_return(mock_tags)
       get :show, :id => "37"
-      assigns[:admin_tag].should equal(mock_tags)
+      expect(assigns[:admin_tag]).to equal(mock_tags)
     end
   end
 
   describe "GET new" do
     it "assigns a new tags as @tags" do
-      Admin::Tag.stub(:new).and_return(mock_tags)
+      allow(Admin::Tag).to receive(:new).and_return(mock_tags)
       get :new
-      assigns[:admin_tag].should equal(mock_tags)
+      expect(assigns[:admin_tag]).to equal(mock_tags)
     end
   end
 
   describe "GET edit" do
     it "assigns the requested tags as @tags" do
-      Admin::Tag.stub(:find).with("37").and_return(mock_tags)
+      allow(Admin::Tag).to receive(:find).with("37").and_return(mock_tags)
       get :edit, :id => "37"
-      assigns[:admin_tag].should equal(mock_tags)
+      expect(assigns[:admin_tag]).to equal(mock_tags)
     end
   end
 
@@ -46,29 +46,29 @@ describe Admin::TagsController do
 
     describe "with valid params" do
       it "assigns a newly created tags as @tags" do
-        Admin::Tag.stub(:new).with({'these' => 'params'}).and_return(mock_tags(:save => true))
+        allow(Admin::Tag).to receive(:new).with({'these' => 'params'}).and_return(mock_tags(:save => true))
         post :create, :admin_tag => {:these => 'params'}
-        assigns[:admin_tag].should equal(mock_tags)
+        expect(assigns[:admin_tag]).to equal(mock_tags)
       end
 
       it "redirects to the created tags" do
-        Admin::Tag.stub(:new).and_return(mock_tags(:save => true))
+        allow(Admin::Tag).to receive(:new).and_return(mock_tags(:save => true))
         post :create, :admin_tag => {}
-        response.should redirect_to(admin_tag_url(mock_tags))
+        expect(response).to redirect_to(admin_tag_url(mock_tags))
       end
     end
 
     describe "with invalid params" do
       it "assigns a newly created but unsaved tags as @tags" do
-        Admin::Tag.stub(:new).with({'these' => 'params'}).and_return(mock_tags(:save => false))
+        allow(Admin::Tag).to receive(:new).with({'these' => 'params'}).and_return(mock_tags(:save => false))
         post :create, :admin_tag => {:these => 'params'}
-        assigns[:admin_tag].should equal(mock_tags)
+        expect(assigns[:admin_tag]).to equal(mock_tags)
       end
 
       it "re-renders the 'new' template" do
-        Admin::Tag.stub(:new).and_return(mock_tags(:save => false))
+        allow(Admin::Tag).to receive(:new).and_return(mock_tags(:save => false))
         post :create, :admin_tag => {}
-        response.should render_template('new')
+        expect(response).to render_template('new')
       end
     end
 
@@ -78,41 +78,41 @@ describe Admin::TagsController do
 
     describe "with valid params" do
       it "updates the requested tags" do
-        Admin::Tag.should_receive(:find).with("37").and_return(mock_tags)
-        mock_tags.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(Admin::Tag).to receive(:find).with("37").and_return(mock_tags)
+        expect(mock_tags).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :admin_tag => {:these => 'params'}
       end
 
       it "assigns the requested tags as @tags" do
-        Admin::Tag.stub(:find).and_return(mock_tags(:update_attributes => true))
+        allow(Admin::Tag).to receive(:find).and_return(mock_tags(:update_attributes => true))
         put :update, :id => "1"
-        assigns[:admin_tag].should equal(mock_tags)
+        expect(assigns[:admin_tag]).to equal(mock_tags)
       end
 
       it "redirects to the tags" do
-        Admin::Tag.stub(:find).and_return(mock_tags(:update_attributes => true))
+        allow(Admin::Tag).to receive(:find).and_return(mock_tags(:update_attributes => true))
         put :update, :id => "1"
-        response.should redirect_to(admin_tag_url(mock_tags))
+        expect(response).to redirect_to(admin_tag_url(mock_tags))
       end
     end
 
     describe "with invalid params" do
       it "updates the requested tags" do
-        Admin::Tag.should_receive(:find).with("37").and_return(mock_tags)
-        mock_tags.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(Admin::Tag).to receive(:find).with("37").and_return(mock_tags)
+        expect(mock_tags).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :admin_tag => {:these => 'params'}
       end
 
       it "assigns the tags as @tags" do
-        Admin::Tag.stub(:find).and_return(mock_tags(:update_attributes => false))
+        allow(Admin::Tag).to receive(:find).and_return(mock_tags(:update_attributes => false))
         put :update, :id => "1"
-        assigns[:admin_tag].should equal(mock_tags)
+        expect(assigns[:admin_tag]).to equal(mock_tags)
       end
 
       it "re-renders the 'edit' template" do
-        Admin::Tag.stub(:find).and_return(mock_tags(:update_attributes => false))
+        allow(Admin::Tag).to receive(:find).and_return(mock_tags(:update_attributes => false))
         put :update, :id => "1"
-        response.should render_template('edit')
+        expect(response).to render_template('edit')
       end
     end
 
@@ -120,15 +120,15 @@ describe Admin::TagsController do
 
   describe "DELETE destroy" do
     it "destroys the requested tags" do
-      Admin::Tag.should_receive(:find).with("37").and_return(mock_tags)
-      mock_tags.should_receive(:destroy)
+      expect(Admin::Tag).to receive(:find).with("37").and_return(mock_tags)
+      expect(mock_tags).to receive(:destroy)
       delete :destroy, :id => "37"
     end
 
     it "redirects to the admin_tags list" do
-      Admin::Tag.stub(:find).and_return(mock_tags(:destroy => true))
+      allow(Admin::Tag).to receive(:find).and_return(mock_tags(:destroy => true))
       delete :destroy, :id => "1"
-      response.should redirect_to(admin_tags_url)
+      expect(response).to redirect_to(admin_tags_url)
     end
   end
 

--- a/spec/controllers/api/v1/classes_controller_spec.rb
+++ b/spec/controllers/api/v1/classes_controller_spec.rb
@@ -22,7 +22,7 @@ describe API::V1::ClassesController do
 
     it "returns a 200 code for a valid class" do
       get :show, id: clazz.id
-      response.status.should eql(200)
+      expect(response.status).to eql(200)
     end
 
     it "returns only non archived offerings" do

--- a/spec/controllers/api/v1/collaborations_controller_spec.rb
+++ b/spec/controllers/api/v1/collaborations_controller_spec.rb
@@ -97,7 +97,7 @@ describe API::V1::CollaborationsController do
 
   describe "GET #collaborators_data" do
     let(:lara_token)   { 'xyzzy'                            }
-    let(:clients)      { [ mock(:app_secret => lara_token)] }
+    let(:clients)      { [ double(:app_secret => lara_token)] }
     before(:each)      { Client.stub(:all => clients)       }
 
     before do

--- a/spec/controllers/api/v1/external_activities_controller_spec.rb
+++ b/spec/controllers/api/v1/external_activities_controller_spec.rb
@@ -15,7 +15,7 @@ describe API::V1::ExternalActivitiesController do
 
       it "fails with valid parameters" do
         post :create, :name => "test", :url => "http://example.com/"
-        response.status.should eql(403)
+        expect(response.status).to eql(403)
       end
     end
 
@@ -26,7 +26,7 @@ describe API::V1::ExternalActivitiesController do
 
       it "fails with valid parameters" do
         post :create, :name => "test", :url => "http://example.com/"
-        response.status.should eql(403)
+        expect(response.status).to eql(403)
       end
     end
 
@@ -37,7 +37,7 @@ describe API::V1::ExternalActivitiesController do
 
       it "succeeds with valid parameters" do
         post :create, :name => "test", :url => "http://example.com/"
-        response.status.should eql(201)
+        expect(response.status).to eql(201)
       end
     end
 
@@ -48,7 +48,7 @@ describe API::V1::ExternalActivitiesController do
 
       it "succeeds with valid parameters" do
         post :create, :name => "test", :url => "http://example.com/"
-        response.status.should eql(201)
+        expect(response.status).to eql(201)
       end
     end
 
@@ -59,22 +59,22 @@ describe API::V1::ExternalActivitiesController do
 
       it "fails with a missing name parameter" do
         post :create, :url => "http://example.com/"
-        response.status.should eql(400)
+        expect(response.status).to eql(400)
       end
 
       it "fails with a missing url parameter" do
         post :create, :url => "http://example.com/"
-        response.status.should eql(400)
+        expect(response.status).to eql(400)
       end
 
       it "fails with an invalid url parameter" do
         post :create, :url => "invalid"
-        response.status.should eql(400)
+        expect(response.status).to eql(400)
       end
 
       it "succeeds with valid minimal parameters" do
         post :create, :name => "test", :url => "http://example.com/"
-        response.status.should eql(201)
+        expect(response.status).to eql(201)
       end
     end
   end

--- a/spec/controllers/api/v1/jwt_controller.rb
+++ b/spec/controllers/api/v1/jwt_controller.rb
@@ -111,7 +111,7 @@ SHlL1Ceaqm35aMguGMBcTs6T5jRJ36K2OPEXU2ZOiRygxcZhFw==
         body = JSON.parse(response.body)
         token = body["token"]
         decoded_token = SignedJWT::decode_firebase_token(token, firebase_app_name)
-        decoded_token[:data]["uid"].should eql uid
+        expect(decoded_token[:data]["uid"]).to eql uid
       end
     end
 
@@ -129,17 +129,17 @@ SHlL1Ceaqm35aMguGMBcTs6T5jRJ36K2OPEXU2ZOiRygxcZhFw==
         token = body["token"]
         decoded_token = SignedJWT::decode_firebase_token(token, firebase_app_name)
 
-        decoded_token[:data]["uid"].should eql uid
-        decoded_token[:data]["domain"].should eql root_url
-        decoded_token[:data]["externalId"].should eql learner.id
-        decoded_token[:data]["returnUrl"].should_not be_nil
-        decoded_token[:data]["logging"].should eql true
-        decoded_token[:data]["domain_uid"].should eql user.id
-        decoded_token[:data]["class_info_url"].should_not be_nil
-        decoded_token[:data]["claims"]["user_type"].should eq "learner"
-        decoded_token[:data]["claims"]["user_id"].should eq url_for_user
-        decoded_token[:data]["claims"]["class_hash"].should_not be_nil
-        decoded_token[:data]["claims"]["offering_id"].should eq offering.id
+        expect(decoded_token[:data]["uid"]).to eql uid
+        expect(decoded_token[:data]["domain"]).to eql root_url
+        expect(decoded_token[:data]["externalId"]).to eql learner.id
+        expect(decoded_token[:data]["returnUrl"]).not_to be_nil
+        expect(decoded_token[:data]["logging"]).to eql true
+        expect(decoded_token[:data]["domain_uid"]).to eql user.id
+        expect(decoded_token[:data]["class_info_url"]).not_to be_nil
+        expect(decoded_token[:data]["claims"]["user_type"]).to eq "learner"
+        expect(decoded_token[:data]["claims"]["user_id"]).to eq url_for_user
+        expect(decoded_token[:data]["claims"]["class_hash"]).not_to be_nil
+        expect(decoded_token[:data]["claims"]["offering_id"]).to eq offering.id
       end
     end
 
@@ -157,11 +157,11 @@ SHlL1Ceaqm35aMguGMBcTs6T5jRJ36K2OPEXU2ZOiRygxcZhFw==
         token = body["token"]
         decoded_token = SignedJWT::decode_firebase_token(token, firebase_app_name)
 
-        decoded_token[:data]["uid"].should eql uid
-        decoded_token[:data]["domain"].should eql root_url
-        decoded_token[:data]["claims"]["user_type"].should eq "teacher"
-        decoded_token[:data]["claims"]["user_id"].should eq url_for_user
-        decoded_token[:data]["claims"]["class_hash"].should eq nil
+        expect(decoded_token[:data]["uid"]).to eql uid
+        expect(decoded_token[:data]["domain"]).to eql root_url
+        expect(decoded_token[:data]["claims"]["user_type"]).to eq "teacher"
+        expect(decoded_token[:data]["claims"]["user_id"]).to eq url_for_user
+        expect(decoded_token[:data]["claims"]["class_hash"]).to eq nil
       end
 
       it "returns a valid JWT with teacher params with a class hash" do
@@ -172,7 +172,7 @@ SHlL1Ceaqm35aMguGMBcTs6T5jRJ36K2OPEXU2ZOiRygxcZhFw==
         token = body["token"]
         decoded_token = SignedJWT::decode_firebase_token(token, firebase_app_name)
 
-        decoded_token[:data]["claims"]["class_hash"].should eq clazz.class_hash
+        expect(decoded_token[:data]["claims"]["class_hash"]).to eq clazz.class_hash
       end
     end
   end
@@ -190,7 +190,7 @@ SHlL1Ceaqm35aMguGMBcTs6T5jRJ36K2OPEXU2ZOiRygxcZhFw==
       body = JSON.parse(response.body)
       token = body["token"]
       decoded_token = SignedJWT::decode_portal_token(token)
-      decoded_token[:data]["uid"].should eql user.id
+      expect(decoded_token[:data]["uid"]).to eql user.id
     end
   end
 
@@ -207,13 +207,13 @@ SHlL1Ceaqm35aMguGMBcTs6T5jRJ36K2OPEXU2ZOiRygxcZhFw==
       token = body["token"]
       decoded_token = SignedJWT::decode_portal_token(token)
 
-      decoded_token[:data]["uid"].should eql user.id
-      decoded_token[:data]["domain"].should eql root_url
-      decoded_token[:data]["user_type"].should eq "learner"
-      decoded_token[:data]["user_id"].should_not be_nil
-      decoded_token[:data]["learner_id"].should eq learner.id
-      decoded_token[:data]["class_info_url"].should_not be_nil
-      decoded_token[:data]["offering_id"].should eq offering.id
+      expect(decoded_token[:data]["uid"]).to eql user.id
+      expect(decoded_token[:data]["domain"]).to eql root_url
+      expect(decoded_token[:data]["user_type"]).to eq "learner"
+      expect(decoded_token[:data]["user_id"]).not_to be_nil
+      expect(decoded_token[:data]["learner_id"]).to eq learner.id
+      expect(decoded_token[:data]["class_info_url"]).not_to be_nil
+      expect(decoded_token[:data]["offering_id"]).to eq offering.id
     end
   end
 
@@ -230,11 +230,11 @@ SHlL1Ceaqm35aMguGMBcTs6T5jRJ36K2OPEXU2ZOiRygxcZhFw==
       token = body["token"]
       decoded_token = SignedJWT::decode_portal_token(token)
 
-      decoded_token[:data]["uid"].should eql user.id
-      decoded_token[:data]["domain"].should eql root_url
-      decoded_token[:data]["user_type"].should eq "teacher"
-      decoded_token[:data]["user_id"].should_not be_nil
-      decoded_token[:data]["teacher_id"].should eq class_teacher.id
+      expect(decoded_token[:data]["uid"]).to eql user.id
+      expect(decoded_token[:data]["domain"]).to eql root_url
+      expect(decoded_token[:data]["user_type"]).to eq "teacher"
+      expect(decoded_token[:data]["user_id"]).not_to be_nil
+      expect(decoded_token[:data]["teacher_id"]).to eq class_teacher.id
     end
   end
 end

--- a/spec/controllers/api/v1/offerings_controller_spec.rb
+++ b/spec/controllers/api/v1/offerings_controller_spec.rb
@@ -48,7 +48,7 @@ describe API::V1::OfferingsController do
     describe "when there is no offering with given ID" do
       it "returns 404" do
         get :show, id: 123
-        response.status.should eq 404
+        expect(response.status).to eq 404
       end
     end
 
@@ -58,7 +58,7 @@ describe API::V1::OfferingsController do
       end
       it "returns 403 error" do
         get :show, id: offering.id
-        response.status.should eql(403)
+        expect(response.status).to eql(403)
       end
     end
 
@@ -68,7 +68,7 @@ describe API::V1::OfferingsController do
       end
       it "returns error 403" do
         get :show, :id => offering.id
-        response.status.should eql(403)
+        expect(response.status).to eql(403)
       end
     end
 
@@ -78,9 +78,9 @@ describe API::V1::OfferingsController do
       end
       it "returns 200 and valid JSON response" do
         get :show, :id => offering.id
-        response.status.should eq 200
+        expect(response.status).to eq 200
         json = JSON.parse(response.body)
-        json.should_not eq nil
+        expect(json).not_to eq nil
       end
     end
 
@@ -92,7 +92,7 @@ describe API::V1::OfferingsController do
         end
         it "returns error 403" do
           get :show, :id => offering.id
-          response.status.should eq 403
+          expect(response.status).to eq 403
         end
       end
 
@@ -102,9 +102,9 @@ describe API::V1::OfferingsController do
         end
         it "returns 200 and valid JSON response" do
           get :show, :id => offering.id
-          response.status.should eq 200
+          expect(response.status).to eq 200
           json = JSON.parse(response.body)
-          json.should_not eq nil
+          expect(json).not_to eq nil
         end
       end
     end
@@ -118,31 +118,31 @@ describe API::V1::OfferingsController do
       end
       it "returns an description of the activity and students list with 0 progress" do
         get :show, id: offering.id
-        response.status.should eq 200
+        expect(response.status).to eq 200
         json = JSON.parse(response.body)
         json["id"] = offering.id
-        json["clazz"].should eq clazz.name
-        json["activity"].should eq runnable.name
-        json["report_url"].should eql report_portal_offering_url(id: offering.id, host: 'test.host')
+        expect(json["clazz"]).to eq clazz.name
+        expect(json["activity"]).to eq runnable.name
+        expect(json["report_url"]).to eql report_portal_offering_url(id: offering.id, host: 'test.host')
 
-        json["preview_url"].should eql external_activity_url(runnable, {format: runnable.run_format})
-        json["students"].length.should eq 2
+        expect(json["preview_url"]).to eql external_activity_url(runnable, {format: runnable.run_format})
+        expect(json["students"].length).to eq 2
 
         student1 = json["students"][0]
-        student1["first_name"].should eq student_a.user.first_name
-        student1["last_name"].should eq student_a.user.last_name
-        student1["started_activity"].should eq false
-        student1["last_run"].should eq nil
-        student1["total_progress"].should eq 0
-        student1["detailed_progress"].should eq nil
+        expect(student1["first_name"]).to eq student_a.user.first_name
+        expect(student1["last_name"]).to eq student_a.user.last_name
+        expect(student1["started_activity"]).to eq false
+        expect(student1["last_run"]).to eq nil
+        expect(student1["total_progress"]).to eq 0
+        expect(student1["detailed_progress"]).to eq nil
 
         student2 = json["students"][1]
-        student2["first_name"].should eq student_b.user.first_name
-        student2["last_name"].should eq student_b.user.last_name
-        student2["started_activity"].should eq false
-        student2["last_run"].should eq nil
-        student2["total_progress"].should eq 0
-        student2["detailed_progress"].should eq nil
+        expect(student2["first_name"]).to eq student_b.user.first_name
+        expect(student2["last_name"]).to eq student_b.user.last_name
+        expect(student2["started_activity"]).to eq false
+        expect(student2["last_run"]).to eq nil
+        expect(student2["total_progress"]).to eq 0
+        expect(student2["detailed_progress"]).to eq nil
       end
     end
 
@@ -157,22 +157,22 @@ describe API::V1::OfferingsController do
       end
       it "returns an description of the activity and students list with appropriate progress" do
         get :show, id: offering.id
-        response.status.should eq 200
+        expect(response.status).to eq 200
         json = JSON.parse(response.body)
         student1 = json["students"][0]
-        student1["started_activity"].should eq true
-        student1["last_run"].should_not eq nil
-        student1["total_progress"].should eq 25
-        student1["detailed_progress"][0]["activity_name"].should eq activity_1.name
-        student1["detailed_progress"][0]["progress"].should eq 50
-        student1["detailed_progress"][1]["activity_name"].should eq activity_2.name
-        student1["detailed_progress"][1]["progress"].should eq 0
+        expect(student1["started_activity"]).to eq true
+        expect(student1["last_run"]).not_to eq nil
+        expect(student1["total_progress"]).to eq 25
+        expect(student1["detailed_progress"][0]["activity_name"]).to eq activity_1.name
+        expect(student1["detailed_progress"][0]["progress"]).to eq 50
+        expect(student1["detailed_progress"][1]["activity_name"]).to eq activity_2.name
+        expect(student1["detailed_progress"][1]["progress"]).to eq 0
 
         student2 = json["students"][1]
-        student2["started_activity"].should eq false
-        student2["last_run"].should eq nil
-        student2["total_progress"].should eq 0
-        student2["detailed_progress"].should eq nil
+        expect(student2["started_activity"]).to eq false
+        expect(student2["last_run"]).to eq nil
+        expect(student2["total_progress"]).to eq 0
+        expect(student2["detailed_progress"]).to eq nil
       end
     end
 
@@ -189,25 +189,25 @@ describe API::V1::OfferingsController do
       end
       it "returns an description of the activity and students list with appropriate progress" do
         get :show, id: offering.id
-        response.status.should eq 200
+        expect(response.status).to eq 200
         json = JSON.parse(response.body)
         student1 = json["students"][0]
-        student1["started_activity"].should eq true
-        student1["last_run"].should_not eq nil
-        student1["total_progress"].should eq 25
-        student1["detailed_progress"][0]["activity_name"].should eq activity_1.name
-        student1["detailed_progress"][0]["progress"].should eq 50
-        student1["detailed_progress"][1]["activity_name"].should eq activity_2.name
-        student1["detailed_progress"][1]["progress"].should eq 0
+        expect(student1["started_activity"]).to eq true
+        expect(student1["last_run"]).not_to eq nil
+        expect(student1["total_progress"]).to eq 25
+        expect(student1["detailed_progress"][0]["activity_name"]).to eq activity_1.name
+        expect(student1["detailed_progress"][0]["progress"]).to eq 50
+        expect(student1["detailed_progress"][1]["activity_name"]).to eq activity_2.name
+        expect(student1["detailed_progress"][1]["progress"]).to eq 0
 
         student2 = json["students"][1]
-        student2["started_activity"].should eq true
-        student2["last_run"].should_not eq nil
-        student2["total_progress"].should eq 50
-        student2["detailed_progress"][0]["activity_name"].should eq activity_1.name
-        student2["detailed_progress"][0]["progress"].should eq 0
-        student2["detailed_progress"][1]["activity_name"].should eq activity_2.name
-        student2["detailed_progress"][1]["progress"].should eq 100
+        expect(student2["started_activity"]).to eq true
+        expect(student2["last_run"]).not_to eq nil
+        expect(student2["total_progress"]).to eq 50
+        expect(student2["detailed_progress"][0]["activity_name"]).to eq activity_1.name
+        expect(student2["detailed_progress"][0]["progress"]).to eq 0
+        expect(student2["detailed_progress"][1]["activity_name"]).to eq activity_2.name
+        expect(student2["detailed_progress"][1]["progress"]).to eq 100
       end
     end
 
@@ -230,26 +230,26 @@ describe API::V1::OfferingsController do
       end
       it "returns an description of the activity and students list with appropriate progress" do
         get :show, id: offering.id
-        response.status.should eq 200
+        expect(response.status).to eq 200
         json = JSON.parse(response.body)
         student1 = json["students"][0]
-        student1["started_activity"].should eq true
-        student1["last_run"].should_not eq nil
-        student1["total_progress"].should eq 100
-        student1["detailed_progress"][0]["activity_name"].should eq activity_1.name
-        student1["detailed_progress"][0]["progress"].should eq 100
-        student1["detailed_progress"][1]["activity_name"].should eq activity_2.name
-        student1["detailed_progress"][1]["progress"].should eq 100
+        expect(student1["started_activity"]).to eq true
+        expect(student1["last_run"]).not_to eq nil
+        expect(student1["total_progress"]).to eq 100
+        expect(student1["detailed_progress"][0]["activity_name"]).to eq activity_1.name
+        expect(student1["detailed_progress"][0]["progress"]).to eq 100
+        expect(student1["detailed_progress"][1]["activity_name"]).to eq activity_2.name
+        expect(student1["detailed_progress"][1]["progress"]).to eq 100
 
 
         student2 = json["students"][1]
-        student2["started_activity"].should eq true
-        student2["last_run"].should_not eq nil
-        student2["total_progress"].should eq 100
-        student2["detailed_progress"][0]["activity_name"].should eq activity_1.name
-        student2["detailed_progress"][0]["progress"].should eq 100
-        student2["detailed_progress"][1]["activity_name"].should eq activity_2.name
-        student2["detailed_progress"][1]["progress"].should eq 100
+        expect(student2["started_activity"]).to eq true
+        expect(student2["last_run"]).not_to eq nil
+        expect(student2["total_progress"]).to eq 100
+        expect(student2["detailed_progress"][0]["activity_name"]).to eq activity_1.name
+        expect(student2["detailed_progress"][0]["progress"]).to eq 100
+        expect(student2["detailed_progress"][1]["activity_name"]).to eq activity_2.name
+        expect(student2["detailed_progress"][1]["progress"]).to eq 100
       end
     end
 
@@ -263,11 +263,11 @@ describe API::V1::OfferingsController do
       end
       it "returns information about external report" do
         get :show, id: offering.id
-        response.status.should eq 200
+        expect(response.status).to eq 200
         json = JSON.parse(response.body)
-        json["external_report"].should_not eq nil
-        json["external_report"]["url"].should eq portal_external_report_url(id: offering.id, report_id: external_report.id, host: 'test.host')
-        json["external_report"]["launch_text"].should eq external_report.launch_text
+        expect(json["external_report"]).not_to eq nil
+        expect(json["external_report"]["url"]).to eq portal_external_report_url(id: offering.id, report_id: external_report.id, host: 'test.host')
+        expect(json["external_report"]["launch_text"]).to eq external_report.launch_text
       end
     end
   end
@@ -279,7 +279,7 @@ describe API::V1::OfferingsController do
       end
       it "returns 403 error" do
         get :index
-        response.status.should eql(403)
+        expect(response.status).to eql(403)
       end
     end
 
@@ -289,7 +289,7 @@ describe API::V1::OfferingsController do
       end
       it "returns 403 error" do
         get :index
-        response.status.should eql(403)
+        expect(response.status).to eql(403)
       end
     end
 
@@ -299,9 +299,9 @@ describe API::V1::OfferingsController do
       end
       it "returns an empty array" do
         get :index
-        response.status.should eql(200)
+        expect(response.status).to eql(200)
         json = JSON.parse(response.body)
-        json.should eq []
+        expect(json).to eq []
       end
     end
 
@@ -313,9 +313,9 @@ describe API::V1::OfferingsController do
       end
       it "returns 200 and valid json response" do
         get :index
-        response.status.should eql(200)
+        expect(response.status).to eql(200)
         json = JSON.parse(response.body)
-        json.length.should eq 1
+        expect(json.length).to eq 1
       end
     end
 
@@ -342,9 +342,9 @@ describe API::V1::OfferingsController do
           offering_2_json = JSON.parse(response.body)
 
           get :index
-          response.status.should eql(200)
+          expect(response.status).to eql(200)
           json = JSON.parse(response.body)
-          json.should eq [offering_1_json, offering_2_json]
+          expect(json).to eq [offering_1_json, offering_2_json]
         end
 
         describe "when class_id param is provided" do
@@ -354,16 +354,16 @@ describe API::V1::OfferingsController do
               offering_json = JSON.parse(response.body)
 
               get :index, class_id: clazz.id
-              response.status.should eql(200)
+              expect(response.status).to eql(200)
               json = JSON.parse(response.body)
-              json.should eq [offering_json]
+              expect(json).to eq [offering_json]
             end
           end
 
           describe "and teacher is not an owner of given class" do
             it "should return 403 error" do
               get :index, class_id: clazz_b.id
-              response.status.should eql(403)
+              expect(response.status).to eql(403)
             end
           end
         end
@@ -378,16 +378,16 @@ describe API::V1::OfferingsController do
 
 
               get :index, user_id: teacher.user.id
-              response.status.should eql(200)
+              expect(response.status).to eql(200)
               json = JSON.parse(response.body)
-              json.should eq [offering_1_json, offering_2_json]
+              expect(json).to eq [offering_1_json, offering_2_json]
             end
           end
 
           describe "and teacher is not a given user" do
             it "should return 403 error" do
               get :index, class_id: clazz_b.id
-              response.status.should eql(403)
+              expect(response.status).to eql(403)
             end
           end
         end
@@ -409,9 +409,9 @@ describe API::V1::OfferingsController do
           offering_b_json = JSON.parse(response.body)
 
           get :index
-          response.status.should eql(200)
+          expect(response.status).to eql(200)
           json = JSON.parse(response.body)
-          json.should eq [offering_1_json, offering_2_json, offering_b_json]
+          expect(json).to eq [offering_1_json, offering_2_json, offering_b_json]
         end
 
         describe "when class_id param is provided" do
@@ -420,9 +420,9 @@ describe API::V1::OfferingsController do
             offering_json = JSON.parse(response.body)
 
             get :index, class_id: clazz.id
-            response.status.should eql(200)
+            expect(response.status).to eql(200)
             json = JSON.parse(response.body)
-            json.should eq [offering_json]
+            expect(json).to eq [offering_json]
           end
         end
 
@@ -434,9 +434,9 @@ describe API::V1::OfferingsController do
             offering_2_json = JSON.parse(response.body)
 
             get :index, user_id: teacher.user.id
-            response.status.should eql(200)
+            expect(response.status).to eql(200)
             json = JSON.parse(response.body)
-            json.should eq [offering_1_json, offering_2_json]
+            expect(json).to eq [offering_1_json, offering_2_json]
           end
         end
       end
@@ -458,9 +458,9 @@ describe API::V1::OfferingsController do
         show_json = JSON.parse(response.body)
 
         get :index
-        response.status.should eql(200)
+        expect(response.status).to eql(200)
         own_json = JSON.parse(response.body)
-        own_json.should eq [ show_json ]
+        expect(own_json).to eq [ show_json ]
       end
     end
   end
@@ -472,7 +472,7 @@ describe API::V1::OfferingsController do
       end
       it "returns 403 error" do
         put :update, id: offering.id, active: false
-        response.status.should eql(403)
+        expect(response.status).to eql(403)
       end
     end
 
@@ -482,7 +482,7 @@ describe API::V1::OfferingsController do
       end
       it "returns 403 error" do
         put :update, id: offering.id, active: false
-        response.status.should eql(403)
+        expect(response.status).to eql(403)
       end
     end
 
@@ -492,7 +492,7 @@ describe API::V1::OfferingsController do
       end
       it "returns 403 error" do
         put :update, id: offering.id, active: false
-        response.status.should eql(403)
+        expect(response.status).to eql(403)
       end
     end
 
@@ -502,7 +502,7 @@ describe API::V1::OfferingsController do
       end
       it "returns 403 error" do
         put :update, id: offering.id, active: false
-        response.status.should eql(403)
+        expect(response.status).to eql(403)
       end
     end
 
@@ -514,15 +514,15 @@ describe API::V1::OfferingsController do
       it "should update basic params of the offering" do
         new_active = !offering.active
         put :update, id: offering.id, active: new_active
-        response.status.should eql(200)
+        expect(response.status).to eql(200)
         offering.reload
-        offering.active.should eq new_active
+        expect(offering.active).to eq new_active
 
         new_locked = !offering.locked
         put :update, id: offering.id, locked: new_locked
-        response.status.should eql(200)
+        expect(response.status).to eql(200)
         offering.reload
-        offering.locked.should eq new_locked
+        expect(offering.locked).to eq new_locked
       end
 
       describe "when there are multiple offerings" do
@@ -531,22 +531,22 @@ describe API::V1::OfferingsController do
         let(:offering_3) { Factory.create(:portal_offering, {clazz: clazz, runnable: runnable}) }
 
         it "should let user reorder them" do
-          clazz.offerings.should eq [ offering_1, offering_2, offering_3 ]
+          expect(clazz.offerings).to eq [ offering_1, offering_2, offering_3 ]
 
           put :update, id: offering_1.id, position: 1
-          response.status.should eql(200)
+          expect(response.status).to eql(200)
           clazz.reload
-          clazz.offerings.should eq [ offering_2, offering_1, offering_3 ]
+          expect(clazz.offerings).to eq [ offering_2, offering_1, offering_3 ]
 
           put :update, id: offering_2.id, position: 2
-          response.status.should eql(200)
+          expect(response.status).to eql(200)
           clazz.reload
-          clazz.offerings.should eq [ offering_1, offering_3, offering_2 ]
+          expect(clazz.offerings).to eq [ offering_1, offering_3, offering_2 ]
 
           put :update, id: offering_3.id, position: 0
-          response.status.should eql(200)
+          expect(response.status).to eql(200)
           clazz.reload
-          clazz.offerings.should eq [ offering_3, offering_1, offering_2 ]
+          expect(clazz.offerings).to eq [ offering_3, offering_1, offering_2 ]
         end
       end
     end
@@ -580,18 +580,18 @@ describe API::V1::OfferingsController do
 
         get :for_class, id: offering.id
         json = JSON.parse(response.body)
-        json.should eq [offering_1_json, offering_2_json]
+        expect(json).to eq [offering_1_json, offering_2_json]
 
         get :for_class, id: offering_2.id
         json = JSON.parse(response.body)
-        json.should eq [offering_1_json, offering_2_json]
+        expect(json).to eq [offering_1_json, offering_2_json]
 
         get :for_class, id: offering_3.id
         json = JSON.parse(response.body)
-        json.should eq [offering_3_json]
+        expect(json).to eq [offering_3_json]
 
         get :for_class, id: offering_b.id
-        response.status.should eql(403) # Different class, no access!
+        expect(response.status).to eql(403) # Different class, no access!
       end
     end
   end
@@ -620,14 +620,14 @@ describe API::V1::OfferingsController do
 
         get :for_teacher, id: offering.id
         json = JSON.parse(response.body)
-        json.should eq [offering_1_json, offering_2_json]
+        expect(json).to eq [offering_1_json, offering_2_json]
 
         get :for_teacher, id: offering_2.id
         json = JSON.parse(response.body)
-        json.should eq [offering_1_json, offering_2_json]
+        expect(json).to eq [offering_1_json, offering_2_json]
 
         get :for_teacher, id: offering_b.id
-        response.status.should eql(403) # different class, no access!
+        expect(response.status).to eql(403) # different class, no access!
       end
     end
   end

--- a/spec/controllers/api/v1/report_learners_es_controller_spec.rb
+++ b/spec/controllers/api/v1/report_learners_es_controller_spec.rb
@@ -68,7 +68,7 @@ describe API::V1::ReportLearnersEsController do
     describe "GET index" do
       it "wont allow index, returns error 403" do
         get :index
-        response.status.should eql(403)
+        expect(response.status).to eql(403)
       end
     end
   end
@@ -80,7 +80,7 @@ describe API::V1::ReportLearnersEsController do
     describe "GET index" do
       it "wont allow index, returns error 403" do
         get :index
-        response.status.should eql(403)
+        expect(response.status).to eql(403)
       end
     end
   end
@@ -92,7 +92,7 @@ describe API::V1::ReportLearnersEsController do
     describe "GET index" do
       it "allows index" do
         get :index
-        response.status.should eql(200)
+        expect(response.status).to eql(200)
       end
       it "makes a request to ES with the correct body" do
         get :index
@@ -105,7 +105,7 @@ describe API::V1::ReportLearnersEsController do
       end
       it "directly renders the ES response" do
         get :index
-        response.body.should eq fake_response
+        expect(response.body).to eq fake_response
       end
     end
   end
@@ -117,7 +117,7 @@ describe API::V1::ReportLearnersEsController do
     describe "GET index" do
       it "allows index" do
         get :index
-        response.status.should eql(200)
+        expect(response.status).to eql(200)
       end
     end
   end
@@ -135,7 +135,7 @@ describe API::V1::ReportLearnersEsController do
     describe "GET index" do
       it "allows index" do
         get :index
-        response.status.should eql(200)
+        expect(response.status).to eql(200)
       end
       it "makes a request to ES with the correct body, restricting permission forms" do
         get :index

--- a/spec/controllers/api/v1/report_spec.rb
+++ b/spec/controllers/api/v1/report_spec.rb
@@ -63,23 +63,23 @@ describe API::V1::ReportsController do
   end
 
   def feedback_should_be_enabled
-    question.should include({"feedback_enabled" => true})
+    expect(question).to include({"feedback_enabled" => true})
   end
 
   def feedback_should_be_disabled
-    question.should include({"feedback_enabled" => false})
+    expect(question).to include({"feedback_enabled" => false})
   end
 
   def score_should_be_enabled
-    question.should include({"score_enabled" => true})
+    expect(question).to include({"score_enabled" => true})
   end
 
   def score_should_be_disabled
-    question.should include({"score_enabled" => false})
+    expect(question).to include({"score_enabled" => false})
   end
 
   def max_score_should_be(value)
-    question.should include({"max_score" => value})
+    expect(question).to include({"max_score" => value})
   end
 
   before(:each) do
@@ -89,7 +89,7 @@ describe API::V1::ReportsController do
     activity.save
     runnable.template = activity
     runnable.save
-    Portal::Offering.stub!(:find).and_return(offering)
+    allow(Portal::Offering).to receive(:find).and_return(offering)
     sign_in user
     add_answer_for_learner(learner_a, open_response, {"answer" => "testing from #{learner_a.student.user.id}"} )
     add_answer_for_learner(learner_b, open_response, {"answer" => "testing from #{learner_b.student.user.id}"} )
@@ -104,23 +104,23 @@ describe API::V1::ReportsController do
     describe "For the offering's teacher" do
       it 'should render the report json' do
         show
-        response.status.should eql(200)
-        json_path("report_version").should eql "1.1.0"
-        json_path("report.name").should eql "the activity"
-        json_path("class.students").should include_hash({"started_offering"=>true, "name"=>"joe user"})
+        expect(response.status).to eql(200)
+        expect(json_path("report_version")).to eql "1.1.0"
+        expect(json_path("report.name")).to eql "the activity"
+        expect(json_path("class.students")).to include_hash({"started_offering"=>true, "name"=>"joe user"})
         max_score_should_be 0
         feedback_should_be_disabled
         score_should_be_disabled
-        question.should include({"show_in_featured_question_report" => true})
-        question.should include({"is_required" => true})
-        answers.should include_hash({"answer" => "testing from #{learner_a.student.user.id}"})
+        expect(question).to include({"show_in_featured_question_report" => true})
+        expect(question).to include({"is_required" => true})
+        expect(answers).to include_hash({"answer" => "testing from #{learner_a.student.user.id}"})
       end
     end
     describe "For an anonymous user" do
       it "should return 403" do
         logout_user
         show
-        response.status.should eql(403)
+        expect(response.status).to eql(403)
       end
     end
   end
@@ -136,8 +136,8 @@ describe API::V1::ReportsController do
       it "should save the filter settings" do
         update opts
         show
-        response.status.should eql 200
-        json_path("visibility_filter.active").should be_false
+        expect(response.status).to eql 200
+        expect(json_path("visibility_filter.active")).to be_falsey
       end
     end
 
@@ -146,8 +146,8 @@ describe API::V1::ReportsController do
       it "should save the filter settings" do
         update(opts)
         show
-        response.status.should eql(200)
-        json_path("visibility_filter.active").should be_true
+        expect(response.status).to eql(200)
+        expect(json_path("visibility_filter.active")).to be_truthy
       end
     end
   end
@@ -171,11 +171,11 @@ describe API::V1::ReportsController do
       it "should disable feedback for our question" do
         update(opts)
         show
-        response.status.should eql(200)
+        expect(response.status).to eql(200)
         md = Portal::OfferingEmbeddableMetadata.find_by_offering_id_and_embeddable_id_and_embeddable_type(offering.id, open_response.id, open_response.class.name)
-        md.enable_text_feedback.should be_false
-        md.enable_score.should be_false
-        md.max_score.should eq 0
+        expect(md.enable_text_feedback).to be_falsey
+        expect(md.enable_score).to be_falsey
+        expect(md.max_score).to eq 0
       end
     end
 
@@ -184,11 +184,11 @@ describe API::V1::ReportsController do
       it "should disable feedback for our question" do
         update(opts)
         show
-        response.status.should eql(200)
+        expect(response.status).to eql(200)
         md = Portal::OfferingEmbeddableMetadata.find_by_offering_id_and_embeddable_id_and_embeddable_type(offering.id, open_response.id, open_response.class.name)
-        md.enable_text_feedback.should be_false
-        md.enable_score.should be_true
-        md.max_score.should eq 0
+        expect(md.enable_text_feedback).to be_falsey
+        expect(md.enable_score).to be_truthy
+        expect(md.max_score).to eq 0
       end
     end
 
@@ -197,11 +197,11 @@ describe API::V1::ReportsController do
       it "should disable feedback for our question" do
         update(opts)
         show
-        response.status.should eql(200)
+        expect(response.status).to eql(200)
         md = Portal::OfferingEmbeddableMetadata.find_by_offering_id_and_embeddable_id_and_embeddable_type(offering.id, open_response.id, open_response.class.name)
-        md.enable_text_feedback.should be_false
-        md.enable_score.should be_false
-        md.max_score.should eq 20
+        expect(md.enable_text_feedback).to be_falsey
+        expect(md.enable_score).to be_falsey
+        expect(md.max_score).to eq 20
       end
     end
   end
@@ -229,10 +229,10 @@ describe API::V1::ReportsController do
       it "should make the scoring automatic" do
         update(opts)
         show
-        response.status.should eql(200)
-        found_feedback.score_type.should eql Portal::OfferingActivityFeedback::SCORE_AUTO
-        found_feedback.enable_text_feedback.should be_false
-        found_feedback.max_score.should eq 10
+        expect(response.status).to eql(200)
+        expect(found_feedback.score_type).to eql Portal::OfferingActivityFeedback::SCORE_AUTO
+        expect(found_feedback.enable_text_feedback).to be_falsey
+        expect(found_feedback.max_score).to eq 10
       end
     end
 
@@ -241,8 +241,8 @@ describe API::V1::ReportsController do
       it "should make max score be 20" do
         update(opts)
         show
-        response.status.should eql(200)
-        found_feedback.max_score.should eq 20
+        expect(response.status).to eql(200)
+        expect(found_feedback.max_score).to eq 20
       end
     end
 
@@ -251,8 +251,8 @@ describe API::V1::ReportsController do
       it "should specify to use a rubric" do
         update(opts)
         show
-        response.status.should eql(200)
-        found_feedback.use_rubric.should be_true
+        expect(response.status).to eql(200)
+        expect(found_feedback.use_rubric).to be_truthy
       end
     end
   end
@@ -294,9 +294,9 @@ describe API::V1::ReportsController do
     it "should update the learners feedback" do
       update(opts)
       show
-      response.status.should eql(200)
+      expect(response.status).to eql(200)
       feedback = Portal::LearnerActivityFeedback.open_feedback_for(learner, activity_feedback)
-      feedback.rubric_feedback["C1"]["id"].should eql "R1"
+      expect(feedback.rubric_feedback["C1"]["id"]).to eql "R1"
     end
   end
 end

--- a/spec/controllers/api/v1/search_controller_spec.rb
+++ b/spec/controllers/api/v1/search_controller_spec.rb
@@ -70,7 +70,7 @@ describe API::V1::SearchController do
   let(:activity_results)      { [] }
 
   let(:search_results) {{ Investigation => investigation_results, Activity => activity_results }}
-  let(:mock_search)    { mock('results', {:results => search_results})}
+  let(:mock_search)    { double('results', {:results => search_results})}
 
   before(:all) do
     solr_setup
@@ -101,16 +101,16 @@ describe API::V1::SearchController do
 
       describe "with no filter parameters" do
         it "should return search results that shows only external activity based materials" do
-          assigns[:search].should_not be_nil
-          assigns[:search].results[Search::InvestigationMaterial].should_not be_nil
-          assigns[:search].results[Search::InvestigationMaterial].length.should be(1)
+          expect(assigns[:search]).not_to be_nil
+          expect(assigns[:search].results[Search::InvestigationMaterial]).not_to be_nil
+          expect(assigns[:search].results[Search::InvestigationMaterial].length).to be(1)
           assigns[:search].results[Search::InvestigationMaterial].each do |investigation|
-            all_investigations.should include(investigation)
+            expect(all_investigations).to include(investigation)
           end
-          assigns[:search].results[Search::ActivityMaterial].should_not be_nil
-          assigns[:search].results[Search::ActivityMaterial].length.should be(3)
+          expect(assigns[:search].results[Search::ActivityMaterial]).not_to be_nil
+          expect(assigns[:search].results[Search::ActivityMaterial].length).to be(3)
           assigns[:search].results[Search::ActivityMaterial].each do |activity|
-            all_activities.should include(activity)
+            expect(all_activities).to include(activity)
           end
         end
       end
@@ -118,21 +118,21 @@ describe API::V1::SearchController do
       describe "searching only official materials" do
         let(:get_params) { {:include_official => 1} }
         it "should show all official study materials" do
-          assigns[:search].results[Search::InvestigationMaterial].should_not be_nil
-          assigns[:search].results[Search::InvestigationMaterial].length.should be(1)
+          expect(assigns[:search].results[Search::InvestigationMaterial]).not_to be_nil
+          expect(assigns[:search].results[Search::InvestigationMaterial].length).to be(1)
           assigns[:search].results[Search::InvestigationMaterial].each do |investigation|
-            all_investigations.should include(investigation)
+            expect(all_investigations).to include(investigation)
           end
-          assigns[:search].results[Search::ActivityMaterial].should_not be_nil
-          assigns[:search].results[Search::ActivityMaterial].length.should be(2)
+          expect(assigns[:search].results[Search::ActivityMaterial]).not_to be_nil
+          expect(assigns[:search].results[Search::ActivityMaterial].length).to be(2)
           assigns[:search].results[Search::ActivityMaterial].each do |activity|
-            official_activities.should include(activity)
+            expect(official_activities).to include(activity)
           end
         end
 
         it "should not return any contributed activities" do
           assigns[:search].results[Search::ActivityMaterial].each do |activity|
-            contributed_activities.should_not include(activity)
+            expect(contributed_activities).not_to include(activity)
           end
         end
       end
@@ -142,33 +142,33 @@ describe API::V1::SearchController do
         let(:activity_results) {[]}
 
         it "should return all investigations" do
-          assigns[:search].results[Search::InvestigationMaterial].should_not be_nil
-          assigns[:search].results[Search::InvestigationMaterial].length.should be(1)
+          expect(assigns[:search].results[Search::InvestigationMaterial]).not_to be_nil
+          expect(assigns[:search].results[Search::InvestigationMaterial].length).to be(1)
         end
 
         it "should not return any activities" do
           get :search, get_params
-          assigns[:search].results[Search::ActivityMaterial].should be_nil
+          expect(assigns[:search].results[Search::ActivityMaterial]).to be_nil
         end
       end
 
       describe "searching only activities" do
         let(:get_params) {{:material_types => [Search::ActivityMaterial]}}
         it "should not include investigations" do
-          assigns[:search].results[Search::InvestigationMaterial].should be_nil
+          expect(assigns[:search].results[Search::InvestigationMaterial]).to be_nil
         end
         it "should return all activities" do
-          assigns[:search].results[Search::ActivityMaterial].should_not be_nil
-          assigns[:search].results[Search::ActivityMaterial].length.should be(3)
+          expect(assigns[:search].results[Search::ActivityMaterial]).not_to be_nil
+          expect(assigns[:search].results[Search::ActivityMaterial].length).to be(3)
           assigns[:search].results[Search::ActivityMaterial].each do |activity|
-            all_activities.should include(activity)
+            expect(all_activities).to include(activity)
           end
         end
         describe "including contributed activities" do
           let(:get_params) {{ :material_types => ['Activity'], :include_contributed => 1 }}
           it "should include contributed activities" do
-            assigns[:search].results[Search::ActivityMaterial].length.should == 1
-            assigns[:search].results[Search::ActivityMaterial].should include(contributed_activity)
+            expect(assigns[:search].results[Search::ActivityMaterial].length).to eq(1)
+            expect(assigns[:search].results[Search::ActivityMaterial]).to include(contributed_activity)
           end
         end
       end

--- a/spec/controllers/browse/external_activities_controller_spec.rb
+++ b/spec/controllers/browse/external_activities_controller_spec.rb
@@ -18,7 +18,7 @@ describe Browse::ExternalActivitiesController do
 
         expect(assigns[:wide_content_layout]).to eq(true)
 
-        assigns[:back_to_search_url].should match /.*search\?activity_page=1&investigation_page=1&search_term=#{@external_activity.name}$/
+        expect(assigns[:back_to_search_url]).to match /.*search\?activity_page=1&investigation_page=1&search_term=#{@external_activity.name}$/
         expect(assigns[:search_material]).not_to be_nil
         expect(assigns[:search_material].material).to eq(@external_activity)
       end

--- a/spec/controllers/dataservice/blobs_controller_spec.rb
+++ b/spec/controllers/dataservice/blobs_controller_spec.rb
@@ -12,25 +12,25 @@ describe Dataservice::BlobsController do
 
   describe "GET show" do
     it "assigns the requested blob as @blob" do
-      Dataservice::Blob.stub(:find).with("37").and_return(mock_blob)
+      allow(Dataservice::Blob).to receive(:find).with("37").and_return(mock_blob)
       get :show, :id => "37"
-      assigns[:dataservice_blob].should equal(mock_blob)
+      expect(assigns[:dataservice_blob]).to equal(mock_blob)
     end
   end
 
   describe "GET new" do
     it "assigns a new blob as @blob" do
-      Dataservice::Blob.stub(:new).and_return(mock_blob)
+      allow(Dataservice::Blob).to receive(:new).and_return(mock_blob)
       get :new
-      assigns[:dataservice_blob].should equal(mock_blob)
+      expect(assigns[:dataservice_blob]).to equal(mock_blob)
     end
   end
 
   describe "GET edit" do
     it "assigns the requested blob as @blob" do
-      Dataservice::Blob.stub(:find).with("37").and_return(mock_blob)
+      allow(Dataservice::Blob).to receive(:find).with("37").and_return(mock_blob)
       get :edit, :id => "37"
-      assigns[:dataservice_blob].should equal(mock_blob)
+      expect(assigns[:dataservice_blob]).to equal(mock_blob)
     end
   end
 
@@ -38,29 +38,29 @@ describe Dataservice::BlobsController do
 
     describe "with valid params" do
       it "assigns a newly created blob as @blob" do
-        Dataservice::Blob.stub(:new).with({'these' => 'params'}).and_return(mock_blob(:save => true))
+        allow(Dataservice::Blob).to receive(:new).with({'these' => 'params'}).and_return(mock_blob(:save => true))
         post :create, :blob => {:these => 'params'}
-        assigns[:dataservice_blob].should equal(mock_blob)
+        expect(assigns[:dataservice_blob]).to equal(mock_blob)
       end
 
       it "redirects to the created blob" do
-        Dataservice::Blob.stub(:new).and_return(mock_blob(:save => true))
+        allow(Dataservice::Blob).to receive(:new).and_return(mock_blob(:save => true))
         post :create, :blob => {}
-        response.should redirect_to(dataservice_blob_url(mock_blob))
+        expect(response).to redirect_to(dataservice_blob_url(mock_blob))
       end
     end
 
     describe "with invalid params" do
       it "assigns a newly created but unsaved blob as @blob" do
-        Dataservice::Blob.stub(:new).with({'these' => 'params'}).and_return(mock_blob(:save => false))
+        allow(Dataservice::Blob).to receive(:new).with({'these' => 'params'}).and_return(mock_blob(:save => false))
         post :create, :blob => {:these => 'params'}
-        assigns[:dataservice_blob].should equal(mock_blob)
+        expect(assigns[:dataservice_blob]).to equal(mock_blob)
       end
 
       it "re-renders the 'new' template" do
-        Dataservice::Blob.stub(:new).and_return(mock_blob(:save => false))
+        allow(Dataservice::Blob).to receive(:new).and_return(mock_blob(:save => false))
         post :create, :blob => {}
-        response.should render_template('new')
+        expect(response).to render_template('new')
       end
     end
 
@@ -70,41 +70,41 @@ describe Dataservice::BlobsController do
 
     describe "with valid params" do
       it "updates the requested blob" do
-        Dataservice::Blob.should_receive(:find).with("37").and_return(mock_blob)
-        mock_blob.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(Dataservice::Blob).to receive(:find).with("37").and_return(mock_blob)
+        expect(mock_blob).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :blob => {:these => 'params'}
       end
 
       it "assigns the requested blob as @blob" do
-        Dataservice::Blob.stub(:find).and_return(mock_blob(:update_attributes => true))
+        allow(Dataservice::Blob).to receive(:find).and_return(mock_blob(:update_attributes => true))
         put :update, :id => "1"
-        assigns[:dataservice_blob].should equal(mock_blob)
+        expect(assigns[:dataservice_blob]).to equal(mock_blob)
       end
 
       it "redirects to the blob" do
-        Dataservice::Blob.stub(:find).and_return(mock_blob(:update_attributes => true))
+        allow(Dataservice::Blob).to receive(:find).and_return(mock_blob(:update_attributes => true))
         put :update, :id => "1"
-        response.should redirect_to(dataservice_blob_url(mock_blob))
+        expect(response).to redirect_to(dataservice_blob_url(mock_blob))
       end
     end
 
     describe "with invalid params" do
       it "updates the requested blob" do
-        Dataservice::Blob.should_receive(:find).with("37").and_return(mock_blob)
-        mock_blob.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(Dataservice::Blob).to receive(:find).with("37").and_return(mock_blob)
+        expect(mock_blob).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :blob => {:these => 'params'}
       end
 
       it "assigns the blob as @blob" do
-        Dataservice::Blob.stub(:find).and_return(mock_blob(:update_attributes => false))
+        allow(Dataservice::Blob).to receive(:find).and_return(mock_blob(:update_attributes => false))
         put :update, :id => "1"
-        assigns[:dataservice_blob].should equal(mock_blob)
+        expect(assigns[:dataservice_blob]).to equal(mock_blob)
       end
 
       it "re-renders the 'edit' template" do
-        Dataservice::Blob.stub(:find).and_return(mock_blob(:update_attributes => false))
+        allow(Dataservice::Blob).to receive(:find).and_return(mock_blob(:update_attributes => false))
         put :update, :id => "1"
-        response.should render_template('edit')
+        expect(response).to render_template('edit')
       end
     end
 
@@ -112,15 +112,15 @@ describe Dataservice::BlobsController do
 
   describe "DELETE destroy" do
     it "destroys the requested blob" do
-      Dataservice::Blob.should_receive(:find).with("37").and_return(mock_blob)
-      mock_blob.should_receive(:destroy)
+      expect(Dataservice::Blob).to receive(:find).with("37").and_return(mock_blob)
+      expect(mock_blob).to receive(:destroy)
       delete :destroy, :id => "37"
     end
 
     it "redirects to the dataservice_blobs list" do
-      Dataservice::Blob.stub(:find).and_return(mock_blob(:destroy => true))
+      allow(Dataservice::Blob).to receive(:find).and_return(mock_blob(:destroy => true))
       delete :destroy, :id => "1"
-      response.should redirect_to(dataservice_blobs_url)
+      expect(response).to redirect_to(dataservice_blobs_url)
     end
   end
 

--- a/spec/controllers/dataservice/bundle_contents_controller_spec.rb
+++ b/spec/controllers/dataservice/bundle_contents_controller_spec.rb
@@ -8,37 +8,37 @@ describe Dataservice::BundleContentsController do
 
   describe "GET index" do
     it "assigns all dataservice_bundle_contents as @dataservice_bundle_contents" do
-      Dataservice::BundleContent.should_receive(:search).with(nil, nil, nil).and_return([mock_bundle_content])
+      expect(Dataservice::BundleContent).to receive(:search).with(nil, nil, nil).and_return([mock_bundle_content])
       login_admin
       get :index
-      assigns[:dataservice_bundle_contents].should == [mock_bundle_content]
+      expect(assigns[:dataservice_bundle_contents]).to eq([mock_bundle_content])
     end
   end
 
   describe "GET show" do
     it "assigns the requested bundle_content as @dataservice_bundle_content" do
-      Dataservice::BundleContent.should_receive(:find).with("37").and_return(mock_bundle_content)
+      expect(Dataservice::BundleContent).to receive(:find).with("37").and_return(mock_bundle_content)
       login_admin
       get :show, :id => "37"
-      assigns[:dataservice_bundle_content].should equal(mock_bundle_content)
+      expect(assigns[:dataservice_bundle_content]).to equal(mock_bundle_content)
     end
   end
 
   describe "GET new" do
     it "assigns a new bundle_content as @dataservice_bundle_content" do
-      Dataservice::BundleContent.should_receive(:new).and_return(mock_bundle_content)
+      expect(Dataservice::BundleContent).to receive(:new).and_return(mock_bundle_content)
       login_admin
       get :new
-      assigns[:dataservice_bundle_content].should equal(mock_bundle_content)
+      expect(assigns[:dataservice_bundle_content]).to equal(mock_bundle_content)
     end
   end
 
   describe "GET edit" do
     it "assigns the requested bundle_content as @dataservice_bundle_content" do
-      Dataservice::BundleContent.should_receive(:find).with("37").and_return(mock_bundle_content)
+      expect(Dataservice::BundleContent).to receive(:find).with("37").and_return(mock_bundle_content)
       login_admin
       get :edit, :id => "37"
-      assigns[:dataservice_bundle_content].should equal(mock_bundle_content)
+      expect(assigns[:dataservice_bundle_content]).to equal(mock_bundle_content)
     end
   end
 
@@ -46,33 +46,33 @@ describe Dataservice::BundleContentsController do
 
     describe "with valid params" do
       it "assigns a newly created bundle_content as @dataservice_bundle_content" do
-        Dataservice::BundleContent.should_receive(:new).with({'these' => 'params'}).and_return(mock_bundle_content(:save => true))
+        expect(Dataservice::BundleContent).to receive(:new).with({'these' => 'params'}).and_return(mock_bundle_content(:save => true))
         login_admin
         post :create, :dataservice_bundle_content => {:these => 'params'}
-        assigns[:dataservice_bundle_content].should equal(mock_bundle_content)
+        expect(assigns[:dataservice_bundle_content]).to equal(mock_bundle_content)
       end
 
       it "redirects to the created bundle_content" do
-        Dataservice::BundleContent.should_receive(:new).and_return(mock_bundle_content(:save => true))
+        expect(Dataservice::BundleContent).to receive(:new).and_return(mock_bundle_content(:save => true))
         login_admin
         post :create, :dataservice_bundle_content => {}
-        response.should redirect_to(dataservice_bundle_content_url(mock_bundle_content))
+        expect(response).to redirect_to(dataservice_bundle_content_url(mock_bundle_content))
       end
     end
 
     describe "with invalid params" do
       it "assigns a newly created but unsaved bundle_content as @dataservice_bundle_content" do
-        Dataservice::BundleContent.should_receive(:new).with({'these' => 'params'}).and_return(mock_bundle_content(:save => false))
+        expect(Dataservice::BundleContent).to receive(:new).with({'these' => 'params'}).and_return(mock_bundle_content(:save => false))
         login_admin
         post :create, :dataservice_bundle_content => {:these => 'params'}
-        assigns[:dataservice_bundle_content].should equal(mock_bundle_content)
+        expect(assigns[:dataservice_bundle_content]).to equal(mock_bundle_content)
       end
 
       it "re-renders the 'new' template" do
-        Dataservice::BundleContent.should_receive(:new).and_return(mock_bundle_content(:save => false))
+        expect(Dataservice::BundleContent).to receive(:new).and_return(mock_bundle_content(:save => false))
         login_admin
         post :create, :dataservice_bundle_content => {}
-        response.should render_template('new')
+        expect(response).to render_template('new')
       end
     end
 
@@ -82,47 +82,47 @@ describe Dataservice::BundleContentsController do
 
     describe "with valid params" do
       it "updates the requested bundle_content" do
-        Dataservice::BundleContent.should_receive(:find).with("37").and_return(mock_bundle_content)
+        expect(Dataservice::BundleContent).to receive(:find).with("37").and_return(mock_bundle_content)
         login_admin
-        mock_bundle_content.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(mock_bundle_content).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :dataservice_bundle_content => {:these => 'params'}
       end
 
       it "assigns the requested bundle_content as @dataservice_bundle_content" do
-        Dataservice::BundleContent.should_receive(:find).and_return(mock_bundle_content(:update_attributes => true))
+        expect(Dataservice::BundleContent).to receive(:find).and_return(mock_bundle_content(:update_attributes => true))
         login_admin
         put :update, :id => "1"
-        assigns[:dataservice_bundle_content].should equal(mock_bundle_content)
+        expect(assigns[:dataservice_bundle_content]).to equal(mock_bundle_content)
       end
 
       it "redirects to the bundle_content" do
-        Dataservice::BundleContent.should_receive(:find).and_return(mock_bundle_content(:update_attributes => true))
+        expect(Dataservice::BundleContent).to receive(:find).and_return(mock_bundle_content(:update_attributes => true))
         login_admin
         put :update, :id => "1"
-        response.should redirect_to(dataservice_bundle_content_url(mock_bundle_content))
+        expect(response).to redirect_to(dataservice_bundle_content_url(mock_bundle_content))
       end
     end
 
     describe "with invalid params" do
       it "updates the requested bundle_content" do
-        Dataservice::BundleContent.should_receive(:find).with("37").and_return(mock_bundle_content)
+        expect(Dataservice::BundleContent).to receive(:find).with("37").and_return(mock_bundle_content)
         login_admin
-        mock_bundle_content.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(mock_bundle_content).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :dataservice_bundle_content => {:these => 'params'}
       end
 
       it "assigns the bundle_content as @dataservice_bundle_content" do
-        Dataservice::BundleContent.should_receive(:find).and_return(mock_bundle_content(:update_attributes => false))
+        expect(Dataservice::BundleContent).to receive(:find).and_return(mock_bundle_content(:update_attributes => false))
         login_admin
         put :update, :id => "1"
-        assigns[:dataservice_bundle_content].should equal(mock_bundle_content)
+        expect(assigns[:dataservice_bundle_content]).to equal(mock_bundle_content)
       end
 
       it "re-renders the 'edit' template" do
-        Dataservice::BundleContent.should_receive(:find).and_return(mock_bundle_content(:update_attributes => false))
+        expect(Dataservice::BundleContent).to receive(:find).and_return(mock_bundle_content(:update_attributes => false))
         login_admin
         put :update, :id => "1"
-        response.should render_template('edit')
+        expect(response).to render_template('edit')
       end
     end
 
@@ -130,17 +130,17 @@ describe Dataservice::BundleContentsController do
 
   describe "DELETE destroy" do
     it "destroys the requested bundle_content" do
-      Dataservice::BundleContent.should_receive(:find).with("37").and_return(mock_bundle_content)
+      expect(Dataservice::BundleContent).to receive(:find).with("37").and_return(mock_bundle_content)
       login_admin
-      mock_bundle_content.should_receive(:destroy)
+      expect(mock_bundle_content).to receive(:destroy)
       delete :destroy, :id => "37"
     end
 
     it "redirects to the dataservice_bundle_contents list" do
-      Dataservice::BundleContent.should_receive(:find).and_return(mock_bundle_content(:destroy => true))
+      expect(Dataservice::BundleContent).to receive(:find).and_return(mock_bundle_content(:destroy => true))
       login_admin
       delete :destroy, :id => "1"
-      response.should redirect_to(dataservice_bundle_contents_url)
+      expect(response).to redirect_to(dataservice_bundle_contents_url)
     end
   end
 

--- a/spec/controllers/dataservice/bundle_contents_metal_controller_spec.rb
+++ b/spec/controllers/dataservice/bundle_contents_metal_controller_spec.rb
@@ -4,18 +4,18 @@ describe Dataservice::BundleContentsMetalController do
   describe "POST create" do
   	before :each do
       @mock_bundle_logger = mock_model(Dataservice::BundleLogger)
-      Dataservice::BundleLogger.should_receive(:find).with("37").and_return(@mock_bundle_logger)
+      expect(Dataservice::BundleLogger).to receive(:find).with("37").and_return(@mock_bundle_logger)
       @mock_bundle_content = mock_model(Dataservice::BundleContent)
-      @mock_bundle_logger.should_receive(:in_progress_bundle).twice.and_return(@mock_bundle_content)
-      Dataservice::LaunchProcessEvent.should_receive(:create)
-      @mock_bundle_logger.should_receive(:bundle_contents).and_return([@mock_bundle_content])
-      @mock_bundle_content.should_receive(:created_at).and_return(Time.now)
+      expect(@mock_bundle_logger).to receive(:in_progress_bundle).twice.and_return(@mock_bundle_content)
+      expect(Dataservice::LaunchProcessEvent).to receive(:create)
+      expect(@mock_bundle_logger).to receive(:bundle_contents).and_return([@mock_bundle_content])
+      expect(@mock_bundle_content).to receive(:created_at).and_return(Time.now)
       login_admin
   	end
 
     it "ends the bundle with the body of the post" do
       body_content = "body content of bundle"
-      @mock_bundle_logger.should_receive(:end_bundle).with({:body => body_content , :upload_time => nil })
+      expect(@mock_bundle_logger).to receive(:end_bundle).with({:body => body_content , :upload_time => nil })
       @request.env['RAW_POST_DATA'] = body_content
       post :create, id: 37
     end
@@ -23,7 +23,7 @@ describe Dataservice::BundleContentsMetalController do
     it "records upload time if X-Queue-Start header is set" do
       body_content = "body content of bundle"
 
-      @mock_bundle_logger.should_receive(:end_bundle).with({:body => body_content , :upload_time => be_within(1).of(21) })
+      expect(@mock_bundle_logger).to receive(:end_bundle).with({:body => body_content , :upload_time => be_within(1).of(21) })
       @request.env['RAW_POST_DATA'] = body_content
       # set a start of 20 seconds before now
       @request.env['X-Queue-Start'] = "t=#{((Time.now - 20).to_f*1000000).to_i}"

--- a/spec/controllers/dataservice/bundle_loggers_controller_spec.rb
+++ b/spec/controllers/dataservice/bundle_loggers_controller_spec.rb
@@ -14,39 +14,39 @@ describe Dataservice::BundleLoggersController do
 
   describe "GET index" do
     it "assigns all dataservice_bundle_loggers as @dataservice_bundle_loggers" do
-      Dataservice::BundleLogger.should_receive(:search).with(nil, nil, nil).and_return([mock_bundle_logger])
+      expect(Dataservice::BundleLogger).to receive(:search).with(nil, nil, nil).and_return([mock_bundle_logger])
       login_admin
       get :index
-      assigns[:dataservice_bundle_loggers].should == [mock_bundle_logger]
+      expect(assigns[:dataservice_bundle_loggers]).to eq([mock_bundle_logger])
     end
   end
 
   describe "GET show" do
     it "assigns the requested bundle_logger as @dataservice_bundle_logger" do
       logger = mock_bundle_logger
-      Dataservice::BundleLogger.should_receive(:find).with("37").and_return(logger)
-      logger.should_receive(:in_progress_bundle).twice.and_return(mock_bundle_content)
+      expect(Dataservice::BundleLogger).to receive(:find).with("37").and_return(logger)
+      expect(logger).to receive(:in_progress_bundle).twice.and_return(mock_bundle_content)
       login_admin
       get :show, :id => "37"
-      assigns[:dataservice_bundle_logger].should equal(mock_bundle_logger)
+      expect(assigns[:dataservice_bundle_logger]).to equal(mock_bundle_logger)
     end
   end
 
   describe "GET new" do
     it "assigns a new bundle_logger as @dataservice_bundle_logger" do
-      Dataservice::BundleLogger.should_receive(:new).and_return(mock_bundle_logger)
+      expect(Dataservice::BundleLogger).to receive(:new).and_return(mock_bundle_logger)
       login_admin
       get :new
-      assigns[:dataservice_bundle_logger].should equal(mock_bundle_logger)
+      expect(assigns[:dataservice_bundle_logger]).to equal(mock_bundle_logger)
     end
   end
 
   describe "GET edit" do
     it "assigns the requested bundle_logger as @dataservice_bundle_logger" do
-      Dataservice::BundleLogger.should_receive(:find).with("37").and_return(mock_bundle_logger)
+      expect(Dataservice::BundleLogger).to receive(:find).with("37").and_return(mock_bundle_logger)
       login_admin
       get :edit, :id => "37"
-      assigns[:dataservice_bundle_logger].should equal(mock_bundle_logger)
+      expect(assigns[:dataservice_bundle_logger]).to equal(mock_bundle_logger)
     end
   end
 
@@ -54,33 +54,33 @@ describe Dataservice::BundleLoggersController do
 
     describe "with valid params" do
       it "assigns a newly created bundle_logger as @dataservice_bundle_logger" do
-        Dataservice::BundleLogger.should_receive(:new).with({'these' => 'params'}).and_return(mock_bundle_logger(:save => true))
+        expect(Dataservice::BundleLogger).to receive(:new).with({'these' => 'params'}).and_return(mock_bundle_logger(:save => true))
         login_admin
         post :create, :dataservice_bundle_logger => {:these => 'params'}
-        assigns[:dataservice_bundle_logger].should equal(mock_bundle_logger)
+        expect(assigns[:dataservice_bundle_logger]).to equal(mock_bundle_logger)
       end
 
       it "redirects to the created bundle_logger" do
-        Dataservice::BundleLogger.should_receive(:new).and_return(mock_bundle_logger(:save => true))
+        expect(Dataservice::BundleLogger).to receive(:new).and_return(mock_bundle_logger(:save => true))
         login_admin
         post :create, :dataservice_bundle_logger => {}
-        response.should redirect_to(dataservice_bundle_logger_url(mock_bundle_logger))
+        expect(response).to redirect_to(dataservice_bundle_logger_url(mock_bundle_logger))
       end
     end
 
     describe "with invalid params" do
       it "assigns a newly created but unsaved bundle_logger as @dataservice_bundle_logger" do
-        Dataservice::BundleLogger.should_receive(:new).with({'these' => 'params'}).and_return(mock_bundle_logger(:save => false))
+        expect(Dataservice::BundleLogger).to receive(:new).with({'these' => 'params'}).and_return(mock_bundle_logger(:save => false))
         login_admin
         post :create, :dataservice_bundle_logger => {:these => 'params'}
-        assigns[:dataservice_bundle_logger].should equal(mock_bundle_logger)
+        expect(assigns[:dataservice_bundle_logger]).to equal(mock_bundle_logger)
       end
 
       it "re-renders the 'new' template" do
-        Dataservice::BundleLogger.should_receive(:new).and_return(mock_bundle_logger(:save => false))
+        expect(Dataservice::BundleLogger).to receive(:new).and_return(mock_bundle_logger(:save => false))
         login_admin
         post :create, :dataservice_bundle_logger => {}
-        response.should render_template('new')
+        expect(response).to render_template('new')
       end
     end
 
@@ -90,47 +90,47 @@ describe Dataservice::BundleLoggersController do
 
     describe "with valid params" do
       it "updates the requested bundle_logger" do
-        Dataservice::BundleLogger.should_receive(:find).with("37").and_return(mock_bundle_logger)
-        mock_bundle_logger.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(Dataservice::BundleLogger).to receive(:find).with("37").and_return(mock_bundle_logger)
+        expect(mock_bundle_logger).to receive(:update_attributes).with({'these' => 'params'})
         login_admin
         put :update, :id => "37", :dataservice_bundle_logger => {:these => 'params'}
       end
 
       it "assigns the requested bundle_logger as @dataservice_bundle_logger" do
-        Dataservice::BundleLogger.should_receive(:find).and_return(mock_bundle_logger(:update_attributes => true))
+        expect(Dataservice::BundleLogger).to receive(:find).and_return(mock_bundle_logger(:update_attributes => true))
         login_admin
         put :update, :id => "1"
-        assigns[:dataservice_bundle_logger].should equal(mock_bundle_logger)
+        expect(assigns[:dataservice_bundle_logger]).to equal(mock_bundle_logger)
       end
 
       it "redirects to the bundle_logger" do
-        Dataservice::BundleLogger.should_receive(:find).and_return(mock_bundle_logger(:update_attributes => true))
+        expect(Dataservice::BundleLogger).to receive(:find).and_return(mock_bundle_logger(:update_attributes => true))
         login_admin
         put :update, :id => "1"
-        response.should redirect_to(dataservice_bundle_logger_url(mock_bundle_logger))
+        expect(response).to redirect_to(dataservice_bundle_logger_url(mock_bundle_logger))
       end
     end
 
     describe "with invalid params" do
       it "updates the requested bundle_logger" do
-        Dataservice::BundleLogger.should_receive(:find).with("37").and_return(mock_bundle_logger)
-        mock_bundle_logger.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(Dataservice::BundleLogger).to receive(:find).with("37").and_return(mock_bundle_logger)
+        expect(mock_bundle_logger).to receive(:update_attributes).with({'these' => 'params'})
         login_admin
         put :update, :id => "37", :dataservice_bundle_logger => {:these => 'params'}
       end
 
       it "assigns the bundle_logger as @dataservice_bundle_logger" do
-        Dataservice::BundleLogger.should_receive(:find).and_return(mock_bundle_logger(:update_attributes => false))
+        expect(Dataservice::BundleLogger).to receive(:find).and_return(mock_bundle_logger(:update_attributes => false))
         login_admin
         put :update, :id => "1"
-        assigns[:dataservice_bundle_logger].should equal(mock_bundle_logger)
+        expect(assigns[:dataservice_bundle_logger]).to equal(mock_bundle_logger)
       end
 
       it "re-renders the 'edit' template" do
-        Dataservice::BundleLogger.should_receive(:find).and_return(mock_bundle_logger(:update_attributes => false))
+        expect(Dataservice::BundleLogger).to receive(:find).and_return(mock_bundle_logger(:update_attributes => false))
         login_admin
         put :update, :id => "1"
-        response.should render_template('edit')
+        expect(response).to render_template('edit')
       end
     end
 
@@ -138,17 +138,17 @@ describe Dataservice::BundleLoggersController do
 
   describe "DELETE destroy" do
     it "destroys the requested bundle_logger" do
-      Dataservice::BundleLogger.should_receive(:find).with("37").and_return(mock_bundle_logger)
-      mock_bundle_logger.should_receive(:destroy)
+      expect(Dataservice::BundleLogger).to receive(:find).with("37").and_return(mock_bundle_logger)
+      expect(mock_bundle_logger).to receive(:destroy)
       login_admin
       delete :destroy, :id => "37"
     end
 
     it "redirects to the dataservice_bundle_loggers list" do
-      Dataservice::BundleLogger.should_receive(:find).and_return(mock_bundle_logger(:destroy => true))
+      expect(Dataservice::BundleLogger).to receive(:find).and_return(mock_bundle_logger(:destroy => true))
       login_admin
       delete :destroy, :id => "1"
-      response.should redirect_to(dataservice_bundle_loggers_url)
+      expect(response).to redirect_to(dataservice_bundle_loggers_url)
     end
   end
 

--- a/spec/controllers/dataservice/console_contents_controller_spec.rb
+++ b/spec/controllers/dataservice/console_contents_controller_spec.rb
@@ -8,37 +8,37 @@ describe Dataservice::ConsoleContentsController do
 
   describe "GET index" do
     it "assigns all dataservice_console_contents as @dataservice_console_contents" do
-      Dataservice::ConsoleContent.should_receive(:search).with(nil, nil, nil).and_return([mock_console_content])
+      expect(Dataservice::ConsoleContent).to receive(:search).with(nil, nil, nil).and_return([mock_console_content])
       login_admin
       get :index
-      assigns[:dataservice_console_contents].should == [mock_console_content]
+      expect(assigns[:dataservice_console_contents]).to eq([mock_console_content])
     end
   end
 
   describe "GET show" do
     it "assigns the requested console_content as @dataservice_console_content" do
-      Dataservice::ConsoleContent.should_receive(:find).with("37").and_return(mock_console_content)
+      expect(Dataservice::ConsoleContent).to receive(:find).with("37").and_return(mock_console_content)
       login_admin
       get :show, :id => "37"
-      assigns[:dataservice_console_content].should equal(mock_console_content)
+      expect(assigns[:dataservice_console_content]).to equal(mock_console_content)
     end
   end
 
   describe "GET new" do
     it "assigns a new console_content as @dataservice_console_content" do
-      Dataservice::ConsoleContent.should_receive(:new).and_return(mock_console_content)
+      expect(Dataservice::ConsoleContent).to receive(:new).and_return(mock_console_content)
       login_admin
       get :new
-      assigns[:dataservice_console_content].should equal(mock_console_content)
+      expect(assigns[:dataservice_console_content]).to equal(mock_console_content)
     end
   end
 
   describe "GET edit" do
     it "assigns the requested console_content as @dataservice_console_content" do
-      Dataservice::ConsoleContent.should_receive(:find).with("37").and_return(mock_console_content)
+      expect(Dataservice::ConsoleContent).to receive(:find).with("37").and_return(mock_console_content)
       login_admin
       get :edit, :id => "37"
-      assigns[:dataservice_console_content].should equal(mock_console_content)
+      expect(assigns[:dataservice_console_content]).to equal(mock_console_content)
     end
   end
 
@@ -46,33 +46,33 @@ describe Dataservice::ConsoleContentsController do
 
     describe "with valid params" do
       it "assigns a newly created console_content as @dataservice_console_content" do
-        Dataservice::ConsoleContent.should_receive(:new).with({'these' => 'params'}).and_return(mock_console_content(:save => true))
+        expect(Dataservice::ConsoleContent).to receive(:new).with({'these' => 'params'}).and_return(mock_console_content(:save => true))
         login_admin
         post :create, :dataservice_console_content => {:these => 'params'}
-        assigns[:dataservice_console_content].should equal(mock_console_content)
+        expect(assigns[:dataservice_console_content]).to equal(mock_console_content)
       end
 
       it "redirects to the created console_content" do
-        Dataservice::ConsoleContent.should_receive(:new).and_return(mock_console_content(:save => true))
+        expect(Dataservice::ConsoleContent).to receive(:new).and_return(mock_console_content(:save => true))
         login_admin
         post :create, :dataservice_console_content => {}
-        response.should redirect_to(dataservice_console_content_url(mock_console_content))
+        expect(response).to redirect_to(dataservice_console_content_url(mock_console_content))
       end
     end
 
     describe "with invalid params" do
       it "assigns a newly created but unsaved console_content as @dataservice_console_content" do
-        Dataservice::ConsoleContent.should_receive(:new).with({'these' => 'params'}).and_return(mock_console_content(:save => false))
+        expect(Dataservice::ConsoleContent).to receive(:new).with({'these' => 'params'}).and_return(mock_console_content(:save => false))
         login_admin
         post :create, :dataservice_console_content => {:these => 'params'}
-        assigns[:dataservice_console_content].should equal(mock_console_content)
+        expect(assigns[:dataservice_console_content]).to equal(mock_console_content)
       end
 
       it "re-renders the 'new' template" do
-        Dataservice::ConsoleContent.should_receive(:new).and_return(mock_console_content(:save => false))
+        expect(Dataservice::ConsoleContent).to receive(:new).and_return(mock_console_content(:save => false))
         login_admin
         post :create, :dataservice_console_content => {}
-        response.should render_template('new')
+        expect(response).to render_template('new')
       end
     end
 
@@ -82,47 +82,47 @@ describe Dataservice::ConsoleContentsController do
 
     describe "with valid params" do
       it "updates the requested console_content" do
-        Dataservice::ConsoleContent.should_receive(:find).with("37").and_return(mock_console_content)
-        mock_console_content.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(Dataservice::ConsoleContent).to receive(:find).with("37").and_return(mock_console_content)
+        expect(mock_console_content).to receive(:update_attributes).with({'these' => 'params'})
         login_admin
         put :update, :id => "37", :dataservice_console_content => {:these => 'params'}
       end
 
       it "assigns the requested console_content as @dataservice_console_content" do
-        Dataservice::ConsoleContent.should_receive(:find).and_return(mock_console_content(:update_attributes => true))
+        expect(Dataservice::ConsoleContent).to receive(:find).and_return(mock_console_content(:update_attributes => true))
         login_admin
         put :update, :id => "1"
-        assigns[:dataservice_console_content].should equal(mock_console_content)
+        expect(assigns[:dataservice_console_content]).to equal(mock_console_content)
       end
 
       it "redirects to the console_content" do
-        Dataservice::ConsoleContent.should_receive(:find).and_return(mock_console_content(:update_attributes => true))
+        expect(Dataservice::ConsoleContent).to receive(:find).and_return(mock_console_content(:update_attributes => true))
         login_admin
         put :update, :id => "1"
-        response.should redirect_to(dataservice_console_content_url(mock_console_content))
+        expect(response).to redirect_to(dataservice_console_content_url(mock_console_content))
       end
     end
 
     describe "with invalid params" do
       it "updates the requested console_content" do
-        Dataservice::ConsoleContent.should_receive(:find).with("37").and_return(mock_console_content)
-        mock_console_content.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(Dataservice::ConsoleContent).to receive(:find).with("37").and_return(mock_console_content)
+        expect(mock_console_content).to receive(:update_attributes).with({'these' => 'params'})
         login_admin
         put :update, :id => "37", :dataservice_console_content => {:these => 'params'}
       end
 
       it "assigns the console_content as @dataservice_console_content" do
-        Dataservice::ConsoleContent.should_receive(:find).and_return(mock_console_content(:update_attributes => false))
+        expect(Dataservice::ConsoleContent).to receive(:find).and_return(mock_console_content(:update_attributes => false))
         login_admin
         put :update, :id => "1"
-        assigns[:dataservice_console_content].should equal(mock_console_content)
+        expect(assigns[:dataservice_console_content]).to equal(mock_console_content)
       end
 
       it "re-renders the 'edit' template" do
-        Dataservice::ConsoleContent.should_receive(:find).and_return(mock_console_content(:update_attributes => false))
+        expect(Dataservice::ConsoleContent).to receive(:find).and_return(mock_console_content(:update_attributes => false))
         login_admin
         put :update, :id => "1"
-        response.should render_template('edit')
+        expect(response).to render_template('edit')
       end
     end
 
@@ -130,17 +130,17 @@ describe Dataservice::ConsoleContentsController do
 
   describe "DELETE destroy" do
     it "destroys the requested console_content" do
-      Dataservice::ConsoleContent.should_receive(:find).with("37").and_return(mock_console_content)
-      mock_console_content.should_receive(:destroy)
+      expect(Dataservice::ConsoleContent).to receive(:find).with("37").and_return(mock_console_content)
+      expect(mock_console_content).to receive(:destroy)
       login_admin
       delete :destroy, :id => "37"
     end
 
     it "redirects to the dataservice_console_contents list" do
-      Dataservice::ConsoleContent.should_receive(:find).and_return(mock_console_content(:destroy => true))
+      expect(Dataservice::ConsoleContent).to receive(:find).and_return(mock_console_content(:destroy => true))
       login_admin
       delete :destroy, :id => "1"
-      response.should redirect_to(dataservice_console_contents_url)
+      expect(response).to redirect_to(dataservice_console_contents_url)
     end
   end
 

--- a/spec/controllers/dataservice/console_loggers_controller_spec.rb
+++ b/spec/controllers/dataservice/console_loggers_controller_spec.rb
@@ -14,37 +14,37 @@ describe Dataservice::ConsoleLoggersController do
 
   describe "GET index" do
     it "assigns all dataservice_console_loggers as @dataservice_console_loggers" do
-      Dataservice::ConsoleLogger.should_receive(:search).with(nil, nil, nil).and_return([mock_console_logger])
+      expect(Dataservice::ConsoleLogger).to receive(:search).with(nil, nil, nil).and_return([mock_console_logger])
       login_admin
       get :index
-      assigns[:dataservice_console_loggers].should == [mock_console_logger]
+      expect(assigns[:dataservice_console_loggers]).to eq([mock_console_logger])
     end
   end
 
   describe "GET show" do
     it "assigns the requested console_logger as @dataservice_console_logger" do
-      Dataservice::ConsoleLogger.should_receive(:find).with("37").and_return(mock_console_logger)
+      expect(Dataservice::ConsoleLogger).to receive(:find).with("37").and_return(mock_console_logger)
       login_admin
       get :show, :id => "37"
-      assigns[:dataservice_console_logger].should equal(mock_console_logger)
+      expect(assigns[:dataservice_console_logger]).to equal(mock_console_logger)
     end
   end
 
   describe "GET new" do
     it "assigns a new console_logger as @dataservice_console_logger" do
-      Dataservice::ConsoleLogger.should_receive(:new).and_return(mock_console_logger)
+      expect(Dataservice::ConsoleLogger).to receive(:new).and_return(mock_console_logger)
       login_admin
       get :new
-      assigns[:dataservice_console_logger].should equal(mock_console_logger)
+      expect(assigns[:dataservice_console_logger]).to equal(mock_console_logger)
     end
   end
 
   describe "GET edit" do
     it "assigns the requested console_logger as @dataservice_console_logger" do
-      Dataservice::ConsoleLogger.should_receive(:find).with("37").and_return(mock_console_logger)
+      expect(Dataservice::ConsoleLogger).to receive(:find).with("37").and_return(mock_console_logger)
       login_admin
       get :edit, :id => "37"
-      assigns[:dataservice_console_logger].should equal(mock_console_logger)
+      expect(assigns[:dataservice_console_logger]).to equal(mock_console_logger)
     end
   end
 
@@ -52,33 +52,33 @@ describe Dataservice::ConsoleLoggersController do
 
     describe "with valid params" do
       it "assigns a newly created console_logger as @dataservice_console_logger" do
-        Dataservice::ConsoleLogger.should_receive(:new).with({'these' => 'params'}).and_return(mock_console_logger(:save => true))
+        expect(Dataservice::ConsoleLogger).to receive(:new).with({'these' => 'params'}).and_return(mock_console_logger(:save => true))
         login_admin
         post :create, :dataservice_console_logger => {:these => 'params'}
-        assigns[:dataservice_console_logger].should equal(mock_console_logger)
+        expect(assigns[:dataservice_console_logger]).to equal(mock_console_logger)
       end
 
       it "redirects to the created console_logger" do
-        Dataservice::ConsoleLogger.should_receive(:new).and_return(mock_console_logger(:save => true))
+        expect(Dataservice::ConsoleLogger).to receive(:new).and_return(mock_console_logger(:save => true))
         login_admin
         post :create, :dataservice_console_logger => {}
-        response.should redirect_to(dataservice_console_logger_url(mock_console_logger))
+        expect(response).to redirect_to(dataservice_console_logger_url(mock_console_logger))
       end
     end
 
     describe "with invalid params" do
       it "assigns a newly created but unsaved console_logger as @dataservice_console_logger" do
-        Dataservice::ConsoleLogger.should_receive(:new).with({'these' => 'params'}).and_return(mock_console_logger(:save => false))
+        expect(Dataservice::ConsoleLogger).to receive(:new).with({'these' => 'params'}).and_return(mock_console_logger(:save => false))
         login_admin
         post :create, :dataservice_console_logger => {:these => 'params'}
-        assigns[:dataservice_console_logger].should equal(mock_console_logger)
+        expect(assigns[:dataservice_console_logger]).to equal(mock_console_logger)
       end
 
       it "re-renders the 'new' template" do
-        Dataservice::ConsoleLogger.should_receive(:new).and_return(mock_console_logger(:save => false))
+        expect(Dataservice::ConsoleLogger).to receive(:new).and_return(mock_console_logger(:save => false))
         login_admin
         post :create, :dataservice_console_logger => {}
-        response.should render_template('new')
+        expect(response).to render_template('new')
       end
     end
 
@@ -88,47 +88,47 @@ describe Dataservice::ConsoleLoggersController do
 
     describe "with valid params" do
       it "updates the requested console_logger" do
-        Dataservice::ConsoleLogger.should_receive(:find).with("37").and_return(mock_console_logger)
-        mock_console_logger.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(Dataservice::ConsoleLogger).to receive(:find).with("37").and_return(mock_console_logger)
+        expect(mock_console_logger).to receive(:update_attributes).with({'these' => 'params'})
         login_admin
         put :update, :id => "37", :dataservice_console_logger => {:these => 'params'}
       end
 
       it "assigns the requested console_logger as @dataservice_console_logger" do
-        Dataservice::ConsoleLogger.should_receive(:find).and_return(mock_console_logger(:update_attributes => true))
+        expect(Dataservice::ConsoleLogger).to receive(:find).and_return(mock_console_logger(:update_attributes => true))
         login_admin
         put :update, :id => "1"
-        assigns[:dataservice_console_logger].should equal(mock_console_logger)
+        expect(assigns[:dataservice_console_logger]).to equal(mock_console_logger)
       end
 
       it "redirects to the console_logger" do
-        Dataservice::ConsoleLogger.should_receive(:find).and_return(mock_console_logger(:update_attributes => true))
+        expect(Dataservice::ConsoleLogger).to receive(:find).and_return(mock_console_logger(:update_attributes => true))
         login_admin
         put :update, :id => "1"
-        response.should redirect_to(dataservice_console_logger_url(mock_console_logger))
+        expect(response).to redirect_to(dataservice_console_logger_url(mock_console_logger))
       end
     end
 
     describe "with invalid params" do
       it "updates the requested console_logger" do
-        Dataservice::ConsoleLogger.should_receive(:find).with("37").and_return(mock_console_logger)
-        mock_console_logger.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(Dataservice::ConsoleLogger).to receive(:find).with("37").and_return(mock_console_logger)
+        expect(mock_console_logger).to receive(:update_attributes).with({'these' => 'params'})
         login_admin
         put :update, :id => "37", :dataservice_console_logger => {:these => 'params'}
       end
 
       it "assigns the console_logger as @dataservice_console_logger" do
-        Dataservice::ConsoleLogger.should_receive(:find).and_return(mock_console_logger(:update_attributes => false))
+        expect(Dataservice::ConsoleLogger).to receive(:find).and_return(mock_console_logger(:update_attributes => false))
         login_admin
         put :update, :id => "1"
-        assigns[:dataservice_console_logger].should equal(mock_console_logger)
+        expect(assigns[:dataservice_console_logger]).to equal(mock_console_logger)
       end
 
       it "re-renders the 'edit' template" do
-        Dataservice::ConsoleLogger.should_receive(:find).and_return(mock_console_logger(:update_attributes => false))
+        expect(Dataservice::ConsoleLogger).to receive(:find).and_return(mock_console_logger(:update_attributes => false))
         login_admin
         put :update, :id => "1"
-        response.should render_template('edit')
+        expect(response).to render_template('edit')
       end
     end
 
@@ -136,17 +136,17 @@ describe Dataservice::ConsoleLoggersController do
 
   describe "DELETE destroy" do
     it "destroys the requested console_logger" do
-      Dataservice::ConsoleLogger.should_receive(:find).with("37").and_return(mock_console_logger)
-      mock_console_logger.should_receive(:destroy)
+      expect(Dataservice::ConsoleLogger).to receive(:find).with("37").and_return(mock_console_logger)
+      expect(mock_console_logger).to receive(:destroy)
       login_admin
       delete :destroy, :id => "37"
     end
 
     it "redirects to the dataservice_console_loggers list" do
-      Dataservice::ConsoleLogger.should_receive(:find).and_return(mock_console_logger(:destroy => true))
+      expect(Dataservice::ConsoleLogger).to receive(:find).and_return(mock_console_logger(:destroy => true))
       login_admin
       delete :destroy, :id => "1"
-      response.should redirect_to(dataservice_console_loggers_url)
+      expect(response).to redirect_to(dataservice_console_loggers_url)
     end
   end
 

--- a/spec/controllers/external_activities_controller_spec.rb
+++ b/spec/controllers/external_activities_controller_spec.rb
@@ -110,15 +110,15 @@ describe ExternalActivitiesController do
   end
 
   before(:each) do
-    @current_settings = mock(
+    @current_settings = double(
       :name => "test settings",
       :use_student_security_questions => false,
       :use_bitmap_snapshots? => false,
       :require_user_consent? => false,
       :default_cohort => nil)
-    Admin::Settings.stub!(:default_settings).and_return(@current_settings)
-    controller.stub(:before_render) {
-      response.template.stub(:net_logo_package_name).and_return("blah")
+    allow(Admin::Settings).to receive(:default_settings).and_return(@current_settings)
+    allow(controller).to receive(:before_render) {
+      allow(response.template).to receive(:net_logo_package_name).and_return("blah")
       response.template.stub_chain(:current_settings).and_return(@current_settings);
     }
 
@@ -135,7 +135,7 @@ describe ExternalActivitiesController do
     it "should assign the activity correctly" do
       get :show, :id => existing.id
       result = assigns(:external_activity)
-      result.name.should == existing.name
+      expect(result.name).to eq(existing.name)
     end
   end
 
@@ -146,10 +146,10 @@ describe ExternalActivitiesController do
         it "should create a new activity" do
           raw_post :publish, {}, activity_hash.to_json
           created = assigns(:external_activity)
-          created.should_not be_nil
-          created.name.should == name
-          created.url.should  == url
-          created.id.should_not == existing.id
+          expect(created).not_to be_nil
+          expect(created.name).to eq(name)
+          expect(created.url).to  eq(url)
+          expect(created.id).not_to eq(existing.id)
         end
       end
 
@@ -158,15 +158,15 @@ describe ExternalActivitiesController do
           existing
           raw_post :publish, {}, activity_hash.to_json
           created = assigns(:external_activity)
-          created.should_not be_nil
-          created.name.should == name
-          created.url.should  == url
-          created.id.should   == existing.id
+          expect(created).not_to be_nil
+          expect(created.name).to eq(name)
+          expect(created.url).to  eq(url)
+          expect(created.id).to   eq(existing.id)
           # See spec/lib/activity_runtime_api_spec.rb for more update tests
-          created.template.sections.should have(1).section
+          expect(created.template.sections.size).to eq(1)
           expect(created.template.pages.size).to eq(1)
-          created.template.open_responses.should have(1).open_response
-          created.template.multiple_choices.should have(1).multiple_choice
+          expect(created.template.open_responses.size).to eq(1)
+          expect(created.template.multiple_choices.size).to eq(1)
         end
       end
     end
@@ -184,11 +184,11 @@ describe ExternalActivitiesController do
         it "should create a new activity" do
           raw_post :publish, { :version => 'v2' }, activity2_hash.to_json
           created = assigns(:external_activity)
-          created.should_not be_nil
-          created.name.should == name
-          created.url.should  == url
-          created.id.should_not == existing.id
-          created.template.should be_an_instance_of(Activity)
+          expect(created).not_to be_nil
+          expect(created.name).to eq(name)
+          expect(created.url).to  eq(url)
+          expect(created.id).not_to eq(existing.id)
+          expect(created.template).to be_an_instance_of(Activity)
         end
       end
 
@@ -197,15 +197,15 @@ describe ExternalActivitiesController do
           existing
           raw_post :publish, { :version => 'v2' }, activity2_hash.to_json
           created = assigns(:external_activity)
-          created.should_not be_nil
-          created.name.should == name
-          created.url.should  == url
-          created.id.should   == existing.id
+          expect(created).not_to be_nil
+          expect(created.name).to eq(name)
+          expect(created.url).to  eq(url)
+          expect(created.id).to   eq(existing.id)
           # See spec/lib/activity_runtime_api_spec.rb for more update tests
-          created.template.sections.should have(1).section
+          expect(created.template.sections.size).to eq(1)
           expect(created.template.pages.size).to eq(1)
-          created.template.open_responses.should have(1).open_response
-          created.template.multiple_choices.should have(1).multiple_choice
+          expect(created.template.open_responses.size).to eq(1)
+          expect(created.template.multiple_choices.size).to eq(1)
         end
       end
 
@@ -214,11 +214,11 @@ describe ExternalActivitiesController do
           sequence_hash['url'] = 'http://activity.org/sequence/2'
           raw_post :publish, { :version => 'v2' }, sequence_hash.to_json
           created = assigns(:external_activity)
-          created.should_not be_nil
-          created.name.should == sequence_name
-          created.url.should  == 'http://activity.org/sequence/2'
-          created.id.should_not == existing_sequence.id
-          created.template.should be_an_instance_of(Investigation)
+          expect(created).not_to be_nil
+          expect(created.name).to eq(sequence_name)
+          expect(created.url).to  eq('http://activity.org/sequence/2')
+          expect(created.id).not_to eq(existing_sequence.id)
+          expect(created.template).to be_an_instance_of(Investigation)
         end
       end
 
@@ -227,10 +227,10 @@ describe ExternalActivitiesController do
           existing_sequence
           raw_post :publish, { :version => 'v2' }, sequence_hash.to_json
           updated = assigns(:external_activity)
-          updated.should_not be_nil
-          updated.name.should == sequence_name
-          updated.url.should  == sequence_url
-          updated.id.should   == existing_sequence.id
+          expect(updated).not_to be_nil
+          expect(updated.name).to eq(sequence_name)
+          expect(updated.url).to  eq(sequence_url)
+          expect(updated.id).to   eq(existing_sequence.id)
           # More about the updated sequence?
         end
       end

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -6,7 +6,7 @@ describe HelpController do
       @admin_user = Factory.next(:admin_user)
       @test_settings = Factory.create(:admin_settings, :user => @admin_user, :id=> 1)
       login_admin
-      Admin::Settings.stub(:default_settings).and_return(@test_settings)
+      allow(Admin::Settings).to receive(:default_settings).and_return(@test_settings)
   end
   
   describe "GET index" do
@@ -19,7 +19,7 @@ describe HelpController do
       @test_settings.external_url = 'www.concord.org'
       @test_settings.help_type = 'external url'
       get :index
-      response.should redirect_to 'www.concord.org'
+      expect(response).to redirect_to 'www.concord.org'
     end
     it "should render index template when help type is help custom html" do
       @test_settings.custom_help_page_html = '<b>Help page</b>'
@@ -60,7 +60,7 @@ describe HelpController do
           :preview_help_page_from_summary_page => "#{@test_settings.id}"
         }
       get :preview_help_page, @post_params
-      response.should redirect_to 'www.concord.org'
+      expect(response).to redirect_to 'www.concord.org'
     end
     
     it "should render preview_help_page template when help type is help custom html and preview is from summary page." do

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -23,20 +23,20 @@ describe HomeController do
     # mock is used and sometimes it is not.
     # see this PT story for more details: https://www.pivotaltracker.com/story/show/145134539
     #
-    @test_settings = mock("settings")
-    Admin::Settings.stub(:default_settings).and_return(@test_settings)
-    @test_settings.stub!(:use_student_security_questions).and_return(false)
-    @test_settings.stub!(:require_user_consent?).and_return(false)
-    @test_settings.stub!(:help_type).and_return('no help')
-    @test_settings.stub!(:anonymous_can_browse_materials).and_return(true)
-    @test_settings.stub!(:allow_default_class).and_return(false)
-    @test_settings.stub!(:allow_adhoc_schools).and_return(false)
-    @test_settings.stub!(:show_collections_menu).and_return(false)
-    @test_settings.stub!(:auto_set_teachers_as_authors).and_return(false)
-    @test_settings.stub!(:wrap_home_page_content?).and_return(true)
-    @test_settings.stub!(:teacher_home_path).and_return(nil)
-    controller.stub(:before_render) {
-      response.template.stub(:current_settings).and_return(@test_settings)
+    @test_settings = double("settings")
+    allow(Admin::Settings).to receive(:default_settings).and_return(@test_settings)
+    allow(@test_settings).to receive(:use_student_security_questions).and_return(false)
+    allow(@test_settings).to receive(:require_user_consent?).and_return(false)
+    allow(@test_settings).to receive(:help_type).and_return('no help')
+    allow(@test_settings).to receive(:anonymous_can_browse_materials).and_return(true)
+    allow(@test_settings).to receive(:allow_default_class).and_return(false)
+    allow(@test_settings).to receive(:allow_adhoc_schools).and_return(false)
+    allow(@test_settings).to receive(:show_collections_menu).and_return(false)
+    allow(@test_settings).to receive(:auto_set_teachers_as_authors).and_return(false)
+    allow(@test_settings).to receive(:wrap_home_page_content?).and_return(true)
+    allow(@test_settings).to receive(:teacher_home_path).and_return(nil)
+    allow(controller).to receive(:before_render) {
+      allow(response.template).to receive(:current_settings).and_return(@test_settings)
     }
     # it appears that some previous tests leave a user logged in somehow
     # so we explicitly log in anonymous here
@@ -47,12 +47,12 @@ describe HomeController do
 
     content = "Test home page content"
 
-    @test_settings.should_receive(:home_page_content).at_least(:once).and_return(content)
-    @test_settings.stub(:name).and_return("Test Settings")
-    @test_settings.stub(:custom_search_path)
+    expect(@test_settings).to receive(:home_page_content).at_least(:once).and_return(content)
+    allow(@test_settings).to receive(:name).and_return("Test Settings")
+    allow(@test_settings).to receive(:custom_search_path)
 
     get :index
-    response.body.should include(content)
+    expect(response.body).to include(content)
   end
 
   describe "Post preview_home_page" do
@@ -63,57 +63,57 @@ describe HomeController do
       }
       post :preview_home_page, @post_params
       expect(response).to be_success
-      response.body.should include(@post_params[:home_page_preview_content])
+      expect(response.body).to include(@post_params[:home_page_preview_content])
     end
   end
 
   describe "STEM resources" do
     before(:each) do
-      @test_settings.stub!(:home_page_content).and_return("stubbed homepage content")
-      @test_settings.stub(:custom_search_path)
+      allow(@test_settings).to receive(:home_page_content).and_return("stubbed homepage content")
+      allow(@test_settings).to receive(:custom_search_path)
     end
 
     # note: in the tests below the "slug" param is always optional
     it "should return 200 when a valid activity is used" do
       get :stem_resources, :id => activity.id
-      response.should be_success
+      expect(response).to be_success
       get :stem_resources, :id => activity.id, :slug => "test"
-      response.should be_success
+      expect(response).to be_success
     end
 
     it "should return 404 when an unknown activity is used" do
       get :stem_resources, :id => 999999999999999
-      response.should_not be_success
+      expect(response).not_to be_success
       get :stem_resources, :id => 999999999999999, :slug => "test"
-      response.should_not be_success
+      expect(response).not_to be_success
     end
 
     it "should return 200 when a valid sequence is used" do
       get :stem_resources, :id => sequence.id
-      response.should be_success
+      expect(response).to be_success
       get :stem_resources, :id => sequence.id, :slug => "test"
-      response.should be_success
+      expect(response).to be_success
     end
 
     it "should return 404 when an unknown sequence is used" do
       get :stem_resources, :id => 999999999999999
-      response.should_not be_success
+      expect(response).not_to be_success
       get :stem_resources, :id => 999999999999999, :slug => "test"
-      response.should_not be_success
+      expect(response).not_to be_success
     end
 
     it "should return 200 when a valid interactive is used" do
       get :stem_resources, :type => "interactive", :id_or_filter_value => interactive.id
-      response.should redirect_to stem_resources_url(interactive.external_activity_id, activity.name.parameterize)
+      expect(response).to redirect_to stem_resources_url(interactive.external_activity_id, activity.name.parameterize)
       get :stem_resources, :type => "interactive", :id_or_filter_value => interactive.id, :slug => "test"
-      response.should redirect_to stem_resources_url(interactive.external_activity_id, activity.name.parameterize)
+      expect(response).to redirect_to stem_resources_url(interactive.external_activity_id, activity.name.parameterize)
     end
 
     it "should return 404 when an unknown interactive is used" do
       get :stem_resources, :type => "interactive", :id_or_filter_value => 999999999999999
-      response.should_not be_success
+      expect(response).not_to be_success
       get :stem_resources, :type => "interactive", :id_or_filter_value => 999999999999999, :slug => "test"
-      response.should_not be_success
+      expect(response).not_to be_success
     end
 
     #
@@ -121,28 +121,28 @@ describe HomeController do
     #
     it "should return 200 when an unknown type is used" do
       get :stem_resources, :type => "unknown-type", :id_or_filter_value => 1
-      response.should be_success
+      expect(response).to be_success
       get :stem_resources, :type => "unknown-type", :id_or_filter_value => 1, :slug => "test"
-      response.should be_success
+      expect(response).to be_success
     end
 
     it "should include the required Javascript when a valid activity is used" do
       get :stem_resources, :id => activity.id
-      response.body.should include("auto_show_lightbox_resource")
-      response.body.should include("PortalPages.settings.autoShowingLightboxResource = {\"id\":#{activity.id},")
-      response.body.should include("PortalPages.renderResourceLightbox(")
+      expect(response.body).to include("auto_show_lightbox_resource")
+      expect(response.body).to include("PortalPages.settings.autoShowingLightboxResource = {\"id\":#{activity.id},")
+      expect(response.body).to include("PortalPages.renderResourceLightbox(")
     end
 
     it "should include the required Javascript when an unknown activity is used" do
       get :stem_resources, :type => "activity", :id => 999999999999999
-      response.body.should include("auto_show_lightbox_resource")
-      response.body.should include("PortalPages.settings.autoShowingLightboxResource = null")
-      response.body.should include("PortalPages.renderResourceLightbox(")
+      expect(response.body).to include("auto_show_lightbox_resource")
+      expect(response.body).to include("PortalPages.settings.autoShowingLightboxResource = null")
+      expect(response.body).to include("PortalPages.renderResourceLightbox(")
     end
 
     it "should set the start of the page title to the resource name" do
       get :stem_resources, :id => activity.id
-      response.body.should include("<title>#{activity.name}")
+      expect(response.body).to include("<title>#{activity.name}")
     end
   end
 end

--- a/spec/controllers/images_controller_spec.rb
+++ b/spec/controllers/images_controller_spec.rb
@@ -6,8 +6,8 @@ describe ImagesController do
   end
 
   def stub_users_scope(results)
-    mock_ar_set = mock(:find => results)
-    Image.should_receive(:visible_to_user_with_drafts).
+    mock_ar_set = double(:find => results)
+    expect(Image).to receive(:visible_to_user_with_drafts).
       with(@logged_in_user).
         and_return(mock_ar_set)
   end
@@ -20,9 +20,9 @@ describe ImagesController do
   describe "responding to GET index" do
 
     it "should expose an array of all the @images" do
-      Image.should_receive(:search_list).and_return([mock_image])
+      expect(Image).to receive(:search_list).and_return([mock_image])
       get :index, :format => :html
-      assigns[:images].should == [mock_image]
+      expect(assigns[:images]).to eq([mock_image])
     end
 
   end
@@ -31,7 +31,7 @@ describe ImagesController do
     it "should expose the requested image as @image" do
       stub_users_scope(mock_image)
       get :show, :id => "37"
-      assigns[:image].should equal(mock_image)
+      expect(assigns[:image]).to equal(mock_image)
     end
 
   end
@@ -39,9 +39,9 @@ describe ImagesController do
   describe "responding to GET new" do
 
     it "should expose a new image as @image" do
-      Image.should_receive(:new).and_return(mock_image)
+      expect(Image).to receive(:new).and_return(mock_image)
       get :new
-      assigns[:image].should equal(mock_image)
+      expect(assigns[:image]).to equal(mock_image)
     end
 
   end
@@ -50,10 +50,10 @@ describe ImagesController do
 
     it "should expose the requested image as @image" do
       img = mock_image
-      img.should_receive(:changeable?).with(@logged_in_user).and_return(true)
-      Image.should_receive(:find).with("37").and_return(img)
+      expect(img).to receive(:changeable?).with(@logged_in_user).and_return(true)
+      expect(Image).to receive(:find).with("37").and_return(img)
       get :edit, :id => "37"
-      assigns[:image].should equal(img)
+      expect(assigns[:image]).to equal(img)
     end
 
   end
@@ -65,30 +65,30 @@ describe ImagesController do
         img = mock_image
         img.stub(:save => true)
 
-        Image.should_receive(:new).with({'these' => 'params', 'user_id' => @logged_in_user.id.to_s}).and_return(img)
+        expect(Image).to receive(:new).with({'these' => 'params', 'user_id' => @logged_in_user.id.to_s}).and_return(img)
         post :create, :image => {:these => 'params'}
-        assigns(:image).should equal(img)
+        expect(assigns(:image)).to equal(img)
       end
 
       it "should redirect to the created image" do
-        Image.stub!(:new).and_return(mock_image(:save => true))
+        allow(Image).to receive(:new).and_return(mock_image(:save => true))
         post :create, :image => {}
-        response.should redirect_to(image_url(mock_image))
+        expect(response).to redirect_to(image_url(mock_image))
       end
 
     end
 
     describe "with invalid params" do
       it "should expose a newly created but unsaved image as @image" do
-        Image.stub!(:new).with({'these' => 'params','user_id' => @logged_in_user.id.to_s}).and_return(mock_image(:save => false))
+        allow(Image).to receive(:new).with({'these' => 'params','user_id' => @logged_in_user.id.to_s}).and_return(mock_image(:save => false))
         post :create, :image => {:these => 'params'}
-        assigns(:image).should equal(mock_image)
+        expect(assigns(:image)).to equal(mock_image)
       end
 
       it "should re-render the 'new' template" do
-        Image.stub!(:new).and_return(mock_image(:save => false))
+        allow(Image).to receive(:new).and_return(mock_image(:save => false))
         post :create, :image => {}
-        response.should render_template('new')
+        expect(response).to render_template('new')
       end
 
     end
@@ -100,24 +100,24 @@ describe ImagesController do
     describe "with valid params" do
       before(:each) do
         @img = mock_image(:save => true, :update_attributes => true, :reload => true)
-        @img.should_receive(:changeable?).with(@logged_in_user).and_return(true)
+        expect(@img).to receive(:changeable?).with(@logged_in_user).and_return(true)
       end
       it "should update the requested image" do
-        Image.should_receive(:find).with("37").and_return(@img)
-        mock_image.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(Image).to receive(:find).with("37").and_return(@img)
+        expect(mock_image).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :image => {:these => 'params'}
       end
 
       it "should expose the requested image as @image" do
-        Image.stub!(:find).and_return(@img)
+        allow(Image).to receive(:find).and_return(@img)
         put :update, :id => "1", :image => {}
-        assigns(:image).should equal(@img)
+        expect(assigns(:image)).to equal(@img)
       end
 
       it "should redirect to the image" do
-        Image.stub!(:find).and_return(@img)
+        allow(Image).to receive(:find).and_return(@img)
         put :update, :id => "1", :format => :html, :image => {}
-        response.should redirect_to(@img)
+        expect(response).to redirect_to(@img)
       end
 
     end
@@ -125,24 +125,24 @@ describe ImagesController do
     describe "with invalid params" do
       before(:each) do
         @img = mock_image(:save => false, :update_attributes => false, :reload => false)
-        @img.should_receive(:changeable?).with(@logged_in_user).and_return(true)
+        expect(@img).to receive(:changeable?).with(@logged_in_user).and_return(true)
       end
       it "should update the requested image" do
-        Image.should_receive(:find).with("37").and_return(@img)
-        @img.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(Image).to receive(:find).with("37").and_return(@img)
+        expect(@img).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :image => {:these => 'params'}
       end
 
       it "should expose the image as @image" do
-        Image.stub!(:find).and_return(@img)
+        allow(Image).to receive(:find).and_return(@img)
         put :update, :id => "1"
-        assigns(:image).should equal(@img)
+        expect(assigns(:image)).to equal(@img)
       end
 
       it "should re-render the 'edit' template" do
-        Image.stub!(:find).and_return(@img)
+        allow(Image).to receive(:find).and_return(@img)
         put :update, :id => "1"
-        response.should render_template('edit')
+        expect(response).to render_template('edit')
       end
 
     end
@@ -152,18 +152,18 @@ describe ImagesController do
   describe "responding to DELETE destroy" do
     before(:each) do
       @img = mock_image(:destroy => true)
-      @img.should_receive(:changeable?).with(@logged_in_user).and_return(true)
+      expect(@img).to receive(:changeable?).with(@logged_in_user).and_return(true)
     end
     it "should destroy the requested image" do
-      Image.should_receive(:find).with("37").and_return(@img)
-      mock_image.should_receive(:destroy)
+      expect(Image).to receive(:find).with("37").and_return(@img)
+      expect(mock_image).to receive(:destroy)
       delete :destroy, :id => "37"
     end
 
     it "should redirect to the images list" do
-      Image.stub!(:find).and_return(@img)
+      allow(Image).to receive(:find).and_return(@img)
       delete :destroy, :id => "1"
-      response.should redirect_to(images_url)
+      expect(response).to redirect_to(images_url)
     end
 
   end

--- a/spec/controllers/interactive_controller_spec.rb
+++ b/spec/controllers/interactive_controller_spec.rb
@@ -53,7 +53,7 @@ describe InteractivesController do
         }
 
         expect(flash[:notice]).to eq("Interactive was successfully created.")
-        assigns(:interactive).publication_status.should be publication_status
+        expect(assigns(:interactive).publication_status).to be publication_status
         expect(response).to redirect_to(interactive_path(assigns(:interactive)))
       end
     end
@@ -73,7 +73,7 @@ describe InteractivesController do
           }
         }
         expect(flash[:notice]).to eq("Interactive was successfully created.")
-        assigns(:interactive).publication_status.should == "draft"
+        expect(assigns(:interactive).publication_status).to eq("draft")
         expect(response).to redirect_to(interactive_path(assigns(:interactive)))
       end
     end
@@ -99,9 +99,9 @@ describe InteractivesController do
           :subject_areas => ["Physical Science"]
         }
         expect(flash[:notice]).to eq("Interactive was successfully created.")
-        assigns(:interactive).model_type_list.should match_array(["model_type_1"])
-        assigns(:interactive).grade_level_list.should match_array(["1","5"])
-        assigns(:interactive).subject_area_list.should match_array(["Physical Science"])
+        expect(assigns(:interactive).model_type_list).to match_array(["model_type_1"])
+        expect(assigns(:interactive).grade_level_list).to match_array(["1","5"])
+        expect(assigns(:interactive).subject_area_list).to match_array(["Physical Science"])
         expect(response).to redirect_to(interactive_path(assigns(:interactive)))
       end
     end
@@ -134,7 +134,7 @@ describe InteractivesController do
       expect(Interactive.count).to eq(existing_interactives)
 
       updated = Interactive.find(test_interactive.id)
-      updated.model_type_list.should match_array(["model_type_2"])
+      expect(updated.model_type_list).to match_array(["model_type_2"])
       expect(flash[:notice]).to eq("Interactive was successfully updated.")
     end
   end
@@ -142,8 +142,8 @@ describe InteractivesController do
   describe "#export_model_library" do 
     it "should export a json file" do
       get :export_model_library
-      response.header["Content-Type"].should == "application/json"
-      response.header["Content-Disposition"].should == "attachment; filename=\"portal_interactives_library.json\""
+      expect(response.header["Content-Type"]).to eq("application/json")
+      expect(response.header["Content-Disposition"]).to eq("attachment; filename=\"portal_interactives_library.json\"")
     end
   end
 

--- a/spec/controllers/materials_collections_controller_spec.rb
+++ b/spec/controllers/materials_collections_controller_spec.rb
@@ -21,7 +21,7 @@ require 'spec_helper'
 describe MaterialsCollectionsController do
   before(:each) do
     @admin_user = Factory.next(:admin_user)
-    controller.stub!(:current_visitor).and_return(@admin_user)
+    allow(controller).to receive(:current_visitor).and_return(@admin_user)
 
     login_admin
   end
@@ -33,28 +33,28 @@ describe MaterialsCollectionsController do
     it "assigns all materials_collections as @materials_collections" do
       materials_collection
       get :index, {}
-      assigns(:materials_collections).to_a.should eq([materials_collection])
+      expect(assigns(:materials_collections).to_a).to eq([materials_collection])
     end
   end
 
   describe "GET show" do
     it "assigns the requested materials_collection as @materials_collection" do
       get :show, {:id => materials_collection.to_param}
-      assigns(:materials_collection).should eq(materials_collection)
+      expect(assigns(:materials_collection)).to eq(materials_collection)
     end
   end
 
   describe "GET new" do
     it "assigns a new materials_collection as @materials_collection" do
       get :new, {}
-      assigns(:materials_collection).should be_a_new(MaterialsCollection)
+      expect(assigns(:materials_collection)).to be_a_new(MaterialsCollection)
     end
   end
 
   describe "GET edit" do
     it "assigns the requested materials_collection as @materials_collection" do
       get :edit, {:id => materials_collection.to_param}
-      assigns(:materials_collection).should eq(materials_collection)
+      expect(assigns(:materials_collection)).to eq(materials_collection)
     end
   end
 
@@ -68,31 +68,31 @@ describe MaterialsCollectionsController do
 
       it "assigns a newly created materials_collection as @materials_collection" do
         post :create, {:materials_collection => valid_attributes}
-        assigns(:materials_collection).should be_a(MaterialsCollection)
-        assigns(:materials_collection).should be_persisted
+        expect(assigns(:materials_collection)).to be_a(MaterialsCollection)
+        expect(assigns(:materials_collection)).to be_persisted
       end
 
       it "redirects to the materials_collections index" do
         post :create, {:materials_collection => valid_attributes}
-        response.should redirect_to(materials_collections_url)
+        expect(response).to redirect_to(materials_collections_url)
       end
     end
 
     describe "with invalid params" do
       it "assigns a newly created but unsaved materials_collection as @materials_collection" do
         # Trigger the behavior that occurs when invalid params are submitted
-        MaterialsCollection.any_instance.stub(:save).and_return(false)
+        allow_any_instance_of(MaterialsCollection).to receive(:save).and_return(false)
         post :create, {:materials_collection => valid_attributes}
-        assigns(:materials_collection).should be_a(MaterialsCollection)
-        assigns(:materials_collection).should_not be_persisted
-        assigns(:materials_collection).should be_a_new(MaterialsCollection)
+        expect(assigns(:materials_collection)).to be_a(MaterialsCollection)
+        expect(assigns(:materials_collection)).not_to be_persisted
+        expect(assigns(:materials_collection)).to be_a_new(MaterialsCollection)
       end
 
       it "re-renders the 'new' template" do
         # Trigger the behavior that occurs when invalid params are submitted
-        MaterialsCollection.any_instance.stub(:save).and_return(false)
+        allow_any_instance_of(MaterialsCollection).to receive(:save).and_return(false)
         post :create, {:materials_collection => valid_attributes}
-        response.should render_template(:new)
+        expect(response).to render_template(:new)
       end
     end
   end
@@ -104,34 +104,34 @@ describe MaterialsCollectionsController do
         # specifies that the MaterialsCollection created on the previous line
         # receives the :update_attributes message with whatever params are
         # submitted in the request.
-        MaterialsCollection.any_instance.should_receive(:update_attributes).with({'name' => 'new name'})
+        expect_any_instance_of(MaterialsCollection).to receive(:update_attributes).with({'name' => 'new name'})
         put :update, {:id => materials_collection.to_param, :materials_collection => {'name' => 'new name'}}
       end
 
       it "assigns the requested materials_collection as @materials_collection" do
         put :update, {:id => materials_collection.to_param, :materials_collection => valid_attributes}
-        assigns(:materials_collection).should eq(materials_collection)
+        expect(assigns(:materials_collection)).to eq(materials_collection)
       end
 
       it "redirects to the materials_collection" do
         put :update, {:id => materials_collection.to_param, :materials_collection => valid_attributes}
-        response.should redirect_to(materials_collection)
+        expect(response).to redirect_to(materials_collection)
       end
     end
 
     describe "with invalid params" do
       it "assigns the materials_collection as @materials_collection" do
         # Trigger the behavior that occurs when invalid params are submitted
-        MaterialsCollection.any_instance.stub(:save).and_return(false)
+        allow_any_instance_of(MaterialsCollection).to receive(:save).and_return(false)
         put :update, {:id => materials_collection.to_param, :materials_collection => valid_attributes}
-        assigns(:materials_collection).should eq(materials_collection)
+        expect(assigns(:materials_collection)).to eq(materials_collection)
       end
 
       it "re-renders the 'edit' template" do
         # Trigger the behavior that occurs when invalid params are submitted
-        MaterialsCollection.any_instance.stub(:save).and_return(false)
+        allow_any_instance_of(MaterialsCollection).to receive(:save).and_return(false)
         put :update, {:id => materials_collection.to_param, :materials_collection => valid_attributes}
-        response.should render_template("edit")
+        expect(response).to render_template("edit")
       end
     end
   end
@@ -146,7 +146,7 @@ describe MaterialsCollectionsController do
 
     it "redirects to the materials_collections list" do
       delete :destroy, {:id => materials_collection.to_param}
-      response.should redirect_to(materials_collections_url)
+      expect(response).to redirect_to(materials_collections_url)
     end
   end
 

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -14,7 +14,7 @@ describe PasswordsController do
       @params = { :login => @forgetful_user.login }
 
       # Stub User.find_by_login because of an rspec-related bug using the dynamic finder
-      User.stub(:find_by_login) do |*login|
+      allow(User).to receive(:find_by_login) do |*login|
         User.first(:conditions => { :login => login })
       end
 
@@ -26,7 +26,7 @@ describe PasswordsController do
       post :create_by_login, @params
 
       expect(response).to be_success
-      flash[:error].should_not be_nil
+      expect(flash[:error]).not_to be_nil
     end
 
     it "will fail gracefully for students without security questions" do
@@ -35,31 +35,31 @@ describe PasswordsController do
       post :create_by_login, @params
 
       expect(response).to be_success
-      flash[:error].should_not be_nil
+      expect(flash[:error]).not_to be_nil
     end
 
     it "will send an email reset notification for non-students with email" do
 
-      message = mock("message")
-      message.should_receive(:deliver)
-      PasswordMailer.should_receive(:forgot_password).and_return(message)
+      message = double("message")
+      expect(message).to receive(:deliver)
+      expect(PasswordMailer).to receive(:forgot_password).and_return(message)
 
       post :create_by_login, @params
 
-      @response.should redirect_to(root_path)
-      flash[:error].should be_nil
+      expect(@response).to redirect_to(root_path)
+      expect(flash[:error]).to be_nil
     end
 
     it "will ask security questions for students" do
       @forgetful_user.portal_student = Factory.create(:portal_student)
       Array.new(3) { |i| SecurityQuestion.create({ :question => "test #{i}", :answer => "test" }) }.each { |q| @forgetful_user.security_questions << q }
 
-      PasswordMailer.should_not_receive(:forgot_password)
+      expect(PasswordMailer).not_to receive(:forgot_password)
 
       post :create_by_login, @params
 
-      @response.should redirect_to(password_questions_path(@forgetful_user))
-      flash[:error].should be_nil
+      expect(@response).to redirect_to(password_questions_path(@forgetful_user))
+      expect(flash[:error]).to be_nil
     end
 
     describe "security questions" do
@@ -84,28 +84,28 @@ describe PasswordsController do
         post :questions, @questions_params
 
         @forgetful_user.security_questions.each do |q|
-          @response.body.should include(q.question)
+          expect(@response.body).to include(q.question)
         end
       end
 
       it "will allow the user to reset their password if they answer their questions correctly" do
-        @forgetful_user.security_questions.each { |q| q.answer.should_receive(:downcase).and_return(q.answer.downcase) }
+        @forgetful_user.security_questions.each { |q| expect(q.answer).to receive(:downcase).and_return(q.answer.downcase) }
 
         post :check_questions, @answers_params
 
         password = assigns[:password]
-        password.should_not be_nil
-        @response.should redirect_to(change_password_path(password.reset_code))
+        expect(password).not_to be_nil
+        expect(@response).to redirect_to(change_password_path(password.reset_code))
       end
 
       it "will reject incorrect answers" do
-        @forgetful_user.security_questions.each { |q| q.answer.should_receive(:downcase).and_return(q.answer.downcase) }
+        @forgetful_user.security_questions.each { |q| expect(q.answer).to receive(:downcase).and_return(q.answer.downcase) }
         @answers_params[:security_questions][:question2][:answer] = "wrong"
 
         post :check_questions, @answers_params
 
-        @response.should redirect_to(password_questions_path(@forgetful_user))
-        flash[:error].should_not be_nil
+        expect(@response).to redirect_to(password_questions_path(@forgetful_user))
+        expect(flash[:error]).not_to be_nil
       end
 
       it "will raise an error if the user submits an answer to a question that does not belong to the current user" do
@@ -130,13 +130,13 @@ describe PasswordsController do
     end
 
     it "will send an email reset notification for email addresses" do
-      message = mock("message")
-      message.should_receive(:deliver)
-      PasswordMailer.should_receive(:forgot_password).and_return(message)
+      message = double("message")
+      expect(message).to receive(:deliver)
+      expect(PasswordMailer).to receive(:forgot_password).and_return(message)
 
       post :create_by_email, @params
 
-      flash[:error].should be_nil
+      expect(flash[:error]).to be_nil
     end
 
   end

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -89,8 +89,6 @@ describe PasswordsController do
       end
 
       it "will allow the user to reset their password if they answer their questions correctly" do
-        @forgetful_user.security_questions.each { |q| expect(q.answer).to receive(:downcase).and_return(q.answer.downcase) }
-
         post :check_questions, @answers_params
 
         password = assigns[:password]
@@ -99,7 +97,6 @@ describe PasswordsController do
       end
 
       it "will reject incorrect answers" do
-        @forgetful_user.security_questions.each { |q| expect(q.answer).to receive(:downcase).and_return(q.answer.downcase) }
         @answers_params[:security_questions][:question2][:answer] = "wrong"
 
         post :check_questions, @answers_params

--- a/spec/controllers/portal/clazzes_controller_spec.rb
+++ b/spec/controllers/portal/clazzes_controller_spec.rb
@@ -45,31 +45,31 @@ describe Portal::ClazzesController do
     @mock_course = Factory.create(:portal_course, :name => @mock_clazz_name, :school => @mock_school)
     @mock_clazz = mock_clazz({ :name => @mock_clazz_name, :teachers => [@authorized_teacher, @another_authorized_teacher], :course => @mock_course })
 
-    @controller.stub(:before_render) {
+    allow(@controller).to receive(:before_render) {
       response.template.stub_chain(:current_settings, :name).and_return("Test Settings")
     }
     @mock_settings = mock_model(Admin::Settings, :name => "Test Settings")
-    @mock_settings.stub(:enable_grade_levels?).and_return(true)
-    @mock_settings.stub(:allow_default_class).and_return(false)
-    @mock_settings.stub(:use_student_security_questions).and_return(false)
-    @mock_settings.stub!(:require_user_consent?).and_return(false)
-    @mock_settings.stub!(:default_cohort).and_return(nil)
-    Admin::Settings.stub(:default_settings).and_return(@mock_settings)
+    allow(@mock_settings).to receive(:enable_grade_levels?).and_return(true)
+    allow(@mock_settings).to receive(:allow_default_class).and_return(false)
+    allow(@mock_settings).to receive(:use_student_security_questions).and_return(false)
+    allow(@mock_settings).to receive(:require_user_consent?).and_return(false)
+    allow(@mock_settings).to receive(:default_cohort).and_return(nil)
+    allow(Admin::Settings).to receive(:default_settings).and_return(@mock_settings)
   end
 
   describe "GET show" do
     it "assigns the requested class as @portal_clazz" do
       login_admin
       get :show, :id => @mock_clazz.id
-      assigns[:portal_clazz].should == @mock_clazz
+      expect(assigns[:portal_clazz]).to eq(@mock_clazz)
     end
 
     it "doesn't show class to unauthorized teacheruser" do
       sign_in @unauthorized_teacher_user
       get :show, { :id => @mock_clazz.id }
 
-      response.should_not be_success
-      response.should redirect_to("/recent_activity")
+      expect(response).not_to be_success
+      expect(response).to redirect_to("/recent_activity")
     end
 
     it "saves the position of the left pane submenu item for an authorized teacher" do
@@ -79,7 +79,7 @@ describe Portal::ClazzesController do
 
       # All users should see the full class details summary
       @authorized_teacher.reload
-      @authorized_teacher.left_pane_submenu_item.should == Portal::Teacher.LEFT_PANE_ITEM['NONE']
+      expect(@authorized_teacher.left_pane_submenu_item).to eq(Portal::Teacher.LEFT_PANE_ITEM['NONE'])
     end
 
   end # end describe GET show
@@ -92,7 +92,7 @@ describe Portal::ClazzesController do
 
       xml_http_html_request :post, :edit, :id => @mock_clazz.id
 
-      response.should_not be_success
+      expect(response).not_to be_success
     end
 
     it "should not allow me to modify the requested class's school" do
@@ -262,9 +262,9 @@ describe Portal::ClazzesController do
         delete :remove_teacher, { :id => @mock_clazz.id, :teacher_id => @authorized_teacher.id }
 
         if user == :authorized_teacher_user
-          @response.body.should include(home_url)
+          expect(@response.body).to include(home_url)
         else
-          @response.body.should_not include(home_url)
+          expect(@response.body).not_to include(home_url)
         end
       end
     end
@@ -363,15 +363,15 @@ describe Portal::ClazzesController do
       @new_clazz = Portal::Clazz.find_by_class_word(@post_params[:portal_clazz][:class_word])
 
       assert @new_clazz
-      @new_clazz.school.should == @mock_school
-      @authorized_teacher.clazzes.should include(@new_clazz)
-      @mock_school.clazzes.should include(@new_clazz)
+      expect(@new_clazz.school).to eq(@mock_school)
+      expect(@authorized_teacher.clazzes).to include(@new_clazz)
+      expect(@mock_school.clazzes).to include(@new_clazz)
     end
 
     it "should attach this class to the appropriate course in the specified school, if one exists" do
       course = Factory.create(:portal_course, :name => @post_params[:portal_clazz][:name], :school => @mock_school)
       assert course
-      course.clazzes.size.should == 0
+      expect(course.clazzes.size).to eq(0)
 
       sign_in @authorized_teacher_user
 
@@ -381,10 +381,10 @@ describe Portal::ClazzesController do
 
       @new_clazz = Portal::Clazz.find_by_class_word(@post_params[:portal_clazz][:class_word])
 
-      @new_clazz.course.should == course
-      course.clazzes.size.should == 1
-      course.clazzes.should include(@new_clazz)
-      course.school.clazzes.should include(@new_clazz)
+      expect(@new_clazz.course).to eq(course)
+      expect(course.clazzes.size).to eq(1)
+      expect(course.clazzes).to include(@new_clazz)
+      expect(course.school.clazzes).to include(@new_clazz)
     end
 
     it "should create a new course in the specified school if this class has a unique name" do
@@ -398,7 +398,7 @@ describe Portal::ClazzesController do
       course = Portal::Course.find_by_name(@post_params[:portal_clazz][:name])
 
       assert course
-      @mock_school.courses.should include(course)
+      expect(@mock_school.courses).to include(course)
     end
 
     it "should create exactly one teacher object for the current user if the current user does not already have one" do
@@ -415,7 +415,7 @@ describe Portal::ClazzesController do
       @random_user.reload
 
       expect(@random_user.portal_teacher).not_to be_nil
-      Portal::Teacher.count(:all).should == current_count + 1
+      expect(Portal::Teacher.count(:all)).to eq(current_count + 1)
     end
 
     it "should not let me create a class with no school" do
@@ -428,7 +428,7 @@ describe Portal::ClazzesController do
       post :create, @post_params
 
       assert flash[:error]
-      Portal::Clazz.count(:all).should == current_count
+      expect(Portal::Clazz.count(:all)).to eq(current_count)
     end
 
     it "should assign the specified grade levels to the new class" do
@@ -440,7 +440,7 @@ describe Portal::ClazzesController do
 
       @post_params[:portal_clazz][:grade_levels].each do |name, v|
         grade = Portal::Grade.find_by_name(name.to_s)
-        @new_clazz.grades.should include(grade)
+        expect(@new_clazz.grades).to include(grade)
       end
     end
 
@@ -454,11 +454,11 @@ describe Portal::ClazzesController do
       post :create, @post_params
 
       assert flash[:error]
-      Portal::Clazz.count(:all).should == current_count
+      expect(Portal::Clazz.count(:all)).to eq(current_count)
     end
 
     it "should let me create a class with no grade levels when grade levels are disabled" do
-      @mock_settings.stub(:enable_grade_levels?).and_return(false)
+      allow(@mock_settings).to receive(:enable_grade_levels?).and_return(false)
       @post_params[:portal_clazz].delete(:grade_levels)
 
       sign_in @authorized_teacher_user
@@ -467,7 +467,7 @@ describe Portal::ClazzesController do
 
       post :create, @post_params
 
-      Portal::Clazz.count(:all).should == (current_count + 1)
+      expect(Portal::Clazz.count(:all)).to eq(current_count + 1)
     end
   end
 
@@ -507,14 +507,14 @@ describe Portal::ClazzesController do
     end
 
     it "should let me update a class with no grade levels when grade levels are disabled" do
-      @mock_settings.stub(:enable_grade_levels?).and_return(false)
+      allow(@mock_settings).to receive(:enable_grade_levels?).and_return(false)
       @post_params[:portal_clazz].delete(:grade_levels)
 
       sign_in @authorized_teacher_user
 
       put :update, @post_params
 
-      Portal::Clazz.find(@mock_clazz.id).name.should == 'New Test Class'
+      expect(Portal::Clazz.find(@mock_clazz.id).name).to eq('New Test Class')
     end
   end
 
@@ -720,7 +720,7 @@ describe Portal::ClazzesController do
 
       # All users should see the full class details summary
       @authorized_teacher.reload
-      @authorized_teacher.left_pane_submenu_item.should == Portal::Teacher.LEFT_PANE_ITEM['CLASS_SETUP']
+      expect(@authorized_teacher.left_pane_submenu_item).to eq(Portal::Teacher.LEFT_PANE_ITEM['CLASS_SETUP'])
     end
 
   end
@@ -735,7 +735,7 @@ describe Portal::ClazzesController do
 
       # All users should see the full class details summary
       @authorized_teacher.reload
-      @authorized_teacher.left_pane_submenu_item.should == Portal::Teacher.LEFT_PANE_ITEM['MATERIALS']
+      expect(@authorized_teacher.left_pane_submenu_item).to eq(Portal::Teacher.LEFT_PANE_ITEM['MATERIALS'])
     end
 
   end
@@ -750,7 +750,7 @@ describe Portal::ClazzesController do
 
       # All users should see the full class details summary
       @authorized_teacher.reload
-      @authorized_teacher.left_pane_submenu_item.should == Portal::Teacher.LEFT_PANE_ITEM['STUDENT_ROSTER']
+      expect(@authorized_teacher.left_pane_submenu_item).to eq(Portal::Teacher.LEFT_PANE_ITEM['STUDENT_ROSTER'])
     end
 
   end
@@ -795,13 +795,13 @@ describe Portal::ClazzesController do
     it "should not allow access for anonymous user" do
       sign_out :user
       get :fullstatus, @params
-      response.should_not be_success
+      expect(response).not_to be_success
     end
     it "should retrieve the class when user is not anonymous user" do
       sign_in @authorized_teacher_user
       get :fullstatus, @params
       expect(assigns[:portal_clazz]).to eq(@mock_clazz)
-      response.should be_success
+      expect(response).to be_success
       expect(response).to render_template("fullstatus")
     end
   end
@@ -819,7 +819,7 @@ describe Portal::ClazzesController do
       @mock_settings.allow_default_class = true
       @mock_settings.jnlp_cdn_hostname = ''
       @mock_settings.save!
-      Admin::Settings.stub(:default_settings).and_return(@mock_settings)
+      allow(Admin::Settings).to receive(:default_settings).and_return(@mock_settings)
 
       sign_in @authorized_teacher_user
 
@@ -827,7 +827,7 @@ describe Portal::ClazzesController do
         :id => @mock_clazz.id
       }
       xhr :post, :add_new_student_popup, @params
-      response.should be_success
+      expect(response).to be_success
       expect(response).to render_template(:partial => "portal/students/_form")
     end
   end

--- a/spec/controllers/portal/districts_controller_spec.rb
+++ b/spec/controllers/portal/districts_controller_spec.rb
@@ -23,33 +23,33 @@ describe Portal::DistrictsController do
 
   describe "GET index" do
     it "assigns all portal_districts as @portal_districts" do
-      Portal::District.stub!(:search).and_return([@district])
+      allow(Portal::District).to receive(:search).and_return([@district])
       get :index
-      assigns[:portal_districts].should include @district
+      expect(assigns[:portal_districts]).to include @district
     end
   end
 
   describe "GET show" do
     it "assigns the requested district as @portal_district" do
-      Portal::District.stub!(:find).with("37").and_return(@district)
+      allow(Portal::District).to receive(:find).with("37").and_return(@district)
       get :show, :id => "37"
-      assigns[:portal_district].should equal(@district)
+      expect(assigns[:portal_district]).to equal(@district)
     end
   end
   
   describe "GET new" do
     it "assigns a new district as @portal_district" do
-      Portal::District.stub!(:new).and_return(@district)
+      allow(Portal::District).to receive(:new).and_return(@district)
       get :new
-      assigns[:portal_district].should equal(@district)
+      expect(assigns[:portal_district]).to equal(@district)
     end
   end
   
   describe "GET edit" do
     it "assigns the requested district as @portal_district" do
-      Portal::District.stub!(:find).with("37").and_return(@district)
+      allow(Portal::District).to receive(:find).with("37").and_return(@district)
       get :edit, :id => "37"
-      assigns[:portal_district].should equal(@district)
+      expect(assigns[:portal_district]).to equal(@district)
     end
   end
   
@@ -58,32 +58,32 @@ describe Portal::DistrictsController do
     describe "with valid params" do
       it "assigns a newly created district as @portal_district" do
         @district.stub(:save => true)
-        Portal::District.stub!(:new).with({'these' => 'params'}).and_return(@district)
+        allow(Portal::District).to receive(:new).with({'these' => 'params'}).and_return(@district)
         post :create, :portal_district => {:these => 'params'}
-        assigns[:portal_district].should equal(@district)
+        expect(assigns[:portal_district]).to equal(@district)
       end
   
       it "redirects to the created district" do
         @district.stub(:id => 37, :save => true )
-        Portal::District.stub!(:new).and_return(@district)
+        allow(Portal::District).to receive(:new).and_return(@district)
         post :create, :portal_district => {}
-        response.should redirect_to(portal_district_url(@district))
+        expect(response).to redirect_to(portal_district_url(@district))
       end
     end
   
     describe "with invalid params" do
       it "assigns a newly created but unsaved district as @portal_district" do
-        @district.stub!(:save => false)
-        Portal::District.stub!(:new).with({'these' => 'params'}).and_return(@district)
+        @district.stub(:save => false)
+        allow(Portal::District).to receive(:new).with({'these' => 'params'}).and_return(@district)
         post :create, :portal_district => {:these => 'params'}
-        assigns[:portal_district].should equal(@district)
+        expect(assigns[:portal_district]).to equal(@district)
       end
   
       it "re-renders the 'new' template" do
-        @district.stub!(:save => false)
-        Portal::District.stub!(:new).and_return(@district)
+        @district.stub(:save => false)
+        allow(Portal::District).to receive(:new).and_return(@district)
         post :create, :portal_district => {}
-        response.should render_template('new')
+        expect(response).to render_template('new')
       end
    end
   
@@ -93,45 +93,45 @@ describe Portal::DistrictsController do
   
     describe "with valid params" do
       it "updates the requested district" do
-        Portal::District.should_receive(:find).with("37").and_return(@district)
-        @mock_district.should_receive(:update_attributes).with({'portal_district' => 'params'}).and_return(true)
+        expect(Portal::District).to receive(:find).with("37").and_return(@district)
+        expect(@mock_district).to receive(:update_attributes).with({'portal_district' => 'params'}).and_return(true)
         put :update, :id => "37", :portal_district => {:portal_district => 'params'}
       end
   
       it "assigns the requested district as @portal_district" do
-        @district.stub!(:update_attributes => true)
-        Portal::District.stub!(:find).and_return(@district)
+        @district.stub(:update_attributes => true)
+        allow(Portal::District).to receive(:find).and_return(@district)
         put :update, :id => "1"
-        assigns[:portal_district].should equal(@district)
+        expect(assigns[:portal_district]).to equal(@district)
       end
   
       it "redirects to the district" do
-        @district.stub!(:update_attributes => true)
-        Portal::District.stub!(:find).and_return(@district)
+        @district.stub(:update_attributes => true)
+        allow(Portal::District).to receive(:find).and_return(@district)
         put :update, :id => "1"
-        response.should redirect_to(portal_district_url(@district))
+        expect(response).to redirect_to(portal_district_url(@district))
       end
     end
   
     describe "with invalid params" do
       it "updates the requested district" do
-        Portal::District.should_receive(:find).with("37").and_return(@district)
-        @district.should_receive(:update_attributes).with({'portal_district' => 'params'}).and_return(false)
+        expect(Portal::District).to receive(:find).with("37").and_return(@district)
+        expect(@district).to receive(:update_attributes).with({'portal_district' => 'params'}).and_return(false)
         put :update, :id => "37", :portal_district => {:portal_district => 'params'}
       end
   
       it "assigns the district as @portal_district" do
-        @district.stub!(:update_attributes => false)
-        Portal::District.stub!(:find).and_return(@district)
+        @district.stub(:update_attributes => false)
+        allow(Portal::District).to receive(:find).and_return(@district)
         put :update, :id => "1"
-        assigns[:portal_district].should equal(@district)
+        expect(assigns[:portal_district]).to equal(@district)
       end
   
       it "re-renders the 'edit' template" do
-        @district.stub!(:update_attributes => false)
-        Portal::District.stub!(:find).and_return(@district)
+        @district.stub(:update_attributes => false)
+        allow(Portal::District).to receive(:find).and_return(@district)
         put :update, :id => "1"
-        response.should render_template('edit')
+        expect(response).to render_template('edit')
       end
     end
  
@@ -139,16 +139,16 @@ describe Portal::DistrictsController do
   
   describe "DELETE destroy" do
     it "destroys the requested district" do
-      @district.should_receive(:destroy).and_return(true)
-      Portal::District.should_receive(:find).with("37").and_return(@district)
+      expect(@district).to receive(:destroy).and_return(true)
+      expect(Portal::District).to receive(:find).with("37").and_return(@district)
       delete :destroy, :id => "37"
     end
   
     it "redirects to the portal_districts list" do
-      @district.should_receive(:destroy).and_return(true)
-      Portal::District.stub!(:find).and_return(@district)
+      expect(@district).to receive(:destroy).and_return(true)
+      allow(Portal::District).to receive(:find).and_return(@district)
       delete :destroy, :id => "1"
-      response.should redirect_to(portal_districts_url)
+      expect(response).to redirect_to(portal_districts_url)
     end
   end
 

--- a/spec/controllers/portal/grade_levels_controller_spec.rb
+++ b/spec/controllers/portal/grade_levels_controller_spec.rb
@@ -4,7 +4,7 @@ describe Portal::GradeLevelsController do
 
   def mock_grade_level(stubs={})
     # @mock_grade_level ||= mock_model(Portal::GradeLevel, stubs)
-    @mock_grade_level.stub!(stubs) unless stubs.empty?
+    allow(@mock_grade_level).to receive(stubs) unless stubs.empty?
     @mock_grade_level
   end
 
@@ -16,33 +16,33 @@ describe Portal::GradeLevelsController do
 
   describe "GET index" do
     it "assigns all portal_grade_levels as @portal_grade_levels" do
-      Portal::GradeLevel.stub!(:all).and_return([mock_grade_level])
+      allow(Portal::GradeLevel).to receive(:all).and_return([mock_grade_level])
       get :index
-      assigns[:portal_grade_levels].should == [mock_grade_level]
+      expect(assigns[:portal_grade_levels]).to eq([mock_grade_level])
     end
   end
 
   describe "GET show" do
     it "assigns the requested grade_level as @portal_grade_level" do
-      Portal::GradeLevel.stub!(:find).with("37").and_return(mock_grade_level)
+      allow(Portal::GradeLevel).to receive(:find).with("37").and_return(mock_grade_level)
       get :show, :id => "37"
-      assigns[:portal_grade_level].should equal(mock_grade_level)
+      expect(assigns[:portal_grade_level]).to equal(mock_grade_level)
     end
   end
   
   describe "GET new" do
     it "assigns a new grade_level as @portal_grade_level" do
-      Portal::GradeLevel.stub!(:new).and_return(mock_grade_level)
+      allow(Portal::GradeLevel).to receive(:new).and_return(mock_grade_level)
       get :new
-      assigns[:portal_grade_level].should equal(mock_grade_level)
+      expect(assigns[:portal_grade_level]).to equal(mock_grade_level)
     end
   end
   
   describe "GET edit" do
     it "assigns the requested grade_level as @portal_grade_level" do
-      Portal::GradeLevel.stub!(:find).with("37").and_return(mock_grade_level)
+      allow(Portal::GradeLevel).to receive(:find).with("37").and_return(mock_grade_level)
       get :edit, :id => "37"
-      assigns[:portal_grade_level].should equal(mock_grade_level)
+      expect(assigns[:portal_grade_level]).to equal(mock_grade_level)
     end
   end
   
@@ -50,29 +50,29 @@ describe Portal::GradeLevelsController do
   
     describe "with valid params" do
       it "assigns a newly created grade_level as @portal_grade_level" do
-        Portal::GradeLevel.stub!(:new).with({'these' => 'params'}).and_return(mock_grade_level(:save => true))
+        allow(Portal::GradeLevel).to receive(:new).with({'these' => 'params'}).and_return(mock_grade_level(:save => true))
         post :create, :portal_grade_level => {:these => 'params'}
-        assigns[:portal_grade_level].should equal(mock_grade_level)
+        expect(assigns[:portal_grade_level]).to equal(mock_grade_level)
       end
   
       it "redirects to the created grade_level" do
-        Portal::GradeLevel.stub!(:new).and_return(mock_grade_level(:save => true))
+        allow(Portal::GradeLevel).to receive(:new).and_return(mock_grade_level(:save => true))
         post :create, :portal_grade_level => {}
-        response.should redirect_to(portal_grade_level_url(mock_grade_level))
+        expect(response).to redirect_to(portal_grade_level_url(mock_grade_level))
       end
     end
   
     describe "with invalid params" do
       it "assigns a newly created but unsaved grade_level as @portal_grade_level" do
-        Portal::GradeLevel.stub!(:new).with({'these' => 'params'}).and_return(mock_grade_level(:save => false))
+        allow(Portal::GradeLevel).to receive(:new).with({'these' => 'params'}).and_return(mock_grade_level(:save => false))
         post :create, :portal_grade_level => {:these => 'params'}
-        assigns[:portal_grade_level].should equal(mock_grade_level)
+        expect(assigns[:portal_grade_level]).to equal(mock_grade_level)
       end
   
       it "re-renders the 'new' template" do
-        Portal::GradeLevel.stub!(:new).and_return(mock_grade_level(:save => false))
+        allow(Portal::GradeLevel).to receive(:new).and_return(mock_grade_level(:save => false))
         post :create, :portal_grade_level => {}
-        response.should render_template('new')
+        expect(response).to render_template('new')
       end
     end
   
@@ -82,41 +82,41 @@ describe Portal::GradeLevelsController do
   
     describe "with valid params" do
       it "updates the requested grade_level" do
-        Portal::GradeLevel.should_receive(:find).with("37").and_return(mock_grade_level)
-        mock_grade_level.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(Portal::GradeLevel).to receive(:find).with("37").and_return(mock_grade_level)
+        expect(mock_grade_level).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :portal_grade_level => {:these => 'params'}
       end
   
       it "assigns the requested grade_level as @portal_grade_level" do
-        Portal::GradeLevel.stub!(:find).and_return(mock_grade_level(:update_attributes => true))
+        allow(Portal::GradeLevel).to receive(:find).and_return(mock_grade_level(:update_attributes => true))
         put :update, :id => "1"
-        assigns[:portal_grade_level].should equal(mock_grade_level)
+        expect(assigns[:portal_grade_level]).to equal(mock_grade_level)
       end
   
       it "redirects to the grade_level" do
-        Portal::GradeLevel.stub!(:find).and_return(mock_grade_level(:update_attributes => true))
+        allow(Portal::GradeLevel).to receive(:find).and_return(mock_grade_level(:update_attributes => true))
         put :update, :id => "1"
-        response.should redirect_to(portal_grade_level_url(mock_grade_level))
+        expect(response).to redirect_to(portal_grade_level_url(mock_grade_level))
       end
     end
   
     describe "with invalid params" do
       it "updates the requested grade_level" do
-        Portal::GradeLevel.should_receive(:find).with("37").and_return(mock_grade_level)
-        mock_grade_level.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(Portal::GradeLevel).to receive(:find).with("37").and_return(mock_grade_level)
+        expect(mock_grade_level).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :portal_grade_level => {:these => 'params'}
       end
   
       it "assigns the grade_level as @portal_grade_level" do
-        Portal::GradeLevel.stub!(:find).and_return(mock_grade_level(:update_attributes => false))
+        allow(Portal::GradeLevel).to receive(:find).and_return(mock_grade_level(:update_attributes => false))
         put :update, :id => "1"
-        assigns[:portal_grade_level].should equal(mock_grade_level)
+        expect(assigns[:portal_grade_level]).to equal(mock_grade_level)
       end
   
       it "re-renders the 'edit' template" do
-        Portal::GradeLevel.stub!(:find).and_return(mock_grade_level(:update_attributes => false))
+        allow(Portal::GradeLevel).to receive(:find).and_return(mock_grade_level(:update_attributes => false))
         put :update, :id => "1"
-        response.should render_template('edit')
+        expect(response).to render_template('edit')
       end
     end
   
@@ -124,15 +124,15 @@ describe Portal::GradeLevelsController do
   
   describe "DELETE destroy" do
     it "destroys the requested grade_level" do
-      Portal::GradeLevel.should_receive(:find).with("37").and_return(mock_grade_level)
-      mock_grade_level.should_receive(:destroy)
+      expect(Portal::GradeLevel).to receive(:find).with("37").and_return(mock_grade_level)
+      expect(mock_grade_level).to receive(:destroy)
       delete :destroy, :id => "37"
     end
   
     it "redirects to the portal_grade_levels list" do
-      Portal::GradeLevel.stub!(:find).and_return(mock_grade_level(:destroy => true))
+      allow(Portal::GradeLevel).to receive(:find).and_return(mock_grade_level(:destroy => true))
       delete :destroy, :id => "1"
-      response.should redirect_to(portal_grade_levels_url)
+      expect(response).to redirect_to(portal_grade_levels_url)
     end
   end
 

--- a/spec/controllers/portal/grade_levels_controller_spec.rb
+++ b/spec/controllers/portal/grade_levels_controller_spec.rb
@@ -3,8 +3,9 @@ require File.expand_path('../../../spec_helper', __FILE__)
 describe Portal::GradeLevelsController do
 
   def mock_grade_level(stubs={})
-    # @mock_grade_level ||= mock_model(Portal::GradeLevel, stubs)
-    allow(@mock_grade_level).to receive(stubs) unless stubs.empty?
+    stubs.each do |key, value|
+      allow(@mock_grade_level).to receive(key).and_return(value)
+    end
     @mock_grade_level
   end
 
@@ -29,7 +30,7 @@ describe Portal::GradeLevelsController do
       expect(assigns[:portal_grade_level]).to equal(mock_grade_level)
     end
   end
-  
+
   describe "GET new" do
     it "assigns a new grade_level as @portal_grade_level" do
       allow(Portal::GradeLevel).to receive(:new).and_return(mock_grade_level)
@@ -37,7 +38,7 @@ describe Portal::GradeLevelsController do
       expect(assigns[:portal_grade_level]).to equal(mock_grade_level)
     end
   end
-  
+
   describe "GET edit" do
     it "assigns the requested grade_level as @portal_grade_level" do
       allow(Portal::GradeLevel).to receive(:find).with("37").and_return(mock_grade_level)
@@ -45,90 +46,90 @@ describe Portal::GradeLevelsController do
       expect(assigns[:portal_grade_level]).to equal(mock_grade_level)
     end
   end
-  
+
   describe "POST create" do
-  
+
     describe "with valid params" do
       it "assigns a newly created grade_level as @portal_grade_level" do
         allow(Portal::GradeLevel).to receive(:new).with({'these' => 'params'}).and_return(mock_grade_level(:save => true))
         post :create, :portal_grade_level => {:these => 'params'}
         expect(assigns[:portal_grade_level]).to equal(mock_grade_level)
       end
-  
+
       it "redirects to the created grade_level" do
         allow(Portal::GradeLevel).to receive(:new).and_return(mock_grade_level(:save => true))
         post :create, :portal_grade_level => {}
         expect(response).to redirect_to(portal_grade_level_url(mock_grade_level))
       end
     end
-  
+
     describe "with invalid params" do
       it "assigns a newly created but unsaved grade_level as @portal_grade_level" do
         allow(Portal::GradeLevel).to receive(:new).with({'these' => 'params'}).and_return(mock_grade_level(:save => false))
         post :create, :portal_grade_level => {:these => 'params'}
         expect(assigns[:portal_grade_level]).to equal(mock_grade_level)
       end
-  
+
       it "re-renders the 'new' template" do
         allow(Portal::GradeLevel).to receive(:new).and_return(mock_grade_level(:save => false))
         post :create, :portal_grade_level => {}
         expect(response).to render_template('new')
       end
     end
-  
+
   end
-  
+
   describe "PUT update" do
-  
+
     describe "with valid params" do
       it "updates the requested grade_level" do
         expect(Portal::GradeLevel).to receive(:find).with("37").and_return(mock_grade_level)
         expect(mock_grade_level).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :portal_grade_level => {:these => 'params'}
       end
-  
+
       it "assigns the requested grade_level as @portal_grade_level" do
         allow(Portal::GradeLevel).to receive(:find).and_return(mock_grade_level(:update_attributes => true))
         put :update, :id => "1"
         expect(assigns[:portal_grade_level]).to equal(mock_grade_level)
       end
-  
+
       it "redirects to the grade_level" do
         allow(Portal::GradeLevel).to receive(:find).and_return(mock_grade_level(:update_attributes => true))
         put :update, :id => "1"
         expect(response).to redirect_to(portal_grade_level_url(mock_grade_level))
       end
     end
-  
+
     describe "with invalid params" do
       it "updates the requested grade_level" do
         expect(Portal::GradeLevel).to receive(:find).with("37").and_return(mock_grade_level)
         expect(mock_grade_level).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :portal_grade_level => {:these => 'params'}
       end
-  
+
       it "assigns the grade_level as @portal_grade_level" do
         allow(Portal::GradeLevel).to receive(:find).and_return(mock_grade_level(:update_attributes => false))
         put :update, :id => "1"
         expect(assigns[:portal_grade_level]).to equal(mock_grade_level)
       end
-  
+
       it "re-renders the 'edit' template" do
         allow(Portal::GradeLevel).to receive(:find).and_return(mock_grade_level(:update_attributes => false))
         put :update, :id => "1"
         expect(response).to render_template('edit')
       end
     end
-  
+
   end
-  
+
   describe "DELETE destroy" do
     it "destroys the requested grade_level" do
       expect(Portal::GradeLevel).to receive(:find).with("37").and_return(mock_grade_level)
       expect(mock_grade_level).to receive(:destroy)
       delete :destroy, :id => "37"
     end
-  
+
     it "redirects to the portal_grade_levels list" do
       allow(Portal::GradeLevel).to receive(:find).and_return(mock_grade_level(:destroy => true))
       delete :destroy, :id => "1"

--- a/spec/controllers/portal/grades_controller_spec.rb
+++ b/spec/controllers/portal/grades_controller_spec.rb
@@ -4,7 +4,7 @@ describe Portal::GradesController do
 
   def mock_grade(stubs={})
     # @mock_grade ||= mock_model(Portal::Grade, stubs)
-    @mock_grade.stub!(stubs) unless stubs.empty?
+    allow(@mock_grade).to receive(stubs) unless stubs.empty?
     @mock_grade
   end
 
@@ -16,33 +16,33 @@ describe Portal::GradesController do
 
   describe "GET index" do
     it "assigns all portal_grades as @portal_grades" do
-      Portal::Grade.stub!(:all).and_return([mock_grade])
+      allow(Portal::Grade).to receive(:all).and_return([mock_grade])
       get :index
-      assigns[:portal_grades].should == [mock_grade]
+      expect(assigns[:portal_grades]).to eq([mock_grade])
     end
   end
 
   describe "GET show" do
     it "assigns the requested grade as @portal_grade" do
-      Portal::Grade.stub!(:find).with("37").and_return(mock_grade)
+      allow(Portal::Grade).to receive(:find).with("37").and_return(mock_grade)
       get :show, :id => "37"
-      assigns[:portal_grade].should equal(mock_grade)
+      expect(assigns[:portal_grade]).to equal(mock_grade)
     end
   end
 
   describe "GET new" do
     it "assigns a new grade as @portal_grade" do
-      Portal::Grade.stub!(:new).and_return(mock_grade)
+      allow(Portal::Grade).to receive(:new).and_return(mock_grade)
       get :new
-      assigns[:portal_grade].should equal(mock_grade)
+      expect(assigns[:portal_grade]).to equal(mock_grade)
     end
   end
 
   describe "GET edit" do
     it "assigns the requested grade as @portal_grade" do
-      Portal::Grade.stub!(:find).with("37").and_return(mock_grade)
+      allow(Portal::Grade).to receive(:find).with("37").and_return(mock_grade)
       get :edit, :id => "37"
-      assigns[:portal_grade].should equal(mock_grade)
+      expect(assigns[:portal_grade]).to equal(mock_grade)
     end
   end
 
@@ -50,29 +50,29 @@ describe Portal::GradesController do
 
     describe "with valid params" do
       it "assigns a newly created grade as @portal_grade" do
-          Portal::Grade.stub!(:new).with({'these' => 'params'}).and_return(mock_grade(:save => true))
+          allow(Portal::Grade).to receive(:new).with({'these' => 'params'}).and_return(mock_grade(:save => true))
         post :create, :portal_grade => {:these => 'params'}
-        assigns[:portal_grade].should equal(mock_grade)
+        expect(assigns[:portal_grade]).to equal(mock_grade)
       end
 
       it "redirects to the created grade" do
-          Portal::Grade.stub!(:new).and_return(mock_grade(:save => true))
+          allow(Portal::Grade).to receive(:new).and_return(mock_grade(:save => true))
         post :create, :portal_grade => {}
-        response.should redirect_to(portal_grade_url(mock_grade))
+        expect(response).to redirect_to(portal_grade_url(mock_grade))
       end
     end
 
     describe "with invalid params" do
       it "assigns a newly created but unsaved grade as @portal_grade" do
-          Portal::Grade.stub!(:new).with({'these' => 'params'}).and_return(mock_grade(:save => false))
+          allow(Portal::Grade).to receive(:new).with({'these' => 'params'}).and_return(mock_grade(:save => false))
         post :create, :portal_grade => {:these => 'params'}
-        assigns[:portal_grade].should equal(mock_grade)
+        expect(assigns[:portal_grade]).to equal(mock_grade)
       end
 
       it "re-renders the 'new' template" do
-          Portal::Grade.stub!(:new).and_return(mock_grade(:save => false))
+          allow(Portal::Grade).to receive(:new).and_return(mock_grade(:save => false))
         post :create, :portal_grade => {}
-        response.should render_template('new')
+        expect(response).to render_template('new')
       end
     end
 
@@ -82,41 +82,41 @@ describe Portal::GradesController do
 
     describe "with valid params" do
       it "updates the requested grade" do
-          Portal::Grade.should_receive(:find).with("37").and_return(mock_grade)
-        mock_grade.should_receive(:update_attributes).with({'these' => 'params'})
+          expect(Portal::Grade).to receive(:find).with("37").and_return(mock_grade)
+        expect(mock_grade).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :portal_grade => {:these => 'params'}
       end
 
       it "assigns the requested grade as @portal_grade" do
-          Portal::Grade.stub!(:find).and_return(mock_grade(:update_attributes => true))
+          allow(Portal::Grade).to receive(:find).and_return(mock_grade(:update_attributes => true))
         put :update, :id => "1"
-        assigns[:portal_grade].should equal(mock_grade)
+        expect(assigns[:portal_grade]).to equal(mock_grade)
       end
 
       it "redirects to the grade" do
-          Portal::Grade.stub!(:find).and_return(mock_grade(:update_attributes => true))
+          allow(Portal::Grade).to receive(:find).and_return(mock_grade(:update_attributes => true))
         put :update, :id => "1"
-        response.should redirect_to(portal_grade_url(mock_grade))
+        expect(response).to redirect_to(portal_grade_url(mock_grade))
       end
     end
 
     describe "with invalid params" do
       it "updates the requested grade" do
-          Portal::Grade.should_receive(:find).with("37").and_return(mock_grade)
-        mock_grade.should_receive(:update_attributes).with({'these' => 'params'})
+          expect(Portal::Grade).to receive(:find).with("37").and_return(mock_grade)
+        expect(mock_grade).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :portal_grade => {:these => 'params'}
       end
 
       it "assigns the grade as @portal_grade" do
-          Portal::Grade.stub!(:find).and_return(mock_grade(:update_attributes => false))
+          allow(Portal::Grade).to receive(:find).and_return(mock_grade(:update_attributes => false))
         put :update, :id => "1"
-        assigns[:portal_grade].should equal(mock_grade)
+        expect(assigns[:portal_grade]).to equal(mock_grade)
       end
 
       it "re-renders the 'edit' template" do
-          Portal::Grade.stub!(:find).and_return(mock_grade(:update_attributes => false))
+          allow(Portal::Grade).to receive(:find).and_return(mock_grade(:update_attributes => false))
         put :update, :id => "1"
-        response.should render_template('edit')
+        expect(response).to render_template('edit')
       end
     end
 
@@ -124,15 +124,15 @@ describe Portal::GradesController do
 
   describe "DELETE destroy" do
     it "destroys the requested grade" do
-      Portal::Grade.should_receive(:find).with("37").and_return(mock_grade)
-      mock_grade.should_receive(:destroy)
+      expect(Portal::Grade).to receive(:find).with("37").and_return(mock_grade)
+      expect(mock_grade).to receive(:destroy)
       delete :destroy, :id => "37"
     end
 
     it "redirects to the portal_grades list" do
-      Portal::Grade.stub!(:find).and_return(mock_grade(:destroy => true))
+      allow(Portal::Grade).to receive(:find).and_return(mock_grade(:destroy => true))
       delete :destroy, :id => "1"
-      response.should redirect_to(portal_grades_url)
+      expect(response).to redirect_to(portal_grades_url)
     end
   end
 

--- a/spec/controllers/portal/grades_controller_spec.rb
+++ b/spec/controllers/portal/grades_controller_spec.rb
@@ -3,8 +3,9 @@ require File.expand_path('../../../spec_helper', __FILE__)
 describe Portal::GradesController do
 
   def mock_grade(stubs={})
-    # @mock_grade ||= mock_model(Portal::Grade, stubs)
-    allow(@mock_grade).to receive(stubs) unless stubs.empty?
+    stubs.each do |key, value|
+      allow(@mock_grade).to receive(key).and_return(value)
+    end
     @mock_grade
   end
 

--- a/spec/controllers/portal/learners_controller_spec.rb
+++ b/spec/controllers/portal/learners_controller_spec.rb
@@ -28,7 +28,7 @@ describe Portal::LearnersController do
 
     before(:each) do
       sign_in user
-      Portal::Learner.stub(:find).and_return(learner)
+      allow(Portal::Learner).to receive(:find).and_return(learner)
     end
 
     describe "When the teacher of the class requests the report" do
@@ -36,22 +36,22 @@ describe Portal::LearnersController do
       let(:report_url)     { "https://concord-consortium.github.io/portal-report/" }
       let(:report_domains) { "concord-consortium.github.io" }
       before(:each) do
-        ENV.stub(:[]).and_return('')
-        ENV.stub(:[]).with("REPORT_VIEW_URL").and_return(report_url)
-        ENV.stub(:[]).with("REPORT_DOMAINS").and_return(report_domains)
+        allow(ENV).to receive(:[]).and_return('')
+        allow(ENV).to receive(:[]).with("REPORT_VIEW_URL").and_return(report_url)
+        allow(ENV).to receive(:[]).with("REPORT_DOMAINS").and_return(report_domains)
       end
 
       it "should redirect to the external reporting service as configured by the environment" do
         get :report, post_params
-        response.location.should =~ /#{report_url}/
+        expect(response.location).to match(/#{report_url}/)
       end
       it "should include an authentication token parameter" do
         get :report, post_params
-        response.location.should =~ /token=([0-9]|[a-f]){32}/
+        expect(response.location).to match(/token=([0-9]|[a-f]){32}/)
       end
       it "should include the student_ids parameter" do
         get :report, post_params
-        response.location.should =~ /student_ids/
+        expect(response.location).to match(/student_ids/)
       end
     end
 
@@ -59,7 +59,7 @@ describe Portal::LearnersController do
       let(:user) { teacher_b.user }
       it "should redirect the user to /recent_activity" do
         get :report, post_params
-        response.should redirect_to :recent_activity
+        expect(response).to redirect_to :recent_activity
       end
     end
   end

--- a/spec/controllers/portal/offerings_controller_spec.rb
+++ b/spec/controllers/portal/offerings_controller_spec.rb
@@ -7,7 +7,7 @@ describe Portal::OfferingsController do
       admin = Factory.next :admin_user
       sign_in admin
       get :show, :id => offering.id, :format => :jnlp
-      response.should render_template('shared/_installer')
+      expect(response).to render_template('shared/_installer')
     end
 
     it "renders a jnlp for a teacher" do
@@ -15,14 +15,14 @@ describe Portal::OfferingsController do
       offering = Factory(:portal_offering, :clazz => teacher.clazzes.first)
       sign_in teacher.user
       get :show, :id => offering.id, :format => :jnlp
-      response.should render_template('shared/_installer')
+      expect(response).to render_template('shared/_installer')
     end
 
     it "renders a jnlp as a learner" do
       learner = Factory(:full_portal_learner)
       sign_in learner.student.user
       get :show, :id => learner.offering.id, :format => :jnlp
-      response.should render_template('shared/_installer')
+      expect(response).to render_template('shared/_installer')
     end
   end
 
@@ -30,7 +30,7 @@ describe Portal::OfferingsController do
     before(:each) do
       generate_default_settings_and_jnlps_with_mocks
       generate_portal_resources_with_mocks
-      Admin::Settings.stub!(:default_settings).and_return(@mock_settings)
+      allow(Admin::Settings).to receive(:default_settings).and_return(@mock_settings)
 
       # this seems like it would all be better with some factories for clazz, runnable, offering, and learner
       @clazz = mock_model(Portal::Clazz, :is_student? => true, :is_teacher? => false)
@@ -44,8 +44,8 @@ describe Portal::OfferingsController do
       @user = Factory(:confirmed_user, :email => "test@test.com", :password => "password", :password_confirmation => "password")
       @portal_student = mock_model(Portal::Student)
       @learner = mock_model(Portal::Learner, :id => 34, :offering => @offering, :student => @portal_student)
-      controller.stub!(:setup_portal_student).and_return(@learner)
-      Portal::Offering.stub!(:find).and_return(@offering)
+      allow(controller).to receive(:setup_portal_student).and_return(@learner)
+      allow(Portal::Offering).to receive(:find).and_return(@offering)
       sign_in @user
     end
 
@@ -53,20 +53,20 @@ describe Portal::OfferingsController do
       @runnable.append_learner_id_to_url = false
 
       get :show, :id => @offering.id, :format => 'run_resource_html'
-      response.cookies["save_path"].should == @offering.runnable.save_path
-      response.cookies["learner_id"].should == @learner.id.to_s
-      response.cookies["student_name"].should == "#{@user.first_name} #{@user.last_name}"
-      response.cookies["activity_name"].should == @offering.runnable.name
-      response.cookies["class_id"].should == @clazz.id.to_s
+      expect(response.cookies["save_path"]).to eq(@offering.runnable.save_path)
+      expect(response.cookies["learner_id"]).to eq(@learner.id.to_s)
+      expect(response.cookies["student_name"]).to eq("#{@user.first_name} #{@user.last_name}")
+      expect(response.cookies["activity_name"]).to eq(@offering.runnable.name)
+      expect(response.cookies["class_id"]).to eq(@clazz.id.to_s)
 
-      response.should redirect_to(@runnable_opts[:url])
+      expect(response).to redirect_to(@runnable_opts[:url])
     end
 
     it "appends the learner id to the url" do
       @runnable.append_learner_id_to_url = true
       # @runnable.stub!(:append_learner_id_to_url).and_return(true)
       get :show, :id => @offering.id, :format => 'run_resource_html'
-      response.should redirect_to(@runnable_opts[:url] + "?learner=#{@learner.id}")
+      expect(response).to redirect_to(@runnable_opts[:url] + "?learner=#{@learner.id}")
     end
   end
 
@@ -91,27 +91,27 @@ describe Portal::OfferingsController do
     it "should render nothing and return for users other than teacher" do
       login_admin
       xhr :post, :offering_collapsed_status, @params
-      response.body.should be_blank
+      expect(response.body).to be_blank
 
       sign_in @manager_user
       xhr :post, :offering_collapsed_status, @params
-      response.body.should be_blank
+      expect(response.body).to be_blank
 
       sign_in @researcher_user
       xhr :post, :offering_collapsed_status, @params
-      response.body.should be_blank
+      expect(response.body).to be_blank
 
       sign_in @author_user
       xhr :post, :offering_collapsed_status, @params
-      response.body.should be_blank
+      expect(response.body).to be_blank
 
       sign_in @guest_user
       xhr :post, :offering_collapsed_status, @params
-      response.body.should be_blank
+      expect(response.body).to be_blank
 
       sign_in @student_user
       xhr :post, :offering_collapsed_status, @params
-      response.body.should be_blank
+      expect(response.body).to be_blank
     end
     it "should maintain the offering collapse expand status when user is a teacher" do
       sign_in @authorized_teacher_user
@@ -124,14 +124,14 @@ describe Portal::OfferingsController do
       portal_teacher_full_status = Portal::TeacherFullStatus.find_by_offering_id_and_teacher_id(@params[:id], @authorized_teacher.id)
       expect(portal_teacher_full_status).not_to be_nil
       expect(portal_teacher_full_status.offering_collapsed).to eq(false)
-      response.body.should be_blank
+      expect(response.body).to be_blank
 
       #when teacher has collapsed and expanded many times before
       xhr :post, :offering_collapsed_status, @params
       portal_teacher_full_status.reload
       expect(portal_teacher_full_status).not_to be_nil
       expect(portal_teacher_full_status.offering_collapsed).to eq(true)
-      response.body.should be_blank
+      expect(response.body).to be_blank
     end
   end
 
@@ -162,18 +162,18 @@ describe Portal::OfferingsController do
       let(:report_url)     { "https://concord-consortium.github.io/portal-report/" }
       let(:report_domains) { "concord-consortium.github.io" }
       before(:each) do
-        ENV.stub(:[]).and_return('')
-        ENV.stub(:[]).with("REPORT_VIEW_URL").and_return(report_url)
-        ENV.stub(:[]).with("REPORT_DOMAINS").and_return(report_domains)
+        allow(ENV).to receive(:[]).and_return('')
+        allow(ENV).to receive(:[]).with("REPORT_VIEW_URL").and_return(report_url)
+        allow(ENV).to receive(:[]).with("REPORT_DOMAINS").and_return(report_domains)
       end
 
       it "should redirect to the external reporting service as configured by the environment" do
         get :report, post_params
-        response.location.should =~ /#{report_url}/
+        expect(response.location).to match(/#{report_url}/)
       end
       it "should include an authentication token parameter" do
         get :report, post_params
-        response.location.should =~ /token=([0-9]|[a-f]){32}/
+        expect(response.location).to match(/token=([0-9]|[a-f]){32}/)
       end
     end
 
@@ -181,7 +181,7 @@ describe Portal::OfferingsController do
       let(:user) { teacher_b.user }
       it "should redirect the user to /recent_activity" do
         get :report, post_params
-        response.should redirect_to :recent_activity
+        expect(response).to redirect_to :recent_activity
       end
     end
   end

--- a/spec/controllers/portal/offerings_metal_controller.rb
+++ b/spec/controllers/portal/offerings_metal_controller.rb
@@ -5,7 +5,7 @@ describe Portal::OfferingsMetalController do
     it "should return 'Not Found' without a user" do
       offering = Factory(:portal_offering)
       get :launch_status, :id => offering.id
-      response.body.should == "Not Found"
+      expect(response.body).to eq("Not Found")
     end
 
     it "should return no_session with a user not running anything" do
@@ -14,7 +14,7 @@ describe Portal::OfferingsMetalController do
       get :launch_status, :id => learner.offering.id
       response.content_type == 'application/json'
       json_body = JSON.parse(response.body)
-      json_body['event_type'].should == 'no_session'
+      expect(json_body['event_type']).to eq('no_session')
     end
   end
 end

--- a/spec/controllers/portal/schools_controller_spec.rb
+++ b/spec/controllers/portal/schools_controller_spec.rb
@@ -4,7 +4,7 @@ describe Portal::SchoolsController do
   # render_views
 
   def mock_school(_stubs={})
-    clazzes = mock(:active => [], :length => 0, :size => 0)
+    clazzes = double(:active => [], :length => 0, :size => 0)
     stubs = {
       :name => "school",
       :description => "school description",
@@ -22,7 +22,7 @@ describe Portal::SchoolsController do
   end
 
   def nces_mock_school(_stubs={})
-    clazzes = mock(:active => [], :length => 0, :size => 0)
+    clazzes = double(:active => [], :length => 0, :size => 0)
     stubs = {
       :SCHNAM => "AMHERST REGIONAL MS",
       :changeable? => true  # admin user in most test cases..
@@ -43,34 +43,34 @@ describe Portal::SchoolsController do
 
   describe "GET index" do
     it "assigns all portal_schools as @portal_schools" do
-      Portal::School.stub!(:search).with(nil,nil,nil).and_return([@school])
+      allow(Portal::School).to receive(:search).with(nil,nil,nil).and_return([@school])
       get :index
-      assigns[:portal_schools].should == [@school]
+      expect(assigns[:portal_schools]).to eq([@school])
     end
   end
 
   describe "GET show" do
     it "assigns the requested school as @portal_school" do
-      Portal::School.stub!(:find).with("37").and_return(@school)
+      allow(Portal::School).to receive(:find).with("37").and_return(@school)
       get :show, :id => "37"
-      assigns[:portal_school].should equal(@school)
+      expect(assigns[:portal_school]).to equal(@school)
     end
   end
   
   describe "GET new" do
     it "assigns a new school as @portal_school" do
-      Portal::School.stub!(:new).and_return(@school)
+      allow(Portal::School).to receive(:new).and_return(@school)
       get :new
-      assigns[:portal_school].should equal(@school)
+      expect(assigns[:portal_school]).to equal(@school)
     end
   end
   
   describe "GET edit" do
     it "assigns the requested school as @portal_school" do
       #@school.should_receive(:changeable?).and_return(:true)
-      Portal::School.stub!(:find).with("37").and_return(@school)
+      allow(Portal::School).to receive(:find).with("37").and_return(@school)
       get :edit, :id => "37"
-      assigns[:portal_school].should equal(@school)
+      expect(assigns[:portal_school]).to equal(@school)
     end
   end
   
@@ -78,35 +78,35 @@ describe Portal::SchoolsController do
   
     describe "with valid nces_school params" do
       it "assigns a newly created school as @portal_school" do
-        @school.should_receive(:save).and_return(true)
-        Portal::Nces06School.stub!(:find).with('123').and_return(@nces_school)
-        Portal::School.stub!(:find_or_create_by_nces_school).with(@nces_school).and_return(@school)
+        expect(@school).to receive(:save).and_return(true)
+        allow(Portal::Nces06School).to receive(:find).with('123').and_return(@nces_school)
+        allow(Portal::School).to receive(:find_or_create_by_nces_school).with(@nces_school).and_return(@school)
         post :create, :nces_school => {:id => '123'}
-        assigns[:portal_school].should equal(@school)
+        expect(assigns[:portal_school]).to equal(@school)
       end
   
       it "redirects to the created school" do
-        @school.should_receive(:save).and_return(true)
-        Portal::Nces06School.stub!(:find).with('123').and_return(@nces_school)
-        Portal::School.stub!(:find_or_create_by_nces_school).with(@nces_school).and_return(@school)
+        expect(@school).to receive(:save).and_return(true)
+        allow(Portal::Nces06School).to receive(:find).with('123').and_return(@nces_school)
+        allow(Portal::School).to receive(:find_or_create_by_nces_school).with(@nces_school).and_return(@school)
         post :create, :nces_school => {:id => '123'}
-        response.should redirect_to(portal_school_url(@school))
+        expect(response).to redirect_to(portal_school_url(@school))
       end
     end
   
     describe "with invalid portal_school params" do
       it "assigns a newly created but unsaved school as @portal_school" do
-        @school.should_receive(:save).and_return(true)
-        Portal::School.stub!(:new).with({'these' => 'params'}).and_return(@school)
+        expect(@school).to receive(:save).and_return(true)
+        allow(Portal::School).to receive(:new).with({'these' => 'params'}).and_return(@school)
         post :create, :portal_school => {:these => 'params'}
-        assigns[:portal_school].should equal(@school)
+        expect(assigns[:portal_school]).to equal(@school)
       end
   
       it "re-renders the 'new' template" do
-        @school.should_receive(:save).and_return(false)
-        Portal::School.stub!(:new).and_return(@school)
+        expect(@school).to receive(:save).and_return(false)
+        allow(Portal::School).to receive(:new).and_return(@school)
         post :create, :portal_school => {}
-        response.should render_template('new')
+        expect(response).to render_template('new')
       end
     end
   
@@ -116,43 +116,43 @@ describe Portal::SchoolsController do
   
     describe "with valid params" do
       it "updates the requested school" do
-        Portal::School.should_receive(:find).with("37").and_return(@school)
-        @school.should_receive(:update_attributes).with({'portal_school' => 'params'})
+        expect(Portal::School).to receive(:find).with("37").and_return(@school)
+        expect(@school).to receive(:update_attributes).with({'portal_school' => 'params'})
         put :update, :id => "37", :portal_school => {:portal_school => 'params'}
       end
   
       it "assigns the requested school as @portal_school" do
-        @school.should_receive(:update_attributes).and_return(true)
-        Portal::School.stub!(:find).and_return(@school)
+        expect(@school).to receive(:update_attributes).and_return(true)
+        allow(Portal::School).to receive(:find).and_return(@school)
         put :update, :id => "1"
-        assigns[:portal_school].should equal(@school)
+        expect(assigns[:portal_school]).to equal(@school)
       end
   
       it "redirects to the school" do
-        @school.stub!(:id => 1)
-        @school.should_receive(:update_attributes).and_return(true)
-        Portal::School.stub!(:find).and_return(@school)
+        @school.stub(:id => 1)
+        expect(@school).to receive(:update_attributes).and_return(true)
+        allow(Portal::School).to receive(:find).and_return(@school)
         put :update, :id => "1"
-        response.should redirect_to(portal_school_url(@school))
+        expect(response).to redirect_to(portal_school_url(@school))
       end
     end
   
     describe "with invalid params" do
 
       before(:each) do
-        @school.stub!(:id => 1)
-        @school.should_receive(:update_attributes).with({'portal_school' => 'params'}).and_return(false)
-        Portal::School.stub!(:find).and_return(@school)
+        @school.stub(:id => 1)
+        expect(@school).to receive(:update_attributes).with({'portal_school' => 'params'}).and_return(false)
+        allow(Portal::School).to receive(:find).and_return(@school)
       end
 
       it "assigns the school as @portal_school" do
         put :update, :id => "1", :portal_school => {:portal_school => 'params'}
-        assigns[:portal_school].should equal(@school)
+        expect(assigns[:portal_school]).to equal(@school)
       end
   
       it "re-renders the 'edit' template" do
         put :update, :id => "1", :portal_school => {:portal_school => 'params'}
-        response.should render_template('edit')
+        expect(response).to render_template('edit')
       end
     end
   
@@ -162,9 +162,9 @@ describe Portal::SchoolsController do
     render_views
 
     before(:each) do
-      @school.stub!(:id => 1)
-      @school.should_receive(:destroy).and_return(true)
-      Portal::School.should_receive(:find).with("1").and_return(@school)
+      @school.stub(:id => 1)
+      expect(@school).to receive(:destroy).and_return(true)
+      expect(Portal::School).to receive(:find).with("1").and_return(@school)
     end
     
     it "destroys the requested school" do
@@ -173,12 +173,12 @@ describe Portal::SchoolsController do
   
     it "redirects to the portal_schools list" do
       delete :destroy, :id => "1"
-      response.should redirect_to(portal_schools_url)
+      expect(response).to redirect_to(portal_schools_url)
     end
 
     it "renders the rjs template" do
       xhr :post, :destroy, :id => "1"
-      response.should render_template('destroy')
+      expect(response).to render_template('destroy')
       assert_select_rjs
     end
 

--- a/spec/controllers/portal/students_controller_spec.rb
+++ b/spec/controllers/portal/students_controller_spec.rb
@@ -6,8 +6,8 @@ describe Portal::StudentsController do
   before(:each) do
     generate_default_settings_and_jnlps_with_mocks
     generate_portal_resources_with_mocks
-    Admin::Settings.stub!(:default_settings).and_return(@mock_settings)
-    @mock_settings.stub!(:allow_default_class).and_return(true)
+    allow(Admin::Settings).to receive(:default_settings).and_return(@mock_settings)
+    allow(@mock_settings).to receive(:allow_default_class).and_return(true)
   end
 
   describe "POST create" do
@@ -48,7 +48,7 @@ describe Portal::StudentsController do
       user_attributes[:email] = Portal::Student.generate_user_email
 
       @new_user = User.new(user_attributes)
-      User.stub!(:new).and_return(@new_user)
+      allow(User).to receive(:new).and_return(@new_user)
       @new_user
     end
 
@@ -60,8 +60,8 @@ describe Portal::StudentsController do
 
       post :create, @params_for_creation
 
-      User.count(:all).should == current_user_count + 1
-      Portal::Student.count(:all).should == current_student_count + 1
+      expect(User.count(:all)).to eq(current_user_count + 1)
+      expect(Portal::Student.count(:all)).to eq(current_student_count + 1)
 
     end
 
@@ -72,7 +72,7 @@ describe Portal::StudentsController do
       stub_user_with_params
       post :create, @params_for_creation
 
-      response.should redirect_to(thanks_for_sign_up_url(:type=>"student", :login=>@new_user.login))
+      expect(response).to redirect_to(thanks_for_sign_up_url(:type=>"student", :login=>@new_user.login))
 
     end
 
@@ -80,7 +80,7 @@ describe Portal::StudentsController do
     it "does not show any of the students classes after successful creation" do
       stub_user_with_params
       post :create, @params_for_creation
-      response.should redirect_to(thanks_for_sign_up_url(:type=>"student",:login=>@new_user.login))
+      expect(response).to redirect_to(thanks_for_sign_up_url(:type=>"student",:login=>@new_user.login))
     end
 
     it "does not create a user or a student when given incorrect password_confirmation" do
@@ -91,8 +91,8 @@ describe Portal::StudentsController do
 
       post :create, @params_for_creation
 
-      User.count(:all).should == current_user_count
-      Portal::Student.count(:all).should == current_student_count
+      expect(User.count(:all)).to eq(current_user_count)
+      expect(Portal::Student.count(:all)).to eq(current_student_count)
     end
 
     it "does not create a user or a student when given an invalid classword" do
@@ -103,30 +103,30 @@ describe Portal::StudentsController do
 
       post :create, @params_for_creation
 
-      User.count(:all).should == current_user_count
-      Portal::Student.count(:all).should == current_student_count
+      expect(User.count(:all)).to eq(current_user_count)
+      expect(Portal::Student.count(:all)).to eq(current_student_count)
     end
 
 
     describe "security questions" do
       before(:each) do
-        @mock_settings.stub!(:use_student_security_questions).and_return(true)
+        allow(@mock_settings).to receive(:use_student_security_questions).and_return(true)
       end
 
       it "creates security questions when given valid parameters" do
         stub_user_with_params
 
-        SecurityQuestion.should_receive(:make_questions_from_hash_and_user)
-        SecurityQuestion.should_receive(:errors_for_questions_list!)
-        @new_user.should_receive(:update_security_questions!)
+        expect(SecurityQuestion).to receive(:make_questions_from_hash_and_user)
+        expect(SecurityQuestion).to receive(:errors_for_questions_list!)
+        expect(@new_user).to receive(:update_security_questions!)
 
         current_user_count = User.count(:all)
         current_student_count = Portal::Student.count(:all)
 
         post :create, @params_for_creation
 
-        User.count(:all).should == current_user_count + 1
-        Portal::Student.count(:all).should == current_student_count + 1
+        expect(User.count(:all)).to eq(current_user_count + 1)
+        expect(Portal::Student.count(:all)).to eq(current_student_count + 1)
       end
 
       it "does not create a user or a student when given bad security questions" do
@@ -137,16 +137,16 @@ describe Portal::StudentsController do
 
         post :create, @params_for_creation
 
-        User.count(:all).should == current_user_count
-        Portal::Student.count(:all).should == current_student_count
+        expect(User.count(:all)).to eq(current_user_count)
+        expect(Portal::Student.count(:all)).to eq(current_student_count)
       end
 
       it "does not check for security questions when they are not enabled in the settings" do
-        @mock_settings.stub!(:use_student_security_questions).and_return(false)
+        allow(@mock_settings).to receive(:use_student_security_questions).and_return(false)
         stub_user_with_params
 
-        SecurityQuestion.should_not_receive(:errors_for_questions_list!)
-        @new_user.should_not_receive(:update_security_questions!)
+        expect(SecurityQuestion).not_to receive(:errors_for_questions_list!)
+        expect(@new_user).not_to receive(:update_security_questions!)
 
         post :create, @params_for_creation
       end
@@ -159,8 +159,8 @@ describe Portal::StudentsController do
 
         stub_user_with_params
 
-        SecurityQuestion.should_not_receive(:errors_for_questions_list!)
-        @new_user.should_not_receive(:update_security_questions!)
+        expect(SecurityQuestion).not_to receive(:errors_for_questions_list!)
+        expect(@new_user).not_to receive(:update_security_questions!)
 
         post :create, @params_for_creation
       end
@@ -168,8 +168,8 @@ describe Portal::StudentsController do
       it "checks for security questions when a student signs themselves up" do
         stub_user_with_params
 
-        SecurityQuestion.should_receive(:errors_for_questions_list!)
-        @new_user.should_receive(:update_security_questions!)
+        expect(SecurityQuestion).to receive(:errors_for_questions_list!)
+        expect(@new_user).to receive(:update_security_questions!)
 
         post :create, @params_for_creation
       end

--- a/spec/controllers/portal/teachers_controller_spec.rb
+++ b/spec/controllers/portal/teachers_controller_spec.rb
@@ -4,8 +4,8 @@ describe Portal::TeachersController do
   describe "POST create" do
     it "should complain if the login is the same except for case" do
       school   = Factory.create(:portal_school)
-      selector = mock(:portal_selector, :school => school, :valid? => true)
-      Portal::SchoolSelector.stub!(:new).and_return(selector) 
+      selector = double(:portal_selector, :school => school, :valid? => true)
+      allow(Portal::SchoolSelector).to receive(:new).and_return(selector) 
       Factory.create(:user, :login => "tteacher")
 
       params = {
@@ -21,7 +21,7 @@ describe Portal::TeachersController do
         
       post :create, params
 
-      assigns(:user).should_not be_valid
+      expect(assigns(:user)).not_to be_valid
     end
   end
 
@@ -38,10 +38,10 @@ describe Portal::TeachersController do
       @selector = Portal::SchoolSelector.new({
         :country => Portal::SchoolSelector::USA,
         :state   => 'MA'})
-      @selector.stub!(:valid?).and_return true
+      allow(@selector).to receive(:valid?).and_return true
       @selector.school = @school
       @selector.district = @school.district
-      Portal::SchoolSelector.stub!(:new).and_return(@selector) 
+      allow(Portal::SchoolSelector).to receive(:new).and_return(@selector) 
     end
 
     describe "POST create" do
@@ -62,7 +62,7 @@ describe Portal::TeachersController do
         
         post :create, params
         
-        @response.should redirect_to(thanks_for_sign_up_url(:type=>'teacher',:login=>params[:user][:login]))
+        expect(@response).to redirect_to(thanks_for_sign_up_url(:type=>'teacher',:login=>params[:user][:login]))
         
       end
       
@@ -77,7 +77,7 @@ describe Portal::TeachersController do
             :password_confirmation => "password"
           }
         }
-        @selector.stub!(:valid?).and_return false
+        allow(@selector).to receive(:valid?).and_return false
         current_user_count = User.count(:all)
         current_teacher_count = Portal::Teacher.count(:all)
         
@@ -88,8 +88,8 @@ describe Portal::TeachersController do
 
         #expect(flash.now[:error]).not_to be_nil
         expect(flash[:notice]).to be_nil
-        @response.body.should include("must select a school")
-        @response.body.should include("Sorry")
+        expect(@response.body).to include("must select a school")
+        expect(@response.body).to include("Sorry")
       end
     end
   end  

--- a/spec/controllers/report/learner_controller_spec.rb
+++ b/spec/controllers/report/learner_controller_spec.rb
@@ -5,20 +5,20 @@ describe Report::LearnerController do
   def new_learner(learner_stubs)
     learner = Factory(:full_portal_learner)
     learner_stubs.keys.each do |key|
-      learner.stub(key).and_return(learner_stubs[key])
+      allow(learner).to receive(key).and_return(learner_stubs[key])
     end
     learner
   end
 
   before(:each) do
-    Report::Learner.stub(:find_by_user_id_and_offering_id).and_return(learner)
+    allow(Report::Learner).to receive(:find_by_user_id_and_offering_id).and_return(learner)
   end
 
   let(:learner_stubs)   { {}                }
   let(:learner)         { new_learner(learner_stubs) }
   describe "A working test setup" do
     it "The learner should exist" do
-      learner.should_not be_nil
+      expect(learner).not_to be_nil
     end
   end
 
@@ -28,16 +28,16 @@ describe Report::LearnerController do
       describe 'json format' do
         it "should return a json hash containing update_at time" do
           get :updated_at, :format => :json, :id => learner.id
-          response.status.should eq 200
+          expect(response.status).to eq 200
           json = JSON.parse(response.body)
-          json['modification_time'].should == '30758400'
+          expect(json['modification_time']).to eq('30758400')
         end
       end
       describe 'html format' do
         it "should return a string containing formatted time" do
           get :updated_at, :format => :html, :id => learner.id
-          response.status.should eq 200
-          response.body.should match '30758400'
+          expect(response.status).to eq 200
+          expect(response.body).to match '30758400'
         end
       end
     end
@@ -50,16 +50,16 @@ describe Report::LearnerController do
         it "should return an empty string" do
           get :updated_at, :format => :json, :id => learner.id
           json = JSON.parse(response.body)
-          response.status.should eq 400
-          json['modification_time'].should be_nil
-          json['error_msg'].should match not_run_text
+          expect(response.status).to eq 400
+          expect(json['modification_time']).to be_nil
+          expect(json['error_msg']).to match not_run_text
         end
       end
       describe 'html format' do
         it "should return a string containing formatted time" do
           get :updated_at, :format => :html, :id => learner.id
-          response.status.should eq 400
-          response.body.should match not_run_text
+          expect(response.status).to eq 400
+          expect(response.body).to match not_run_text
         end
       end
     end

--- a/spec/controllers/ri_gse/assessment_targets_controller_spec.rb
+++ b/spec/controllers/ri_gse/assessment_targets_controller_spec.rb
@@ -15,19 +15,19 @@ describe RiGse::AssessmentTargetsController do
   describe "responding to GET index" do
 
     it "should expose an array of all the @assessment_targets" do
-      RiGse::AssessmentTarget.should_receive(:search).and_return([mock_assessment_target])
+      expect(RiGse::AssessmentTarget).to receive(:search).and_return([mock_assessment_target])
       get :index
-      assigns[:assessment_targets].should == [mock_assessment_target]
+      expect(assigns[:assessment_targets]).to eq([mock_assessment_target])
     end
 
     describe "with mime type of xml" do
   
       it "should render all assessment_targets as xml" do
         request.env["HTTP_ACCEPT"] = "application/xml"
-        RiGse::AssessmentTarget.should_receive(:all).and_return(assessment_targets = mock("Array of AssessmentTargets"))
-        assessment_targets.should_receive(:to_xml).and_return("generated XML")
+        expect(RiGse::AssessmentTarget).to receive(:all).and_return(assessment_targets = double("Array of AssessmentTargets"))
+        expect(assessment_targets).to receive(:to_xml).and_return("generated XML")
         get :index
-        response.body.should == "generated XML"
+        expect(response.body).to eq("generated XML")
       end
     
     end
@@ -37,19 +37,19 @@ describe RiGse::AssessmentTargetsController do
   describe "responding to GET show" do
 
     it "should expose the requested assessment_target as @assessment_target" do
-      RiGse::AssessmentTarget.should_receive(:find).with("37").and_return(mock_assessment_target)
+      expect(RiGse::AssessmentTarget).to receive(:find).with("37").and_return(mock_assessment_target)
       get :show, :id => "37"
-      assigns[:assessment_target].should equal(mock_assessment_target)
+      expect(assigns[:assessment_target]).to equal(mock_assessment_target)
     end
     
     describe "with mime type of xml" do
 
       it "should render the requested assessment_target as xml" do
         request.env["HTTP_ACCEPT"] = "application/xml"
-        RiGse::AssessmentTarget.should_receive(:find).with("37").and_return(mock_assessment_target)
-        mock_assessment_target.should_receive(:to_xml).and_return("generated XML")
+        expect(RiGse::AssessmentTarget).to receive(:find).with("37").and_return(mock_assessment_target)
+        expect(mock_assessment_target).to receive(:to_xml).and_return("generated XML")
         get :show, :id => "37"
-        response.body.should == "generated XML"
+        expect(response.body).to eq("generated XML")
       end
 
     end
@@ -59,9 +59,9 @@ describe RiGse::AssessmentTargetsController do
   describe "responding to GET new" do
   
     it "should expose a new assessment_target as @assessment_target" do
-      RiGse::AssessmentTarget.should_receive(:new).and_return(mock_assessment_target)
+      expect(RiGse::AssessmentTarget).to receive(:new).and_return(mock_assessment_target)
       get :new
-      assigns[:assessment_target].should equal(mock_assessment_target)
+      expect(assigns[:assessment_target]).to equal(mock_assessment_target)
     end
 
   end
@@ -69,9 +69,9 @@ describe RiGse::AssessmentTargetsController do
   describe "responding to GET edit" do
   
     it "should expose the requested assessment_target as @assessment_target" do
-      RiGse::AssessmentTarget.should_receive(:find).with("37").and_return(mock_assessment_target)
+      expect(RiGse::AssessmentTarget).to receive(:find).with("37").and_return(mock_assessment_target)
       get :edit, :id => "37"
-      assigns[:assessment_target].should equal(mock_assessment_target)
+      expect(assigns[:assessment_target]).to equal(mock_assessment_target)
     end
 
   end
@@ -81,15 +81,15 @@ describe RiGse::AssessmentTargetsController do
     describe "with valid params" do
       
       it "should expose a newly created assessment_target as @assessment_target" do
-        RiGse::AssessmentTarget.should_receive(:new).with({'these' => 'params'}).and_return(mock_assessment_target(:save => true))
+        expect(RiGse::AssessmentTarget).to receive(:new).with({'these' => 'params'}).and_return(mock_assessment_target(:save => true))
         post :create, :assessment_target => {:these => 'params'}
-        assigns(:assessment_target).should equal(mock_assessment_target)
+        expect(assigns(:assessment_target)).to equal(mock_assessment_target)
       end
 
       it "should redirect to the created assessment_target" do
-        RiGse::AssessmentTarget.stub!(:new).and_return(mock_assessment_target(:save => true))
+        allow(RiGse::AssessmentTarget).to receive(:new).and_return(mock_assessment_target(:save => true))
         post :create, :assessment_target => {}
-        response.should redirect_to(ri_gse_assessment_target_url(mock_assessment_target))
+        expect(response).to redirect_to(ri_gse_assessment_target_url(mock_assessment_target))
       end
       
     end
@@ -97,15 +97,15 @@ describe RiGse::AssessmentTargetsController do
     describe "with invalid params" do
 
       it "should expose a newly created but unsaved assessment_target as @assessment_target" do
-        RiGse::AssessmentTarget.stub!(:new).with({'these' => 'params'}).and_return(mock_assessment_target(:save => false))
+        allow(RiGse::AssessmentTarget).to receive(:new).with({'these' => 'params'}).and_return(mock_assessment_target(:save => false))
         post :create, :assessment_target => {:these => 'params'}
-        assigns(:assessment_target).should equal(mock_assessment_target)
+        expect(assigns(:assessment_target)).to equal(mock_assessment_target)
       end
 
       it "should re-render the 'new' template" do
-        RiGse::AssessmentTarget.stub!(:new).and_return(mock_assessment_target(:save => false))
+        allow(RiGse::AssessmentTarget).to receive(:new).and_return(mock_assessment_target(:save => false))
         post :create, :assessment_target => {}
-        response.should render_template('new')
+        expect(response).to render_template('new')
       end
       
     end
@@ -117,21 +117,21 @@ describe RiGse::AssessmentTargetsController do
     describe "with valid params" do
 
       it "should update the requested assessment_target" do
-        RiGse::AssessmentTarget.should_receive(:find).with("37").and_return(mock_assessment_target)
-        mock_assessment_target.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(RiGse::AssessmentTarget).to receive(:find).with("37").and_return(mock_assessment_target)
+        expect(mock_assessment_target).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :assessment_target => {:these => 'params'}
       end
 
       it "should expose the requested assessment_target as @assessment_target" do
-        RiGse::AssessmentTarget.stub!(:find).and_return(mock_assessment_target(:update_attributes => true))
+        allow(RiGse::AssessmentTarget).to receive(:find).and_return(mock_assessment_target(:update_attributes => true))
         put :update, :id => "1"
-        assigns(:assessment_target).should equal(mock_assessment_target)
+        expect(assigns(:assessment_target)).to equal(mock_assessment_target)
       end
 
       it "should redirect to the assessment_target" do
-        RiGse::AssessmentTarget.stub!(:find).and_return(mock_assessment_target(:update_attributes => true))
+        allow(RiGse::AssessmentTarget).to receive(:find).and_return(mock_assessment_target(:update_attributes => true))
         put :update, :id => "1"
-        response.should redirect_to(ri_gse_assessment_target_url(mock_assessment_target))
+        expect(response).to redirect_to(ri_gse_assessment_target_url(mock_assessment_target))
       end
 
     end
@@ -139,21 +139,21 @@ describe RiGse::AssessmentTargetsController do
     describe "with invalid params" do
 
       it "should update the requested assessment_target" do
-        RiGse::AssessmentTarget.should_receive(:find).with("37").and_return(mock_assessment_target)
-        mock_assessment_target.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(RiGse::AssessmentTarget).to receive(:find).with("37").and_return(mock_assessment_target)
+        expect(mock_assessment_target).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :assessment_target => {:these => 'params'}
       end
 
       it "should expose the assessment_target as @assessment_target" do
-        RiGse::AssessmentTarget.stub!(:find).and_return(mock_assessment_target(:update_attributes => false))
+        allow(RiGse::AssessmentTarget).to receive(:find).and_return(mock_assessment_target(:update_attributes => false))
         put :update, :id => "1"
-        assigns(:assessment_target).should equal(mock_assessment_target)
+        expect(assigns(:assessment_target)).to equal(mock_assessment_target)
       end
 
       it "should re-render the 'edit' template" do
-        RiGse::AssessmentTarget.stub!(:find).and_return(mock_assessment_target(:update_attributes => false))
+        allow(RiGse::AssessmentTarget).to receive(:find).and_return(mock_assessment_target(:update_attributes => false))
         put :update, :id => "1"
-        response.should render_template('edit')
+        expect(response).to render_template('edit')
       end
 
     end
@@ -163,15 +163,15 @@ describe RiGse::AssessmentTargetsController do
   describe "responding to DELETE destroy" do
 
     it "should destroy the requested assessment_target" do
-      RiGse::AssessmentTarget.should_receive(:find).with("37").and_return(mock_assessment_target)
-      mock_assessment_target.should_receive(:destroy)
+      expect(RiGse::AssessmentTarget).to receive(:find).with("37").and_return(mock_assessment_target)
+      expect(mock_assessment_target).to receive(:destroy)
       delete :destroy, :id => "37"
     end
   
     it "should redirect to the assessment_targets list" do
-      RiGse::AssessmentTarget.stub!(:find).and_return(mock_assessment_target(:destroy => true))
+      allow(RiGse::AssessmentTarget).to receive(:find).and_return(mock_assessment_target(:destroy => true))
       delete :destroy, :id => "1"
-      response.should redirect_to(assessment_targets_url)
+      expect(response).to redirect_to(assessment_targets_url)
     end
 
   end

--- a/spec/controllers/ri_gse/big_ideas_controller_spec.rb
+++ b/spec/controllers/ri_gse/big_ideas_controller_spec.rb
@@ -15,19 +15,19 @@ describe RiGse::BigIdeasController do
   describe "responding to GET index" do
 
     it "should expose an array of all the @big_ideas" do
-      RiGse::BigIdea.should_receive(:all).and_return([mock_big_idea])
+      expect(RiGse::BigIdea).to receive(:all).and_return([mock_big_idea])
       get :index
-      assigns[:big_ideas].should == [mock_big_idea]
+      expect(assigns[:big_ideas]).to eq([mock_big_idea])
     end
 
     describe "with mime type of xml" do
   
       it "should render all big_ideas as xml" do
         request.env["HTTP_ACCEPT"] = "application/xml"
-        RiGse::BigIdea.should_receive(:all).and_return(big_ideas = mock("Array of BigIdeas"))
-        big_ideas.should_receive(:to_xml).and_return("generated XML")
+        expect(RiGse::BigIdea).to receive(:all).and_return(big_ideas = double("Array of BigIdeas"))
+        expect(big_ideas).to receive(:to_xml).and_return("generated XML")
         get :index
-        response.body.should == "generated XML"
+        expect(response.body).to eq("generated XML")
       end
     
     end
@@ -37,19 +37,19 @@ describe RiGse::BigIdeasController do
   describe "responding to GET show" do
 
     it "should expose the requested big_idea as @big_idea" do
-      RiGse::BigIdea.should_receive(:find).with("37").and_return(mock_big_idea)
+      expect(RiGse::BigIdea).to receive(:find).with("37").and_return(mock_big_idea)
       get :show, :id => "37"
-      assigns[:big_idea].should equal(mock_big_idea)
+      expect(assigns[:big_idea]).to equal(mock_big_idea)
     end
     
     describe "with mime type of xml" do
 
       it "should render the requested big_idea as xml" do
         request.env["HTTP_ACCEPT"] = "application/xml"
-        RiGse::BigIdea.should_receive(:find).with("37").and_return(mock_big_idea)
-        mock_big_idea.should_receive(:to_xml).and_return("generated XML")
+        expect(RiGse::BigIdea).to receive(:find).with("37").and_return(mock_big_idea)
+        expect(mock_big_idea).to receive(:to_xml).and_return("generated XML")
         get :show, :id => "37"
-        response.body.should == "generated XML"
+        expect(response.body).to eq("generated XML")
       end
 
     end
@@ -59,9 +59,9 @@ describe RiGse::BigIdeasController do
   describe "responding to GET new" do
   
     it "should expose a new big_idea as @big_idea" do
-      RiGse::BigIdea.should_receive(:new).and_return(mock_big_idea)
+      expect(RiGse::BigIdea).to receive(:new).and_return(mock_big_idea)
       get :new
-      assigns[:big_idea].should equal(mock_big_idea)
+      expect(assigns[:big_idea]).to equal(mock_big_idea)
     end
 
   end
@@ -69,9 +69,9 @@ describe RiGse::BigIdeasController do
   describe "responding to GET edit" do
   
     it "should expose the requested big_idea as @big_idea" do
-      RiGse::BigIdea.should_receive(:find).with("37").and_return(mock_big_idea)
+      expect(RiGse::BigIdea).to receive(:find).with("37").and_return(mock_big_idea)
       get :edit, :id => "37"
-      assigns[:big_idea].should equal(mock_big_idea)
+      expect(assigns[:big_idea]).to equal(mock_big_idea)
     end
 
   end
@@ -81,15 +81,15 @@ describe RiGse::BigIdeasController do
     describe "with valid params" do
       
       it "should expose a newly created big_idea as @big_idea" do
-        RiGse::BigIdea.should_receive(:new).with({'these' => 'params'}).and_return(mock_big_idea(:save => true))
+        expect(RiGse::BigIdea).to receive(:new).with({'these' => 'params'}).and_return(mock_big_idea(:save => true))
         post :create, :big_idea => {:these => 'params'}
-        assigns(:big_idea).should equal(mock_big_idea)
+        expect(assigns(:big_idea)).to equal(mock_big_idea)
       end
 
       it "should redirect to the created big_idea" do
-        RiGse::BigIdea.stub!(:new).and_return(mock_big_idea(:save => true))
+        allow(RiGse::BigIdea).to receive(:new).and_return(mock_big_idea(:save => true))
         post :create, :big_idea => {}
-        response.should redirect_to(ri_gse_big_idea_url(mock_big_idea))
+        expect(response).to redirect_to(ri_gse_big_idea_url(mock_big_idea))
       end
       
     end
@@ -97,15 +97,15 @@ describe RiGse::BigIdeasController do
     describe "with invalid params" do
 
       it "should expose a newly created but unsaved big_idea as @big_idea" do
-        RiGse::BigIdea.stub!(:new).with({'these' => 'params'}).and_return(mock_big_idea(:save => false))
+        allow(RiGse::BigIdea).to receive(:new).with({'these' => 'params'}).and_return(mock_big_idea(:save => false))
         post :create, :big_idea => {:these => 'params'}
-        assigns(:big_idea).should equal(mock_big_idea)
+        expect(assigns(:big_idea)).to equal(mock_big_idea)
       end
 
       it "should re-render the 'new' template" do
-        RiGse::BigIdea.stub!(:new).and_return(mock_big_idea(:save => false))
+        allow(RiGse::BigIdea).to receive(:new).and_return(mock_big_idea(:save => false))
         post :create, :big_idea => {}
-        response.should render_template('new')
+        expect(response).to render_template('new')
       end
       
     end
@@ -117,21 +117,21 @@ describe RiGse::BigIdeasController do
     describe "with valid params" do
 
       it "should update the requested big_idea" do
-        RiGse::BigIdea.should_receive(:find).with("37").and_return(mock_big_idea)
-        mock_big_idea.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(RiGse::BigIdea).to receive(:find).with("37").and_return(mock_big_idea)
+        expect(mock_big_idea).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :big_idea => {:these => 'params'}
       end
 
       it "should expose the requested big_idea as @big_idea" do
-        RiGse::BigIdea.stub!(:find).and_return(mock_big_idea(:update_attributes => true))
+        allow(RiGse::BigIdea).to receive(:find).and_return(mock_big_idea(:update_attributes => true))
         put :update, :id => "1"
-        assigns(:big_idea).should equal(mock_big_idea)
+        expect(assigns(:big_idea)).to equal(mock_big_idea)
       end
 
       it "should redirect to the big_idea" do
-        RiGse::BigIdea.stub!(:find).and_return(mock_big_idea(:update_attributes => true))
+        allow(RiGse::BigIdea).to receive(:find).and_return(mock_big_idea(:update_attributes => true))
         put :update, :id => "1"
-        response.should redirect_to(ri_gse_big_idea_url(mock_big_idea))
+        expect(response).to redirect_to(ri_gse_big_idea_url(mock_big_idea))
       end
 
     end
@@ -139,21 +139,21 @@ describe RiGse::BigIdeasController do
     describe "with invalid params" do
 
       it "should update the requested big_idea" do
-        RiGse::BigIdea.should_receive(:find).with("37").and_return(mock_big_idea)
-        mock_big_idea.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(RiGse::BigIdea).to receive(:find).with("37").and_return(mock_big_idea)
+        expect(mock_big_idea).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :big_idea => {:these => 'params'}
       end
 
       it "should expose the big_idea as @big_idea" do
-        RiGse::BigIdea.stub!(:find).and_return(mock_big_idea(:update_attributes => false))
+        allow(RiGse::BigIdea).to receive(:find).and_return(mock_big_idea(:update_attributes => false))
         put :update, :id => "1"
-        assigns(:big_idea).should equal(mock_big_idea)
+        expect(assigns(:big_idea)).to equal(mock_big_idea)
       end
 
       it "should re-render the 'edit' template" do
-        RiGse::BigIdea.stub!(:find).and_return(mock_big_idea(:update_attributes => false))
+        allow(RiGse::BigIdea).to receive(:find).and_return(mock_big_idea(:update_attributes => false))
         put :update, :id => "1"
-        response.should render_template('edit')
+        expect(response).to render_template('edit')
       end
 
     end
@@ -163,15 +163,15 @@ describe RiGse::BigIdeasController do
   describe "responding to DELETE destroy" do
 
     it "should destroy the requested big_idea" do
-      RiGse::BigIdea.should_receive(:find).with("37").and_return(mock_big_idea)
-      mock_big_idea.should_receive(:destroy)
+      expect(RiGse::BigIdea).to receive(:find).with("37").and_return(mock_big_idea)
+      expect(mock_big_idea).to receive(:destroy)
       delete :destroy, :id => "37"
     end
   
     it "should redirect to the big_ideas list" do
-      RiGse::BigIdea.stub!(:find).and_return(mock_big_idea(:destroy => true))
+      allow(RiGse::BigIdea).to receive(:find).and_return(mock_big_idea(:destroy => true))
       delete :destroy, :id => "1"
-      response.should redirect_to(big_ideas_url)
+      expect(response).to redirect_to(big_ideas_url)
     end
 
   end

--- a/spec/controllers/ri_gse/domains_controller_spec.rb
+++ b/spec/controllers/ri_gse/domains_controller_spec.rb
@@ -15,19 +15,19 @@ describe RiGse::DomainsController do
   describe "responding to GET index" do
 
     it "should expose an array of all the @domains" do
-      RiGse::Domain.should_receive(:all).and_return([mock_domain])
+      expect(RiGse::Domain).to receive(:all).and_return([mock_domain])
       get :index
-      assigns[:domains].should == [mock_domain]
+      expect(assigns[:domains]).to eq([mock_domain])
     end
 
     describe "with mime type of xml" do
   
       it "should render all domains as xml" do
         request.env["HTTP_ACCEPT"] = "application/xml"
-        RiGse::Domain.should_receive(:all).and_return(domains = mock("Array of Domains"))
-        domains.should_receive(:to_xml).and_return("generated XML")
+        expect(RiGse::Domain).to receive(:all).and_return(domains = double("Array of Domains"))
+        expect(domains).to receive(:to_xml).and_return("generated XML")
         get :index
-        response.body.should == "generated XML"
+        expect(response.body).to eq("generated XML")
       end
     
     end
@@ -37,19 +37,19 @@ describe RiGse::DomainsController do
   describe "responding to GET show" do
 
     it "should expose the requested domain as @domain" do
-      RiGse::Domain.should_receive(:find).with("37").and_return(mock_domain)
+      expect(RiGse::Domain).to receive(:find).with("37").and_return(mock_domain)
       get :show, :id => "37"
-      assigns[:domain].should equal(mock_domain)
+      expect(assigns[:domain]).to equal(mock_domain)
     end
     
     describe "with mime type of xml" do
 
       it "should render the requested domain as xml" do
         request.env["HTTP_ACCEPT"] = "application/xml"
-        RiGse::Domain.should_receive(:find).with("37").and_return(mock_domain)
-        mock_domain.should_receive(:to_xml).and_return("generated XML")
+        expect(RiGse::Domain).to receive(:find).with("37").and_return(mock_domain)
+        expect(mock_domain).to receive(:to_xml).and_return("generated XML")
         get :show, :id => "37"
-        response.body.should == "generated XML"
+        expect(response.body).to eq("generated XML")
       end
 
     end
@@ -59,9 +59,9 @@ describe RiGse::DomainsController do
   describe "responding to GET new" do
   
     it "should expose a new domain as @domain" do
-      RiGse::Domain.should_receive(:new).and_return(mock_domain)
+      expect(RiGse::Domain).to receive(:new).and_return(mock_domain)
       get :new
-      assigns[:domain].should equal(mock_domain)
+      expect(assigns[:domain]).to equal(mock_domain)
     end
 
   end
@@ -69,9 +69,9 @@ describe RiGse::DomainsController do
   describe "responding to GET edit" do
   
     it "should expose the requested domain as @domain" do
-      RiGse::Domain.should_receive(:find).with("37").and_return(mock_domain)
+      expect(RiGse::Domain).to receive(:find).with("37").and_return(mock_domain)
       get :edit, :id => "37"
-      assigns[:domain].should equal(mock_domain)
+      expect(assigns[:domain]).to equal(mock_domain)
     end
 
   end
@@ -81,15 +81,15 @@ describe RiGse::DomainsController do
     describe "with valid params" do
       
       it "should expose a newly created domain as @domain" do
-        RiGse::Domain.should_receive(:new).with({'these' => 'params'}).and_return(mock_domain(:save => true))
+        expect(RiGse::Domain).to receive(:new).with({'these' => 'params'}).and_return(mock_domain(:save => true))
         post :create, :domain => {:these => 'params'}
-        assigns(:domain).should equal(mock_domain)
+        expect(assigns(:domain)).to equal(mock_domain)
       end
 
       it "should redirect to the created domain" do
-        RiGse::Domain.stub!(:new).and_return(mock_domain(:save => true))
+        allow(RiGse::Domain).to receive(:new).and_return(mock_domain(:save => true))
         post :create, :domain => {}
-        response.should redirect_to(ri_gse_domain_url(mock_domain))
+        expect(response).to redirect_to(ri_gse_domain_url(mock_domain))
       end
       
     end
@@ -97,15 +97,15 @@ describe RiGse::DomainsController do
     describe "with invalid params" do
 
       it "should expose a newly created but unsaved domain as @domain" do
-        RiGse::Domain.stub!(:new).with({'these' => 'params'}).and_return(mock_domain(:save => false))
+        allow(RiGse::Domain).to receive(:new).with({'these' => 'params'}).and_return(mock_domain(:save => false))
         post :create, :domain => {:these => 'params'}
-        assigns(:domain).should equal(mock_domain)
+        expect(assigns(:domain)).to equal(mock_domain)
       end
 
       it "should re-render the 'new' template" do
-        RiGse::Domain.stub!(:new).and_return(mock_domain(:save => false))
+        allow(RiGse::Domain).to receive(:new).and_return(mock_domain(:save => false))
         post :create, :domain => {}
-        response.should render_template('new')
+        expect(response).to render_template('new')
       end
       
     end
@@ -117,21 +117,21 @@ describe RiGse::DomainsController do
     describe "with valid params" do
 
       it "should update the requested domain" do
-        RiGse::Domain.should_receive(:find).with("37").and_return(mock_domain)
-        mock_domain.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(RiGse::Domain).to receive(:find).with("37").and_return(mock_domain)
+        expect(mock_domain).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :domain => {:these => 'params'}
       end
 
       it "should expose the requested domain as @domain" do
-        RiGse::Domain.stub!(:find).and_return(mock_domain(:update_attributes => true))
+        allow(RiGse::Domain).to receive(:find).and_return(mock_domain(:update_attributes => true))
         put :update, :id => "1"
-        assigns(:domain).should equal(mock_domain)
+        expect(assigns(:domain)).to equal(mock_domain)
       end
 
       it "should redirect to the domain" do
-        RiGse::Domain.stub!(:find).and_return(mock_domain(:update_attributes => true))
+        allow(RiGse::Domain).to receive(:find).and_return(mock_domain(:update_attributes => true))
         put :update, :id => "1"
-        response.should redirect_to(ri_gse_domain_url(mock_domain))
+        expect(response).to redirect_to(ri_gse_domain_url(mock_domain))
       end
 
     end
@@ -139,21 +139,21 @@ describe RiGse::DomainsController do
     describe "with invalid params" do
 
       it "should update the requested domain" do
-        RiGse::Domain.should_receive(:find).with("37").and_return(mock_domain)
-        mock_domain.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(RiGse::Domain).to receive(:find).with("37").and_return(mock_domain)
+        expect(mock_domain).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :domain => {:these => 'params'}
       end
 
       it "should expose the domain as @domain" do
-        RiGse::Domain.stub!(:find).and_return(mock_domain(:update_attributes => false))
+        allow(RiGse::Domain).to receive(:find).and_return(mock_domain(:update_attributes => false))
         put :update, :id => "1"
-        assigns(:domain).should equal(mock_domain)
+        expect(assigns(:domain)).to equal(mock_domain)
       end
 
       it "should re-render the 'edit' template" do
-        RiGse::Domain.stub!(:find).and_return(mock_domain(:update_attributes => false))
+        allow(RiGse::Domain).to receive(:find).and_return(mock_domain(:update_attributes => false))
         put :update, :id => "1"
-        response.should render_template('edit')
+        expect(response).to render_template('edit')
       end
 
     end
@@ -163,15 +163,15 @@ describe RiGse::DomainsController do
   describe "responding to DELETE destroy" do
 
     it "should destroy the requested domain" do
-      RiGse::Domain.should_receive(:find).with("37").and_return(mock_domain)
-      mock_domain.should_receive(:destroy)
+      expect(RiGse::Domain).to receive(:find).with("37").and_return(mock_domain)
+      expect(mock_domain).to receive(:destroy)
       delete :destroy, :id => "37"
     end
   
     it "should redirect to the domains list" do
-      RiGse::Domain.stub!(:find).and_return(mock_domain(:destroy => true))
+      allow(RiGse::Domain).to receive(:find).and_return(mock_domain(:destroy => true))
       delete :destroy, :id => "1"
-      response.should redirect_to(domains_url)
+      expect(response).to redirect_to(domains_url)
     end
 
   end

--- a/spec/controllers/ri_gse/expectation_stems_controller_spec.rb
+++ b/spec/controllers/ri_gse/expectation_stems_controller_spec.rb
@@ -15,19 +15,19 @@ describe RiGse::ExpectationStemsController do
   describe "responding to GET index" do
 
     it "should expose an array of all the @expectation_stems" do
-      RiGse::ExpectationStem.should_receive(:all).and_return([mock_expectation_stem])
+      expect(RiGse::ExpectationStem).to receive(:all).and_return([mock_expectation_stem])
       get :index
-      assigns[:expectation_stems].should == [mock_expectation_stem]
+      expect(assigns[:expectation_stems]).to eq([mock_expectation_stem])
     end
 
     describe "with mime type of xml" do
   
       it "should render all expectation_stems as xml" do
         request.env["HTTP_ACCEPT"] = "application/xml"
-        RiGse::ExpectationStem.should_receive(:all).and_return(expectation_stems = mock("Array of ExpectationStems"))
-        expectation_stems.should_receive(:to_xml).and_return("generated XML")
+        expect(RiGse::ExpectationStem).to receive(:all).and_return(expectation_stems = double("Array of ExpectationStems"))
+        expect(expectation_stems).to receive(:to_xml).and_return("generated XML")
         get :index
-        response.body.should == "generated XML"
+        expect(response.body).to eq("generated XML")
       end
     
     end
@@ -37,19 +37,19 @@ describe RiGse::ExpectationStemsController do
   describe "responding to GET show" do
 
     it "should expose the requested expectation_stem as @expectation_stem" do
-      RiGse::ExpectationStem.should_receive(:find).with("37").and_return(mock_expectation_stem)
+      expect(RiGse::ExpectationStem).to receive(:find).with("37").and_return(mock_expectation_stem)
       get :show, :id => "37"
-      assigns[:expectation_stem].should equal(mock_expectation_stem)
+      expect(assigns[:expectation_stem]).to equal(mock_expectation_stem)
     end
     
     describe "with mime type of xml" do
 
       it "should render the requested expectation_stem as xml" do
         request.env["HTTP_ACCEPT"] = "application/xml"
-        RiGse::ExpectationStem.should_receive(:find).with("37").and_return(mock_expectation_stem)
-        mock_expectation_stem.should_receive(:to_xml).and_return("generated XML")
+        expect(RiGse::ExpectationStem).to receive(:find).with("37").and_return(mock_expectation_stem)
+        expect(mock_expectation_stem).to receive(:to_xml).and_return("generated XML")
         get :show, :id => "37"
-        response.body.should == "generated XML"
+        expect(response.body).to eq("generated XML")
       end
 
     end
@@ -59,9 +59,9 @@ describe RiGse::ExpectationStemsController do
   describe "responding to GET new" do
   
     it "should expose a new expectation_stem as @expectation_stem" do
-      RiGse::ExpectationStem.should_receive(:new).and_return(mock_expectation_stem)
+      expect(RiGse::ExpectationStem).to receive(:new).and_return(mock_expectation_stem)
       get :new
-      assigns[:expectation_stem].should equal(mock_expectation_stem)
+      expect(assigns[:expectation_stem]).to equal(mock_expectation_stem)
     end
 
   end
@@ -69,9 +69,9 @@ describe RiGse::ExpectationStemsController do
   describe "responding to GET edit" do
   
     it "should expose the requested expectation_stem as @expectation_stem" do
-      RiGse::ExpectationStem.should_receive(:find).with("37").and_return(mock_expectation_stem)
+      expect(RiGse::ExpectationStem).to receive(:find).with("37").and_return(mock_expectation_stem)
       get :edit, :id => "37"
-      assigns[:expectation_stem].should equal(mock_expectation_stem)
+      expect(assigns[:expectation_stem]).to equal(mock_expectation_stem)
     end
 
   end
@@ -81,15 +81,15 @@ describe RiGse::ExpectationStemsController do
     describe "with valid params" do
       
       it "should expose a newly created expectation_stem as @expectation_stem" do
-        RiGse::ExpectationStem.should_receive(:new).with({'these' => 'params'}).and_return(mock_expectation_stem(:save => true))
+        expect(RiGse::ExpectationStem).to receive(:new).with({'these' => 'params'}).and_return(mock_expectation_stem(:save => true))
         post :create, :expectation_stem => {:these => 'params'}
-        assigns(:expectation_stem).should equal(mock_expectation_stem)
+        expect(assigns(:expectation_stem)).to equal(mock_expectation_stem)
       end
 
       it "should redirect to the created expectation_stem" do
-        RiGse::ExpectationStem.stub!(:new).and_return(mock_expectation_stem(:save => true))
+        allow(RiGse::ExpectationStem).to receive(:new).and_return(mock_expectation_stem(:save => true))
         post :create, :expectation_stem => {}
-        response.should redirect_to(ri_gse_expectation_stem_url(mock_expectation_stem))
+        expect(response).to redirect_to(ri_gse_expectation_stem_url(mock_expectation_stem))
       end
       
     end
@@ -97,15 +97,15 @@ describe RiGse::ExpectationStemsController do
     describe "with invalid params" do
 
       it "should expose a newly created but unsaved expectation_stem as @expectation_stem" do
-        RiGse::ExpectationStem.stub!(:new).with({'these' => 'params'}).and_return(mock_expectation_stem(:save => false))
+        allow(RiGse::ExpectationStem).to receive(:new).with({'these' => 'params'}).and_return(mock_expectation_stem(:save => false))
         post :create, :expectation_stem => {:these => 'params'}
-        assigns(:expectation_stem).should equal(mock_expectation_stem)
+        expect(assigns(:expectation_stem)).to equal(mock_expectation_stem)
       end
 
       it "should re-render the 'new' template" do
-        RiGse::ExpectationStem.stub!(:new).and_return(mock_expectation_stem(:save => false))
+        allow(RiGse::ExpectationStem).to receive(:new).and_return(mock_expectation_stem(:save => false))
         post :create, :expectation_stem => {}
-        response.should render_template('new')
+        expect(response).to render_template('new')
       end
       
     end
@@ -117,21 +117,21 @@ describe RiGse::ExpectationStemsController do
     describe "with valid params" do
 
       it "should update the requested expectation_stem" do
-        RiGse::ExpectationStem.should_receive(:find).with("37").and_return(mock_expectation_stem)
-        mock_expectation_stem.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(RiGse::ExpectationStem).to receive(:find).with("37").and_return(mock_expectation_stem)
+        expect(mock_expectation_stem).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :expectation_stem => {:these => 'params'}
       end
 
       it "should expose the requested expectation_stem as @expectation_stem" do
-        RiGse::ExpectationStem.stub!(:find).and_return(mock_expectation_stem(:update_attributes => true))
+        allow(RiGse::ExpectationStem).to receive(:find).and_return(mock_expectation_stem(:update_attributes => true))
         put :update, :id => "1"
-        assigns(:expectation_stem).should equal(mock_expectation_stem)
+        expect(assigns(:expectation_stem)).to equal(mock_expectation_stem)
       end
 
       it "should redirect to the expectation_stem" do
-        RiGse::ExpectationStem.stub!(:find).and_return(mock_expectation_stem(:update_attributes => true))
+        allow(RiGse::ExpectationStem).to receive(:find).and_return(mock_expectation_stem(:update_attributes => true))
         put :update, :id => "1"
-        response.should redirect_to(ri_gse_expectation_stem_url(mock_expectation_stem))
+        expect(response).to redirect_to(ri_gse_expectation_stem_url(mock_expectation_stem))
       end
 
     end
@@ -139,21 +139,21 @@ describe RiGse::ExpectationStemsController do
     describe "with invalid params" do
 
       it "should update the requested expectation_stem" do
-        RiGse::ExpectationStem.should_receive(:find).with("37").and_return(mock_expectation_stem)
-        mock_expectation_stem.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(RiGse::ExpectationStem).to receive(:find).with("37").and_return(mock_expectation_stem)
+        expect(mock_expectation_stem).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :expectation_stem => {:these => 'params'}
       end
 
       it "should expose the expectation_stem as @expectation_stem" do
-        RiGse::ExpectationStem.stub!(:find).and_return(mock_expectation_stem(:update_attributes => false))
+        allow(RiGse::ExpectationStem).to receive(:find).and_return(mock_expectation_stem(:update_attributes => false))
         put :update, :id => "1"
-        assigns(:expectation_stem).should equal(mock_expectation_stem)
+        expect(assigns(:expectation_stem)).to equal(mock_expectation_stem)
       end
 
       it "should re-render the 'edit' template" do
-        RiGse::ExpectationStem.stub!(:find).and_return(mock_expectation_stem(:update_attributes => false))
+        allow(RiGse::ExpectationStem).to receive(:find).and_return(mock_expectation_stem(:update_attributes => false))
         put :update, :id => "1"
-        response.should render_template('edit')
+        expect(response).to render_template('edit')
       end
 
     end
@@ -163,15 +163,15 @@ describe RiGse::ExpectationStemsController do
   describe "responding to DELETE destroy" do
 
     it "should destroy the requested expectation_stem" do
-      RiGse::ExpectationStem.should_receive(:find).with("37").and_return(mock_expectation_stem)
-      mock_expectation_stem.should_receive(:destroy)
+      expect(RiGse::ExpectationStem).to receive(:find).with("37").and_return(mock_expectation_stem)
+      expect(mock_expectation_stem).to receive(:destroy)
       delete :destroy, :id => "37"
     end
   
     it "should redirect to the expectation_stems list" do
-      RiGse::ExpectationStem.stub!(:find).and_return(mock_expectation_stem(:destroy => true))
+      allow(RiGse::ExpectationStem).to receive(:find).and_return(mock_expectation_stem(:destroy => true))
       delete :destroy, :id => "1"
-      response.should redirect_to(expectation_stems_url)
+      expect(response).to redirect_to(expectation_stems_url)
     end
 
   end

--- a/spec/controllers/ri_gse/expectations_controller_spec.rb
+++ b/spec/controllers/ri_gse/expectations_controller_spec.rb
@@ -15,19 +15,19 @@ describe RiGse::ExpectationsController do
   describe "responding to GET index" do
 
     it "should expose an array of all the @expectations" do
-      RiGse::Expectation.should_receive(:all).and_return([mock_expectation])
+      expect(RiGse::Expectation).to receive(:all).and_return([mock_expectation])
       get :index
-      assigns[:expectations].should == [mock_expectation]
+      expect(assigns[:expectations]).to eq([mock_expectation])
     end
 
     describe "with mime type of xml" do
   
       it "should render all expectations as xml" do
         request.env["HTTP_ACCEPT"] = "application/xml"
-        RiGse::Expectation.should_receive(:all).and_return(expectations = mock("Array of Expectations"))
-        expectations.should_receive(:to_xml).and_return("generated XML")
+        expect(RiGse::Expectation).to receive(:all).and_return(expectations = double("Array of Expectations"))
+        expect(expectations).to receive(:to_xml).and_return("generated XML")
         get :index
-        response.body.should == "generated XML"
+        expect(response.body).to eq("generated XML")
       end
     
     end
@@ -37,19 +37,19 @@ describe RiGse::ExpectationsController do
   describe "responding to GET show" do
 
     it "should expose the requested expectation as @expectation" do
-      RiGse::Expectation.should_receive(:find).with("37").and_return(mock_expectation)
+      expect(RiGse::Expectation).to receive(:find).with("37").and_return(mock_expectation)
       get :show, :id => "37"
-      assigns[:expectation].should equal(mock_expectation)
+      expect(assigns[:expectation]).to equal(mock_expectation)
     end
     
     describe "with mime type of xml" do
 
       it "should render the requested expectation as xml" do
         request.env["HTTP_ACCEPT"] = "application/xml"
-        RiGse::Expectation.should_receive(:find).with("37").and_return(mock_expectation)
-        mock_expectation.should_receive(:to_xml).and_return("generated XML")
+        expect(RiGse::Expectation).to receive(:find).with("37").and_return(mock_expectation)
+        expect(mock_expectation).to receive(:to_xml).and_return("generated XML")
         get :show, :id => "37"
-        response.body.should == "generated XML"
+        expect(response.body).to eq("generated XML")
       end
 
     end
@@ -59,9 +59,9 @@ describe RiGse::ExpectationsController do
   describe "responding to GET new" do
   
     it "should expose a new expectation as @expectation" do
-      RiGse::Expectation.should_receive(:new).and_return(mock_expectation)
+      expect(RiGse::Expectation).to receive(:new).and_return(mock_expectation)
       get :new
-      assigns[:expectation].should equal(mock_expectation)
+      expect(assigns[:expectation]).to equal(mock_expectation)
     end
 
   end
@@ -69,9 +69,9 @@ describe RiGse::ExpectationsController do
   describe "responding to GET edit" do
   
     it "should expose the requested expectation as @expectation" do
-      RiGse::Expectation.should_receive(:find).with("37").and_return(mock_expectation)
+      expect(RiGse::Expectation).to receive(:find).with("37").and_return(mock_expectation)
       get :edit, :id => "37"
-      assigns[:expectation].should equal(mock_expectation)
+      expect(assigns[:expectation]).to equal(mock_expectation)
     end
 
   end
@@ -81,15 +81,15 @@ describe RiGse::ExpectationsController do
     describe "with valid params" do
       
       it "should expose a newly created expectation as @expectation" do
-        RiGse::Expectation.should_receive(:new).with({'these' => 'params'}).and_return(mock_expectation(:save => true))
+        expect(RiGse::Expectation).to receive(:new).with({'these' => 'params'}).and_return(mock_expectation(:save => true))
         post :create, :expectation => {:these => 'params'}
-        assigns(:expectation).should equal(mock_expectation)
+        expect(assigns(:expectation)).to equal(mock_expectation)
       end
 
       it "should redirect to the created expectation" do
-        RiGse::Expectation.stub!(:new).and_return(mock_expectation(:save => true))
+        allow(RiGse::Expectation).to receive(:new).and_return(mock_expectation(:save => true))
         post :create, :expectation => {}
-        response.should redirect_to(ri_gse_expectation_url(mock_expectation))
+        expect(response).to redirect_to(ri_gse_expectation_url(mock_expectation))
       end
       
     end
@@ -97,15 +97,15 @@ describe RiGse::ExpectationsController do
     describe "with invalid params" do
 
       it "should expose a newly created but unsaved expectation as @expectation" do
-        RiGse::Expectation.stub!(:new).with({'these' => 'params'}).and_return(mock_expectation(:save => false))
+        allow(RiGse::Expectation).to receive(:new).with({'these' => 'params'}).and_return(mock_expectation(:save => false))
         post :create, :expectation => {:these => 'params'}
-        assigns(:expectation).should equal(mock_expectation)
+        expect(assigns(:expectation)).to equal(mock_expectation)
       end
 
       it "should re-render the 'new' template" do
-        RiGse::Expectation.stub!(:new).and_return(mock_expectation(:save => false))
+        allow(RiGse::Expectation).to receive(:new).and_return(mock_expectation(:save => false))
         post :create, :expectation => {}
-        response.should render_template('new')
+        expect(response).to render_template('new')
       end
       
     end
@@ -117,21 +117,21 @@ describe RiGse::ExpectationsController do
     describe "with valid params" do
 
       it "should update the requested expectation" do
-        RiGse::Expectation.should_receive(:find).with("37").and_return(mock_expectation)
-        mock_expectation.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(RiGse::Expectation).to receive(:find).with("37").and_return(mock_expectation)
+        expect(mock_expectation).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :expectation => {:these => 'params'}
       end
 
       it "should expose the requested expectation as @expectation" do
-        RiGse::Expectation.stub!(:find).and_return(mock_expectation(:update_attributes => true))
+        allow(RiGse::Expectation).to receive(:find).and_return(mock_expectation(:update_attributes => true))
         put :update, :id => "1"
-        assigns(:expectation).should equal(mock_expectation)
+        expect(assigns(:expectation)).to equal(mock_expectation)
       end
 
       it "should redirect to the expectation" do
-        RiGse::Expectation.stub!(:find).and_return(mock_expectation(:update_attributes => true))
+        allow(RiGse::Expectation).to receive(:find).and_return(mock_expectation(:update_attributes => true))
         put :update, :id => "1"
-        response.should redirect_to(ri_gse_expectation_url(mock_expectation))
+        expect(response).to redirect_to(ri_gse_expectation_url(mock_expectation))
       end
 
     end
@@ -139,21 +139,21 @@ describe RiGse::ExpectationsController do
     describe "with invalid params" do
 
       it "should update the requested expectation" do
-        RiGse::Expectation.should_receive(:find).with("37").and_return(mock_expectation)
-        mock_expectation.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(RiGse::Expectation).to receive(:find).with("37").and_return(mock_expectation)
+        expect(mock_expectation).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :expectation => {:these => 'params'}
       end
 
       it "should expose the expectation as @expectation" do
-        RiGse::Expectation.stub!(:find).and_return(mock_expectation(:update_attributes => false))
+        allow(RiGse::Expectation).to receive(:find).and_return(mock_expectation(:update_attributes => false))
         put :update, :id => "1"
-        assigns(:expectation).should equal(mock_expectation)
+        expect(assigns(:expectation)).to equal(mock_expectation)
       end
 
       it "should re-render the 'edit' template" do
-        RiGse::Expectation.stub!(:find).and_return(mock_expectation(:update_attributes => false))
+        allow(RiGse::Expectation).to receive(:find).and_return(mock_expectation(:update_attributes => false))
         put :update, :id => "1"
-        response.should render_template('edit')
+        expect(response).to render_template('edit')
       end
 
     end
@@ -163,15 +163,15 @@ describe RiGse::ExpectationsController do
   describe "responding to DELETE destroy" do
 
     it "should destroy the requested expectation" do
-      RiGse::Expectation.should_receive(:find).with("37").and_return(mock_expectation)
-      mock_expectation.should_receive(:destroy)
+      expect(RiGse::Expectation).to receive(:find).with("37").and_return(mock_expectation)
+      expect(mock_expectation).to receive(:destroy)
       delete :destroy, :id => "37"
     end
   
     it "should redirect to the expectations list" do
-      RiGse::Expectation.stub!(:find).and_return(mock_expectation(:destroy => true))
+      allow(RiGse::Expectation).to receive(:find).and_return(mock_expectation(:destroy => true))
       delete :destroy, :id => "1"
-      response.should redirect_to(expectations_url)
+      expect(response).to redirect_to(expectations_url)
     end
 
   end

--- a/spec/controllers/ri_gse/grade_span_expectations_controller_spec.rb
+++ b/spec/controllers/ri_gse/grade_span_expectations_controller_spec.rb
@@ -15,19 +15,19 @@ describe RiGse::GradeSpanExpectationsController do
   describe "responding to GET index" do
 
     it "should expose a paginated array of @grade_span_expectations" do
-      RiGse::GradeSpanExpectation.should_receive(:search).and_return([mock_grade_span_expectation])
+      expect(RiGse::GradeSpanExpectation).to receive(:search).and_return([mock_grade_span_expectation])
       get :index
-      assigns[:grade_span_expectations].should == [mock_grade_span_expectation]
+      expect(assigns[:grade_span_expectations]).to eq([mock_grade_span_expectation])
     end
 
     describe "with mime type of xml" do
   
       it "should render all grade_span_expectations as xml" do
         request.env["HTTP_ACCEPT"] = "application/xml"
-        RiGse::GradeSpanExpectation.should_receive(:all).and_return(grade_span_expectations = mock("Array of GradeSpanExpectations"))
-        grade_span_expectations.should_receive(:to_xml).and_return("generated XML")
+        expect(RiGse::GradeSpanExpectation).to receive(:all).and_return(grade_span_expectations = double("Array of GradeSpanExpectations"))
+        expect(grade_span_expectations).to receive(:to_xml).and_return("generated XML")
         get :index
-        response.body.should == "generated XML"
+        expect(response.body).to eq("generated XML")
       end
     
     end
@@ -37,19 +37,19 @@ describe RiGse::GradeSpanExpectationsController do
   describe "responding to GET show" do
 
     it "should expose the requested grade_span_expectation as @grade_span_expectation" do
-      RiGse::GradeSpanExpectation.should_receive(:find).with("37").and_return(mock_grade_span_expectation)
+      expect(RiGse::GradeSpanExpectation).to receive(:find).with("37").and_return(mock_grade_span_expectation)
       get :show, :id => "37"
-      assigns[:grade_span_expectation].should equal(mock_grade_span_expectation)
+      expect(assigns[:grade_span_expectation]).to equal(mock_grade_span_expectation)
     end
     
     describe "with mime type of xml" do
 
       it "should render the requested grade_span_expectation as xml" do
         request.env["HTTP_ACCEPT"] = "application/xml"
-        RiGse::GradeSpanExpectation.should_receive(:find).with("37").and_return(mock_grade_span_expectation)
-        mock_grade_span_expectation.should_receive(:to_xml).and_return("generated XML")
+        expect(RiGse::GradeSpanExpectation).to receive(:find).with("37").and_return(mock_grade_span_expectation)
+        expect(mock_grade_span_expectation).to receive(:to_xml).and_return("generated XML")
         get :show, :id => "37"
-        response.body.should == "generated XML"
+        expect(response.body).to eq("generated XML")
       end
 
     end
@@ -59,9 +59,9 @@ describe RiGse::GradeSpanExpectationsController do
   describe "responding to GET new" do
   
     it "should expose a new grade_span_expectation as @grade_span_expectation" do
-      RiGse::GradeSpanExpectation.should_receive(:new).and_return(mock_grade_span_expectation)
+      expect(RiGse::GradeSpanExpectation).to receive(:new).and_return(mock_grade_span_expectation)
       get :new
-      assigns[:grade_span_expectation].should equal(mock_grade_span_expectation)
+      expect(assigns[:grade_span_expectation]).to equal(mock_grade_span_expectation)
     end
 
   end
@@ -69,9 +69,9 @@ describe RiGse::GradeSpanExpectationsController do
   describe "responding to GET edit" do
   
     it "should expose the requested grade_span_expectation as @grade_span_expectation" do
-      RiGse::GradeSpanExpectation.should_receive(:find).with("37").and_return(mock_grade_span_expectation)
+      expect(RiGse::GradeSpanExpectation).to receive(:find).with("37").and_return(mock_grade_span_expectation)
       get :edit, :id => "37"
-      assigns[:grade_span_expectation].should equal(mock_grade_span_expectation)
+      expect(assigns[:grade_span_expectation]).to equal(mock_grade_span_expectation)
     end
 
   end
@@ -81,15 +81,15 @@ describe RiGse::GradeSpanExpectationsController do
     describe "with valid params" do
       
       it "should expose a newly created grade_span_expectation as @grade_span_expectation" do
-        RiGse::GradeSpanExpectation.should_receive(:new).with({'these' => 'params'}).and_return(mock_grade_span_expectation(:save => true))
+        expect(RiGse::GradeSpanExpectation).to receive(:new).with({'these' => 'params'}).and_return(mock_grade_span_expectation(:save => true))
         post :create, :grade_span_expectation => {:these => 'params'}
-        assigns(:grade_span_expectation).should equal(mock_grade_span_expectation)
+        expect(assigns(:grade_span_expectation)).to equal(mock_grade_span_expectation)
       end
 
       it "should redirect to the created grade_span_expectation" do
-        RiGse::GradeSpanExpectation.stub!(:new).and_return(mock_grade_span_expectation(:save => true))
+        allow(RiGse::GradeSpanExpectation).to receive(:new).and_return(mock_grade_span_expectation(:save => true))
         post :create, :grade_span_expectation => {}
-        response.should redirect_to(ri_gse_grade_span_expectation_url(mock_grade_span_expectation))
+        expect(response).to redirect_to(ri_gse_grade_span_expectation_url(mock_grade_span_expectation))
       end
       
     end
@@ -97,15 +97,15 @@ describe RiGse::GradeSpanExpectationsController do
     describe "with invalid params" do
 
       it "should expose a newly created but unsaved grade_span_expectation as @grade_span_expectation" do
-        RiGse::GradeSpanExpectation.stub!(:new).with({'these' => 'params'}).and_return(mock_grade_span_expectation(:save => false))
+        allow(RiGse::GradeSpanExpectation).to receive(:new).with({'these' => 'params'}).and_return(mock_grade_span_expectation(:save => false))
         post :create, :grade_span_expectation => {:these => 'params'}
-        assigns(:grade_span_expectation).should equal(mock_grade_span_expectation)
+        expect(assigns(:grade_span_expectation)).to equal(mock_grade_span_expectation)
       end
 
       it "should re-render the 'new' template" do
-        RiGse::GradeSpanExpectation.stub!(:new).and_return(mock_grade_span_expectation(:save => false))
+        allow(RiGse::GradeSpanExpectation).to receive(:new).and_return(mock_grade_span_expectation(:save => false))
         post :create, :grade_span_expectation => {}
-        response.should render_template('new')
+        expect(response).to render_template('new')
       end
       
     end
@@ -117,21 +117,21 @@ describe RiGse::GradeSpanExpectationsController do
     describe "with valid params" do
 
       it "should update the requested grade_span_expectation" do
-        RiGse::GradeSpanExpectation.should_receive(:find).with("37").and_return(mock_grade_span_expectation)
-        mock_grade_span_expectation.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(RiGse::GradeSpanExpectation).to receive(:find).with("37").and_return(mock_grade_span_expectation)
+        expect(mock_grade_span_expectation).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :grade_span_expectation => {:these => 'params'}
       end
 
       it "should expose the requested grade_span_expectation as @grade_span_expectation" do
-        RiGse::GradeSpanExpectation.stub!(:find).and_return(mock_grade_span_expectation(:update_attributes => true))
+        allow(RiGse::GradeSpanExpectation).to receive(:find).and_return(mock_grade_span_expectation(:update_attributes => true))
         put :update, :id => "1"
-        assigns(:grade_span_expectation).should equal(mock_grade_span_expectation)
+        expect(assigns(:grade_span_expectation)).to equal(mock_grade_span_expectation)
       end
 
       it "should redirect to the grade_span_expectation" do
-        RiGse::GradeSpanExpectation.stub!(:find).and_return(mock_grade_span_expectation(:update_attributes => true))
+        allow(RiGse::GradeSpanExpectation).to receive(:find).and_return(mock_grade_span_expectation(:update_attributes => true))
         put :update, :id => "1"
-        response.should redirect_to(ri_gse_grade_span_expectation_url(mock_grade_span_expectation))
+        expect(response).to redirect_to(ri_gse_grade_span_expectation_url(mock_grade_span_expectation))
       end
 
     end
@@ -139,21 +139,21 @@ describe RiGse::GradeSpanExpectationsController do
     describe "with invalid params" do
 
       it "should update the requested grade_span_expectation" do
-        RiGse::GradeSpanExpectation.should_receive(:find).with("37").and_return(mock_grade_span_expectation)
-        mock_grade_span_expectation.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(RiGse::GradeSpanExpectation).to receive(:find).with("37").and_return(mock_grade_span_expectation)
+        expect(mock_grade_span_expectation).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :grade_span_expectation => {:these => 'params'}
       end
 
       it "should expose the grade_span_expectation as @grade_span_expectation" do
-        RiGse::GradeSpanExpectation.stub!(:find).and_return(mock_grade_span_expectation(:update_attributes => false))
+        allow(RiGse::GradeSpanExpectation).to receive(:find).and_return(mock_grade_span_expectation(:update_attributes => false))
         put :update, :id => "1"
-        assigns(:grade_span_expectation).should equal(mock_grade_span_expectation)
+        expect(assigns(:grade_span_expectation)).to equal(mock_grade_span_expectation)
       end
 
       it "should re-render the 'edit' template" do
-        RiGse::GradeSpanExpectation.stub!(:find).and_return(mock_grade_span_expectation(:update_attributes => false))
+        allow(RiGse::GradeSpanExpectation).to receive(:find).and_return(mock_grade_span_expectation(:update_attributes => false))
         put :update, :id => "1"
-        response.should render_template('edit')
+        expect(response).to render_template('edit')
       end
 
     end
@@ -163,15 +163,15 @@ describe RiGse::GradeSpanExpectationsController do
   describe "responding to DELETE destroy" do
 
     it "should destroy the requested grade_span_expectation" do
-      RiGse::GradeSpanExpectation.should_receive(:find).with("37").and_return(mock_grade_span_expectation)
-      mock_grade_span_expectation.should_receive(:destroy)
+      expect(RiGse::GradeSpanExpectation).to receive(:find).with("37").and_return(mock_grade_span_expectation)
+      expect(mock_grade_span_expectation).to receive(:destroy)
       delete :destroy, :id => "37"
     end
   
     it "should redirect to the grade_span_expectations list" do
-      RiGse::GradeSpanExpectation.stub!(:find).and_return(mock_grade_span_expectation(:destroy => true))
+      allow(RiGse::GradeSpanExpectation).to receive(:find).and_return(mock_grade_span_expectation(:destroy => true))
       delete :destroy, :id => "1"
-      response.should redirect_to(grade_span_expectations_url)
+      expect(response).to redirect_to(grade_span_expectations_url)
     end
 
   end

--- a/spec/controllers/ri_gse/knowledge_statements_controller_spec.rb
+++ b/spec/controllers/ri_gse/knowledge_statements_controller_spec.rb
@@ -15,19 +15,19 @@ describe RiGse::KnowledgeStatementsController do
   describe "responding to GET index" do
 
     it "should expose an array of all the @knowledge_statements" do
-      RiGse::KnowledgeStatement.should_receive(:all).and_return([mock_knowledge_statement])
+      expect(RiGse::KnowledgeStatement).to receive(:all).and_return([mock_knowledge_statement])
       get :index
-      assigns[:knowledge_statements].should == [mock_knowledge_statement]
+      expect(assigns[:knowledge_statements]).to eq([mock_knowledge_statement])
     end
 
     describe "with mime type of xml" do
   
       it "should render all knowledge_statements as xml" do
         request.env["HTTP_ACCEPT"] = "application/xml"
-        RiGse::KnowledgeStatement.should_receive(:all).and_return(knowledge_statements = mock("Array of KnowledgeStatements"))
-        knowledge_statements.should_receive(:to_xml).and_return("generated XML")
+        expect(RiGse::KnowledgeStatement).to receive(:all).and_return(knowledge_statements = double("Array of KnowledgeStatements"))
+        expect(knowledge_statements).to receive(:to_xml).and_return("generated XML")
         get :index
-        response.body.should == "generated XML"
+        expect(response.body).to eq("generated XML")
       end
     
     end
@@ -37,19 +37,19 @@ describe RiGse::KnowledgeStatementsController do
   describe "responding to GET show" do
 
     it "should expose the requested knowledge_statement as @knowledge_statement" do
-      RiGse::KnowledgeStatement.should_receive(:find).with("37").and_return(mock_knowledge_statement)
+      expect(RiGse::KnowledgeStatement).to receive(:find).with("37").and_return(mock_knowledge_statement)
       get :show, :id => "37"
-      assigns[:knowledge_statement].should equal(mock_knowledge_statement)
+      expect(assigns[:knowledge_statement]).to equal(mock_knowledge_statement)
     end
     
     describe "with mime type of xml" do
 
       it "should render the requested knowledge_statement as xml" do
         request.env["HTTP_ACCEPT"] = "application/xml"
-        RiGse::KnowledgeStatement.should_receive(:find).with("37").and_return(mock_knowledge_statement)
-        mock_knowledge_statement.should_receive(:to_xml).and_return("generated XML")
+        expect(RiGse::KnowledgeStatement).to receive(:find).with("37").and_return(mock_knowledge_statement)
+        expect(mock_knowledge_statement).to receive(:to_xml).and_return("generated XML")
         get :show, :id => "37"
-        response.body.should == "generated XML"
+        expect(response.body).to eq("generated XML")
       end
 
     end
@@ -59,9 +59,9 @@ describe RiGse::KnowledgeStatementsController do
   describe "responding to GET new" do
   
     it "should expose a new knowledge_statement as @knowledge_statement" do
-      RiGse::KnowledgeStatement.should_receive(:new).and_return(mock_knowledge_statement)
+      expect(RiGse::KnowledgeStatement).to receive(:new).and_return(mock_knowledge_statement)
       get :new
-      assigns[:knowledge_statement].should equal(mock_knowledge_statement)
+      expect(assigns[:knowledge_statement]).to equal(mock_knowledge_statement)
     end
 
   end
@@ -69,9 +69,9 @@ describe RiGse::KnowledgeStatementsController do
   describe "responding to GET edit" do
   
     it "should expose the requested knowledge_statement as @knowledge_statement" do
-      RiGse::KnowledgeStatement.should_receive(:find).with("37").and_return(mock_knowledge_statement)
+      expect(RiGse::KnowledgeStatement).to receive(:find).with("37").and_return(mock_knowledge_statement)
       get :edit, :id => "37"
-      assigns[:knowledge_statement].should equal(mock_knowledge_statement)
+      expect(assigns[:knowledge_statement]).to equal(mock_knowledge_statement)
     end
 
   end
@@ -81,15 +81,15 @@ describe RiGse::KnowledgeStatementsController do
     describe "with valid params" do
       
       it "should expose a newly created knowledge_statement as @knowledge_statement" do
-        RiGse::KnowledgeStatement.should_receive(:new).with({'these' => 'params'}).and_return(mock_knowledge_statement(:save => true))
+        expect(RiGse::KnowledgeStatement).to receive(:new).with({'these' => 'params'}).and_return(mock_knowledge_statement(:save => true))
         post :create, :knowledge_statement => {:these => 'params'}
-        assigns(:knowledge_statement).should equal(mock_knowledge_statement)
+        expect(assigns(:knowledge_statement)).to equal(mock_knowledge_statement)
       end
 
       it "should redirect to the created knowledge_statement" do
-        RiGse::KnowledgeStatement.stub!(:new).and_return(mock_knowledge_statement(:save => true))
+        allow(RiGse::KnowledgeStatement).to receive(:new).and_return(mock_knowledge_statement(:save => true))
         post :create, :knowledge_statement => {}
-        response.should redirect_to(ri_gse_knowledge_statement_url(mock_knowledge_statement))
+        expect(response).to redirect_to(ri_gse_knowledge_statement_url(mock_knowledge_statement))
       end
       
     end
@@ -97,15 +97,15 @@ describe RiGse::KnowledgeStatementsController do
     describe "with invalid params" do
 
       it "should expose a newly created but unsaved knowledge_statement as @knowledge_statement" do
-        RiGse::KnowledgeStatement.stub!(:new).with({'these' => 'params'}).and_return(mock_knowledge_statement(:save => false))
+        allow(RiGse::KnowledgeStatement).to receive(:new).with({'these' => 'params'}).and_return(mock_knowledge_statement(:save => false))
         post :create, :knowledge_statement => {:these => 'params'}
-        assigns(:knowledge_statement).should equal(mock_knowledge_statement)
+        expect(assigns(:knowledge_statement)).to equal(mock_knowledge_statement)
       end
 
       it "should re-render the 'new' template" do
-        RiGse::KnowledgeStatement.stub!(:new).and_return(mock_knowledge_statement(:save => false))
+        allow(RiGse::KnowledgeStatement).to receive(:new).and_return(mock_knowledge_statement(:save => false))
         post :create, :knowledge_statement => {}
-        response.should render_template('new')
+        expect(response).to render_template('new')
       end
       
     end
@@ -117,21 +117,21 @@ describe RiGse::KnowledgeStatementsController do
     describe "with valid params" do
 
       it "should update the requested knowledge_statement" do
-        RiGse::KnowledgeStatement.should_receive(:find).with("37").and_return(mock_knowledge_statement)
-        mock_knowledge_statement.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(RiGse::KnowledgeStatement).to receive(:find).with("37").and_return(mock_knowledge_statement)
+        expect(mock_knowledge_statement).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :knowledge_statement => {:these => 'params'}
       end
 
       it "should expose the requested knowledge_statement as @knowledge_statement" do
-        RiGse::KnowledgeStatement.stub!(:find).and_return(mock_knowledge_statement(:update_attributes => true))
+        allow(RiGse::KnowledgeStatement).to receive(:find).and_return(mock_knowledge_statement(:update_attributes => true))
         put :update, :id => "1"
-        assigns(:knowledge_statement).should equal(mock_knowledge_statement)
+        expect(assigns(:knowledge_statement)).to equal(mock_knowledge_statement)
       end
 
       it "should redirect to the knowledge_statement" do
-        RiGse::KnowledgeStatement.stub!(:find).and_return(mock_knowledge_statement(:update_attributes => true))
+        allow(RiGse::KnowledgeStatement).to receive(:find).and_return(mock_knowledge_statement(:update_attributes => true))
         put :update, :id => "1"
-        response.should redirect_to(ri_gse_knowledge_statement_url(mock_knowledge_statement))
+        expect(response).to redirect_to(ri_gse_knowledge_statement_url(mock_knowledge_statement))
       end
 
     end
@@ -139,21 +139,21 @@ describe RiGse::KnowledgeStatementsController do
     describe "with invalid params" do
 
       it "should update the requested knowledge_statement" do
-        RiGse::KnowledgeStatement.should_receive(:find).with("37").and_return(mock_knowledge_statement)
-        mock_knowledge_statement.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(RiGse::KnowledgeStatement).to receive(:find).with("37").and_return(mock_knowledge_statement)
+        expect(mock_knowledge_statement).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :knowledge_statement => {:these => 'params'}
       end
 
       it "should expose the knowledge_statement as @knowledge_statement" do
-        RiGse::KnowledgeStatement.stub!(:find).and_return(mock_knowledge_statement(:update_attributes => false))
+        allow(RiGse::KnowledgeStatement).to receive(:find).and_return(mock_knowledge_statement(:update_attributes => false))
         put :update, :id => "1"
-        assigns(:knowledge_statement).should equal(mock_knowledge_statement)
+        expect(assigns(:knowledge_statement)).to equal(mock_knowledge_statement)
       end
 
       it "should re-render the 'edit' template" do
-        RiGse::KnowledgeStatement.stub!(:find).and_return(mock_knowledge_statement(:update_attributes => false))
+        allow(RiGse::KnowledgeStatement).to receive(:find).and_return(mock_knowledge_statement(:update_attributes => false))
         put :update, :id => "1"
-        response.should render_template('edit')
+        expect(response).to render_template('edit')
       end
 
     end
@@ -163,15 +163,15 @@ describe RiGse::KnowledgeStatementsController do
   describe "responding to DELETE destroy" do
 
     it "should destroy the requested knowledge_statement" do
-      RiGse::KnowledgeStatement.should_receive(:find).with("37").and_return(mock_knowledge_statement)
-      mock_knowledge_statement.should_receive(:destroy)
+      expect(RiGse::KnowledgeStatement).to receive(:find).with("37").and_return(mock_knowledge_statement)
+      expect(mock_knowledge_statement).to receive(:destroy)
       delete :destroy, :id => "37"
     end
   
     it "should redirect to the knowledge_statements list" do
-      RiGse::KnowledgeStatement.stub!(:find).and_return(mock_knowledge_statement(:destroy => true))
+      allow(RiGse::KnowledgeStatement).to receive(:find).and_return(mock_knowledge_statement(:destroy => true))
       delete :destroy, :id => "1"
-      response.should redirect_to(knowledge_statements_url)
+      expect(response).to redirect_to(knowledge_statements_url)
     end
 
   end

--- a/spec/controllers/ri_gse/unifying_themes_controller_spec.rb
+++ b/spec/controllers/ri_gse/unifying_themes_controller_spec.rb
@@ -15,19 +15,19 @@ describe RiGse::UnifyingThemesController do
   describe "responding to GET index" do
 
     it "should expose an array of all the @unifying_themes" do
-      RiGse::UnifyingTheme.should_receive(:all).and_return([mock_unifying_theme])
+      expect(RiGse::UnifyingTheme).to receive(:all).and_return([mock_unifying_theme])
       get :index
-      assigns[:unifying_themes].should == [mock_unifying_theme]
+      expect(assigns[:unifying_themes]).to eq([mock_unifying_theme])
     end
 
     describe "with mime type of xml" do
   
       it "should render all unifying_themes as xml" do
         request.env["HTTP_ACCEPT"] = "application/xml"
-        RiGse::UnifyingTheme.should_receive(:all).and_return(unifying_themes = mock("Array of UnifyingThemes"))
-        unifying_themes.should_receive(:to_xml).and_return("generated XML")
+        expect(RiGse::UnifyingTheme).to receive(:all).and_return(unifying_themes = double("Array of UnifyingThemes"))
+        expect(unifying_themes).to receive(:to_xml).and_return("generated XML")
         get :index
-        response.body.should == "generated XML"
+        expect(response.body).to eq("generated XML")
       end
     
     end
@@ -37,19 +37,19 @@ describe RiGse::UnifyingThemesController do
   describe "responding to GET show" do
 
     it "should expose the requested unifying_theme as @unifying_theme" do
-      RiGse::UnifyingTheme.should_receive(:find).with("37").and_return(mock_unifying_theme)
+      expect(RiGse::UnifyingTheme).to receive(:find).with("37").and_return(mock_unifying_theme)
       get :show, :id => "37"
-      assigns[:unifying_theme].should equal(mock_unifying_theme)
+      expect(assigns[:unifying_theme]).to equal(mock_unifying_theme)
     end
     
     describe "with mime type of xml" do
 
       it "should render the requested unifying_theme as xml" do
         request.env["HTTP_ACCEPT"] = "application/xml"
-        RiGse::UnifyingTheme.should_receive(:find).with("37").and_return(mock_unifying_theme)
-        mock_unifying_theme.should_receive(:to_xml).and_return("generated XML")
+        expect(RiGse::UnifyingTheme).to receive(:find).with("37").and_return(mock_unifying_theme)
+        expect(mock_unifying_theme).to receive(:to_xml).and_return("generated XML")
         get :show, :id => "37"
-        response.body.should == "generated XML"
+        expect(response.body).to eq("generated XML")
       end
 
     end
@@ -59,9 +59,9 @@ describe RiGse::UnifyingThemesController do
   describe "responding to GET new" do
   
     it "should expose a new unifying_theme as @unifying_theme" do
-      RiGse::UnifyingTheme.should_receive(:new).and_return(mock_unifying_theme)
+      expect(RiGse::UnifyingTheme).to receive(:new).and_return(mock_unifying_theme)
       get :new
-      assigns[:unifying_theme].should equal(mock_unifying_theme)
+      expect(assigns[:unifying_theme]).to equal(mock_unifying_theme)
     end
 
   end
@@ -69,9 +69,9 @@ describe RiGse::UnifyingThemesController do
   describe "responding to GET edit" do
   
     it "should expose the requested unifying_theme as @unifying_theme" do
-      RiGse::UnifyingTheme.should_receive(:find).with("37").and_return(mock_unifying_theme)
+      expect(RiGse::UnifyingTheme).to receive(:find).with("37").and_return(mock_unifying_theme)
       get :edit, :id => "37"
-      assigns[:unifying_theme].should equal(mock_unifying_theme)
+      expect(assigns[:unifying_theme]).to equal(mock_unifying_theme)
     end
 
   end
@@ -81,15 +81,15 @@ describe RiGse::UnifyingThemesController do
     describe "with valid params" do
       
       it "should expose a newly created unifying_theme as @unifying_theme" do
-        RiGse::UnifyingTheme.should_receive(:new).with({'these' => 'params'}).and_return(mock_unifying_theme(:save => true))
+        expect(RiGse::UnifyingTheme).to receive(:new).with({'these' => 'params'}).and_return(mock_unifying_theme(:save => true))
         post :create, :unifying_theme => {:these => 'params'}
-        assigns(:unifying_theme).should equal(mock_unifying_theme)
+        expect(assigns(:unifying_theme)).to equal(mock_unifying_theme)
       end
 
       it "should redirect to the created unifying_theme" do
-        RiGse::UnifyingTheme.stub!(:new).and_return(mock_unifying_theme(:save => true))
+        allow(RiGse::UnifyingTheme).to receive(:new).and_return(mock_unifying_theme(:save => true))
         post :create, :unifying_theme => {}
-        response.should redirect_to(ri_gse_unifying_theme_url(mock_unifying_theme))
+        expect(response).to redirect_to(ri_gse_unifying_theme_url(mock_unifying_theme))
       end
       
     end
@@ -97,15 +97,15 @@ describe RiGse::UnifyingThemesController do
     describe "with invalid params" do
 
       it "should expose a newly created but unsaved unifying_theme as @unifying_theme" do
-        RiGse::UnifyingTheme.stub!(:new).with({'these' => 'params'}).and_return(mock_unifying_theme(:save => false))
+        allow(RiGse::UnifyingTheme).to receive(:new).with({'these' => 'params'}).and_return(mock_unifying_theme(:save => false))
         post :create, :unifying_theme => {:these => 'params'}
-        assigns(:unifying_theme).should equal(mock_unifying_theme)
+        expect(assigns(:unifying_theme)).to equal(mock_unifying_theme)
       end
 
       it "should re-render the 'new' template" do
-        RiGse::UnifyingTheme.stub!(:new).and_return(mock_unifying_theme(:save => false))
+        allow(RiGse::UnifyingTheme).to receive(:new).and_return(mock_unifying_theme(:save => false))
         post :create, :unifying_theme => {}
-        response.should render_template('new')
+        expect(response).to render_template('new')
       end
       
     end
@@ -117,21 +117,21 @@ describe RiGse::UnifyingThemesController do
     describe "with valid params" do
 
       it "should update the requested unifying_theme" do
-        RiGse::UnifyingTheme.should_receive(:find).with("37").and_return(mock_unifying_theme)
-        mock_unifying_theme.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(RiGse::UnifyingTheme).to receive(:find).with("37").and_return(mock_unifying_theme)
+        expect(mock_unifying_theme).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :unifying_theme => {:these => 'params'}
       end
 
       it "should expose the requested unifying_theme as @unifying_theme" do
-        RiGse::UnifyingTheme.stub!(:find).and_return(mock_unifying_theme(:update_attributes => true))
+        allow(RiGse::UnifyingTheme).to receive(:find).and_return(mock_unifying_theme(:update_attributes => true))
         put :update, :id => "1"
-        assigns(:unifying_theme).should equal(mock_unifying_theme)
+        expect(assigns(:unifying_theme)).to equal(mock_unifying_theme)
       end
 
       it "should redirect to the unifying_theme" do
-        RiGse::UnifyingTheme.stub!(:find).and_return(mock_unifying_theme(:update_attributes => true))
+        allow(RiGse::UnifyingTheme).to receive(:find).and_return(mock_unifying_theme(:update_attributes => true))
         put :update, :id => "1"
-        response.should redirect_to(ri_gse_unifying_theme_url(mock_unifying_theme))
+        expect(response).to redirect_to(ri_gse_unifying_theme_url(mock_unifying_theme))
       end
 
     end
@@ -139,21 +139,21 @@ describe RiGse::UnifyingThemesController do
     describe "with invalid params" do
 
       it "should update the requested unifying_theme" do
-        RiGse::UnifyingTheme.should_receive(:find).with("37").and_return(mock_unifying_theme)
-        mock_unifying_theme.should_receive(:update_attributes).with({'these' => 'params'})
+        expect(RiGse::UnifyingTheme).to receive(:find).with("37").and_return(mock_unifying_theme)
+        expect(mock_unifying_theme).to receive(:update_attributes).with({'these' => 'params'})
         put :update, :id => "37", :unifying_theme => {:these => 'params'}
       end
 
       it "should expose the unifying_theme as @unifying_theme" do
-        RiGse::UnifyingTheme.stub!(:find).and_return(mock_unifying_theme(:update_attributes => false))
+        allow(RiGse::UnifyingTheme).to receive(:find).and_return(mock_unifying_theme(:update_attributes => false))
         put :update, :id => "1"
-        assigns(:unifying_theme).should equal(mock_unifying_theme)
+        expect(assigns(:unifying_theme)).to equal(mock_unifying_theme)
       end
 
       it "should re-render the 'edit' template" do
-        RiGse::UnifyingTheme.stub!(:find).and_return(mock_unifying_theme(:update_attributes => false))
+        allow(RiGse::UnifyingTheme).to receive(:find).and_return(mock_unifying_theme(:update_attributes => false))
         put :update, :id => "1"
-        response.should render_template('edit')
+        expect(response).to render_template('edit')
       end
 
     end
@@ -163,15 +163,15 @@ describe RiGse::UnifyingThemesController do
   describe "responding to DELETE destroy" do
 
     it "should destroy the requested unifying_theme" do
-      RiGse::UnifyingTheme.should_receive(:find).with("37").and_return(mock_unifying_theme)
-      mock_unifying_theme.should_receive(:destroy)
+      expect(RiGse::UnifyingTheme).to receive(:find).with("37").and_return(mock_unifying_theme)
+      expect(mock_unifying_theme).to receive(:destroy)
       delete :destroy, :id => "37"
     end
   
     it "should redirect to the unifying_themes list" do
-      RiGse::UnifyingTheme.stub!(:find).and_return(mock_unifying_theme(:destroy => true))
+      allow(RiGse::UnifyingTheme).to receive(:find).and_return(mock_unifying_theme(:destroy => true))
       delete :destroy, :id => "1"
-      response.should redirect_to(unifying_themes_url)
+      expect(response).to redirect_to(unifying_themes_url)
     end
 
   end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -43,7 +43,7 @@ describe SearchController do
   let(:activity_results)      { [] }
 
   let(:search_results) {{ Investigation => investigation_results, Activity => activity_results }}
-  let(:mock_search)    { mock('results', {:results => search_results})}
+  let(:mock_search)    { double('results', {:results => search_results})}
 
   before(:all) do
     solr_setup
@@ -68,16 +68,16 @@ describe SearchController do
     describe "when its a student visiting" do
       it "should redirect to student home" do
         student # Ensure student_user has a PortalStudent
-        controller.stub!(:current_user).and_return(student_user)
+        allow(controller).to receive(:current_user).and_return(student_user)
         get :index
-        response.should redirect_to("/my_classes")
+        expect(response).to redirect_to("/my_classes")
       end
     end
 
     describe "when there are no query parameters" do
       it "should redirect to ?include_official=1" do
         get :index
-        response.should redirect_to action: :index, include_official: '1'
+        expect(response).to redirect_to action: :index, include_official: '1'
       end
     end
   end
@@ -115,10 +115,10 @@ describe SearchController do
         :material_id => activity_for_all_clazz.id
       }
       xhr :post, :get_current_material_unassigned_clazzes, post_params
-      should render_template('_material_unassigned_clazzes')
-      assigns[:material].should eq [activity_for_all_clazz]
-      assigns[:assigned_clazzes].should eq [physics_clazz]
-      assigns[:unassigned_clazzes].should eq [chemistry_clazz, mathematics_clazz]
+      is_expected.to render_template('_material_unassigned_clazzes')
+      expect(assigns[:material]).to eq [activity_for_all_clazz]
+      expect(assigns[:assigned_clazzes]).to eq [physics_clazz]
+      expect(assigns[:unassigned_clazzes]).to eq [chemistry_clazz, mathematics_clazz]
     end
 
     it "should get all the classes to which the investigation is not assigned. Material to be assigned is a single investigation" do
@@ -127,9 +127,9 @@ describe SearchController do
         :material_id => investigations_for_all_clazz.id
       }
       xhr :post, :get_current_material_unassigned_clazzes, post_params
-      assigns[:material].should eq [investigations_for_all_clazz]
-      assigns[:assigned_clazzes].should eq [physics_clazz]
-      assigns[:unassigned_clazzes].should eq [chemistry_clazz, mathematics_clazz]
+      expect(assigns[:material]).to eq [investigations_for_all_clazz]
+      expect(assigns[:assigned_clazzes]).to eq [physics_clazz]
+      expect(assigns[:unassigned_clazzes]).to eq [chemistry_clazz, mathematics_clazz]
     end
 
     it "should get all the classes to which the activity is not assigned. Material to be assigned is a multiple activity" do
@@ -139,9 +139,9 @@ describe SearchController do
         :material_id => "#{activity_for_all_clazz.id},#{another_activity_for_all_clazz.id}"
       }
       xhr :post, :get_current_material_unassigned_clazzes, post_params
-      assigns[:material].should eq [activity_for_all_clazz, another_activity_for_all_clazz]
-      assigns[:assigned_clazzes].should eq []
-      assigns[:unassigned_clazzes].should eq [physics_clazz, chemistry_clazz, mathematics_clazz]
+      expect(assigns[:material]).to eq [activity_for_all_clazz, another_activity_for_all_clazz]
+      expect(assigns[:assigned_clazzes]).to eq []
+      expect(assigns[:unassigned_clazzes]).to eq [physics_clazz, chemistry_clazz, mathematics_clazz]
     end
 
   end
@@ -168,12 +168,12 @@ describe SearchController do
       offering_for_clazz = Portal::Offering.find_all_by_clazz_id_and_runnable_type_and_runnable_id(clazz.id, runnable_type, runnable_id)
       offering_for_another_clazz = Portal::Offering.find_all_by_clazz_id_and_runnable_type_and_runnable_id(another_clazz.id, runnable_type, runnable_id)
 
-      offering_for_clazz.length.should be(1)
-      offering_for_clazz.first.should == already_assigned_offering
+      expect(offering_for_clazz.length).to be(1)
+      expect(offering_for_clazz.first).to eq(already_assigned_offering)
 
-      offering_for_another_clazz.length.should be(1)
-      offering_for_another_clazz.first.runnable_id.should be(chemistry_investigation.id)
-      offering_for_another_clazz.first.clazz_id.should be(another_clazz.id)
+      expect(offering_for_another_clazz.length).to be(1)
+      expect(offering_for_another_clazz.first.runnable_id).to be(chemistry_investigation.id)
+      expect(offering_for_another_clazz.first.clazz_id).to be(another_clazz.id)
     end
 
     it "should assign activities to the classes" do
@@ -190,7 +190,7 @@ describe SearchController do
       post_params[:clazz_id].each do |clazz_id|
         runnable_ids.each do |runnable_id|
           offering = Portal::Offering.find_all_by_clazz_id_and_runnable_type_and_runnable_id(clazz_id, runnable_type, runnable_id)
-          offering.length.should be(1)
+          expect(offering.length).to be(1)
         end
       end
     end

--- a/spec/controllers/security_questions_controller_spec.rb
+++ b/spec/controllers/security_questions_controller_spec.rb
@@ -6,16 +6,16 @@ describe SecurityQuestionsController do
   before(:each) do
     @student = Factory.create(:portal_student, :user => Factory.create(:confirmed_user))
     sign_in @student.user
-    @test_settings = mock("settings",:name=> "Test Settings")
-    @test_settings.should_receive(:use_student_security_questions).and_return(true)
-    @test_settings.stub!(:require_user_consent?).and_return(false)
-    @test_settings.stub!(:help_type).and_return('no help')
-    @test_settings.stub!(:enabled_bookmark_types).and_return([])
-    @test_settings.stub!(:anonymous_can_browse_materials).and_return(true)
-    @test_settings.stub!(:show_collections_menu).and_return(false)
-    @test_settings.stub!(:auto_set_teachers_as_authors).and_return(false)
-    @test_settings.stub!(:teacher_home_path).and_return(nil)
-    Admin::Settings.stub(:default_settings).and_return(@test_settings)
+    @test_settings = double("settings",:name=> "Test Settings")
+    expect(@test_settings).to receive(:use_student_security_questions).and_return(true)
+    allow(@test_settings).to receive(:require_user_consent?).and_return(false)
+    allow(@test_settings).to receive(:help_type).and_return('no help')
+    allow(@test_settings).to receive(:enabled_bookmark_types).and_return([])
+    allow(@test_settings).to receive(:anonymous_can_browse_materials).and_return(true)
+    allow(@test_settings).to receive(:show_collections_menu).and_return(false)
+    allow(@test_settings).to receive(:auto_set_teachers_as_authors).and_return(false)
+    allow(@test_settings).to receive(:teacher_home_path).and_return(nil)
+    allow(Admin::Settings).to receive(:default_settings).and_return(@test_settings)
   end
 
   describe "GET edit" do
@@ -55,14 +55,14 @@ describe SecurityQuestionsController do
     end
 
     it "updates the user's security questions" do
-      SecurityQuestion.should_receive(:make_questions_from_hash_and_user)
-      SecurityQuestion.should_receive(:errors_for_questions_list!)
+      expect(SecurityQuestion).to receive(:make_questions_from_hash_and_user)
+      expect(SecurityQuestion).to receive(:errors_for_questions_list!)
 
       # In the controller current_user recreates the user object based on a user id
       # in the session, so we have to stub current_user here to make sure the controller
       # is using the same object
-      controller.stub(:current_user).and_return @student.user
-      @student.user.should_receive(:update_security_questions!)
+      allow(controller).to receive(:current_user).and_return @student.user
+      expect(@student.user).to receive(:update_security_questions!)
 
       put :update, @params_for_update
     end
@@ -70,15 +70,15 @@ describe SecurityQuestionsController do
     it "redirects the user to their home page once they set their security questions" do
       put :update, @params_for_update
 
-      @response.should redirect_to(root_path)
+      expect(@response).to redirect_to(root_path)
     end
 
     it "does not accept invalid question values" do
-      SecurityQuestion.should_receive(:errors_for_questions_list!).and_return(["Wicked bad errors!"])
+      expect(SecurityQuestion).to receive(:errors_for_questions_list!).and_return(["Wicked bad errors!"])
 
       put :update, @params_for_update
 
-      flash[:error].should include("Wicked bad errors!")
+      expect(flash[:error]).to include("Wicked bad errors!")
       expect(response).to render_template("edit")
     end
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -11,98 +11,98 @@ describe UsersController do
   end
 
   it 'allows signup' do
-    pending "Broken example"
-    lambda do
+    skip "Broken example"
+    expect do
       create_user
-      response.should be_redirect
-    end.should change(User, :count).by(1)
+      expect(response).to be_redirect
+    end.to change(User, :count).by(1)
   end
 
   it 'signs up user in pending state' do
-    pending "Broken example"
+    skip "Broken example"
     create_user
     assigns(:user).reload
-    assigns(:user).should be_pending
+    expect(assigns(:user)).to be_pending
   end
 
   it 'signs up user with activation code' do
-    pending "Broken example"
+    skip "Broken example"
     create_user
     assigns(:user).reload
-    assigns(:user).activation_code.should_not be_nil
+    expect(assigns(:user).activation_code).not_to be_nil
   end
   it 'requires login on signup' do
-    pending "Broken example"
-    lambda do
+    skip "Broken example"
+    expect do
       create_user(:login => nil)
-      assigns[:user].errors[:login].should_not be_nil
-      response.should be_success
-    end.should_not change(User, :count)
+      expect(assigns[:user].errors[:login]).not_to be_nil
+      expect(response).to be_success
+    end.not_to change(User, :count)
   end
   
   it 'requires password on signup' do
-    pending "Broken example"
-    lambda do
+    skip "Broken example"
+    expect do
       create_user(:password => nil)
-      assigns[:user].errors[:password].should_not be_nil
-      response.should be_success
-    end.should_not change(User, :count)
+      expect(assigns[:user].errors[:password]).not_to be_nil
+      expect(response).to be_success
+    end.not_to change(User, :count)
   end
   
   it 'requires password confirmation on signup' do
-    pending "Broken example"
-    lambda do
+    skip "Broken example"
+    expect do
       create_user(:password_confirmation => nil)
-      assigns[:user].errors[:password_confirmation].should_not be_nil
-      response.should be_success
-    end.should_not change(User, :count)
+      expect(assigns[:user].errors[:password_confirmation]).not_to be_nil
+      expect(response).to be_success
+    end.not_to change(User, :count)
   end
 
   it 'requires email on signup' do
-    pending "Broken example"
-    lambda do
+    skip "Broken example"
+    expect do
       create_user(:email => nil)
-      assigns[:user].errors[:email].should_not be_nil
-      response.should be_success
-    end.should_not change(User, :count)
+      expect(assigns[:user].errors[:email]).not_to be_nil
+      expect(response).to be_success
+    end.not_to change(User, :count)
   end
   
   it 'activates user' do
-    pending "Broken example"
-    User.authenticate('aaron', 'monkey').should be_nil
+    skip "Broken example"
+    expect(User.authenticate('aaron', 'monkey')).to be_nil
     get :activate, :activation_code => users(:aaron).activation_code
-    response.should redirect_to('/login')
-    flash[:notice].should_not be_nil
-    flash[:error ].should     be_nil
-    User.authenticate('aaron', 'monkey').should == users(:aaron)
+    expect(response).to redirect_to('/login')
+    expect(flash[:notice]).not_to be_nil
+    expect(flash[:error ]).to     be_nil
+    expect(User.authenticate('aaron', 'monkey')).to eq(users(:aaron))
   end
   
   it 'does not activate user without key' do
-    pending "Broken example"
+    skip "Broken example"
     get :activate
-    flash[:notice].should     be_nil
-    flash[:error ].should_not be_nil
+    expect(flash[:notice]).to     be_nil
+    expect(flash[:error ]).not_to be_nil
   end
   
   it 'does not activate user with blank key' do
-    pending "Broken example"
+    skip "Broken example"
     get :activate, :activation_code => ''
-    flash[:notice].should     be_nil
-    flash[:error ].should_not be_nil
+    expect(flash[:notice]).to     be_nil
+    expect(flash[:error ]).not_to be_nil
   end
   
   it 'does not activate user with bogus key' do
-    pending "Broken example"
+    skip "Broken example"
     get :activate, :activation_code => 'i_haxxor_joo'
-    flash[:notice].should     be_nil
-    flash[:error ].should_not be_nil
+    expect(flash[:notice]).to     be_nil
+    expect(flash[:error ]).not_to be_nil
   end
   
   it 'shows thank you page to teacher on successful registration' do
     
     get :registration_successful, {:type => 'teacher'}
     
-    @response.should render_template("users/thanks")
+    expect(@response).to render_template("users/thanks")
     
     assert_select 'h2', /thanks/i
     assert_select 'p', /activation code/i
@@ -113,7 +113,7 @@ describe UsersController do
     
     get :registration_successful, {:type => 'student'}
     
-    @response.should render_template("portal/students/signup_success")
+    expect(@response).to render_template("portal/students/signup_success")
     
     # should show text "your username is"
     assert_select "p", /username\s+is/i

--- a/spec/core_extensions/object_extensions_spec.rb
+++ b/spec/core_extensions/object_extensions_spec.rb
@@ -36,31 +36,31 @@ describe "Object#display_name" do
   describe "when a plain old object doesn't define its own method" do
     it "should use Class.name.humaize.titlecase" do
       instance = RandomClass.new
-      instance.display_name.should == RandomClass.name.humanize.titlecase
+      expect(instance.display_name).to eq(RandomClass.name.humanize.titlecase)
     end
   end
 
   describe "when an ActiveModel class does not define its own #display_name" do
     it "should use the global class method" do
       instance = TestClass.new
-      TestClass.display_name.should == 'Test Class'
-      instance.class.display_name.should == 'Test Class'
+      expect(TestClass.display_name).to eq('Test Class')
+      expect(instance.class.display_name).to eq('Test Class')
     end
   end
 
   describe "when the object does define its own #display_name" do
     it "should not call LocalNames.instance#local_name_for" do
       instance = HasOwnDisplayName.new
-      instance.should_not_receive(:display_name)
-      instance.class.display_name.should == HasOwnDisplayName::DisplayNameValue
-      HasOwnDisplayName.display_name.should == HasOwnDisplayName::DisplayNameValue
+      expect(instance).not_to receive(:display_name)
+      expect(instance.class.display_name).to eq(HasOwnDisplayName::DisplayNameValue)
+      expect(HasOwnDisplayName.display_name).to eq(HasOwnDisplayName::DisplayNameValue)
     end
   end
 
   describe 'when the model is part of a module' do
     it 'should not include the module name as part of the #display_name' do
       instance = TestModule::InnerTest::TestClass.new
-      instance.class.display_name.should == 'Test Class'
+      expect(instance.class.display_name).to eq('Test Class')
     end
   end
 end

--- a/spec/core_extensions/string_extensions_spec.rb
+++ b/spec/core_extensions/string_extensions_spec.rb
@@ -3,35 +3,35 @@ require File.expand_path('../../spec_helper', __FILE__)
 describe "String#underscore_module" do
 
   it "should replace '::' with '_'" do
-    "Activity".underscore_module.should eql('activity')
-    "Embeddable::Smartgraph::RangeQuestion" .underscore_module.should eql('embeddable_smartgraph_range_question')
+    expect("Activity".underscore_module).to eql('activity')
+    expect("Embeddable::Smartgraph::RangeQuestion" .underscore_module).to eql('embeddable_smartgraph_range_question')
   end
 
   it "should replace '/' with '_'" do
-    "activity".underscore_module.should eql('activity')
-    "embeddable/smartgraph/range_question" .underscore_module.should eql('embeddable_smartgraph_range_question')
+    expect("activity".underscore_module).to eql('activity')
+    expect("embeddable/smartgraph/range_question" .underscore_module).to eql('embeddable_smartgraph_range_question')
   end
   
 end
 
 describe "String#delete_module" do
   it "should remove one module delimited with '::' from the beginning of the string" do
-    "Activity".delete_module.should eql('Activity')
-    "Embeddable::Smartgraph::RangeQuestion".delete_module.should eql('Smartgraph::RangeQuestion')
+    expect("Activity".delete_module).to eql('Activity')
+    expect("Embeddable::Smartgraph::RangeQuestion".delete_module).to eql('Smartgraph::RangeQuestion')
   end
   
   it "should remove one module delimited with '/' from the beginning of the string" do
-    "activity".delete_module.should eql('activity')
-    "embeddable/smartgraph/range_question".delete_module.should eql('smartgraph/range_question')
+    expect("activity".delete_module).to eql('activity')
+    expect("embeddable/smartgraph/range_question".delete_module).to eql('smartgraph/range_question')
   end
 
   it "should remove more modules delimited with '::' from the beginning of the string when a numerical argument is passed" do
-    "Activity".delete_module(2).should eql('Activity')
-    "Embeddable::Smartgraph::RangeQuestion".delete_module(2).should eql('RangeQuestion')
+    expect("Activity".delete_module(2)).to eql('Activity')
+    expect("Embeddable::Smartgraph::RangeQuestion".delete_module(2)).to eql('RangeQuestion')
   end
   
   it "should optionally remove more modules delimited with '/' from the beginning of the string when a numerical argument is passed" do
-    "activity".delete_module(2).should eql('activity')
-    "embeddable/smartgraph/range_question".delete_module(2).should eql('range_question')
+    expect("activity".delete_module(2)).to eql('activity')
+    expect("embeddable/smartgraph/range_question".delete_module(2)).to eql('range_question')
   end
 end

--- a/spec/helpers/admin/tags_helper_spec.rb
+++ b/spec/helpers/admin/tags_helper_spec.rb
@@ -5,7 +5,7 @@ describe Admin::TagsHelper do
   #Delete this example and add some real ones or delete this file
   it "is included in the helper object" do
     included_modules = (class << helper; self; end).send :included_modules
-    included_modules.should include(Admin::TagsHelper)
+    expect(included_modules).to include(Admin::TagsHelper)
   end
 
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -6,12 +6,12 @@ describe ApplicationHelper do
 
   describe "title" do
     it "should set @page_title" do
-      title_tag('hello').should be_nil
-      page_title.should eql('hello')
+      expect(title_tag('hello')).to be_nil
+      expect(page_title).to eql('hello')
     end
 
     it "should output container if set" do
-      title_tag('hello', :h2).should have_selector('h2', :content => 'hello')
+      expect(title_tag('hello', :h2)).to have_selector('h2', :content => 'hello')
     end
   end
 
@@ -27,11 +27,11 @@ describe ApplicationHelper do
         @original_user = @anonymous_user
       end
       it "should display appropriate login messages" do
-        login_line.should match(/login/i)
-        login_line.should_not match(/welcome/i)
-        login_line(:guest => "guest").should match(/welcome\s*guest/i)
-        login_line(:login => "Log In").should match(/Log In/)
-        login_line(:signup => "Sign Up").should match(/Sign Up/)
+        expect(login_line).to match(/login/i)
+        expect(login_line).not_to match(/welcome/i)
+        expect(login_line(:guest => "guest")).to match(/welcome\s*guest/i)
+        expect(login_line(:login => "Log In")).to match(/Log In/)
+        expect(login_line(:signup => "Sign Up")).to match(/Sign Up/)
       end
     end
 
@@ -41,9 +41,9 @@ describe ApplicationHelper do
         @original_user = @admin_user
       end
       it "should display appropriate login messages" do
-        login_line.should match(/log\s*out/i)
-        login_line.should match(/switch/i)
-        login_line(:logout => "Log Out").should match(/Log Out/)
+        expect(login_line).to match(/log\s*out/i)
+        expect(login_line).to match(/switch/i)
+        expect(login_line(:logout => "Log Out")).to match(/Log Out/)
       end
     end
   end

--- a/spec/helpers/dataservice/blobs_helper_spec.rb
+++ b/spec/helpers/dataservice/blobs_helper_spec.rb
@@ -5,7 +5,7 @@ describe Dataservice::BlobsHelper do
   #Delete this example and add some real ones or delete this file
   it "is included in the helper object" do
     included_modules = (class << helper; self; end).send :included_modules
-    included_modules.should include(Dataservice::BlobsHelper)
+    expect(included_modules).to include(Dataservice::BlobsHelper)
   end
 
   describe "blob_url_for(answer)" do
@@ -16,7 +16,7 @@ describe Dataservice::BlobsHelper do
       answer = {}
       answer[:blob] = blob
       url = blob_url_for(answer)
-      url.should match %r[dataservice/blobs/10.blob/9db05e66b61d11e08a75000c29231be6]
+      expect(url).to match %r[dataservice/blobs/10.blob/9db05e66b61d11e08a75000c29231be6]
     end
   end
 

--- a/spec/helpers/dataservice/bundle_contents_helper_spec.rb
+++ b/spec/helpers/dataservice/bundle_contents_helper_spec.rb
@@ -5,7 +5,7 @@ describe Dataservice::BundleContentsHelper do
   #Delete this example and add some real ones or delete this file
   it "is included in the helper object" do
     included_modules = (class << helper; self; end).send :included_modules
-    included_modules.should include(Dataservice::BundleContentsHelper)
+    expect(included_modules).to include(Dataservice::BundleContentsHelper)
   end
 
 end

--- a/spec/helpers/dataservice/bundle_loggers_helper_spec.rb
+++ b/spec/helpers/dataservice/bundle_loggers_helper_spec.rb
@@ -5,7 +5,7 @@ describe Dataservice::BundleLoggersHelper do
   #Delete this example and add some real ones or delete this file
   it "is included in the helper object" do
     included_modules = (class << helper; self; end).send :included_modules
-    included_modules.should include(Dataservice::BundleLoggersHelper)
+    expect(included_modules).to include(Dataservice::BundleLoggersHelper)
   end
 
 end

--- a/spec/helpers/dataservice/console_contents_helper_spec.rb
+++ b/spec/helpers/dataservice/console_contents_helper_spec.rb
@@ -5,7 +5,7 @@ describe Dataservice::ConsoleContentsHelper do
   #Delete this example and add some real ones or delete this file
   it "is included in the helper object" do
     included_modules = (class << helper; self; end).send :included_modules
-    included_modules.should include(Dataservice::ConsoleContentsHelper)
+    expect(included_modules).to include(Dataservice::ConsoleContentsHelper)
   end
 
 end

--- a/spec/helpers/dataservice/console_loggers_helper_spec.rb
+++ b/spec/helpers/dataservice/console_loggers_helper_spec.rb
@@ -5,7 +5,7 @@ describe Dataservice::ConsoleLoggersHelper do
   #Delete this example and add some real ones or delete this file
   it "is included in the helper object" do
     included_modules = (class << helper; self; end).send :included_modules
-    included_modules.should include(Dataservice::ConsoleLoggersHelper)
+    expect(included_modules).to include(Dataservice::ConsoleLoggersHelper)
   end
 
 end

--- a/spec/helpers/jnlp_helper_spec.rb
+++ b/spec/helpers/jnlp_helper_spec.rb
@@ -6,12 +6,12 @@ describe JnlpHelper do
   describe "pub_interval" do
     describe "uses seconds in settings" do
       it "should be 30000 when the settings say 30" do
-        Admin::Settings.stub(:pub_interval).and_return(30)
-        subject.pub_interval.should == 30000
+        allow(Admin::Settings).to receive(:pub_interval).and_return(30)
+        expect(subject.pub_interval).to eq(30000)
       end
       it "should be 10000 when the settings say 10" do
-        Admin::Settings.stub(:pub_interval).and_return(10)
-        subject.pub_interval.should == 10000
+        allow(Admin::Settings).to receive(:pub_interval).and_return(10)
+        expect(subject.pub_interval).to eq(10000)
       end
     end
   end
@@ -21,24 +21,24 @@ describe JnlpHelper do
       before :each do
         @settings = Admin::Settings.new(:pub_interval => 10,
           :use_periodic_bundle_uploading => true)
-        @student = mock()
+        @student = double()
         @user = Factory(:user)
         @student.stub(:user => @user)
-        pbl   = mock()
-        @learner = mock(:student => @student, :periodic_bundle_logger => pbl)
+        pbl   = double()
+        @learner = double(:student => @student, :periodic_bundle_logger => pbl)
       end
       it "should include the update interval as a property" do
         subject.stub(:current_settings => @settings)
         subject.stub(:current_visitor => @user)
-        subject.stub(:dataservice_periodic_bundle_logger_periodic_bundle_contents_url).and_return("URL")
-        subject.stub(:dataservice_periodic_bundle_logger_session_end_notification_url).and_return("URL")
+        allow(subject).to receive(:dataservice_periodic_bundle_logger_periodic_bundle_contents_url).and_return("URL")
+        allow(subject).to receive(:dataservice_periodic_bundle_logger_session_end_notification_url).and_return("URL")
         props = subject.system_properties(:learner => @learner)
         found = props.detect do |pair|
           key,value = pair
           key == "otrunk.periodic.uploading.interval"
           value = subject.pub_interval
         end
-        found.should_not be_empty
+        expect(found).not_to be_empty
       end
     end
   end

--- a/spec/helpers/navigation_helper_spec.rb
+++ b/spec/helpers/navigation_helper_spec.rb
@@ -5,43 +5,43 @@ describe NavigationHelper do
   let(:name) { "fredrique" }
   let(:itsi_links) do
     [
-      mock(link_id: '/resources/activities', name: 'activities', href: '/itsi', pop_out: false),
-      mock(link_id: '/resources/interactives', name: 'interactives', href: '/interactives', pop_out: true),
-      mock(link_id: '/resources/images', name: 'images', href: '/images', pop_out: true),
-      mock(link_id: '/resources/guides', name: 'Teacher Guides', href: 'https://guides.itsi.concord.org/', pop_out: true),
-      mock(link_id: '/resources/careers', name: 'Careersight', href: 'https://careersight.concord.org/', pop_out: true),
-      mock(link_id: '/resources/probes', name: 'Probesight', href: 'https://probesight.concord.org/', pop_out: true),
-      mock(link_id: '/resources/schoology', name: 'Schoology', href: 'https://www.schoology.com/', pop_out: true)
+      double(link_id: '/resources/activities', name: 'activities', href: '/itsi', pop_out: false),
+      double(link_id: '/resources/interactives', name: 'interactives', href: '/interactives', pop_out: true),
+      double(link_id: '/resources/images', name: 'images', href: '/images', pop_out: true),
+      double(link_id: '/resources/guides', name: 'Teacher Guides', href: 'https://guides.itsi.concord.org/', pop_out: true),
+      double(link_id: '/resources/careers', name: 'Careersight', href: 'https://careersight.concord.org/', pop_out: true),
+      double(link_id: '/resources/probes', name: 'Probesight', href: 'https://probesight.concord.org/', pop_out: true),
+      double(link_id: '/resources/schoology', name: 'Schoology', href: 'https://www.schoology.com/', pop_out: true)
     ]
   end
-  let(:itsi_project) { mock(links: itsi_links)}
+  let(:itsi_project) { double(links: itsi_links)}
   let(:fake_clazzes) { FactoryGirl.create_list(:portal_clazz, 3)}
-  let(:fake_teacher_clazzes) { fake_clazzes.map { |c| mock(clazz: c)}}
+  let(:fake_teacher_clazzes) { fake_clazzes.map { |c| double(clazz: c)}}
   let(:fake_student) { FactoryGirl.create(:full_portal_student) }
   let(:fake_teacher) { FactoryGirl.create(:portal_teacher) }
   let(:fake_visitor) { fake_student.user }
   let(:params)       { {greeting: "bonjour"} }
   let(:projects)     { [itsi_project] }
   before(:each) do
-    helper.stub(:current_visitor).and_return(fake_visitor)
-    helper.stub(:current_user).and_return(fake_visitor)
-    fake_visitor.stub(:name).and_return(name)
-    fake_visitor.stub(:projects).and_return(projects)
-    fake_teacher.stub(:teacher_clazzes).and_return(fake_teacher_clazzes)
-    fake_student.stub(:clazzes).and_return(fake_clazzes)
+    allow(helper).to receive(:current_visitor).and_return(fake_visitor)
+    allow(helper).to receive(:current_user).and_return(fake_visitor)
+    allow(fake_visitor).to receive(:name).and_return(name)
+    allow(fake_visitor).to receive(:projects).and_return(projects)
+    allow(fake_teacher).to receive(:teacher_clazzes).and_return(fake_teacher_clazzes)
+    allow(fake_student).to receive(:clazzes).and_return(fake_clazzes)
   end
   describe "get_nav_content" do
     describe "schema validation" do
       subject { helper.navigation_service(params).to_json }
-      it { should match_response_schema("navigation") }
+      it { is_expected.to match_response_schema("navigation") }
     end
     describe "values" do
       subject { helper.navigation_service(params).to_hash }
-      it { should include(name:  name )}
-      it { should include(greeting: "bonjour") }
-      it { should include(:help) }
-      it { should include(:links) }
-      it { should_not include("xxx") }
+      it { is_expected.to include(name:  name )}
+      it { is_expected.to include(greeting: "bonjour") }
+      it { is_expected.to include(:help) }
+      it { is_expected.to include(:links) }
+      it { is_expected.not_to include("xxx") }
     end
   end
   describe "teacher links" do
@@ -49,28 +49,28 @@ describe NavigationHelper do
     subject { JSON.pretty_generate(helper.navigation_service(params).to_hash) }
     it "should inlude teacher links" do
       fake_clazzes.each do |clazz|
-        subject.should match %r{"url": "/portal/classes/#{clazz.id}/materials"}
-        subject.should match %r{"url": "/portal/classes/#{clazz.id}/roster"}
-        subject.should match %r{"url": "/portal/classes/#{clazz.id}/edit"}
-        subject.should match %r{"id": "/classes/#{clazz.id}"}
+        expect(subject).to match %r{"url": "/portal/classes/#{clazz.id}/materials"}
+        expect(subject).to match %r{"url": "/portal/classes/#{clazz.id}/roster"}
+        expect(subject).to match %r{"url": "/portal/classes/#{clazz.id}/edit"}
+        expect(subject).to match %r{"id": "/classes/#{clazz.id}"}
       end
-      subject.should_not match %r{"url": "/admin}
+      expect(subject).not_to match %r{"url": "/admin}
     end
 
     describe "teacher that is also a project admin" do
       before(:each) do
-        fake_visitor.stub(:is_project_admin?).and_return(true)
+        allow(fake_visitor).to receive(:is_project_admin?).and_return(true)
       end
       it "should still include teacher clazz links" do
         fake_clazzes.each do |clazz|
-          subject.should match %r{"url": "/portal/classes/#{clazz.id}/materials"}
+          expect(subject).to match %r{"url": "/portal/classes/#{clazz.id}/materials"}
         end
       end
       it "should include admin links" do
-        subject.should match %r{"url": "/admin}
+        expect(subject).to match %r{"url": "/admin}
       end
       it "should include favorites links" do
-        subject.should match %r{"label": "Favorites"}
+        expect(subject).to match %r{"label": "Favorites"}
       end
     end
   end
@@ -81,23 +81,23 @@ describe NavigationHelper do
 
     it "should include class links" do
       fake_clazzes.each do |clazz|
-        subject.should match %r{"url": "/portal/classes/#{clazz.id}"}
+        expect(subject).to match %r{"url": "/portal/classes/#{clazz.id}"}
       end
     end
 
     it "should not inlude teacher links" do
       fake_clazzes.each do |clazz|
-        subject.should_not match %r{"url": "/portal/classes/#{clazz.id}/materials"}
-        subject.should_not match %r{"url": "/portal/classes/#{clazz.id}/roster"}
-        subject.should_not match %r{"url": "/portal/classes/#{clazz.id}/edit"}
-        subject.should_not match %r{"url": "/portal/classes/#{clazz.id}/fullstatus"}
-        subject.should_not match %r{"section": "classes/#{clazz.name}"}
+        expect(subject).not_to match %r{"url": "/portal/classes/#{clazz.id}/materials"}
+        expect(subject).not_to match %r{"url": "/portal/classes/#{clazz.id}/roster"}
+        expect(subject).not_to match %r{"url": "/portal/classes/#{clazz.id}/edit"}
+        expect(subject).not_to match %r{"url": "/portal/classes/#{clazz.id}/fullstatus"}
+        expect(subject).not_to match %r{"section": "classes/#{clazz.name}"}
       end
-      subject.should_not match %r{"url": "/admin}
+      expect(subject).not_to match %r{"url": "/admin}
     end
 
     it "should not include favorites links" do
-      subject.should_not match %r{"label": "Favorites"}
+      expect(subject).not_to match %r{"label": "Favorites"}
     end
   end
 
@@ -113,10 +113,10 @@ describe NavigationHelper do
       let(:path) { helper.url_for([:materials, clazz]) }
       let(:clazz) { fake_clazzes.first }
       it "should have the correct selected section" do
-        subject.selected_section.should == "/classes/#{clazz.id}/assignments"
+        expect(subject.selected_section).to eq("/classes/#{clazz.id}/assignments")
       end
       it "The selected link should be to the fake first class." do
-        subject.links.find { |l| l.selected }.label.should == "Assignments"
+        expect(subject.links.find { |l| l.selected }.label).to eq("Assignments")
       end
     end
   end
@@ -128,26 +128,26 @@ describe NavigationHelper do
       let(:projects)     { [itsi_project] }
 
       it "should have several links" do
-        subject.links.should have(24).links
+        expect(subject.links.size).to eq(24)
       end
       it "should have several sections" do
-        subject.sections.should have(6).sections
+        expect(subject.sections.size).to eq(6)
       end
       it "should have resources, and classes sections" do
-        subject.sections.keys.should include("/resources", "/classes")
+        expect(subject.sections.keys).to include("/resources", "/classes")
       end
     end
 
     describe "Not in any Projects" do
       let(:projects)     { [] }
       it "should have several links" do
-        subject.links.should have(17).links
+        expect(subject.links.size).to eq(17)
       end
       it "should have several sections" do
-        subject.sections.should have(5).sections
+        expect(subject.sections.size).to eq(5)
       end
       it "should not have resources sections" do
-        subject.sections.keys.should_not include("/resources")
+        expect(subject.sections.keys).not_to include("/resources")
       end
     end
   end

--- a/spec/helpers/portal/grade_levels_helper_spec.rb
+++ b/spec/helpers/portal/grade_levels_helper_spec.rb
@@ -5,7 +5,7 @@ describe Portal::GradeLevelsHelper do
   #Delete this example and add some real ones or delete this file
   it "is included in the helper object" do
     included_modules = (class << helper; self; end).send :included_modules
-    included_modules.should include(Portal::GradeLevelsHelper)
+    expect(included_modules).to include(Portal::GradeLevelsHelper)
   end
 
 end

--- a/spec/helpers/portal/grades_helper_spec.rb
+++ b/spec/helpers/portal/grades_helper_spec.rb
@@ -5,7 +5,7 @@ describe Portal::GradesHelper do
   #Delete this example and add some real ones or delete this file
   it "is included in the helper object" do
     included_modules = (class << helper; self; end).send :included_modules
-    included_modules.should include(Portal::GradesHelper)
+    expect(included_modules).to include(Portal::GradesHelper)
   end
 
 end

--- a/spec/helpers/runnables_helper_spec.rb
+++ b/spec/helpers/runnables_helper_spec.rb
@@ -5,46 +5,46 @@ describe RunnablesHelper do
   include RunnablesLinkMatcher
   before :each do
     @anonymous_user = mock_model(User, :roles => ["guest"], :anonymous? => true, :name => "guest")
-    helper.stub!(:current_visitor).and_return(@anonymous_user)
-    helper.stub!(:authenticate_with_http_basic).and_return nil
+    allow(helper).to receive(:current_visitor).and_return(@anonymous_user)
+    allow(helper).to receive(:authenticate_with_http_basic).and_return nil
   end
 
   describe ".display_workgroups_run_link?" do
     context "with workgroups enabled" do
       before :each do
-        helper.stub!(:use_adhoc_workgroups?).and_return true
+        allow(helper).to receive(:use_adhoc_workgroups?).and_return true
       end
 
       context "with a jnlp launchable" do
         let :offering do
           runnable = Object.new().extend(JnlpLaunchable)
-          mock(:runnable => runnable)
+          double(:runnable => runnable)
         end
         it "should return true" do
-          helper.display_workgroups_run_link?(offering).should be_true
+          expect(helper.display_workgroups_run_link?(offering)).to be_truthy
         end
       end
       context "with non-jlnp launchables" do
         let :offering do
-          mock(:runnable => Object.new)
+          double(:runnable => Object.new)
         end
         it "should return false" do
-          helper.display_workgroups_run_link?(offering).should be_false
+          expect(helper.display_workgroups_run_link?(offering)).to be_falsey
         end
       end
     end
 
     context "with workgroups disabled" do
       before :each do
-        helper.stub!(:use_adhoc_workgroups?).and_return false
+        allow(helper).to receive(:use_adhoc_workgroups?).and_return false
       end
 
       context "with a jnlp launchable" do
         let :offering do
-          mock(:runnable => Object.new().extend(JnlpLaunchable))
+          double(:runnable => Object.new().extend(JnlpLaunchable))
         end
         it "should return false" do
-          helper.display_workgroups_run_link?(offering).should be_false
+          expect(helper.display_workgroups_run_link?(offering)).to be_falsey
         end
       end
     end
@@ -53,18 +53,18 @@ describe RunnablesHelper do
   describe ".display_status_updates?" do
       context "with an offering that can update statuses" do
         let :offering do
-          mock(:runnable => mock(:has_update_status? => true))
+          double(:runnable => double(:has_update_status? => true))
         end
         it "should return true" do
-          helper.display_status_updates?(offering).should be_true
+          expect(helper.display_status_updates?(offering)).to be_truthy
         end
       end
       context "with simpler offering" do
         let :offering do
-          mock(:runnable => Object.new())
+          double(:runnable => Object.new())
         end
         it "should return false" do
-          helper.display_status_updates?(offering).should be_false
+          expect(helper.display_status_updates?(offering)).to be_falsey
         end
       end
 
@@ -84,22 +84,22 @@ describe RunnablesHelper do
     describe "for an external activity offering" do
       describe "when the external activity template is nil" do
         it "should include the word investigation (or sequence)" do
-          runnable.template_type.should be_nil
-          subject.should == t('activerecord.models.ExternalActivity')
+          expect(runnable.template_type).to be_nil
+          expect(subject).to eq(t('activerecord.models.ExternalActivity'))
         end
       end
 
       describe "when the external activity template is an investigation" do
         let(:runnable) { mock_model(ExternalActivity, :template_type => "Investigation", :material_type => "Investigation" )}
         it "should include the word investigation (or sequence)" do
-          subject.should == t('activerecord.models.Investigation')
+          expect(subject).to eq(t('activerecord.models.Investigation'))
         end
       end
 
       describe "when the external activity template is an activity" do
         let(:runnable) { mock_model(ExternalActivity, :template_type => "Activity", :material_type => "Activity" )}
         it "should include the word investigation (or sequence)" do
-          subject.should == t('activerecord.models.Activity')
+          expect(subject).to eq(t('activerecord.models.Activity'))
         end
       end
     end
@@ -107,21 +107,21 @@ describe RunnablesHelper do
     describe "for an investigation offering" do
       let(:runnable) { mock_model(Investigation)}
       it "should include the word investigation (or sequence)" do
-        subject.should == t('activerecord.models.Investigation')
+        expect(subject).to eq(t('activerecord.models.Investigation'))
       end
     end
 
     describe "for an activity offering" do
       let(:runnable) { mock_model(Activity)}
       it "should include the word Activity" do
-        subject.should == t('activerecord.models.Activity')
+        expect(subject).to eq(t('activerecord.models.Activity'))
       end
     end
 
     describe "for an activity runnable" do
       let(:offering) { mock_model(Activity)}
       it "should include the word Activity" do
-        subject.should == t('activerecord.models.Activity')
+        expect(subject).to eq(t('activerecord.models.Activity'))
       end
     end
 
@@ -130,7 +130,7 @@ describe RunnablesHelper do
   describe ".run_link_for" do
     it "should render a link for an External Activity" do
       ext_act = stub_model(ExternalActivity, :name => "Fetching Wood", :template_type => "Investigation")
-      helper.run_link_for(ext_act).should be_link_like("http://test.host/eresources/#{ext_act.id}.run_resource_html",
+      expect(helper.run_link_for(ext_act)).to be_link_like("http://test.host/eresources/#{ext_act.id}.run_resource_html",
                                                        "run_link rollover",
                                                        asset_path("run.png"))
     end
@@ -138,10 +138,10 @@ describe RunnablesHelper do
     it "should render a link for a Investigation Offering" do
       offering = mock_model(Portal::Offering, :name => "Investigation Offering")
       investigation = stub_model(Investigation)
-      offering.stub!(:runnable).and_return(investigation)
-      offering.stub!(:run_format).and_return :jnlp
-      offering.stub!(:external_activity?).and_return false
-      helper.run_link_for(offering).should be_link_like("http://test.host/users/#{@anonymous_user.id}/portal/offerings/#{offering.id}.jnlp",
+      allow(offering).to receive(:runnable).and_return(investigation)
+      allow(offering).to receive(:run_format).and_return :jnlp
+      allow(offering).to receive(:external_activity?).and_return false
+      expect(helper.run_link_for(offering)).to be_link_like("http://test.host/users/#{@anonymous_user.id}/portal/offerings/#{offering.id}.jnlp",
                                                              "run_link rollover",
                                                              asset_path("run.png"))
     end

--- a/spec/helpers/status_graph_helper.spec.rb
+++ b/spec/helpers/status_graph_helper.spec.rb
@@ -14,20 +14,20 @@ describe StatusGraphHelper do
   describe ".bar_graph" do
     context "almost complete" do
       let(:percent) { 99.99 } #as in external activities
-      it { should match(/progress/)    }
-      it { should_not match(/complete/) }
+      it { is_expected.to match(/progress/)    }
+      it { is_expected.not_to match(/complete/) }
     end
     context "complete" do
       let(:percent) { 99.993 }
-      it { should match(/progress/) }
-      it { should match(/complete/) }
-      it { should_not match(/activity/) }
+      it { is_expected.to match(/progress/) }
+      it { is_expected.to match(/complete/) }
+      it { is_expected.not_to match(/activity/) }
     end
     context "activity" do
       let(:activity) { true }
-      it { should match(/progress/)    }
-      it { should_not match(/complete/) }
-      it { should match(/activity/) }
+      it { is_expected.to match(/progress/)    }
+      it { is_expected.not_to match(/complete/) }
+      it { is_expected.to match(/activity/) }
     end
   end
 end

--- a/spec/helpers/teacher_guide_helper_spec.rb
+++ b/spec/helpers/teacher_guide_helper_spec.rb
@@ -6,47 +6,47 @@ describe TeacherGuideHelper do
   before :each do
     @helper = Object.new.extend TeacherGuideHelper
     @helper.extend ActionView::Helpers::UrlHelper
-    @helper.stub!(:tag_options).and_return({})
-    @helper.stub!(:current_user).and_return(user)
+    allow(@helper).to receive(:tag_options).and_return({})
+    allow(@helper).to receive(:current_user).and_return(user)
   end
   let(:is_admin)   {false}
   let(:is_teacher) {false}
   let(:stubs)      {{:has_role? => is_admin, :portal_teacher => is_teacher}}
   let(:user)       { mock_model(User, stubs)}
-  let(:material)   { mock({})}
+  let(:material)   { double({})}
   subject { @helper.teacher_guide_link(material)}
   describe "when the user isnt an admin" do
     describe "when the user isnt a teacher" do
-      it { should be_blank }
+      it { is_expected.to be_blank }
     end
     describe "when the user is a teacher" do
       let(:is_teacher) {true}
       let(:is_admin)   {false}
       describe "when there is no guide" do
-        it { should be_blank}
+        it { is_expected.to be_blank}
       end
       describe "When the guide is an empty string" do
-        let(:material) {mock({:teacher_guide_url => ""})}
-        it {should be_blank}
+        let(:material) {double({:teacher_guide_url => ""})}
+        it {is_expected.to be_blank}
       end
       describe "When the guide is an actual url" do
-        let(:material) {mock({:teacher_guide_url => "http://google.com/"})}
-        it {should match "http://google.com"}
+        let(:material) {double({:teacher_guide_url => "http://google.com/"})}
+        it {is_expected.to match "http://google.com"}
       end
     end
     describe "when the user is an admin" do
       let(:is_teacher) {false}
       let(:is_admin)   {true}
       describe "when there is no guide" do
-        it { should be_blank}
+        it { is_expected.to be_blank}
       end
       describe "When the guide is an empty string" do
-        let(:material) {mock({:teacher_guide_url => ""})}
-        it {should be_blank}
+        let(:material) {double({:teacher_guide_url => ""})}
+        it {is_expected.to be_blank}
       end
       describe "When the guide is an actual url" do
-        let(:material) {mock({:teacher_guide_url => "http://google.com/"})}
-        it {should match "http://google.com"}
+        let(:material) {double({:teacher_guide_url => "http://google.com/"})}
+        it {is_expected.to match "http://google.com"}
       end
     end
   end

--- a/spec/helpers/tiny_mce_helper_spec.rb
+++ b/spec/helpers/tiny_mce_helper_spec.rb
@@ -10,7 +10,7 @@ describe TinyMceHelper do
 
     it "should have default settings for buttons" do
       buttons = mce_buttons(1)
-      buttons.should match default_mce_buttons(1)
+      expect(buttons).to match default_mce_buttons(1)
     end
   end
   
@@ -29,10 +29,10 @@ describe TinyMceHelper do
     
     it "should use application settings for tiny_mce buttons" do
       buttons = mce_buttons(1)
-      buttons.should_not match default_mce_buttons(1)
-      buttons.should match(@line1)
-      buttons.should match(@line2)
-      buttons.should match("|") # seperator for button sets.
+      expect(buttons).not_to match default_mce_buttons(1)
+      expect(buttons).to match(@line1)
+      expect(buttons).to match(@line2)
+      expect(buttons).to match("|") # seperator for button sets.
     end
 
   end

--- a/spec/integration/dataservice/dataservice_buckets_spec.rb
+++ b/spec/integration/dataservice/dataservice_buckets_spec.rb
@@ -11,7 +11,7 @@ describe "Dataservice Buckets" do
   it 'should deliver empty bucket data when no bucket contents exist' do
     get "/dataservice/bucket_loggers/learner/#{@learner.id}/bucket_contents.bundle"
 
-    response.body.should == ""
+    expect(response.body).to eq("")
   end
 
   it 'should deliver the most recent bucket contents when more than one contents exist' do
@@ -21,7 +21,7 @@ describe "Dataservice Buckets" do
     Dataservice::BucketContent.create(:bucket_logger_id => log.id, :processed => true, :empty => false, :body => "body3")
     get "/dataservice/bucket_loggers/learner/#{@learner.id}/bucket_contents.bundle"
 
-    response.body.should == "body3"
+    expect(response.body).to eq("body3")
   end
 
   it 'should deliver bucket contents by logger id' do
@@ -30,7 +30,7 @@ describe "Dataservice Buckets" do
     Dataservice::BucketContent.create(:bucket_logger_id => log.id, :processed => true, :empty => false, :body => "body4")
     get "/dataservice/bucket_loggers/#{log.id}.bundle"
 
-    response.body.should == "body4"
+    expect(response.body).to eq("body4")
   end
 
   it 'should accept posted bundle contents by logger id' do
@@ -38,14 +38,14 @@ describe "Dataservice Buckets" do
     post "/dataservice/bucket_loggers/#{log.id}/bucket_contents.bundle", "This is some content"
 
     @learner.reload
-    @learner.bucket_logger.most_recent_content.should == "This is some content"
+    expect(@learner.bucket_logger.most_recent_content).to eq("This is some content")
   end
 
   it 'should accept posted bundle contents by learner id' do
     post "/dataservice/bucket_loggers/learner/#{@learner.id}/bucket_contents.bundle", "This is some content"
 
     @learner.reload
-    @learner.bucket_logger.most_recent_content.should == "This is some content"
+    expect(@learner.bucket_logger.most_recent_content).to eq("This is some content")
   end
 
   it 'should accept multiple posted bundle contents by logger id' do
@@ -55,7 +55,7 @@ describe "Dataservice Buckets" do
     post "/dataservice/bucket_loggers/learner/#{@learner.id}/bucket_contents.bundle", "This is totally different content"
 
     @learner.reload
-    @learner.bucket_logger.most_recent_content.should == "This is totally different content"
+    expect(@learner.bucket_logger.most_recent_content).to eq("This is totally different content")
   end
 
   it 'should accept multiple posted items by logger id and return them all' do
@@ -63,7 +63,7 @@ describe "Dataservice Buckets" do
     post "/dataservice/bucket_loggers/learner/#{@learner.id}/bucket_log_items.bundle", "This is some content 2"
 
     get "/dataservice/bucket_loggers/learner/#{@learner.id}/bucket_log_items.bundle"
-    response.body.should == "[This is some content,This is some content 2]"
+    expect(response.body).to eq("[This is some content,This is some content 2]")
   end
 
   ### BucketLoggers with no learners ###
@@ -79,7 +79,7 @@ describe "Dataservice Buckets" do
       Dataservice::BucketContent.create(:bucket_logger_id => log.id, :processed => true, :empty => false, :body => "body3")
       get "/dataservice/bucket_loggers/name/myBucket/bucket_contents.bundle"
 
-      response.body.should == "body3"
+      expect(response.body).to eq("body3")
     end
 
     it 'should deliver bucket contents by logger id' do
@@ -88,14 +88,14 @@ describe "Dataservice Buckets" do
       Dataservice::BucketContent.create(:bucket_logger_id => log.id, :processed => true, :empty => false, :body => "body4")
       get "/dataservice/bucket_loggers/#{log.id}.bundle"
 
-      response.body.should == "body4"
+      expect(response.body).to eq("body4")
     end
 
     it 'should accept posted bundle contents by arbitrary names' do
       post "/dataservice/bucket_loggers/name/myBucket/bucket_contents.bundle", "This is some content"
       get "/dataservice/bucket_loggers/name/myBucket/bucket_contents.bundle"
 
-      response.body.should == "This is some content"
+      expect(response.body).to eq("This is some content")
     end
 
     it 'should accept multiple posted bundle contents by arbitrary names' do
@@ -105,7 +105,7 @@ describe "Dataservice Buckets" do
       post "/dataservice/bucket_loggers/name/myBucket/bucket_contents.bundle", "This is totally different content"
       get "/dataservice/bucket_loggers/name/myBucket/bucket_contents.bundle"
 
-      response.body.should == "This is totally different content"
+      expect(response.body).to eq("This is totally different content")
     end
 
     it 'should accept multiple posted items by name and return them all' do
@@ -113,7 +113,7 @@ describe "Dataservice Buckets" do
       post "/dataservice/bucket_loggers/name/myBucket/bucket_log_items.bundle", "This is some content 2"
 
       get "/dataservice/bucket_loggers/name/myBucket/bucket_log_items.bundle"
-      response.body.should == "[This is some content,This is some content 2]"
+      expect(response.body).to eq("[This is some content,This is some content 2]")
     end
   end
 end

--- a/spec/integration/investigation_jnlp.rb
+++ b/spec/integration/investigation_jnlp.rb
@@ -8,8 +8,8 @@ describe "Investigation" do
     visit investigation_path(:id => investigation.id, :format => :jnlp)
     xml = Nokogiri::XML(page.driver.response.body)
     jnlp_elements = xml.xpath("/jnlp")
-    jnlp_elements.should_not be_empty
+    expect(jnlp_elements).not_to be_empty
     main_class = xml.xpath("/jnlp/application-desc/@main-class")
-    main_class.text.should == 'org.concord.LaunchJnlp'
+    expect(main_class.text).to eq('org.concord.LaunchJnlp')
   end
 end

--- a/spec/libs/activity_runtime_api_spec.rb
+++ b/spec/libs/activity_runtime_api_spec.rb
@@ -265,32 +265,32 @@ describe ActivityRuntimeAPI do
     describe "When publishing a new external activity" do
       it 'should get nil from update_activity' do
         result = ActivityRuntimeAPI.update_activity(new_hash)
-        result.should be_nil
+        expect(result).to be_nil
       end
 
       it "should create a new activity" do
         result = ActivityRuntimeAPI.publish_activity(new_hash, user)
-        result.should_not be_nil
-        result.should have_multiple_choice_like "What color is the sky"
-        result.should have_choice_like "blue"
-        result.template.should be_a_kind_of(Activity)
-        result.template.is_template.should be_true
-        result.should_not have_choice_like "brown"
-        result.should have_image_question_like "draw a picture"
-        result.should have_image_question_like "now explain"
-        result.should have_iframe_like "http://test.interactive.com"
-        result.should have_page_like "Cool Activity Page 1", page_1_url
+        expect(result).not_to be_nil
+        expect(result).to have_multiple_choice_like "What color is the sky"
+        expect(result).to have_choice_like "blue"
+        expect(result.template).to be_a_kind_of(Activity)
+        expect(result.template.is_template).to be_truthy
+        expect(result).not_to have_choice_like "brown"
+        expect(result).to have_image_question_like "draw a picture"
+        expect(result).to have_image_question_like "now explain"
+        expect(result).to have_iframe_like "http://test.interactive.com"
+        expect(result).to have_page_like "Cool Activity Page 1", page_1_url
         # Portal should ignore description
-        result.short_description.should be_nil
-        result.long_description.should be_nil
-        result.long_description_for_teacher.should be_nil
-        result.student_report_enabled.should be_true
+        expect(result.short_description).to be_nil
+        expect(result.long_description).to be_nil
+        expect(result.long_description_for_teacher).to be_nil
+        expect(result.student_report_enabled).to be_truthy
       end
 
       it "should cause that parent investigation and activities are recognized as templates" do
         result = ActivityRuntimeAPI.publish_activity(new_hash, user)
-        result.template.is_template.should be_true
-        result.template.investigation.is_template.should be_true
+        expect(result.template.is_template).to be_truthy
+        expect(result.template.investigation.is_template).to be_truthy
       end
     end
 
@@ -302,19 +302,19 @@ describe ActivityRuntimeAPI do
         it "should delete the non-mapped embeddables in the existing activity" do
           existing
           result = ActivityRuntimeAPI.update_activity(new_hash)
-          result.should_not be_nil
-          result.id.should == existing.id
-          result.template.multiple_choices.should have(1).question
-          result.template.open_responses.should have(1).question
-          result.should have_open_response_like("dislike this activity")
-          result.should have_image_question_like("draw a picture")
+          expect(result).not_to be_nil
+          expect(result.id).to eq(existing.id)
+          expect(result.template.multiple_choices.size).to eq(1)
+          expect(result.template.open_responses.size).to eq(1)
+          expect(result).to have_open_response_like("dislike this activity")
+          expect(result).to have_image_question_like("draw a picture")
         end
 
         it "should update student_report_enabled if changed" do
           existing
           result = ActivityRuntimeAPI.update_activity(new_hash)
-          result.should_not be_nil
-          result.student_report_enabled.should be_false
+          expect(result).not_to be_nil
+          expect(result.student_report_enabled).to be_falsey
         end
 
         it "should ignore description value" do
@@ -325,10 +325,10 @@ describe ActivityRuntimeAPI do
           existing.long_description_for_teacher = portal_description
           existing.save!
           result = ActivityRuntimeAPI.update_activity(new_hash)
-          result.should_not be_nil
-          result.short_description.should == portal_description
-          result.long_description.should == portal_description
-          result.long_description_for_teacher.should == portal_description
+          expect(result).not_to be_nil
+          expect(result.short_description).to eq(portal_description)
+          expect(result.long_description).to eq(portal_description)
+          expect(result.long_description_for_teacher).to eq(portal_description)
         end
       end
 
@@ -345,9 +345,9 @@ describe ActivityRuntimeAPI do
           original_id = open_response.id
           existing
           result = ActivityRuntimeAPI.update_activity(new_hash)
-          result.template.open_responses.first.id.should == original_id
-          result.should have_open_response_like("dislike this activity", required: true, featured: true)
-          result.should_not have_open_response_like("original prompt")
+          expect(result.template.open_responses.first.id).to eq(original_id)
+          expect(result).to have_open_response_like("dislike this activity", required: true, featured: true)
+          expect(result).not_to have_open_response_like("original prompt")
         end
       end
 
@@ -362,12 +362,12 @@ describe ActivityRuntimeAPI do
         end
         it "should update the image_question" do
           original_id = image_question.id
-          image_question.external_id.should == "987654321"
+          expect(image_question.external_id).to eq("987654321")
           existing
           result = ActivityRuntimeAPI.publish(new_hash, user)
-          result.template.image_questions.first.id.should == original_id
-          result.should have_image_question_like("draw a picture", required: true, featured: true)
-          result.should_not have_image_question_like("original prompt")
+          expect(result.template.image_questions.first.id).to eq(original_id)
+          expect(result).to have_image_question_like("draw a picture", required: true, featured: true)
+          expect(result).not_to have_image_question_like("original prompt")
         end
       end
 
@@ -382,12 +382,12 @@ describe ActivityRuntimeAPI do
         end
         it "should update the iframe" do
           original_id = iframe.id
-          iframe.external_id.should == "if_123"
+          expect(iframe.external_id).to eq("if_123")
           existing
           result = ActivityRuntimeAPI.publish(new_hash, user)
-          result.template.iframes.first.id.should == original_id
-          result.should have_iframe_like("http://test.interactive.com", featured: true, required: true)
-          result.should_not have_iframe_like("http://original.url")
+          expect(result.template.iframes.first.id).to eq(original_id)
+          expect(result).to have_iframe_like("http://test.interactive.com", featured: true, required: true)
+          expect(result).not_to have_iframe_like("http://original.url")
         end
       end
 
@@ -426,22 +426,22 @@ describe ActivityRuntimeAPI do
         end
 
         it "should update the existing question" do
-          @result.template.multiple_choices.first.id.should == @original_id
+          expect(@result.template.multiple_choices.first.id).to eq(@original_id)
         end
 
         it "should have the new prompt, be required and featured" do
-          @result.should have_multiple_choice_like("What color is the sky?", required: true, featured: true)
+          expect(@result).to have_multiple_choice_like("What color is the sky?", required: true, featured: true)
         end
 
         it "should not have the original choices" do
-          @result.should_not have_choice_like("original choice")
-          @result.should_not have_choice_like("this choice should be deleted")
+          expect(@result).not_to have_choice_like("original choice")
+          expect(@result).not_to have_choice_like("this choice should be deleted")
         end
 
         it "should have the new choices" do
-          @result.should have_choice_like("red")
-          @result.should have_choice_like("blue")
-          @result.should have_choice_like("green")
+          expect(@result).to have_choice_like("red")
+          expect(@result).to have_choice_like("blue")
+          expect(@result).to have_choice_like("green")
         end
 
         describe "updating choices that exist" do
@@ -469,21 +469,21 @@ describe ActivityRuntimeAPI do
 
           it "The original choice should be updated" do
             choice.reload
-            choice.choice.should == "the content has changed"
-            choice.id.should == @original_choice_id
+            expect(choice.choice).to eq("the content has changed")
+            expect(choice.id).to eq(@original_choice_id)
           end
 
           it "The other choice should be deleted" do
-            @result.should_not have_choice_like("this choice should be deleted")
+            expect(@result).not_to have_choice_like("this choice should be deleted")
           end
 
           it "should have the new choices" do
             @result.reload
-            @result.should have_choice_like("red")
-            @result.should have_choice_like("blue")
-            @result.should have_choice_like("green")
-            @result.should have_choice_like("the content has changed")
-            @result.should have_choice_id choice.id
+            expect(@result).to have_choice_like("red")
+            expect(@result).to have_choice_like("blue")
+            expect(@result).to have_choice_like("green")
+            expect(@result).to have_choice_like("the content has changed")
+            expect(@result).to have_choice_id choice.id
           end
         end
 
@@ -498,28 +498,28 @@ describe ActivityRuntimeAPI do
       let(:result) { ActivityRuntimeAPI.publish_sequence(sequence_hash, user) }
 
       it 'should create a new external activity' do
-        result.should_not be_nil
-        result.should be_a_kind_of(ExternalActivity)
-        result.url.should == sequence_url
-        result.activities.length.should > 0
-        result.name.should == sequence_name
-        result.student_report_enabled.should be_true
+        expect(result).not_to be_nil
+        expect(result).to be_a_kind_of(ExternalActivity)
+        expect(result.url).to eq(sequence_url)
+        expect(result.activities.length).to be > 0
+        expect(result.name).to eq(sequence_name)
+        expect(result.student_report_enabled).to be_truthy
       end
       it 'should create a new investigation' do
-        result.template.should be_a_kind_of(Investigation)
-        result.template.is_template.should be_true
-        result.activities.length.should > 0
+        expect(result.template).to be_a_kind_of(Investigation)
+        expect(result.template.is_template).to be_truthy
+        expect(result.activities.length).to be > 0
       end
 
       it 'should keep order of activities' do
-        result.activities[0].position.should <= result.activities[1].position
-        result.activities[0].name.should == sequence_hash['activities'][0]['name']
-        result.activities[1].name.should == sequence_hash['activities'][1]['name']
+        expect(result.activities[0].position).to be <= result.activities[1].position
+        expect(result.activities[0].name).to eq(sequence_hash['activities'][0]['name'])
+        expect(result.activities[1].name).to eq(sequence_hash['activities'][1]['name'])
       end
 
       it "should cause that parent investigation and activities are recognized as templates" do
-        result.template.is_template.should be_true
-        result.template.activities.map { |a| a.is_template.should be_true }
+        expect(result.template.is_template).to be_truthy
+        result.template.activities.map { |a| expect(a.is_template).to be_truthy }
       end
     end
 
@@ -529,12 +529,12 @@ describe ActivityRuntimeAPI do
       it 'should update the existing investigation details' do
         existing_sequence
         result = ActivityRuntimeAPI.update_sequence(sequence_hash)
-        result.id.should == existing_sequence.id
-        result.name.should match /something new/
-        result.template.name.should match /something new/
-        result.author_url.should == sequence_author_url
-        result.print_url.should == sequence_print_url
-        result.student_report_enabled.should be_true
+        expect(result.id).to eq(existing_sequence.id)
+        expect(result.name).to match /something new/
+        expect(result.template.name).to match /something new/
+        expect(result.author_url).to eq(sequence_author_url)
+        expect(result.print_url).to eq(sequence_print_url)
+        expect(result.student_report_enabled).to be_truthy
       end
 
       describe 'student_report_enabled' do
@@ -543,7 +543,7 @@ describe ActivityRuntimeAPI do
         it 'if set to false in a activity should update the sequence' do
           existing_sequence
           result = ActivityRuntimeAPI.update_sequence(sequence_hash)
-          result.student_report_enabled.should be_false
+          expect(result.student_report_enabled).to be_falsey
         end
       end
 
@@ -551,7 +551,7 @@ describe ActivityRuntimeAPI do
         existing_locked_sequence
         # the sequence_hash does not provide the is_locked proeprty
         result = ActivityRuntimeAPI.update_sequence(sequence_hash)
-        result.is_locked.should == true
+        expect(result.is_locked).to eq(true)
       end
 
       it 'should update order of activities' do
@@ -559,9 +559,9 @@ describe ActivityRuntimeAPI do
         # Swap position of activities.
         sequence_hash['activities'][0], sequence_hash['activities'][1] = sequence_hash['activities'][1], sequence_hash['activities'][0]
         result = ActivityRuntimeAPI.update_sequence(sequence_hash)
-        result.activities[0].position.should <= result.activities[1].position
-        result.activities[0].name.should == sequence_hash['activities'][0]['name']
-        result.activities[1].name.should == sequence_hash['activities'][1]['name']
+        expect(result.activities[0].position).to be <= result.activities[1].position
+        expect(result.activities[0].name).to eq(sequence_hash['activities'][0]['name'])
+        expect(result.activities[1].name).to eq(sequence_hash['activities'][1]['name'])
       end
 
       describe 'the report_embeddable_filters' do
@@ -569,15 +569,15 @@ describe ActivityRuntimeAPI do
         let(:offerings)   { [offering] }
         let(:mock_filter) { double()   }
         before(:each) do
-          Investigation.any_instance.stub(:offerings).and_return(offerings)
-          Activity.any_instance.stub(:offerings).and_return(offerings)
-          offering.stub!(:report_embeddable_filter).and_return(mock_filter)
+          allow_any_instance_of(Investigation).to receive(:offerings).and_return(offerings)
+          allow_any_instance_of(Activity).to receive(:offerings).and_return(offerings)
+          allow(offering).to receive(:report_embeddable_filter).and_return(mock_filter)
         end
        it 'should reset the filters' do
           existing_sequence
-          mock_filter.should_receive(:clear)
+          expect(mock_filter).to receive(:clear)
           result = ActivityRuntimeAPI.update_sequence(sequence_hash)
-          existing_sequence.template.offerings.should == offerings
+          expect(existing_sequence.template.offerings).to eq(offerings)
         end
       end
     end

--- a/spec/libs/archiveable_spec.rb
+++ b/spec/libs/archiveable_spec.rb
@@ -22,7 +22,7 @@ describe Archiveable do
   describe "A class that doesn't respond to is_archived" do
     describe "archived?" do
       it "should return false" do
-        expect(instance.archived?).to be_false
+        expect(instance.archived?).to be_falsey
       end
     end
     describe "archive!" do
@@ -43,16 +43,16 @@ describe Archiveable do
     describe "archived?" do
       it "should return its own values" do
         instance.is_archived = true
-        expect(instance.archived?).to be_true
+        expect(instance.archived?).to be_truthy
         instance.is_archived = false
-        expect(instance.archived?).to be_false
+        expect(instance.archived?).to be_falsey
       end
     end
     describe "archive!" do
       it "should set the archive status to true" do
         instance.is_archived = false
         instance.archive!
-        expect(instance.archived?).to be_true
+        expect(instance.archived?).to be_truthy
       end
     end
 
@@ -60,7 +60,7 @@ describe Archiveable do
       it "should set the archive status to false" do
         instance.is_archived = true
         instance.unarchive!
-        expect(instance.archived?).to be_false
+        expect(instance.archived?).to be_falsey
       end
     end
   end

--- a/spec/libs/bearer_token/bearer_token_spec.rb
+++ b/spec/libs/bearer_token/bearer_token_spec.rb
@@ -36,7 +36,7 @@ describe BearerToken:BearerTokenAuthenticatable do
   after(:each) { Delorean.back_to_the_present }
   let(:domain_matchers) { "" }
   let(:strategy)        { BearerTokenAuthenticatable::BearerToken.new(nil) }
-  let(:request)         { mock('request') }
+  let(:request)         { double('request') }
   let(:mapping)         { Devise.mappings[:user] }
   let(:expires)         { Time.now + 10.minutes}
   let(:user_token)      { addToken(user, client, expires) }
@@ -63,33 +63,33 @@ describe BearerToken:BearerTokenAuthenticatable do
   )}
   let(:referrer)  { "https://foo.bar.com/some/path.html" }
   before(:each) {
-    request.stub!(:headers).and_return(user_headers)
-    request.stub!(:env).and_return({'HTTP_REFERER' => referrer})
-    request.stub!(:params).and_return(params)
-    strategy.stub!(:mapping).and_return(mapping)
-    strategy.stub!(:request).and_return(request)
+    allow(request).to receive(:headers).and_return(user_headers)
+    allow(request).to receive(:env).and_return({'HTTP_REFERER' => referrer})
+    allow(request).to receive(:params).and_return(params)
+    allow(strategy).to receive(:mapping).and_return(mapping)
+    allow(strategy).to receive(:request).and_return(request)
   }
 
   context 'a user with a short-lived authentication token' do
     let(:expires) { Time.now + 10.minutes}
     it 'should authenticate the user' do
-      strategy.authenticate!.should eql :success
+      expect(strategy.authenticate!).to eql :success
     end
 
     it 'the token should expire 12 minutes into the futre' do
       Delorean.jump(12 * 60) # move 12 minutes into the future
-      strategy.authenticate!.should eql :failure
+      expect(strategy.authenticate!).to eql :failure
     end
     context "from an allowed domain" do
       let(:domain_matchers) { "foo.bar.com" }
       it 'should authenticate the user' do
-        strategy.authenticate!.should eql :success
+        expect(strategy.authenticate!).to eql :success
       end
     end
     context "from a prohibited domain" do
       let(:domain_matchers) { "bar.com" } #no foo
       it 'should not authenticate the user' do
-        strategy.authenticate!.should eql :failure
+        expect(strategy.authenticate!).to eql :failure
       end
     end
   end
@@ -97,7 +97,7 @@ describe BearerToken:BearerTokenAuthenticatable do
   context 'a user with an expired authentication token' do
     let(:expires) { Time.now - 10.minutes}
     it 'should NOT authenticate the user' do
-      strategy.authenticate!.should eql :failure
+      expect(strategy.authenticate!).to eql :failure
     end
   end
 
@@ -107,46 +107,46 @@ describe BearerToken:BearerTokenAuthenticatable do
     context 'when sending the good bearer token' do
       let(:user_token){ good_token }
       it "should authenticate" do
-        strategy.authenticate!.should eql :success
+        expect(strategy.authenticate!).to eql :success
       end
     end
     context 'when sending the expired token' do
       let(:user_token){ expired_token }
       it "authentication should fail" do
-        strategy.authenticate!.should eql :failure
+        expect(strategy.authenticate!).to eql :failure
       end
     end
   end
 
   context 'a learner with a short-lived authentication token' do
     before(:each) {
-      request.stub!(:headers).and_return(learner_headers)
+      allow(request).to receive(:headers).and_return(learner_headers)
     }
 
     let(:expires) { Time.now + 10.minutes}
     it 'should authenticate the learner' do
-      strategy.authenticate!.should eql :success
+      expect(strategy.authenticate!).to eql :success
     end
 
     it 'should be able to get the learner from the token' do
       grant = AccessGrant.find_by_access_token(learner_token)
-      grant.learner.should eql learner
+      expect(grant.learner).to eql learner
     end
   end
 
   context 'a teacher with a short-lived authentication token' do
     before(:each) {
-      request.stub!(:headers).and_return(teacher_headers)
+      allow(request).to receive(:headers).and_return(teacher_headers)
     }
 
     let(:expires) { Time.now + 10.minutes}
     it 'should authenticate the teacher' do
-      strategy.authenticate!.should eql :success
+      expect(strategy.authenticate!).to eql :success
     end
 
     it 'should be able to get the teacher from the token' do
       grant = AccessGrant.find_by_access_token(teacher_token)
-      grant.teacher.should eql class_teacher
+      expect(grant.teacher).to eql class_teacher
     end
   end
 end

--- a/spec/libs/bearer_token/jwt_bearer_token_spec.rb
+++ b/spec/libs/bearer_token/jwt_bearer_token_spec.rb
@@ -6,7 +6,7 @@ ENV['JWT_HMAC_SECRET'] = 'foo'
 
 describe BearerToken:JwtBearerTokenAuthenticatable do
   let(:strategy)      { JwtBearerTokenAuthenticatable::BearerToken.new(nil) }
-  let(:request)       { mock('request') }
+  let(:request)       { double('request') }
   let(:mapping)       { Devise.mappings[:user] }
   let(:expires_in)    { 10.minutes.to_i }
   let(:token)         { SignedJWT.create_portal_token(user, {}, expires_in) }
@@ -15,10 +15,10 @@ describe BearerToken:JwtBearerTokenAuthenticatable do
   let(:user)          { FactoryGirl.create(:user) }
   let(:params)        { {} }
   before(:each) {
-    request.stub!(:headers).and_return(headers)
-    request.stub!(:params).and_return(params)
-    strategy.stub!(:mapping).and_return(mapping)
-    strategy.stub!(:request).and_return(request)
+    allow(request).to receive(:headers).and_return(headers)
+    allow(request).to receive(:params).and_return(params)
+    allow(strategy).to receive(:mapping).and_return(mapping)
+    allow(strategy).to receive(:request).and_return(request)
   }
   after(:each) {
     Delorean.back_to_the_present
@@ -27,16 +27,16 @@ describe BearerToken:JwtBearerTokenAuthenticatable do
   context 'a user with a short-lived authentication token' do
     let(:expires_in) { 10.minutes.to_i }
     it 'should authenticate the user' do
-      strategy.authenticate!.should eql :success
+      expect(strategy.authenticate!).to eql :success
     end
 
     it 'the token should expire 12 minutes into the future' do
       Delorean.jump(12 * 60) # move 12 minutes into the future
-      strategy.authenticate!.should eql :failure
+      expect(strategy.authenticate!).to eql :failure
     end
 
     it 'the token should have a uid set' do
-      decoded_token[:data]["uid"].should eql user.id
+      expect(decoded_token[:data]["uid"]).to eql user.id
     end
   end
 
@@ -44,19 +44,19 @@ describe BearerToken:JwtBearerTokenAuthenticatable do
     let(:token) { SignedJWT.create_portal_token(user, {bar: true, baz: 'bam'}, 10.minutes.to_i) }
 
     it 'should authenticate the user' do
-      strategy.authenticate!.should eql :success
+      expect(strategy.authenticate!).to eql :success
     end
 
     it 'the token should have the claims embedded' do
-      decoded_token[:data]['bar'].should eql true
-      decoded_token[:data]['baz'].should eql 'bam'
+      expect(decoded_token[:data]['bar']).to eql true
+      expect(decoded_token[:data]['baz']).to eql 'bam'
     end
   end
 
   context 'a user with an expired authentication token' do
     let(:expires_in) { -10.minutes.to_i}
     it 'should NOT authenticate the user' do
-      strategy.authenticate!.should eql :failure
+      expect(strategy.authenticate!).to eql :failure
     end
   end
 
@@ -66,13 +66,13 @@ describe BearerToken:JwtBearerTokenAuthenticatable do
     context 'when sending the good bearer token' do
       let(:token) { good_token }
       it "should authenticate" do
-        strategy.authenticate!.should eql :success
+        expect(strategy.authenticate!).to eql :success
       end
     end
     context 'when sending the expired token' do
       let(:token){ expired_token }
       it "authentication should fail" do
-        strategy.authenticate!.should eql :failure
+        expect(strategy.authenticate!).to eql :failure
       end
     end
   end

--- a/spec/libs/bool_env_spec.rb
+++ b/spec/libs/bool_env_spec.rb
@@ -3,7 +3,7 @@ require File.expand_path('../../spec_helper', __FILE__)
 describe BoolENV do
   ["True","true","Yes","yes","1"].each do |truthy_value|
     it "should return true for variable with value #{truthy_value}" do
-      ENV.stub(:[]).with("test_var").and_return(truthy_value)
+      allow(ENV).to receive(:[]).with("test_var").and_return(truthy_value)
       expect(BoolENV["test_var"]).to be true
     end
   end
@@ -12,7 +12,7 @@ describe BoolENV do
   end
   ["","False","false","No","no","0","random text"].each do |falsy_value|
     it "should return false for variable with value #{falsy_value}" do
-      ENV.stub(:[]).with("test_var").and_return(falsy_value)
+      allow(ENV).to receive(:[]).with("test_var").and_return(falsy_value)
       expect(BoolENV["test_var"]).to be false
     end
   end

--- a/spec/libs/enews_subscription_spec.rb
+++ b/spec/libs/enews_subscription_spec.rb
@@ -48,7 +48,7 @@ describe EnewsSubscription do
 
         result = EnewsSubscription.set_status(User_EMail, 'subscribed', User_First, User_Last)
 
-        WebMock.should have_requested(:put, construct_test_uri)
+        expect(WebMock).to have_requested(:put, construct_test_uri)
                .with(:body => subscribed_request_body, :headers => Enews_Mimetype)
                .once
 
@@ -68,7 +68,7 @@ describe EnewsSubscription do
 
         result = EnewsSubscription.set_status(User_EMail, 'unsubscribed', User_First, User_Last)
 
-        WebMock.should have_requested(:put, construct_test_uri)
+        expect(WebMock).to have_requested(:put, construct_test_uri)
                .with(:body => subscribed_request_body, :headers => Enews_Mimetype)
                .once
 
@@ -91,7 +91,7 @@ describe EnewsSubscription do
 
         result = EnewsSubscription.get_status(User_EMail)
 
-        WebMock.should have_requested(:get, construct_test_uri)
+        expect(WebMock).to have_requested(:get, construct_test_uri)
                 .with(:body => {email_address: User_EMail}.to_json,
                       :headers => Enews_Mimetype)
                 .once
@@ -112,7 +112,7 @@ describe EnewsSubscription do
 
         result = EnewsSubscription.get_status(User_EMail)
 
-        WebMock.should have_requested(:get, construct_test_uri)
+        expect(WebMock).to have_requested(:get, construct_test_uri)
                .with(:body => {email_address: User_EMail}.to_json,
                      :headers => Enews_Mimetype)
                .once

--- a/spec/libs/padlet_wrapper_spec.rb
+++ b/spec/libs/padlet_wrapper_spec.rb
@@ -53,7 +53,7 @@ describe PadletWrapper do
     end
 
     it 'should create new Padlet and provide its URL' do
-      PadletWrapper.new.padlet_url.should eql(wall_url)
+      expect(PadletWrapper.new.padlet_url).to eql(wall_url)
     end
   end
 

--- a/spec/libs/rack/config_session_cookies_spec.rb
+++ b/spec/libs/rack/config_session_cookies_spec.rb
@@ -10,7 +10,7 @@ describe Rack::ConfigSessionCookies do
   end
   
   it "should have a stubbed session_key" do
-    @tester.session_key.should eql("_fake_session_key")
+    expect(@tester.session_key).to eql("_fake_session_key")
   end
   
   def make_env(options)
@@ -29,7 +29,7 @@ describe Rack::ConfigSessionCookies do
           session_param = "_fake_session_key=1234#{path}1234"
           env = make_env(:path => path, :query => session_param)
           @tester.call(env)
-          env['HTTP_COOKIE'].should eql(session_param)
+          expect(env['HTTP_COOKIE']).to eql(session_param)
         end
       end
       it "should not set cookies for disallowed paths" do
@@ -37,7 +37,7 @@ describe Rack::ConfigSessionCookies do
           session_param = "_fake_session_key=1234#{path}1234"
           env = make_env(:path => path, :query => session_param)
           @tester.call(env)
-          env['HTTP_COOKIE'].should_not eql(session_param)
+          expect(env['HTTP_COOKIE']).not_to eql(session_param)
         end
       end
     end
@@ -47,7 +47,7 @@ describe Rack::ConfigSessionCookies do
     session_param = "_fake_session_key=1234"
     env = make_env(:query => session_param, :cookie => "_fake_session_key=5678")
     @tester.call(env)
-    env['HTTP_COOKIE'].should eql(session_param)    
+    expect(env['HTTP_COOKIE']).to eql(session_param)    
   end
 
   it "should preserve other parts of the cookie" do
@@ -72,7 +72,7 @@ describe Rack::ConfigSessionCookies do
       env = make_env(:query => new_session, 
                      :cookie => String.new(key))
       @tester.call(env)
-      env['HTTP_COOKIE'].should eql(value)
+      expect(env['HTTP_COOKIE']).to eql(value)
     }
   end
 
@@ -86,7 +86,7 @@ describe Rack::ConfigSessionCookies do
         env['PATH_INFO'] = "blah.config"
         env['QUERY_STRING'] = query
         @tester.call(env)
-        env['HTTP_COOKIE'].should eql(session_param)
+        expect(env['HTTP_COOKIE']).to eql(session_param)
     }
   end
 
@@ -96,7 +96,7 @@ describe Rack::ConfigSessionCookies do
     }
     original_hash = env.hash
     @tester.call(env)
-    env.hash.should equal(original_hash)
+    expect(env.hash).to equal(original_hash)
   end
 
   it "should not change the environment if there is no query string" do
@@ -105,12 +105,12 @@ describe Rack::ConfigSessionCookies do
     env['PATH_INFO'] = "blah.config"
     original_hash = env.hash
     @tester.call(env)
-    env.hash.should equal(original_hash)
+    expect(env.hash).to equal(original_hash)
 
     env['PATH_INFO']  = "blah.jnlp"
     original_hash = env.hash
     @tester.call(env)
-    env.hash.should equal(original_hash)
+    expect(env.hash).to equal(original_hash)
   end
   
   it "should not change the environment if there is a incorrect query string" do
@@ -119,13 +119,13 @@ describe Rack::ConfigSessionCookies do
     env['QUERY_STRING'] = "_wrong_session_key=1234"
     original_hash = env.hash
     @tester.call(env)
-    env.hash.should equal(original_hash)
+    expect(env.hash).to equal(original_hash)
     
     env = {}
     env['PATH_INFO'] = "blah.jnlp"
     env['QUERY_STRING'] = "_wrong_session_key=1234"
     original_hash = env.hash
     @tester.call(env)
-    env.hash.should equal(original_hash)
+    expect(env.hash).to equal(original_hash)
   end
 end

--- a/spec/libs/reports/column_definition_spec.rb
+++ b/spec/libs/reports/column_definition_spec.rb
@@ -5,29 +5,29 @@ describe Reports::ColumnDefinition do
   describe '#initialize' do
     it 'defines default values' do
       column_defs = Reports::ColumnDefinition.new
-      column_defs.title.should == 'Title'
-      column_defs.col_index.should be_nil
+      expect(column_defs.title).to eq('Title')
+      expect(column_defs.col_index).to be_nil
     end
 
     it 'accepts arguments' do
       column_defs = Reports::ColumnDefinition.new({ :title => 'Here is a title' })
-      column_defs.title.should == 'Here is a title'
+      expect(column_defs.title).to eq('Here is a title')
     end
 
     it 'accepts nil arguments' do
       column_defs = Reports::ColumnDefinition.new({ :title => nil })
-      column_defs.title.should == 'Title'
+      expect(column_defs.title).to eq('Title')
     end
 
     it 'ignores width argument (so we can re-add width support later)' do
       column_defs = Reports::ColumnDefinition.new({ :title => 'Here is a title', :width => 13 })
-      column_defs.title.should == 'Here is a title'
+      expect(column_defs.title).to eq('Here is a title')
     end
   end
 
   describe '#write_header' do
     it 'sets the headers of the argument sheet' do
-      pending 'Create a mock sheet'
+      skip 'Create a mock sheet'
     end
   end
 end

--- a/spec/libs/reports/detail_spec.rb
+++ b/spec/libs/reports/detail_spec.rb
@@ -20,7 +20,7 @@ describe Reports::Detail do
   let(:offering)         { FactoryGirl.create(:portal_offering, runnable: runnable)   }
   let(:learner)          { FactoryGirl.create(:portal_learner, student: student, offering: offering)  }
   let(:report_learner)   { learner.report_learner }
-  let(:url_helpers)      { mock(remote_endpoint_url: "noplace.com") }
+  let(:url_helpers)      { double(remote_endpoint_url: "noplace.com") }
   let(:runnables)        { [ runnable ] }
   let(:report_learners)  { [ report_learner ] }
   let(:opts) do
@@ -33,9 +33,9 @@ describe Reports::Detail do
   let(:report) { Reports::Detail.new(opts) }
   describe '#initialize' do
     it 'asigns values' do
-      report.instance_variable_get(:@runnables).should == runnables
-      report.instance_variable_get(:@report_learners).should == report_learners
-      report.instance_variable_get(:@url_helpers).should == url_helpers
+      expect(report.instance_variable_get(:@runnables)).to eq(runnables)
+      expect(report.instance_variable_get(:@report_learners)).to eq(report_learners)
+      expect(report.instance_variable_get(:@url_helpers)).to eq(url_helpers)
     end
   end
   describe '#run_report' do
@@ -47,7 +47,7 @@ describe Reports::Detail do
 
     before(:each) do
       setupReportables()
-      report_learner.stub(:answers) { answers }
+      allow(report_learner).to receive(:answers) { answers }
     end
 
     describe "with a complete answer" do

--- a/spec/libs/rspec_extensions_spec.rb
+++ b/spec/libs/rspec_extensions_spec.rb
@@ -10,61 +10,61 @@ describe "fails_in_themes" do
   end
 
   it "should fail when there's no body" do
-    lambda {
+    expect {
       fails_in_themes
-    }.should raise_error(Exception)
+    }.to raise_error(Exception)
   end
 
   describe "when the example passes" do
     it "should pass when the body passes and we're not running a matching theme" do
       ApplicationController.set_theme("xproject")
       fails_in_themes({ "assessment" => :todo }) do
-        true.should be_true
+        expect(true).to be_truthy
       end
     end
 
     it "should fail when the example passes in the current theme, and the current theme is in :todo mode" do
-      lambda {
+      expect {
         ApplicationController.set_theme("assessment")
         fails_in_themes({ "assessment" => :todo }) do
-          true.should be_true
+          expect(true).to be_truthy
         end
-      }.should raise_error(RSpec::Core::Pending::PendingExampleFixedError)
+      }.to raise_error(RSpec::Core::Pending::PendingExampleFixedError)
     end
 
     it "should fail when the body passes in the current theme, and the current theme is in :expected mode" do
       ApplicationController.set_theme("assessment")
-      lambda {
+      expect {
         fails_in_themes({ "assessment" => :expected }) do
-          true.should be_true
+          expect(true).to be_truthy
         end
-      }.should raise_error(RSpec::Core::Pending::PendingExampleFixedError)
+      }.to raise_error(RSpec::Core::Pending::PendingExampleFixedError)
     end
   end
 
   describe "when the example fails" do
     it "should fail when the body fails and we're not running a matching theme" do
       ApplicationController.set_theme("xproject")
-      lambda {
+      expect {
         fails_in_themes({ "assessment" => :todo }) do
-          true.should be_false
+          expect(true).to be_falsey
         end
-      }.should raise_error(RSpec::Expectations::ExpectationNotMetError)
+      }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
     end
 
     it "should be pending when the body fails in the current theme, and the current theme is set to :todo mode" do
       ApplicationController.set_theme("assessment")
-      lambda {
+      expect {
         fails_in_themes({ "assessment" => :todo }) do
-          true.should be_false
+          expect(true).to be_falsey
         end
-      }.should raise_error(RSpec::Core::Pending::PendingDeclaredInExample)
+      }.to raise_error(RSpec::Core::Pending::PendingDeclaredInExample)
     end
 
     it "should pass when the body fails in the current theme, and the current theme is set to :expected mode" do
       ApplicationController.set_theme("assessment")
       fails_in_themes({ "assessment" => :expected }) do
-        true.should be_false
+        expect(true).to be_falsey
       end
     end
   end
@@ -73,19 +73,19 @@ describe "fails_in_themes" do
     it "should catch mock verifications as test errors, and pass" do
       ApplicationController.set_theme("assessment")
       fails_in_themes({ "assessment" => :expected }) do
-        ApplicationController.should_receive(:foo).once
+        expect(ApplicationController).to receive(:foo).once
       end
     end
 
     it "should not catch mock verifications it does not wrap" do
-      lambda {
+      expect {
         ApplicationController.set_theme("assessment")
-        ApplicationController.should_receive(:foo).once
+        expect(ApplicationController).to receive(:foo).once
         fails_in_themes({ "assessment" => :expected }) do
-          true.should be_false
+          expect(true).to be_falsey
         end
         verify ApplicationController
-      }.should raise_error(RSpec::Mocks::MockExpectationError)
+      }.to raise_error(RSpec::Mocks::MockExpectationError)
     end
   end
 end

--- a/spec/libs/url_checker_spec.rb
+++ b/spec/libs/url_checker_spec.rb
@@ -17,18 +17,18 @@ describe UrlChecker do
 
   it "should validate good image urls" do
       [@small_image_url, @medium_image_url].each do |img|  
-        UrlChecker.valid?(img).should be true
-        UrlChecker.valid?(img).should be true
+        expect(UrlChecker.valid?(img)).to be true
+        expect(UrlChecker.valid?(img)).to be true
       end
   end
   
   it "should not validate good image urls that are too big" do
-    UrlChecker.valid?(@huge_image_url,  :max_size => 99999999).should be false
-    UrlChecker.valid?(@medium_image_url,:max_size =>100000).should be true
+    expect(UrlChecker.valid?(@huge_image_url,  :max_size => 99999999)).to be false
+    expect(UrlChecker.valid?(@medium_image_url,:max_size =>100000)).to be true
   end
   
   it "should not validate bad image urls" do
-    UrlChecker.valid?(@non_existant).should be false
+    expect(UrlChecker.valid?(@non_existant)).to be false
   end
   
 end

--- a/spec/models/access_grant_spec.rb
+++ b/spec/models/access_grant_spec.rb
@@ -37,25 +37,25 @@ describe AccessGrant do
   describe "class methods" do
     describe "#new with valid attributes" do
       it "should return a valid instance with parameters set" do
-        subject.should be_valid
+        expect(subject).to be_valid
       end
       it "should have valid tokens" do
-        subject.code.should match /[a-f|0-9]{32}/
-        subject.access_token.should match /[a-f|0-9]{32}/
-        subject.refresh_token.should match(/[a-f|0-9]{32}/)
+        expect(subject.code).to match /[a-f|0-9]{32}/
+        expect(subject.access_token).to match /[a-f|0-9]{32}/
+        expect(subject.refresh_token).to match(/[a-f|0-9]{32}/)
       end
       it "should not have an expiration time" do
-        subject.access_token_expires_at.should be_nil
+        expect(subject.access_token_expires_at).to be_nil
       end
     end
     describe "#prune!" do
       it "Should remove items that expired more than a day ago" do
         all_grants = old_grants + newer_grants
-        AccessGrant.count.should == all_grants.size
+        expect(AccessGrant.count).to eq(all_grants.size)
         AccessGrant.prune!
-        AccessGrant.count.should == newer_grants.size
+        expect(AccessGrant.count).to eq(newer_grants.size)
         AccessGrant.pluck('access_token_expires_at').each do |exp_time|
-          exp_time.should be > 1.days.ago
+          expect(exp_time).to be > 1.days.ago
         end
       end
     end
@@ -67,12 +67,12 @@ describe AccessGrant do
       end
       it "should return a non-expired token" do
         grant = newer_grants.first
-        AccessGrant.authenticate(grant.code, grant.client_id).should_not be_nil
+        expect(AccessGrant.authenticate(grant.code, grant.client_id)).not_to be_nil
       end
       describe "with an expired token" do
         it "should return nil" do
           grant = old_grants.first
-          AccessGrant.authenticate(grant.code, grant.client_id).should be_nil
+          expect(AccessGrant.authenticate(grant.code, grant.client_id)).to be_nil
         end
       end
     end
@@ -82,19 +82,19 @@ describe AccessGrant do
     describe "#start_expiry_period!" do
       it "should set the expiration date" do
         subject.start_expiry_period!
-        subject.access_token_expires_at.should be_within(1.hour).of(7.days.from_now)
+        expect(subject.access_token_expires_at).to be_within(1.hour).of(7.days.from_now)
       end
     end
 
     describe "#redirect_uri_for" do
       let(:url)      { "http://blarg.com/path" }
       it "should include the token and state" do
-        subject.redirect_uri_for(url).should match /#{url}\?code=[a-f|0-9]{32}&response_type=code&state=what_is_this_for/
+        expect(subject.redirect_uri_for(url)).to match /#{url}\?code=[a-f|0-9]{32}&response_type=code&state=what_is_this_for/
       end
       describe "with qeury string in the url" do
         let(:url)      { "http://blarg.com/path?foo" }
         it "should use ampersands" do
-          subject.redirect_uri_for(url).should match /path\?foo&code=/
+          expect(subject.redirect_uri_for(url)).to match /path\?foo&code=/
         end
       end
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -16,26 +16,26 @@ describe Activity do
   end
 
   it 'has_many for all BASE_EMBEDDABLES' do
-    BASE_EMBEDDABLES.length.should be > 0
+    expect(BASE_EMBEDDABLES.length).to be > 0
     BASE_EMBEDDABLES.each do |e|
-      activity.respond_to?(e[/::(\w+)$/, 1].underscore.pluralize).should be(true)
+      expect(activity.respond_to?(e[/::(\w+)$/, 1].underscore.pluralize)).to be(true)
     end
   end
 
   describe "should be publishable" do
     it "should not be public by default" do
-      activity.published?.should be(false)
+      expect(activity.published?).to be(false)
     end
     it "should be public if published" do
       activity.publish!
-      activity.public?.should be(true)
+      expect(activity.public?).to be(true)
     end
     
     it "should not be public if unpublished " do
       activity.publish!
-      activity.public?.should be(true)
+      expect(activity.public?).to be(true)
       activity.un_publish!
-      activity.public?.should_not be(true)
+      expect(activity.public?).not_to be(true)
     end
   end
 
@@ -117,27 +117,27 @@ describe Activity do
     let(:external_activities)  { [] }
     subject do
       s = Factory.create(:activity)
-      s.stub!(:investigation => investigation)
-      s.stub!(:external_activities => external_activities)
+      s.stub(:investigation => investigation)
+      s.stub(:external_activities => external_activities)
       s.is_template
     end
 
     describe "when an activity has external_activities" do
       let(:external_activities) { [1,2,3]}
-      it { should be_true}
+      it { is_expected.to be_truthy}
     end
     describe "when an activity has no external_activities" do
       let(:external_activities) {[]}
-      it { should be_false}
+      it { is_expected.to be_falsey}
 
       describe "when the activity has an investigation" do
         describe "that is a template" do
           let(:investigation) { investigation_with_template }
-          it { should be_true }
+          it { is_expected.to be_truthy }
         end
         describe "that is not a template" do
           let(:investigation) { investigation_without_template }
-          it { should be_false }
+          it { is_expected.to be_falsey }
         end
       end
     end
@@ -167,7 +167,7 @@ describe Activity do
 
   describe "question_number" do
     before(:each) do
-      activity_with_questions.stub!(:reportable_elements).and_return(elements)
+      allow(activity_with_questions).to receive(:reportable_elements).and_return(elements)
     end
     let(:activity_with_questions) { activity }
     let(:mc_question)         {Factory.create(:multiple_choice) }
@@ -180,19 +180,19 @@ describe Activity do
     subject() { activity_with_questions }
 
     it "should find the multiple choice question in the first position" do
-      subject.question_number(mc_question).should eq 1
+      expect(subject.question_number(mc_question)).to eq 1
     end
 
     it "should find the open response question at the second position" do
-      subject.question_number(or_question).should eq 2
+      expect(subject.question_number(or_question)).to eq 2
     end
 
     it "should return -1 for questions that aren't supposed to be there... " do
-      subject.question_number(another_or_question).should eq -1
+      expect(subject.question_number(another_or_question)).to eq -1
     end
 
     it "should return -1 when nonesense is passed in " do
-      subject.question_number("xxx").should eq -1
+      expect(subject.question_number("xxx")).to eq -1
     end
   end
 

--- a/spec/models/admin/project_link_spec.rb
+++ b/spec/models/admin/project_link_spec.rb
@@ -4,12 +4,12 @@ describe Admin::ProjectLink do
 
   describe "#name and #href and #link_id" do
     it "should be required" do
-      expect(Admin::ProjectLink.new(name: 'foo', href: 'bar', link_id:'/foo/bar').valid?).to be_true
-      expect(Admin::ProjectLink.new(name: 'foo', href: '', link_id: '/foo').valid?).to be_false
-      expect(Admin::ProjectLink.new(name: '', href: 'bar', link_id: '/bar').valid?).to be_false
-      expect(Admin::ProjectLink.new(name: '', href: '', link_id:'/').valid?).to be_false
-      expect(Admin::ProjectLink.new(name: 'foo', href: 'bar', link_id:'').valid?).to be_false
-      expect(Admin::ProjectLink.new().valid?).to be_false
+      expect(Admin::ProjectLink.new(name: 'foo', href: 'bar', link_id:'/foo/bar').valid?).to be_truthy
+      expect(Admin::ProjectLink.new(name: 'foo', href: '', link_id: '/foo').valid?).to be_falsey
+      expect(Admin::ProjectLink.new(name: '', href: 'bar', link_id: '/bar').valid?).to be_falsey
+      expect(Admin::ProjectLink.new(name: '', href: '', link_id:'/').valid?).to be_falsey
+      expect(Admin::ProjectLink.new(name: 'foo', href: 'bar', link_id:'').valid?).to be_falsey
+      expect(Admin::ProjectLink.new().valid?).to be_falsey
     end
   end
 end

--- a/spec/models/admin/projects_spec.rb
+++ b/spec/models/admin/projects_spec.rb
@@ -29,35 +29,35 @@ describe Admin::Project do
 
   describe "#name" do
     it "should be required" do
-      expect(Admin::Project.new(name: 'n').valid?).to be_true
-      expect(Admin::Project.new(name: '').valid?).to be_false
-      expect(Admin::Project.new().valid?).to be_false
+      expect(Admin::Project.new(name: 'n').valid?).to be_truthy
+      expect(Admin::Project.new(name: '').valid?).to be_falsey
+      expect(Admin::Project.new().valid?).to be_falsey
     end
   end
 
   describe "#landing_page_slug" do
     it "should be optional" do
-      expect(Admin::Project.new(name: 'n').valid?).to be_true
-      expect(Admin::Project.new(name: 'n', landing_page_slug: '').valid?).to be_true
+      expect(Admin::Project.new(name: 'n').valid?).to be_truthy
+      expect(Admin::Project.new(name: 'n', landing_page_slug: '').valid?).to be_truthy
     end
 
     it "should be unique (except from nil or empty string)" do
-      expect(Admin::Project.create(name: 'n', landing_page_slug: 'test').valid?).to be_true
-      expect(Admin::Project.create(name: 'n', landing_page_slug: 'test').valid?).to be_false
-      expect(Admin::Project.create(name: 'n', landing_page_slug: '').valid?).to be_true
-      expect(Admin::Project.create(name: 'n', landing_page_slug: '').valid?).to be_true
-      expect(Admin::Project.create(name: 'n').valid?).to be_true
-      expect(Admin::Project.create(name: 'n').valid?).to be_true
+      expect(Admin::Project.create(name: 'n', landing_page_slug: 'test').valid?).to be_truthy
+      expect(Admin::Project.create(name: 'n', landing_page_slug: 'test').valid?).to be_falsey
+      expect(Admin::Project.create(name: 'n', landing_page_slug: '').valid?).to be_truthy
+      expect(Admin::Project.create(name: 'n', landing_page_slug: '').valid?).to be_truthy
+      expect(Admin::Project.create(name: 'n').valid?).to be_truthy
+      expect(Admin::Project.create(name: 'n').valid?).to be_truthy
     end
 
     it "should be limited to lower case letters, digits and '-' character" do
-      expect(Admin::Project.new(name: 'n', landing_page_slug: 'valid-slug').valid?).to be_true
-      expect(Admin::Project.new(name: 'n', landing_page_slug: 'valid-slug-2').valid?).to be_true
-      expect(Admin::Project.new(name: 'n', landing_page_slug: '3-valid-slug').valid?).to be_true
-      expect(Admin::Project.new(name: 'n', landing_page_slug: 'Invalid-slug').valid?).to be_false
-      expect(Admin::Project.new(name: 'n', landing_page_slug: 'invalid/slug').valid?).to be_false
-      expect(Admin::Project.new(name: 'n', landing_page_slug: 'invalid.slug').valid?).to be_false
-      expect(Admin::Project.new(name: 'n', landing_page_slug: 'invalid:slug').valid?).to be_false
+      expect(Admin::Project.new(name: 'n', landing_page_slug: 'valid-slug').valid?).to be_truthy
+      expect(Admin::Project.new(name: 'n', landing_page_slug: 'valid-slug-2').valid?).to be_truthy
+      expect(Admin::Project.new(name: 'n', landing_page_slug: '3-valid-slug').valid?).to be_truthy
+      expect(Admin::Project.new(name: 'n', landing_page_slug: 'Invalid-slug').valid?).to be_falsey
+      expect(Admin::Project.new(name: 'n', landing_page_slug: 'invalid/slug').valid?).to be_falsey
+      expect(Admin::Project.new(name: 'n', landing_page_slug: 'invalid.slug').valid?).to be_falsey
+      expect(Admin::Project.new(name: 'n', landing_page_slug: 'invalid:slug').valid?).to be_falsey
     end
   end
 end

--- a/spec/models/admin/settings_spec.rb
+++ b/spec/models/admin/settings_spec.rb
@@ -8,7 +8,7 @@ describe Admin::Settings do
   end
 
   it "should create a new instance given valid attributes" do
-    @new_valid_settings.should be_valid
+    expect(@new_valid_settings).to be_valid
   end
 
 
@@ -16,14 +16,14 @@ describe Admin::Settings do
     describe "default value" do
       it "should be 5 minutes" do
         five_min = 300
-        @new_valid_settings.pub_interval.should == five_min
+        expect(@new_valid_settings.pub_interval).to eq(five_min)
       end
     end
 
     describe "less than minimum interval" do
       it "should fail validations" do
         @new_valid_settings.pub_interval = Admin::Settings::MinPubInterval - 1
-        @new_valid_settings.should_not be_valid
+        expect(@new_valid_settings).not_to be_valid
         puts @new_valid_settings.errors
       end
     end
@@ -35,22 +35,22 @@ describe Admin::Settings do
       subject  { @new_valid_settings.available_bookmark_types }
 
       it "should return an array" do
-        should be_kind_of Array
+        is_expected.to be_kind_of Array
       end
 
       it "should include a generic bookmark type" do
-        should include Portal::GenericBookmark.name
+        is_expected.to include Portal::GenericBookmark.name
       end
     end
 
     describe "#enabled_bookmark_types" do
       subject  { @new_valid_settings.enabled_bookmark_types }
       it "should return an array" do
-        should be_kind_of Array
+        is_expected.to be_kind_of Array
       end
 
       it "should be empty be default" do
-        should be_empty
+        is_expected.to be_empty
       end
 
     end
@@ -67,52 +67,52 @@ describe Admin::Settings do
     describe "reading configuration settings" do
       describe "settings_for" do
         it "should be a method" do
-          @clazz.should respond_to :settings_for
+          expect(@clazz).to respond_to :settings_for
         end
         it "should return true values" do
-          @clazz.settings_for(:test_value_true).should be_true
+          expect(@clazz.settings_for(:test_value_true)).to be_truthy
         end
         it "should return false values" do
-          @clazz.settings_for(:test_value_false).should be_false
+          expect(@clazz.settings_for(:test_value_false)).to be_falsey
         end
         it "should report nil values" do
-          @clazz.should_receive(:notify_missing_setting)
-          @clazz.settings_for(:test_value_nil).should be_nil
+          expect(@clazz).to receive(:notify_missing_setting)
+          expect(@clazz.settings_for(:test_value_nil)).to be_nil
         end
         it "should report undefined values" do
-          @clazz.should_receive(:notify_missing_setting)
-          @clazz.settings_for(:something_undefined).should be_nil
+          expect(@clazz).to receive(:notify_missing_setting)
+          expect(@clazz.settings_for(:something_undefined)).to be_nil
         end
       end
     end
     describe "require_activity_descriptions" do
       it "should return the APP_CONFIG settings for :require_activity_descriptions" do
-        @clazz.should_receive(:settings_for).with(:require_activity_descriptions).and_return(true)
-        @clazz.require_activity_descriptions.should be_true
-        @clazz.should_receive(:settings_for).with(:require_activity_descriptions).and_return(false)
-        @clazz.require_activity_descriptions.should be_false
+        expect(@clazz).to receive(:settings_for).with(:require_activity_descriptions).and_return(true)
+        expect(@clazz.require_activity_descriptions).to be_truthy
+        expect(@clazz).to receive(:settings_for).with(:require_activity_descriptions).and_return(false)
+        expect(@clazz.require_activity_descriptions).to be_falsey
       end
     end
     describe "unique_activity_names" do
       it "should return the APP_CONFIG settings for :unique_activity_names" do
-        @clazz.should_receive(:settings_for).with(:unique_activity_names).and_return(true)
-        @clazz.unique_activity_names.should be_true
-        @clazz.should_receive(:settings_for).with(:unique_activity_names).and_return(false)
-        @clazz.unique_activity_names.should be_false
+        expect(@clazz).to receive(:settings_for).with(:unique_activity_names).and_return(true)
+        expect(@clazz.unique_activity_names).to be_truthy
+        expect(@clazz).to receive(:settings_for).with(:unique_activity_names).and_return(false)
+        expect(@clazz.unique_activity_names).to be_falsey
       end
     end
 
     describe "teachers_can_author" do
-      let(:active_settings) { mock() }
+      let(:active_settings) { double() }
       it "should return true if the current settings allows teachers to author" do
-        @clazz.should_receive(:default_settings).and_return(active_settings)
-        active_settings.should_receive(:teachers_can_author).and_return(true)
-        @clazz.teachers_can_author?.should == true
+        expect(@clazz).to receive(:default_settings).and_return(active_settings)
+        expect(active_settings).to receive(:teachers_can_author).and_return(true)
+        expect(@clazz.teachers_can_author?).to eq(true)
       end
       it "should return false if the current settings dissalows teachers authoring" do
-        @clazz.should_receive(:default_settings).and_return(active_settings)
-        active_settings.should_receive(:teachers_can_author).and_return(false)
-        @clazz.teachers_can_author?.should == false
+        expect(@clazz).to receive(:default_settings).and_return(active_settings)
+        expect(active_settings).to receive(:teachers_can_author).and_return(false)
+        expect(@clazz.teachers_can_author?).to eq(false)
       end
     end
   end

--- a/spec/models/api/v1/report_spec.rb
+++ b/spec/models/api/v1/report_spec.rb
@@ -35,24 +35,57 @@ describe API::V1::Report do
         let(:enable_feedback)      { true }
         let(:max_score)            { 10   }
 
-        its(:max_score)            { should be 10 }
-        its(:enable_text_feedback) { should be true }
-        its(:enable_score)         { should be true }
+        describe '#max_score' do
+          subject { super().max_score }
+          it { is_expected.to be 10 }
+        end
+
+        describe '#enable_text_feedback' do
+          subject { super().enable_text_feedback }
+          it { is_expected.to be true }
+        end
+
+        describe '#enable_score' do
+          subject { super().enable_score }
+          it { is_expected.to be true }
+        end
 
         describe "changing the max_score to 0" do
           let(:max_score)            { 0 }
 
-          its(:max_score)            { should be 0 }
-          its(:enable_text_feedback) { should be true }
-          its(:enable_score)         { should be true }
+          describe '#max_score' do
+            subject { super().max_score }
+            it { is_expected.to be 0 }
+          end
+
+          describe '#enable_text_feedback' do
+            subject { super().enable_text_feedback }
+            it { is_expected.to be true }
+          end
+
+          describe '#enable_score' do
+            subject { super().enable_score }
+            it { is_expected.to be true }
+          end
         end
 
         describe "disabling text feedback" do
           let(:enable_feedback)      { false }
 
-          its(:max_score)            { should be 10 }
-          its(:enable_text_feedback) { should be false }
-          its(:enable_score)         { should be true  }
+          describe '#max_score' do
+            subject { super().max_score }
+            it { is_expected.to be 10 }
+          end
+
+          describe '#enable_text_feedback' do
+            subject { super().enable_text_feedback }
+            it { is_expected.to be false }
+          end
+
+          describe '#enable_score' do
+            subject { super().enable_score }
+            it { is_expected.to be true  }
+          end
         end
       end
     end
@@ -76,7 +109,7 @@ describe API::V1::Report do
 
       describe "when no feedback or answer has been given yet" do
         it "should indicate that it doesn't need review" do
-          open_response_answer.needs_review?.should be_false
+          expect(open_response_answer.needs_review?).to be_falsey
         end
       end
 
@@ -87,7 +120,7 @@ describe API::V1::Report do
         end
 
         it "should indicate that it does need a review" do
-          open_response_answer.needs_review?.should be_true
+          expect(open_response_answer.needs_review?).to be_truthy
         end
 
         describe 'giving feedback without marking complete' do
@@ -95,15 +128,15 @@ describe API::V1::Report do
           let(:score)          {  10        }
 
           it "should indicate that it does need a review" do
-            open_response_answer.needs_review?.should be_true
+            expect(open_response_answer.needs_review?).to be_truthy
           end
 
           it "should have the correct score" do
-            open_response_answer.current_score.should eq score
+            expect(open_response_answer.current_score).to eq score
           end
 
           it "should have the correct feedback" do
-            open_response_answer.current_feedback.should eq text_feedback
+            expect(open_response_answer.current_feedback).to eq text_feedback
           end
         end
 
@@ -114,16 +147,16 @@ describe API::V1::Report do
           let(:has_been_reviewed) { true        }
 
           it "should show that feedback is complete" do
-            open_response_answer.needs_review?.should be_false
+            expect(open_response_answer.needs_review?).to be_falsey
           end
 
           it "should have the correct score" do
-            open_response_answer.answers.length.should have_at_least(1).answer
-            open_response_answer.current_score.should eq score
+            expect(open_response_answer.answers.length.size).to be >= 1
+            expect(open_response_answer.current_score).to eq score
           end
 
           it "should have the correct feedback" do
-            open_response_answer.current_feedback.should eq text_feedback
+            expect(open_response_answer.current_feedback).to eq text_feedback
           end
         end
       end
@@ -261,36 +294,75 @@ describe API::V1::Report do
           let(:max_score)            { 12 }
           let(:enable_text_feedback) { true }
 
-          its(:max_score)            { should eq 12 }
-          its(:score_type)           { should eq "manual" }
-          its(:enable_text_feedback) { should eq true }
+          describe '#max_score' do
+            subject { super().max_score }
+            it { is_expected.to eq 12 }
+          end
+
+          describe '#score_type' do
+            subject { super().score_type }
+            it { is_expected.to eq "manual" }
+          end
+
+          describe '#enable_text_feedback' do
+            subject { super().enable_text_feedback }
+            it { is_expected.to eq true }
+          end
 
           describe "changing the max_score to 0" do
             let(:max_score)            { 0 }
 
-            its(:max_score)            { should eq 0 }
-            its(:enable_text_feedback) { should eq true }
-            its(:score_type)           { should eq "manual"}
+            describe '#max_score' do
+              subject { super().max_score }
+              it { is_expected.to eq 0 }
+            end
+
+            describe '#enable_text_feedback' do
+              subject { super().enable_text_feedback }
+              it { is_expected.to eq true }
+            end
+
+            describe '#score_type' do
+              subject { super().score_type }
+              it { is_expected.to eq "manual"}
+            end
           end
 
           describe "enabling auto scoring" do
             let(:score_type)           { "auto" }
 
-            its(:max_score)            { should eq 12 }
-            its(:enable_text_feedback) { should be true }
-            its(:score_type)           { should eq "auto"  }
+            describe '#max_score' do
+              subject { super().max_score }
+              it { is_expected.to eq 12 }
+            end
+
+            describe '#enable_text_feedback' do
+              subject { super().enable_text_feedback }
+              it { is_expected.to be true }
+            end
+
+            describe '#score_type' do
+              subject { super().score_type }
+              it { is_expected.to eq "auto"  }
+            end
           end
 
           describe "enabling rubric" do
             let(:use_rubric)   { true }
 
-            its(:use_rubric)   { should be_true }
+            describe '#use_rubric' do
+              subject { super().use_rubric }
+              it { is_expected.to be_truthy }
+            end
           end
 
           describe "setting the rubric" do
             let(:rubric)   { {"version" => "1.0", "timestamp" => Time.now.to_i} }
 
-            its(:rubric)   { should eql rubric }
+            describe '#rubric' do
+              subject { super().rubric }
+              it { is_expected.to eql rubric }
+            end
           end
         end
       end
@@ -323,9 +395,20 @@ describe API::V1::Report do
             let(:rubric_feedback) { {"C1" => {"id"=>"R3"}} }
             subject             { learner_feedback.first }
 
-            its(:score)           { should eql 10 }
-            its(:text_feedback)   { should eql "good job" }
-            its(:rubric_feedback) { should eql rubric_feedback }
+            describe '#score' do
+              subject { super().score }
+              it { is_expected.to eql 10 }
+            end
+
+            describe '#text_feedback' do
+              subject { super().text_feedback }
+              it { is_expected.to eql "good job" }
+            end
+
+            describe '#rubric_feedback' do
+              subject { super().rubric_feedback }
+              it { is_expected.to eql rubric_feedback }
+            end
           end
 
           describe "marking feedback complete" do
@@ -333,10 +416,13 @@ describe API::V1::Report do
             let(:has_been_reviewed) { true }
             let(:score)             { 10   }
 
-            its(:has_been_reviewed) { should be true }
+            describe '#has_been_reviewed' do
+              subject { super().has_been_reviewed }
+              it { is_expected.to be true }
+            end
 
             it "Should create a subsequent entry in the list of feedbacks on next update." do
-              learner_feedback.should have(1).feedback
+              expect(learner_feedback.size).to eq(1)
               a = API::V1::Report.submit_activity_feedback({
                 "score"                => 11,
                 "has_been_reviewed"    => true,
@@ -344,7 +430,7 @@ describe API::V1::Report do
                 "activity_feedback_id" => feedback_id
               })
               new_feedback = Portal::LearnerActivityFeedback.for_learner_and_activity_feedback(learner, activity_feedback)
-              new_feedback.should have(2).feedbacks
+              expect(new_feedback.size).to eq(2)
             end
           end
         end

--- a/spec/models/api/v1/student_registration_spec.rb
+++ b/spec/models/api/v1/student_registration_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 describe API::V1::StudentRegistration do
   before(:each) do
-    API::V1::StudentRegistration.any_instance.stub(:valid_class_word_checker).and_return(true)
+    allow_any_instance_of(API::V1::StudentRegistration).to receive(:valid_class_word_checker).and_return(true)
   end
 
   let(:params) {
@@ -25,8 +25,16 @@ describe API::V1::StudentRegistration do
       registration.save
       registration
     }
-    its(:user)    { should be_valid }
-    its(:student) { should be_valid }
+
+    describe '#user' do
+      subject { super().user }
+      it { is_expected.to be_valid }
+    end
+
+    describe '#student' do
+      subject { super().student }
+      it { is_expected.to be_valid }
+    end
   end
 
   describe "#save" do

--- a/spec/models/api/v1/teacher_registration_spec.rb
+++ b/spec/models/api/v1/teacher_registration_spec.rb
@@ -16,8 +16,8 @@ describe API::V1::TeacherRegistration do
   it_behaves_like 'user registration' do
     let(:good_params) { params }
     before(:each) do
-      Portal::School.stub!(:find).and_return(mock_model(Portal::School))
-      Portal::School.stub!(:exists?).and_return(true)
+      allow(Portal::School).to receive(:find).and_return(mock_model(Portal::School))
+      allow(Portal::School).to receive(:exists?).and_return(true)
     end
   end
 
@@ -26,19 +26,19 @@ describe API::V1::TeacherRegistration do
 
     describe "no school found" do
       before(:each) do
-        Portal::School.stub!(:exists?).and_return(false)
+        allow(Portal::School).to receive(:exists?).and_return(false)
       end
       it {
-        should_not be_valid
-        should have(1).error_on :"school_id"
+        is_expected.not_to be_valid
+        is_expected.to have(1).error_on :"school_id"
       }
     end
 
     describe "school found" do
       before(:each) do
-        Portal::School.stub!(:exists?).and_return(true)
+        allow(Portal::School).to receive(:exists?).and_return(true)
       end
-      it { should be_valid }
+      it { is_expected.to be_valid }
     end
   end
 
@@ -51,12 +51,12 @@ describe API::V1::TeacherRegistration do
 
     describe "when school is found" do
       before(:each) do
-        Portal::School.stub!(:exists?).and_return(true)
-        Portal::School.stub!(:find).and_return(mock_model(Portal::School, id: 123))
+        allow(Portal::School).to receive(:exists?).and_return(true)
+        allow(Portal::School).to receive(:find).and_return(mock_model(Portal::School, id: 123))
       end
 
       it "should have exactly one school" do
-        expect(teacher).to have(1).schools
+        expect(teacher.schools.size).to eq(1)
         expect(teacher.school.id).to eql(123)
       end
     end

--- a/spec/models/bookmark_spec.rb
+++ b/spec/models/bookmark_spec.rb
@@ -4,7 +4,7 @@ describe Portal::Bookmark do
   describe "Class methods" do
     describe "#available_types" do
       it "should return an array of subclasses" do
-        Portal::Bookmark.available_types.should be_kind_of Array
+        expect(Portal::Bookmark.available_types).to be_kind_of Array
       end
     end
   end
@@ -13,15 +13,15 @@ describe Portal::Bookmark do
     it "should preprocess provided URL" do
       b = Portal::Bookmark.new
       b.url = "abc.com"
-      b.url.should eql("http://abc.com")
+      expect(b.url).to eql("http://abc.com")
       b.url = "/abc.com"
-      b.url.should eql("http://abc.com")
+      expect(b.url).to eql("http://abc.com")
       b.url = "//abc.com"
-      b.url.should eql("http://abc.com")
+      expect(b.url).to eql("http://abc.com")
       b.url = "http://abc.com"
-      b.url.should eql("http://abc.com")
+      expect(b.url).to eql("http://abc.com")
       b.url = "https://abc.com"
-      b.url.should eql("https://abc.com")
+      expect(b.url).to eql("https://abc.com")
     end
   end
 end

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -15,36 +15,36 @@ describe Client do
   end
   context "a client that isn't restricted to various domains" do
     it "should validate from any domain" do
-      client.should be_valid_from_referer("http://blargonaut.com/")
-      client.should be_valid_from_referer("http://foo.com/blarg.html")
+      expect(client).to be_valid_from_referer("http://blargonaut.com/")
+      expect(client).to be_valid_from_referer("http://foo.com/blarg.html")
     end
   end
   context "a client that has domains matchers set to whitespace" do
     let(:domain_matchers) { "    \t\n   " }
     it "should validate from any domain" do
-      client.should be_valid_from_referer("http://blargonaut.com/")
-      client.should be_valid_from_referer("http://foo.com/blarg.html")
+      expect(client).to be_valid_from_referer("http://blargonaut.com/")
+      expect(client).to be_valid_from_referer("http://foo.com/blarg.html")
     end
   end
   context "a client that only works for foo.com or baz.com domains" do
     let(:domain_machers) { "foo.com baz.com" }
     it "should not validate for referers of blargonaut" do
-      client.valid_from_referer?("http://blargonaut.com/").should be_false
-      client.valid_from_referer?("http://blargonaut.com/foo.com").should be_false
-      client.valid_from_referer?("http://blargonaut.com/baz.com").should be_false
+      expect(client.valid_from_referer?("http://blargonaut.com/")).to be_falsey
+      expect(client.valid_from_referer?("http://blargonaut.com/foo.com")).to be_falsey
+      expect(client.valid_from_referer?("http://blargonaut.com/baz.com")).to be_falsey
     end
     it "should not validate if HTTP_REFERER is missing" do
-      client.valid_from_referer?("").should be_false
+      expect(client.valid_from_referer?("")).to be_falsey
     end
     it "should validate for referers of foo.com" do
-      client.valid_from_referer?("http://foo.com").should be_true
-      client.valid_from_referer?("https://foo.com/").should be_true
-      client.valid_from_referer?("https://foo.com/index.html").should be_true
+      expect(client.valid_from_referer?("http://foo.com")).to be_truthy
+      expect(client.valid_from_referer?("https://foo.com/")).to be_truthy
+      expect(client.valid_from_referer?("https://foo.com/index.html")).to be_truthy
     end
     it "should validate for referers of baz.com" do
-      client.valid_from_referer?("http://baz.com").should be_true
-      client.valid_from_referer?("https://baz.com/").should be_true
-      client.valid_from_referer?("https://baz.com/index.html").should be_true
+      expect(client.valid_from_referer?("http://baz.com")).to be_truthy
+      expect(client.valid_from_referer?("https://baz.com/")).to be_truthy
+      expect(client.valid_from_referer?("https://baz.com/index.html")).to be_truthy
     end
   end
   describe "a client with an access_grant" do
@@ -55,8 +55,8 @@ describe Client do
       client.reload
     end
     it "should a valid access_grant" do
-      client.access_grants.should have(1).grant
-      user.access_grants.should have(1).grant
+      expect(client.access_grants.size).to eq(1)
+      expect(user.access_grants.size).to eq(1)
     end
 
     describe "deting the client" do
@@ -65,7 +65,7 @@ describe Client do
         user.reload
       end
       it "should remove the grants from the users" do
-        user.access_grants.should have(0).grant
+        expect(user.access_grants.size).to eq(0)
       end
     end
   end

--- a/spec/models/dataservice/blob_spec.rb
+++ b/spec/models/dataservice/blob_spec.rb
@@ -7,7 +7,7 @@ describe Dataservice::Blob do
   describe "a bare instance" do
     %w|content mimetype file_extension checksum learner_id|.each do |attr|
       it "should have a #{attr} attribute" do
-        subject.attributes.should include attr
+        expect(subject.attributes).to include attr
       end
     end
   end
@@ -15,15 +15,26 @@ describe Dataservice::Blob do
   describe "mimetype" do
     describe "with a mimetype attrbiute value set" do
       let(:attributes)  { {'mimetype' => "application/json"} }
-      its(:mimetype)    {      should == "application/json" }
+
+      describe '#mimetype' do
+        subject { super().mimetype }
+        it {      is_expected.to eq("application/json") }
+      end
     end
     describe "backwards compatibility, guessing mimetype" do
       describe "matching png by content" do
         let(:attributes) { {'content' => ".PNG blah blah"} }
-        its(:mimetype)   { should == "image/png" }
+
+        describe '#mimetype' do
+          subject { super().mimetype }
+          it { is_expected.to eq("image/png") }
+        end
       end
       describe "default guess should be application/octet-stream" do
-        its(:mimetype)   { should == "application/octet-stream"}
+        describe '#mimetype' do
+          subject { super().mimetype }
+          it { is_expected.to eq("application/octet-stream")}
+        end
       end
     end
   end
@@ -31,21 +42,36 @@ describe Dataservice::Blob do
   describe "file_extension" do
     describe "with a file_extension attrbiute value set" do
       let(:attributes)    { {'file_extension' => "gif"} }
-      its(:file_extension)      {      should == "gif" }
+
+      describe '#file_extension' do
+        subject { super().file_extension }
+        it {      is_expected.to eq("gif") }
+      end
     end
     describe "backwards compatibility, guess file_extension" do
       describe "by using mimetype info" do
         describe "guessing file_extension for image/png" do
           let(:attributes)     { {'mimetype' => "image/png"} }
-          its(:file_extension) { should == "png" }
+
+          describe '#file_extension' do
+            subject { super().file_extension }
+            it { is_expected.to eq("png") }
+          end
         end
         describe "guessing file_extension for application/octet-stream" do
           let(:attributes)     { {'mimetype' => "application/octet-stream"} }
-          its(:file_extension) { should == "blob" }
+
+          describe '#file_extension' do
+            subject { super().file_extension }
+            it { is_expected.to eq("blob") }
+          end
         end
       end
       describe "guessing file_extension blindly" do
-        its(:file_extension)  { should == "blob"}
+        describe '#file_extension' do
+          subject { super().file_extension }
+          it { is_expected.to eq("blob")}
+        end
       end
     end
   end
@@ -55,17 +81,17 @@ describe Dataservice::Blob do
 
       it "should render an image tag for jpegs" do
         subject.mimetype = "image/jpg"
-        subject.html_content("path").should match /<img src/
+        expect(subject.html_content("path")).to match /<img src/
       end
 
       it "should render an image tag for gifs" do
         subject.mimetype = "image/gif"
-        subject.html_content("path").should match /<img src/
+        expect(subject.html_content("path")).to match /<img src/
       end
 
       it "should render a div tag for others" do
         subject.mimetype = "application/octet-stream"
-        subject.html_content("path").should match /<div/
+        expect(subject.html_content("path")).to match /<div/
       end
     end
   end
@@ -80,13 +106,17 @@ describe Dataservice::Blob do
 
     describe "without hashable attrbiutes" do
       let(:attributes){}
-      its(:checksum) { should_not be_nil }
+
+      describe '#checksum' do
+        subject { super().checksum }
+        it { is_expected.not_to be_nil }
+      end
     end
 
     it "should change when content changes" do
       first_checksum  = subject.checksum
       subject.content  = "updated content value here"
-      subject.checksum.should_not == first_checksum
+      expect(subject.checksum).not_to eq(first_checksum)
     end
   end
 
@@ -108,9 +138,9 @@ describe Dataservice::Blob do
       describe "when there is good content" do
         let(:status) { 200 }
         it "should update its content with the content" do
-          subject.content.should be_nil
+          expect(subject.content).to be_nil
           subject.load_content_from(url)
-          subject.content.should == url_content
+          expect(subject.content).to eq(url_content)
         end
       end
 
@@ -119,7 +149,7 @@ describe Dataservice::Blob do
         it "should leave the content unchanged" do
           subject.content = "booga booga"
           subject.load_content_from(url)
-          subject.content.should_not == url_content
+          expect(subject.content).not_to eq(url_content)
         end
       end
     end
@@ -128,7 +158,7 @@ describe Dataservice::Blob do
       let(:url) { "" }
       # No need to stub a request either, because none will be made
       it "should not change the content" do
-        subject.content.should_not == url_content
+        expect(subject.content).not_to eq(url_content)
       end
     end
 
@@ -153,25 +183,25 @@ describe Dataservice::Blob do
 
       describe "with new content and new learner" do
         it "should have correct values from loading content" do
-          subject.mimetype.should == mimetype
-          subject.file_extension.should == "png"
-          subject.content.should == url_content
-          subject.id.should_not be_nil
-          subject.should be_valid
+          expect(subject.mimetype).to eq(mimetype)
+          expect(subject.file_extension).to eq("png")
+          expect(subject.content).to eq(url_content)
+          expect(subject.id).not_to be_nil
+          expect(subject).to be_valid
         end
 
         it "should not use an existing instance" do
-          subject.should_not == @existing
-          subject.id.should_not == @existing.id
+          expect(subject).not_to eq(@existing)
+          expect(subject.id).not_to eq(@existing.id)
         end
       end
 
       describe "with existing content and learner" do
         let(:existing_content)    { url_content }
         it "should reuse the existing instance" do
-          subject.should == @existing
-          subject.content.should == existing_content
-          subject.id.should == @existing.id
+          expect(subject).to eq(@existing)
+          expect(subject.content).to eq(existing_content)
+          expect(subject.id).to eq(@existing.id)
         end
       end
 

--- a/spec/models/dataservice/bundle_content_observer_spec.rb
+++ b/spec/models/dataservice/bundle_content_observer_spec.rb
@@ -4,9 +4,9 @@ describe Dataservice::BundleContentObserver do
   it "should run delayed process job" do 
       @bc = mock_model(Dataservice::BundleContent)
       @obs = Dataservice::BundleContentObserver.instance
-      @bc.should_receive(:otml_empty?).and_return(false)
-      Dataservice::BundleContent.should_receive(:find).and_return(@bc)
-      @bc.should_receive(:delayed_process_bundle)
+      expect(@bc).to receive(:otml_empty?).and_return(false)
+      expect(Dataservice::BundleContent).to receive(:find).and_return(@bc)
+      expect(@bc).to receive(:delayed_process_bundle)
       @obs.after_save(@bc)
   end
 end

--- a/spec/models/dataservice/bundle_content_saveable_extraction_spec.rb
+++ b/spec/models/dataservice/bundle_content_saveable_extraction_spec.rb
@@ -62,8 +62,8 @@ describe Dataservice::BundleContent do
       learner.save!
       blogger.reload
       learner.reload
-      blogger.learner.should_not be_nil
-      learner.bundle_logger.should_not be_nil
+      expect(blogger.learner).not_to be_nil
+      expect(learner.bundle_logger).not_to be_nil
       @valid_attributes_with_blob[:bundle_logger_id] = blogger.id
       # create open_response with id = 40
       emb = nil
@@ -100,24 +100,24 @@ describe Dataservice::BundleContent do
       bundle_content.save!
       bundle_content.reload
       blogger.reload
-      bundle_content.bundle_logger_id.should eql(learner.bundle_logger.id)
-      bundle_content.bundle_logger.learner.id.should eql(learner.id)
+      expect(bundle_content.bundle_logger_id).to eql(learner.bundle_logger.id)
+      expect(bundle_content.bundle_logger.learner.id).to eql(learner.id)
 
       # 1 open response, 1 multiple choice, 2 image questions
-      learner.open_responses.size.should eql(1)
-      learner.multiple_choices.size.should eql(1)
-      learner.image_questions.size.should eql(2)
+      expect(learner.open_responses.size).to eql(1)
+      expect(learner.multiple_choices.size).to eql(1)
+      expect(learner.image_questions.size).to eql(2)
       learner.open_responses.each do |saveable|
-        saveable.answer.should eql('Jumping jacks with electric sparks')
+        expect(saveable.answer).to eql('Jumping jacks with electric sparks')
       end
       learner.multiple_choices.each do |saveable|
-        saveable.answers.size.should eql(1)
-        saveable.answers[0].answer[0].should include({:answer => 'someChoice', :correct => nil})
-        saveable.answers[0].answer[0].should have_key(:choice_id)
+        expect(saveable.answers.size).to eql(1)
+        expect(saveable.answers[0].answer[0]).to include({:answer => 'someChoice', :correct => nil})
+        expect(saveable.answers[0].answer[0]).to have_key(:choice_id)
       end
       learner.image_questions.each do |saveable|
-        bundle_content.blobs.include?(saveable.answer[:blob]).should be_true
-        saveable.answer[:note].should eql('Add a note describing this entry...')
+        expect(bundle_content.blobs.include?(saveable.answer[:blob])).to be_truthy
+        expect(saveable.answer[:note]).to eql('Add a note describing this entry...')
       end
     end
   end
@@ -191,8 +191,8 @@ describe Dataservice::BundleContent do
       learner.save!
       blogger.reload
       learner.reload
-      blogger.learner.should_not be_nil
-      learner.bundle_logger.should_not be_nil
+      expect(blogger.learner).not_to be_nil
+      expect(learner.bundle_logger).not_to be_nil
       @valid_attributes_with_multiline_snapshot[:bundle_logger_id] = blogger.id
       # create open_response with id = 40
       # create image_question with id = 847
@@ -214,12 +214,12 @@ describe Dataservice::BundleContent do
       bundle_content.save!
       bundle_content.reload
       blogger.reload
-      bundle_content.bundle_logger_id.should eql(learner.bundle_logger.id)
-      bundle_content.bundle_logger.learner.id.should eql(learner.id)
+      expect(bundle_content.bundle_logger_id).to eql(learner.bundle_logger.id)
+      expect(bundle_content.bundle_logger.learner.id).to eql(learner.id)
 
-      learner.image_questions.size.should eql(1)
+      expect(learner.image_questions.size).to eql(1)
       learner.image_questions.each do |saveable|
-        saveable.answer[:note].should eql('One
+        expect(saveable.answer[:note]).to eql('One
 Word
 Lines
 And
@@ -242,8 +242,8 @@ Long')
       learner.save!
       blogger.reload
       learner.reload
-      blogger.learner.should_not be_nil
-      learner.bundle_logger.should_not be_nil
+      expect(blogger.learner).not_to be_nil
+      expect(learner.bundle_logger).not_to be_nil
       @valid_attributes_with_multiple_select_and_rationale[:bundle_logger_id] = blogger.id
 
       # create multiple_choices with ids = 18145
@@ -289,25 +289,25 @@ Long')
       bundle_content.save!
       bundle_content.reload
       blogger.reload
-      bundle_content.bundle_logger_id.should eql(learner.bundle_logger.id)
-      bundle_content.bundle_logger.learner.id.should eql(learner.id)
+      expect(bundle_content.bundle_logger_id).to eql(learner.bundle_logger.id)
+      expect(bundle_content.bundle_logger.learner.id).to eql(learner.id)
 
 
-      learner.multiple_choices.size.should eql(4)
+      expect(learner.multiple_choices.size).to eql(4)
       learner.multiple_choices.each do |saveable|
         case saveable.multiple_choice_id
           when 3897
-          saveable.answer[0].should include({:answer => "someChoice 1", :correct => nil})
+          expect(saveable.answer[0]).to include({:answer => "someChoice 1", :correct => nil})
         when 3901
           # saveable.answer.should eql("someChoice 13, someChoice 14")
-          saveable.answer[0].should include({:answer => "someChoice 13", :correct => nil})
-          saveable.answer[1].should include({:answer => "someChoice 14", :correct => nil})
+          expect(saveable.answer[0]).to include({:answer => "someChoice 13", :correct => nil})
+          expect(saveable.answer[1]).to include({:answer => "someChoice 14", :correct => nil})
         when 3902
-          saveable.answer[0].should include({:answer => "someChoice 18", :rationale => "Soft feels really nice", :correct => nil})
+          expect(saveable.answer[0]).to include({:answer => "someChoice 18", :rationale => "Soft feels really nice", :correct => nil})
         when 3903
           # saveable.answer.should eql("someChoice 21, someChoice 26")
-          saveable.answer[0].should include({:answer => "someChoice 21", :rationale => "It's cold", :correct => nil})
-          saveable.answer[1].should include({:answer => "someChoice 26", :rationale => "Are yellow", :correct => nil})
+          expect(saveable.answer[0]).to include({:answer => "someChoice 21", :rationale => "It's cold", :correct => nil})
+          expect(saveable.answer[1]).to include({:answer => "someChoice 26", :rationale => "Are yellow", :correct => nil})
         else
           raise "Unexpected multiple choice saveable!"
         end
@@ -325,8 +325,8 @@ Long')
       learner.save!
       blogger.reload
       learner.reload
-      blogger.learner.should_not be_nil
-      learner.bundle_logger.should_not be_nil
+      expect(blogger.learner).not_to be_nil
+      expect(learner.bundle_logger).not_to be_nil
       @valid_attributes_with_multiple_select_and_rationale[:bundle_logger_id] = blogger.id
       @valid_attributes_with_multiple_select_and_rationale_updated[:bundle_logger_id] = blogger.id
 
@@ -373,8 +373,8 @@ Long')
       bundle_content.save!
       bundle_content.reload
       blogger.reload
-      bundle_content.bundle_logger_id.should eql(learner.bundle_logger.id)
-      bundle_content.bundle_logger.learner.id.should eql(learner.id)
+      expect(bundle_content.bundle_logger_id).to eql(learner.bundle_logger.id)
+      expect(bundle_content.bundle_logger.learner.id).to eql(learner.id)
 
 
       bundle_content = Dataservice::BundleContent.create!(@valid_attributes_with_multiple_select_and_rationale_updated)
@@ -383,29 +383,29 @@ Long')
       bundle_content.save!
       bundle_content.reload
       blogger.reload
-      bundle_content.bundle_logger_id.should eql(learner.bundle_logger.id)
-      bundle_content.bundle_logger.learner.id.should eql(learner.id)
+      expect(bundle_content.bundle_logger_id).to eql(learner.bundle_logger.id)
+      expect(bundle_content.bundle_logger.learner.id).to eql(learner.id)
 
 
-      learner.multiple_choices.size.should eql(4)
+      expect(learner.multiple_choices.size).to eql(4)
       learner.multiple_choices.each do |saveable|
         case saveable.multiple_choice_id
         when 3897
-          saveable.answer[0].should include({:answer => "someChoice 1", :correct => nil})
+          expect(saveable.answer[0]).to include({:answer => "someChoice 1", :correct => nil})
         when 3901
           # saveable.answer.should eql("someChoice 13, someChoice 14")
-          saveable.answer[0].should include({:answer => "someChoice 13", :correct => nil})
-          saveable.answer[1].should include({:answer => "someChoice 14", :correct => nil})
+          expect(saveable.answer[0]).to include({:answer => "someChoice 13", :correct => nil})
+          expect(saveable.answer[1]).to include({:answer => "someChoice 14", :correct => nil})
         when 3902
-          saveable.answer[0].should include({:answer => "someChoice 18", :rationale => "Soft feels really nice, indeed.", :correct => nil})
+          expect(saveable.answer[0]).to include({:answer => "someChoice 18", :rationale => "Soft feels really nice, indeed.", :correct => nil})
         when 3903
           # saveable.answer.should eql("someChoice 21, someChoice 26")
-          saveable.answer[0].should include({:answer => "someChoice 21", :rationale => "It's cold", :correct => nil})
-          saveable.answer[1].should include({
+          expect(saveable.answer[0]).to include({:answer => "someChoice 21", :rationale => "It's cold", :correct => nil})
+          expect(saveable.answer[1]).to include({
             :answer => "someChoice 22",
             :rationale => "this is a really long answer that wikll keep going and going until the end of the page and keep scrolling",
             :correct => nil})
-          saveable.answer[2].should include({:answer => "someChoice 26", :rationale => "Are yellow", :correct => nil})
+          expect(saveable.answer[2]).to include({:answer => "someChoice 26", :rationale => "Are yellow", :correct => nil})
         else
           raise "Unexpected multiple choice saveable!"
         end

--- a/spec/models/dataservice/bundle_logger_spec.rb
+++ b/spec/models/dataservice/bundle_logger_spec.rb
@@ -11,7 +11,7 @@ describe Dataservice::BundleLogger do
       # also if it is enabled then the factory :full_dataservice_bundle_content needs to be used
       # and finally if the :full_dataservice_bundle_content is used then the bundle_content will have
       # a predefined bundle_logger which then breaks the '<<' assigments below
-      Dataservice::BundleContentObserver.instance.should_receive(:after_save).any_number_of_times
+      allow(Dataservice::BundleContentObserver.instance).to receive(:after_save)
 
       @valid_attributes = {
       
@@ -35,25 +35,25 @@ describe Dataservice::BundleLogger do
         @bad_invalid_xml_content = Factory(:dataservice_bundle_content, :body=>"goo")
       end
       it "should find nothing with no associated content" do
-        @bundle_logger.last_non_empty_bundle_content.should be_nil
+        expect(@bundle_logger.last_non_empty_bundle_content).to be_nil
       end
       it "should find nothing with a null body content" do
         @bundle_logger.bundle_contents << @bad_null_body_content
-        @bundle_logger.last_non_empty_bundle_content.should be_nil
+        expect(@bundle_logger.last_non_empty_bundle_content).to be_nil
       end
       it "should find nothing with invalid xml content" do
         @bundle_logger.bundle_contents << @bad_invalid_xml_content
-        @bundle_logger.last_non_empty_bundle_content.should be_nil
+        expect(@bundle_logger.last_non_empty_bundle_content).to be_nil
       end
       it "should find the first and only content if there is only one valid bundle_conent" do
         @bundle_logger.bundle_contents << @good_bundle_content_1
-        @bundle_logger.last_non_empty_bundle_content.should == @good_bundle_content_1
+        expect(@bundle_logger.last_non_empty_bundle_content).to eq(@good_bundle_content_1)
       end
       it "should find the third content if there are 3 valid bundle_conents" do
         @bundle_logger.bundle_contents << @good_bundle_content_1
         @bundle_logger.bundle_contents << @good_bundle_content_2
         @bundle_logger.bundle_contents << @good_bundle_content_3
-        @bundle_logger.last_non_empty_bundle_content.should == @good_bundle_content_3
+        expect(@bundle_logger.last_non_empty_bundle_content).to eq(@good_bundle_content_3)
       end
 
     end
@@ -77,8 +77,8 @@ describe Dataservice::BundleLogger do
         @logger.bundle_contents << @no_data
         @logger.save
         @logger.reload
-        @logger.bundle_contents.size.should == 4
-        @logger.last_non_empty_bundle_content.should be_nil
+        expect(@logger.bundle_contents.size).to eq(4)
+        expect(@logger.last_non_empty_bundle_content).to be_nil
       end
 
       it "should find the third of three good bundles" do
@@ -87,8 +87,8 @@ describe Dataservice::BundleLogger do
         @logger.bundle_contents << @third
         @logger.save
         @logger.reload
-        @logger.bundle_contents.size.should == 3
-        @logger.last_non_empty_bundle_content.should == @third
+        expect(@logger.bundle_contents.size).to eq(3)
+        expect(@logger.last_non_empty_bundle_content).to eq(@third)
       end
     
       it "should find @second when the third data is bad" do
@@ -97,8 +97,8 @@ describe Dataservice::BundleLogger do
         @logger.bundle_contents << @no_data
         @logger.save
         @logger.reload
-        @logger.bundle_contents.size.should == 3
-        @logger.last_non_empty_bundle_content.should == @second
+        expect(@logger.bundle_contents.size).to eq(3)
+        expect(@logger.last_non_empty_bundle_content).to eq(@second)
       end
 
       it "should find the @second when the first data is bad too" do
@@ -107,8 +107,8 @@ describe Dataservice::BundleLogger do
         @logger.bundle_contents << @no_data
         @logger.save
         @logger.reload
-        @logger.bundle_contents.size.should == 3
-        @logger.last_non_empty_bundle_content.should == @second
+        expect(@logger.bundle_contents.size).to eq(3)
+        expect(@logger.last_non_empty_bundle_content).to eq(@second)
 
       end
 
@@ -127,14 +127,14 @@ describe Dataservice::BundleLogger do
       end
     
       it "should start out with no in_progress_bundle" do
-        @bundle_logger.in_progress_bundle.should be_nil
+        expect(@bundle_logger.in_progress_bundle).to be_nil
       end
 
       describe "start bundle" do
         it "should assign a new in_progress bundle if there is none" do
           @bundle_logger.start_bundle
-          @bundle_logger.in_progress_bundle.should_not be_nil
-          @bundle_logger.in_progress_bundle_id.should_not be_nil
+          expect(@bundle_logger.in_progress_bundle).not_to be_nil
+          expect(@bundle_logger.in_progress_bundle_id).not_to be_nil
         end
       
         it "should create the bundle as the most recent bundle" do
@@ -142,13 +142,13 @@ describe Dataservice::BundleLogger do
           @bundle_logger.bundle_contents << Dataservice::BundleContent.create
           @bundle_logger.bundle_contents << Dataservice::BundleContent.create
           @bundle_logger.start_bundle
-          @bundle_logger.bundle_contents.size.should == 4
-          @bundle_logger.in_progress_bundle.should == @bundle_logger.bundle_contents.last
+          expect(@bundle_logger.bundle_contents.size).to eq(4)
+          expect(@bundle_logger.in_progress_bundle).to eq(@bundle_logger.bundle_contents.last)
         end
 
         it "should create new bundle which is empty and not the last-non-empty bundle" do
           @bundle_logger.start_bundle
-          @bundle_logger.last_non_empty_bundle_content.should_not == @bundle_logger.in_progress_bundle
+          expect(@bundle_logger.last_non_empty_bundle_content).not_to eq(@bundle_logger.in_progress_bundle)
         end
 
         it "should reuse an existing in_progress bundle if there is one" do
@@ -156,7 +156,7 @@ describe Dataservice::BundleLogger do
           @bundle_logger.in_progress_bundle = @new_bundle
           @bundle_logger.save
           @bundle_logger.reload
-          @bundle_logger.in_progress_bundle.should == @new_bundle
+          expect(@bundle_logger.in_progress_bundle).to eq(@new_bundle)
           @bundle_logger.bundle_contents.last == @new_bundle
         end
 
@@ -164,7 +164,7 @@ describe Dataservice::BundleLogger do
           old_size = @bundle_logger.bundle_contents.size
           @bundle_logger.start_bundle
           new_size = @bundle_logger.bundle_contents.size
-          new_size.should be == old_size + 1
+          expect(new_size).to eq(old_size + 1)
         end
       end
 
@@ -173,14 +173,14 @@ describe Dataservice::BundleLogger do
           @bundle_logger.start_bundle
         end
         it "should save! the pending bundle when it ends" do
-          @bundle_logger.in_progress_bundle.should_receive(:save!)
+          expect(@bundle_logger.in_progress_bundle).to receive(:save!)
           @bundle_logger.end_bundle
         end
         it "should not have any new pending bundles after end" do
           @bundle_logger.end_bundle
-          @bundle_logger.in_progress_bundle.should be_nil
+          expect(@bundle_logger.in_progress_bundle).to be_nil
           @bundle_logger.reload
-          @bundle_logger.in_progress_bundle.should be_nil
+          expect(@bundle_logger.in_progress_bundle).to be_nil
         end
       end
     end

--- a/spec/models/dataservice/periodic_bundle_content_saveable_extraction_spec.rb
+++ b/spec/models/dataservice/periodic_bundle_content_saveable_extraction_spec.rb
@@ -29,8 +29,8 @@ describe Dataservice::PeriodicBundleContent do
     learner.save!
     blogger.reload
     learner.reload
-    blogger.learner.should_not be_nil
-    learner.periodic_bundle_logger.should_not be_nil
+    expect(blogger.learner).not_to be_nil
+    expect(learner.periodic_bundle_logger).not_to be_nil
     @valid_attributes_with_blob[:periodic_bundle_logger_id] = blogger.id
     # create open_response with id = 40
     emb = nil
@@ -67,23 +67,23 @@ describe Dataservice::PeriodicBundleContent do
     bundle_content.save!
     bundle_content.reload
     blogger.reload
-    bundle_content.periodic_bundle_logger_id.should eql(learner.periodic_bundle_logger.id)
-    bundle_content.periodic_bundle_logger.learner.id.should eql(learner.id)
+    expect(bundle_content.periodic_bundle_logger_id).to eql(learner.periodic_bundle_logger.id)
+    expect(bundle_content.periodic_bundle_logger.learner.id).to eql(learner.id)
 
     # 1 open response, 1 multiple choice, 2 image questions
-    learner.open_responses.size.should eql(1)
-    learner.multiple_choices.size.should eql(1)
-    learner.image_questions.size.should eql(2)
+    expect(learner.open_responses.size).to eql(1)
+    expect(learner.multiple_choices.size).to eql(1)
+    expect(learner.image_questions.size).to eql(2)
     learner.open_responses.each do |saveable|
-      saveable.answer.should eql('Jumping jacks with electric sparks')
+      expect(saveable.answer).to eql('Jumping jacks with electric sparks')
     end
     learner.multiple_choices.each do |saveable|
-      saveable.answers.size.should eql(1)
-      saveable.answers[0].answer[0].should include({:answer => 'someChoice', :correct => nil})
+      expect(saveable.answers.size).to eql(1)
+      expect(saveable.answers[0].answer[0]).to include({:answer => 'someChoice', :correct => nil})
     end
     learner.image_questions.each do |saveable|
-      bundle_content.blobs.include?(saveable.answer[:blob]).should be_true
-      saveable.answer[:note].should eql('Add a note describing this entry...')
+      expect(bundle_content.blobs.include?(saveable.answer[:blob])).to be_truthy
+      expect(saveable.answer[:note]).to eql('Add a note describing this entry...')
     end
   end
 

--- a/spec/models/dataservice/periodic_bundle_logger_spec.rb
+++ b/spec/models/dataservice/periodic_bundle_logger_spec.rb
@@ -43,40 +43,40 @@ describe Dataservice::PeriodicBundleLogger do
       pb_logger = Dataservice::PeriodicBundleLogger.create
 
       # disable the observer so the parts of this bundle don't get extracted
-      Dataservice::PeriodicBundleContentObserver.instance.stub(:after_create)
+      allow(Dataservice::PeriodicBundleContentObserver.instance).to receive(:after_create)
 
       # note this is invalid otml so if you want to use this for something real you need to at 
       # least add an import for OTBasicObject
       pb_bundle_contents = pb_logger.periodic_bundle_contents.create(:body => fake_bundle_contents )
       pb_logger.stub_chain(:learner, :bundle_logger, :last_non_empty_bundle_content).and_return(nil)
       pb_logger.stub_chain(:learner, :uuid).and_return(UUIDTools::UUID.timestamp_create)
-      pb_logger.stub(:imports).and_return([])
-      pb_bundle_contents.parts_extracted.should == false
-      pb_logger.periodic_bundle_parts.size.should == 0
+      allow(pb_logger).to receive(:imports).and_return([])
+      expect(pb_bundle_contents.parts_extracted).to eq(false)
+      expect(pb_logger.periodic_bundle_parts.size).to eq(0)
       pb_logger.sail_bundle
       pb_bundle_contents.reload
-      pb_bundle_contents.parts_extracted.should == true
-      pb_logger.periodic_bundle_parts.size.should > 0
+      expect(pb_bundle_contents.parts_extracted).to eq(true)
+      expect(pb_logger.periodic_bundle_parts.size).to be > 0
   	end
 
   	it "should extract parts the last non pub bundle if there is one" do
       pb_logger = Dataservice::PeriodicBundleLogger.create
 
       # disable the observer so the parts of this bundle don't get extracted
-      Dataservice::PeriodicBundleContentObserver.instance.stub(:after_create)
+      allow(Dataservice::PeriodicBundleContentObserver.instance).to receive(:after_create)
 
-      non_pub_bundle_contents = mock()
+      non_pub_bundle_contents = double()
       pb_logger.stub_chain(:learner, :bundle_logger, :last_non_empty_bundle_content).and_return(non_pub_bundle_contents)
 
       # note this is invalid otml so if you want to use this for something real you need to at 
       # least add an import for OTBasicObject
-      non_pub_bundle_contents.should_receive(:otml).and_return(fake_bundle_contents)
+      expect(non_pub_bundle_contents).to receive(:otml).and_return(fake_bundle_contents)
 
       pb_logger.stub_chain(:learner, :uuid).and_return(UUIDTools::UUID.timestamp_create)
-      pb_logger.stub(:imports).and_return([])
-      pb_logger.periodic_bundle_parts.size.should == 0
+      allow(pb_logger).to receive(:imports).and_return([])
+      expect(pb_logger.periodic_bundle_parts.size).to eq(0)
       pb_logger.sail_bundle
-      pb_logger.periodic_bundle_parts.size.should > 0
+      expect(pb_logger.periodic_bundle_parts.size).to be > 0
     end
   end
 end

--- a/spec/models/dataservice/process_external_activity_data_job_spec.rb
+++ b/spec/models/dataservice/process_external_activity_data_job_spec.rb
@@ -1,11 +1,11 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 
 describe Dataservice::ProcessExternalActivityDataJob do
-  let(:template)     { mock({open_responses: [], multiple_choices: [], image_questions: [], iframes: []}) }
-  let(:runnable)     { mock(template: template) }
-  let(:offering)     { mock(runnable: runnable, id: 23) }
-  let(:report_learner) { mock('last_run=' => true, update_fields: true)}
-  let(:learner)      { mock(offering: offering, report_learner: report_learner) }
+  let(:template)     { double({open_responses: [], multiple_choices: [], image_questions: [], iframes: []}) }
+  let(:runnable)     { double(template: template) }
+  let(:offering)     { double(runnable: runnable, id: 23) }
+  let(:report_learner) { double('last_run=' => true, update_fields: true)}
+  let(:learner)      { double(offering: offering, report_learner: report_learner) }
   let(:good_content) do
     [
       {
@@ -48,12 +48,12 @@ describe Dataservice::ProcessExternalActivityDataJob do
 
   subject { Dataservice::ProcessExternalActivityDataJob.new(23,json_content)}
   before(:each) do
-    Portal::Learner.stub!(:find => learner)
-    subject.stub!(:internal_process_open_response)
-    subject.stub!(:internal_process_multiple_choice)
-    subject.stub!(:internal_process_image_question)
-    subject.stub!(:internal_process_external_link)
-    subject.stub!(:internal_process_interactive)
+    Portal::Learner.stub(:find => learner)
+    allow(subject).to receive(:internal_process_open_response)
+    allow(subject).to receive(:internal_process_multiple_choice)
+    allow(subject).to receive(:internal_process_image_question)
+    allow(subject).to receive(:internal_process_external_link)
+    allow(subject).to receive(:internal_process_interactive)
   end
 
 
@@ -62,24 +62,24 @@ describe Dataservice::ProcessExternalActivityDataJob do
       let(:json_content) { bad_content }
 
       it "should record a name exception when performing" do
-        subject.content.should == bad_content
-        Rails.logger.should_receive :info
-        NewRelic::Agent.should_receive :notice_error
-        subject.should_receive :internal_process_multiple_choice
+        expect(subject.content).to eq(bad_content)
+        expect(Rails.logger).to receive :info
+        expect(NewRelic::Agent).to receive :notice_error
+        expect(subject).to receive :internal_process_multiple_choice
         subject.perform
       end
     end
 
     describe "with good content" do
       it "should not record any exceptions when performing" do
-        subject.content.should == good_content
-        Rails.logger.should_not_receive :info
-        NewRelic::Agent.should_not_receive :notice_error
-        subject.should_receive :internal_process_open_response
-        subject.should_receive :internal_process_multiple_choice
-        subject.should_receive :internal_process_image_question
-        subject.should_receive :internal_process_external_link
-        subject.should_receive :internal_process_interactive
+        expect(subject.content).to eq(good_content)
+        expect(Rails.logger).not_to receive :info
+        expect(NewRelic::Agent).not_to receive :notice_error
+        expect(subject).to receive :internal_process_open_response
+        expect(subject).to receive :internal_process_multiple_choice
+        expect(subject).to receive :internal_process_image_question
+        expect(subject).to receive :internal_process_external_link
+        expect(subject).to receive :internal_process_interactive
         subject.perform
       end
     end

--- a/spec/models/dataservice/v1/process_external_Activity_data_job_spec.rb
+++ b/spec/models/dataservice/v1/process_external_Activity_data_job_spec.rb
@@ -1,14 +1,14 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
 
 describe Dataservice::V1::ProcessExternalActivityDataJob do
-  let(:template)     { mock({open_responses: [], multiple_choices: [], image_questions: [], iframes: []}) }
-  let(:runnable)     { mock(template: template) }
-  let(:offering)     { mock(runnable: runnable, id: 23) }
-  let(:report_learner) { mock('last_run=' => true, update_fields: true) }
-  let(:learner)      { mock(offering: offering, report_learner: report_learner) }
-  let(:event)        { mock() }
+  let(:template)     { double({open_responses: [], multiple_choices: [], image_questions: [], iframes: []}) }
+  let(:runnable)     { double(template: template) }
+  let(:offering)     { double(runnable: runnable, id: 23) }
+  let(:report_learner) { double('last_run=' => true, update_fields: true) }
+  let(:learner)      { double(offering: offering, report_learner: report_learner) }
+  let(:event)        { double() }
   before(:each) do
-    Portal::Learner.stub!(:find => learner)
+    Portal::Learner.stub(:find => learner)
   end
 
   subject { Dataservice::V1::ProcessExternalActivityDataJob.new(23,json_content, Time.now())}
@@ -23,11 +23,11 @@ describe Dataservice::V1::ProcessExternalActivityDataJob do
       end
 
       it "should build a LearnerProcessingEvent with a nil lara_start" do
-        LearnerProcessingEvent.should_receive(:build_proccesing_event)
+        expect(LearnerProcessingEvent).to receive(:build_proccesing_event)
           .with(learner, nil, an_instance_of(Time), an_instance_of(Time), 0) {
             event
           }
-        event.should_receive(:save)
+        expect(event).to receive(:save)
         subject.perform
       end
     end
@@ -43,11 +43,11 @@ describe Dataservice::V1::ProcessExternalActivityDataJob do
       end
 
       it "the create a LearnerProcessingEvent with lara_start" do
-        LearnerProcessingEvent.should_receive(:build_proccesing_event)
+        expect(LearnerProcessingEvent).to receive(:build_proccesing_event)
           .with(learner, lara_start, an_instance_of(Time), an_instance_of(Time), 0) {
             event
           }
-        event.should_receive(:save)
+        expect(event).to receive(:save)
         subject.perform
       end
     end

--- a/spec/models/deep_cloning_spec.rb
+++ b/spec/models/deep_cloning_spec.rb
@@ -8,28 +8,28 @@ describe DeepCloning do
       @section = Section.create!(:name => "Section", :description => "Section description")
       @section.pages << @page
       @section.pages << @page2
-      @section.pages[0].name.should == "Page"
-      @section.pages[1].name.should == "Page2"
+      expect(@section.pages[0].name).to eq("Page")
+      expect(@section.pages[1].name).to eq("Page2")
     end
 
     it "should keep the pages in the same order" do
       klone = @section.deep_clone :no_duplicates => false, :never_clone => [:uuid, :created_at, :updated_at], :include => :pages
-      klone.pages.size.should == 2
-      klone.pages[0].name.should == "Page"
-      klone.pages[1].name.should == "Page2"
+      expect(klone.pages.size).to eq(2)
+      expect(klone.pages[0].name).to eq("Page")
+      expect(klone.pages[1].name).to eq("Page2")
     end
 
     it "should not modify the source when duplication fails" do
       # have page2 return an object that can't be saved
       bad_clone = Page.new(:name => "Bad Clone")
-      bad_clone.stub(:save).and_return(false)
-      @page2.stub(:dup).and_return(bad_clone)
+      allow(bad_clone).to receive(:save).and_return(false)
+      allow(@page2).to receive(:dup).and_return(bad_clone)
       begin
         klone = @section.deep_clone :no_duplicates => false, :never_clone => [:uuid, :created_at, :updated_at], :include => :pages 
       rescue ActiveRecord::RecordNotSaved
       end
       @section.reload
-      @section.pages.count.should == 2
+      expect(@section.pages.count).to eq(2)
     end
   end
 end

--- a/spec/models/embeddable/image_question.spec.rb
+++ b/spec/models/embeddable/image_question.spec.rb
@@ -13,14 +13,14 @@ describe Embeddable::ImageQuestion do
   it "should create a new instance with default values" do
     image_question = Embeddable::ImageQuestion.new
     image_question.save 
-    image_question.should be_valid
-    image_question.prompt.should == @default_prompt
+    expect(image_question).to be_valid
+    expect(image_question.prompt).to eq(@default_prompt)
   end
   
   it "should create a new instance with valid attributes" do
     image_question = Embeddable::ImageQuestion.create(@valid_attributes)
     image_question.save
-    image_question.should be_valid
+    expect(image_question).to be_valid
   end
  
   # it "should not create a new instance without valid attributes" do

--- a/spec/models/embeddable/multiple_choice_question_spec.rb
+++ b/spec/models/embeddable/multiple_choice_question_spec.rb
@@ -16,21 +16,21 @@ describe Embeddable::MultipleChoice do
 
   describe "a newly created MutipleChoiceQuestion" do    
     it "should have a non-blank propt" do
-      @multichoice.prompt.should_not be_nil
+      expect(@multichoice.prompt).not_to be_nil
     end
     
     it "should have a user" do
-      @multichoice.user.should_not be_nil
-      @multichoice.user.should == @user
+      expect(@multichoice.user).not_to be_nil
+      expect(@multichoice.user).to eq(@user)
     end
     
     it "should belong to a page" do
-      @multichoice.pages.should_not be_nil
-      @multichoice.pages.should include(@page)
+      expect(@multichoice.pages).not_to be_nil
+      expect(@multichoice.pages).to include(@page)
     end
     
     it "should have three initial default answers" do
-      @multichoice.choices.should have(3).answers
+      expect(@multichoice.choices.size).to eq(3)
     end
   end
 
@@ -41,14 +41,14 @@ describe Embeddable::MultipleChoice do
     end
     
     it "should have the new choice" do
-      @multichoice.choices.should include(@choice)
+      expect(@multichoice.choices).to include(@choice)
     end
   
     it "should update its choices when saved" do
       @choice.choice = "fooo"
       @choice.save
       @multichoice.reload
-      @multichoice.choices[3].choice.should == "fooo"
+      expect(@multichoice.choices[3].choice).to eq("fooo")
     end
       
   end

--- a/spec/models/embeddable/open_response_spec.rb
+++ b/spec/models/embeddable/open_response_spec.rb
@@ -9,25 +9,25 @@ describe Embeddable::OpenResponse do
   it "should create a new instance with default values" do
     open_response = Embeddable::OpenResponse.create
     open_response.save 
-    open_response.should be_valid
+    expect(open_response).to be_valid
   end
   
   describe "validations" do
     it "should validate good values" do
-      @orclass.create(:rows => @orclass::MAX_ROWS).should be_valid
-      @orclass.create(:rows => @orclass::MIN_ROWS).should be_valid
-      @orclass.create(:columns => @orclass::MAX_COLUMNS).should be_valid
-      @orclass.create(:columns => @orclass::MIN_COLUMNS).should be_valid
-      @orclass.create(:font_size => @orclass::MAX_FONT_SIZE).should be_valid
-      @orclass.create(:font_size => @orclass::MIN_FONT_SIZE).should be_valid
+      expect(@orclass.create(:rows => @orclass::MAX_ROWS)).to be_valid
+      expect(@orclass.create(:rows => @orclass::MIN_ROWS)).to be_valid
+      expect(@orclass.create(:columns => @orclass::MAX_COLUMNS)).to be_valid
+      expect(@orclass.create(:columns => @orclass::MIN_COLUMNS)).to be_valid
+      expect(@orclass.create(:font_size => @orclass::MAX_FONT_SIZE)).to be_valid
+      expect(@orclass.create(:font_size => @orclass::MIN_FONT_SIZE)).to be_valid
     end
     it "should not validate bad balues" do
-      @orclass.create(:rows => @orclass::MAX_ROWS + 1).should_not be_valid
-      @orclass.create(:rows => @orclass::MIN_ROWS - 1).should_not be_valid
-      @orclass.create(:columns => @orclass::MAX_COLUMNS + 1).should_not be_valid
-      @orclass.create(:columns => @orclass::MIN_COLUMNS - 1).should_not be_valid
-      @orclass.create(:font_size => @orclass::MAX_FONT_SIZE + 1).should_not be_valid
-      @orclass.create(:font_size => @orclass::MIN_FONT_SIZE - 1).should_not be_valid
+      expect(@orclass.create(:rows => @orclass::MAX_ROWS + 1)).not_to be_valid
+      expect(@orclass.create(:rows => @orclass::MIN_ROWS - 1)).not_to be_valid
+      expect(@orclass.create(:columns => @orclass::MAX_COLUMNS + 1)).not_to be_valid
+      expect(@orclass.create(:columns => @orclass::MIN_COLUMNS - 1)).not_to be_valid
+      expect(@orclass.create(:font_size => @orclass::MAX_FONT_SIZE + 1)).not_to be_valid
+      expect(@orclass.create(:font_size => @orclass::MIN_FONT_SIZE - 1)).not_to be_valid
     end
   end
 end

--- a/spec/models/external_activity_spec.rb
+++ b/spec/models/external_activity_spec.rb
@@ -21,32 +21,32 @@ describe ExternalActivity do
     let(:learner) { mock_model(Portal::Learner, :id => 34) }
 
     it "should default to not appending the learner id to the url" do
-      activity.append_learner_id_to_url.should be_false
+      expect(activity.append_learner_id_to_url).to be_falsey
     end
 
     it "should return the original url when appending is false" do
-      activity.url.should eql(valid_attributes[:url])
-      activity.url(learner).should eql(valid_attributes[:url])
+      expect(activity.url).to eql(valid_attributes[:url])
+      expect(activity.url(learner)).to eql(valid_attributes[:url])
     end
 
     it "should return a modified url when appending is true" do
       activity.append_learner_id_to_url = true
-      activity.url.should eql(valid_attributes[:url])
-      activity.url(learner).should eql(valid_attributes[:url] + "?learner=34")
+      expect(activity.url).to eql(valid_attributes[:url])
+      expect(activity.url(learner)).to eql(valid_attributes[:url] + "?learner=34")
     end
 
     it "should return a correct url when appending to a url with existing params" do
       url = "http://www.concord.org/?foo=bar"
       activity.append_learner_id_to_url = true
       activity.url = url
-      activity.url(learner).should eql(url + "&learner=34")
+      expect(activity.url(learner)).to eql(url + "&learner=34")
     end
 
     it "should return a correct url when appending to a url with existing fragment" do
       url = "http://www.concord.org/#3"
       activity.append_learner_id_to_url = true
       activity.url = url
-      activity.url(learner).should eql("http://www.concord.org/?learner=34#3")
+      expect(activity.url(learner)).to eql("http://www.concord.org/?learner=34#3")
     end
   end
 
@@ -57,16 +57,16 @@ describe ExternalActivity do
 
     it 'should return template_type for EAs with templates' do
       activity.template = real_activity
-      activity.material_type.should == 'Activity'
+      expect(activity.material_type).to eq('Activity')
       activity.template = investigation
-      activity.material_type.should == 'Investigation'
+      expect(activity.material_type).to eq('Investigation')
     end
   end
 
   describe '#full_title' do
     let (:activity) { ExternalActivity.create!(valid_attributes) }
     it 'should return external activity name (compatibility with regular activities and sequences)' do
-      activity.full_title.should == valid_attributes[:name]
+      expect(activity.full_title).to eq(valid_attributes[:name])
     end
   end
 
@@ -76,10 +76,10 @@ describe ExternalActivity do
     let(:student_user) { s = FactoryGirl.create(:portal_student); s.user }
 
     it 'should return value of long_description_for_teacher if user is a teacher' do
-      activity.long_description_for_user(teacher_user).should == valid_attributes[:long_description_for_teacher]
+      expect(activity.long_description_for_user(teacher_user)).to eq(valid_attributes[:long_description_for_teacher])
     end
     it 'should return value of long_description if user is not a teacher' do
-      activity.long_description_for_user(student_user).should == valid_attributes[:long_description]
+      expect(activity.long_description_for_user(student_user)).to eq(valid_attributes[:long_description])
     end
   end
 

--- a/spec/models/external_report_spec.rb
+++ b/spec/models/external_report_spec.rb
@@ -13,7 +13,7 @@ describe ExternalReport do
     subject { external_report.url_for_offering(offering, portal_teacher.user, 'https', 'perfect.host.com') }
 
     it "should handle report urls with parameters" do
-      expect(subject.scan('?')).to have(1).question_mark
+      expect(subject.scan('?').size).to eq(1)
       expect(subject).to include('cool=true')
     end
     it "should include the correct parameters" do
@@ -34,7 +34,7 @@ describe ExternalReport do
     subject { external_report.url_for_class(offering.clazz_id, portal_teacher.user, 'https', 'perfect.host.com') }
 
     it "should handle report urls with parameters" do
-      expect(subject.scan('?')).to have(1).question_mark
+      expect(subject.scan('?').size).to eq(1)
       expect(subject).to include('cool=true')
     end
     it "should include the correct parameters" do

--- a/spec/models/favorite_spec.rb
+++ b/spec/models/favorite_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
 describe Favorite do
-  pending "add some examples to (or delete) #{__FILE__}"
+  skip "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/firebase_app_spec.rb
+++ b/spec/models/firebase_app_spec.rb
@@ -36,10 +36,10 @@ nC64AqP02IP2yOxnbxZ1uY2TrdI1VcO3AwcngxSEUMo=
     FirebaseApp.create!(@valid_attributes)
     token = SignedJWT::create_firebase_token(uid, @valid_app_name)
     decoded_token = SignedJWT::decode_firebase_token(token, @valid_app_name)
-    decoded_token[:data]["uid"].should eql uid
-    decoded_token[:data]["iss"].should eql @valid_client_email
-    decoded_token[:data]["sub"].should eql @valid_client_email
-    decoded_token[:data]["aud"].should eql "https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit"
+    expect(decoded_token[:data]["uid"]).to eql uid
+    expect(decoded_token[:data]["iss"]).to eql @valid_client_email
+    expect(decoded_token[:data]["sub"]).to eql @valid_client_email
+    expect(decoded_token[:data]["aud"]).to eql "https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit"
   end
 
   it "should throw an error in a signed JWT when it doesn't exist" do
@@ -51,7 +51,7 @@ nC64AqP02IP2yOxnbxZ1uY2TrdI1VcO3AwcngxSEUMo=
     claims = {foo: "bar"}
     token = SignedJWT::create_firebase_token(uid, @valid_app_name, 3600, claims)
     decoded_token = SignedJWT::decode_firebase_token(token, @valid_app_name)
-    decoded_token[:data]["foo"].should eql "bar"
+    expect(decoded_token[:data]["foo"]).to eql "bar"
   end
 
   it "should throw an error when create a JWT with claims if reserved keys are used" do

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -2,10 +2,10 @@ require File.expand_path('../../spec_helper', __FILE__)
 
 describe Image do
   before(:each) do
-    Paperclip::Geometry.stub!(:from_file).and_return(dimensions)
+    allow(Paperclip::Geometry).to receive(:from_file).and_return(dimensions)
   end
 
-  let(:dimensions)  { mock(:width  => 100, :height => 100)}
+  let(:dimensions)  { double(:width  => 100, :height => 100)}
   let(:license)     { mock_model(CommonsLicense, :code => 'CC-BY') }
   let(:user)        { mock_model(User, :login=>"testuser")}
   let(:img_filename){ "testing_file_name"                 }
@@ -24,7 +24,7 @@ describe Image do
   describe "create" do
     context "with valid params" do
       it "should create a new instance given valid attributes" do
-        subject.should be_valid
+        expect(subject).to be_valid
       end
     end
 
@@ -37,7 +37,7 @@ describe Image do
         }
       end
       it "should produce errors on the model" do
-        subject.should_not be_valid
+        expect(subject).not_to be_valid
       end
     end
 
@@ -51,7 +51,7 @@ describe Image do
       end
 
       it "should produce errors on the model" do
-        subject.should_not be_valid
+        expect(subject).not_to be_valid
       end
     end
 
@@ -65,7 +65,7 @@ describe Image do
 
   end
   describe "clean_image_filename" do
-    let(:image_mock)    { mock              }
+    let(:image_mock)    { double              }
     let(:with_slashes)  { "dangerous/name"  }
     let(:with_colons)   { "dangerous:name"  }
     let(:with_backticks){ "dangerous`name"  }
@@ -75,7 +75,7 @@ describe Image do
     let(:expected)      { "dangerous-name"}
     before(:each) {
       subject.stub(:image => image_mock)
-      image_mock.should_receive(:instance_write).with(:file_name, expected)
+      expect(image_mock).to receive(:instance_write).with(:file_name, expected)
     }
     context "with dangerous names" do
       it "should replace slashes" do
@@ -126,47 +126,47 @@ describe Image do
 
 
       it "wont let unprivledged users create" do
-        user.should_receive(:has_role?).and_return(false)
-        user.should_receive(:portal_teacher).and_return(nil)
-        subject.can_be_created_by?(user).should be_false
+        expect(user).to receive(:has_role?).and_return(false)
+        expect(user).to receive(:portal_teacher).and_return(nil)
+        expect(subject.can_be_created_by?(user)).to be_falsey
       end
       it "will let privleged users creat things" do
-        user.should_receive(:has_role?).and_return(true)
-        subject.can_be_created_by?(user).should be_true
+        expect(user).to receive(:has_role?).and_return(true)
+        expect(subject.can_be_created_by?(user)).to be_truthy
       end
     end
   end
 
   describe "redo_watermark" do
     before(:each) do
-      @mock_image = mock
+      @mock_image = double
       subject.stub(:image => @mock_image)
     end
     it "shouldn't reprocess if processing is in progress" do
-      subject.should_receive(:is_reprocessing).and_return(true)
-      @mock_image.should_not_receive(:reprocess!)
+      expect(subject).to receive(:is_reprocessing).and_return(true)
+      expect(@mock_image).not_to receive(:reprocess!)
       subject.redo_watermark
     end
     it "should reprocess if there is no proecessing in progress" do
-      subject.should_receive(:is_reprocessing).and_return(false)
-      subject.should_receive(:attribution_changed?).and_return(true)
-      @mock_image.should_receive(:reprocess!)
+      expect(subject).to receive(:is_reprocessing).and_return(false)
+      expect(subject).to receive(:attribution_changed?).and_return(true)
+      expect(@mock_image).to receive(:reprocess!)
       subject.redo_watermark
     end
   end
 
   describe "image_size" do
     before(:each) do
-      @mock_image = mock
+      @mock_image = double
       subject.stub(:image => @mock_image)
     end
     it "should return the images size" do
-      @mock_image.should_receive(:size).and_return(100)
-      subject.image_size.should == 100
+      expect(@mock_image).to receive(:size).and_return(100)
+      expect(subject.image_size).to eq(100)
     end
     it "should return 0 even if there is no image" do
       @mock_image = nil
-      subject.image_size.should == 0
+      expect(subject.image_size).to eq(0)
     end
   end
 
@@ -176,7 +176,7 @@ describe Image do
         Image::UseUploadedByInAttribution = true
       end
       it "should return the users login" do
-        subject.uploaded_by_attribution.should == "Uploaded by: testuser"
+        expect(subject.uploaded_by_attribution).to eq("Uploaded by: testuser")
       end
     end
     context "when UseUploadedByInAttribution is set to false" do
@@ -184,7 +184,7 @@ describe Image do
         Image::UseUploadedByInAttribution = false
       end
       it "should return an empty string" do
-        subject.uploaded_by_attribution.should be_blank
+        expect(subject.uploaded_by_attribution).to be_blank
       end
     end
   end

--- a/spec/models/investigation_duplication_spec.rb
+++ b/spec/models/investigation_duplication_spec.rb
@@ -33,56 +33,56 @@ describe Investigation do
 
     describe "original investigation should" do
       it "have pages" do
-        @source_investigation.pages.should have_at_least(1).pages
+        expect(@source_investigation.pages.size).to be >= 1
       end
       it "have a name" do
-        @source_investigation.name.should_not be_nil
+        expect(@source_investigation.name).not_to be_nil
       end
 
       it "not be changeable by the new author" do
-        @source_investigation.should_not be_changeable(@new_author)
+        expect(@source_investigation).not_to be_changeable(@new_author)
       end
     end
 
     describe "new investigation should" do
       it "exist" do
-        @dest_investigation.should_not be_nil
+        expect(@dest_investigation).not_to be_nil
       end
 
       it "have a similar name" do
-        @dest_investigation.name.should match(@source_investigation.name)
-        @dest_investigation.name.should match(/copy/i)
+        expect(@dest_investigation.name).to match(@source_investigation.name)
+        expect(@dest_investigation.name).to match(/copy/i)
       end
 
       it "not have the same name" do
-        @dest_investigation.name.should_not == @source_investigation.name
+        expect(@dest_investigation.name).not_to eq(@source_investigation.name)
       end
 
       it "have a unique id" do
-        @dest_investigation.id.should_not be(@source_investigation.id)
+        expect(@dest_investigation.id).not_to be(@source_investigation.id)
       end
 
       it "be changeable by the new author" do
-        @dest_investigation.should be_changeable(@new_author)
-        @dest_investigation.should_not be_changeable(@original_author)
+        expect(@dest_investigation).to be_changeable(@new_author)
+        expect(@dest_investigation).not_to be_changeable(@original_author)
       end
 
       it "have pages which are changable by the new author" do
-        @dest_investigation.pages[0].should_not be_nil
-        @dest_investigation.pages[0].should be_changeable(@new_author)
-        @dest_investigation.pages[0].should_not be_changeable(@original_author)
+        expect(@dest_investigation.pages[0]).not_to be_nil
+        expect(@dest_investigation.pages[0]).to be_changeable(@new_author)
+        expect(@dest_investigation.pages[0]).not_to be_changeable(@original_author)
       end
 
       it "have an open response which is changeable by the new author" do
-        @dest_investigation.pages[0].open_responses[0].should_not be_nil
-        @dest_investigation.pages[0].open_responses[0].should be_changeable(@new_author)
-        @dest_investigation.pages[0].open_responses[0].should_not be_changeable(@original_author)
+        expect(@dest_investigation.pages[0].open_responses[0]).not_to be_nil
+        expect(@dest_investigation.pages[0].open_responses[0]).to be_changeable(@new_author)
+        expect(@dest_investigation.pages[0].open_responses[0]).not_to be_changeable(@original_author)
       end
 
       it "have a page_element which is changeable by the new author" do
-        @dest_investigation.pages.first.page_elements.first.should_not be_nil
-        @dest_investigation.pages.first.page_elements.first.should be_changeable(@new_author)
-        @dest_investigation.pages.first.page_elements.first.should_not be_changeable(@original_author)
+        expect(@dest_investigation.pages.first.page_elements.first).not_to be_nil
+        expect(@dest_investigation.pages.first.page_elements.first).to be_changeable(@new_author)
+        expect(@dest_investigation.pages.first.page_elements.first).not_to be_changeable(@original_author)
       end
 
     end

--- a/spec/models/investigation_spec.rb
+++ b/spec/models/investigation_spec.rb
@@ -29,10 +29,10 @@ describe Investigation do
   end
   
   it 'has_many for all BASE_EMBEDDABLES' do
-    BASE_EMBEDDABLES.length.should be > 0
+    expect(BASE_EMBEDDABLES.length).to be > 0
     @investigation = Investigation.create!(@valid_attributes)
     BASE_EMBEDDABLES.each do |e|
-      @investigation.respond_to?(e[/::(\w+)$/, 1].underscore.pluralize).should be(true)
+      expect(@investigation.respond_to?(e[/::(\w+)$/, 1].underscore.pluralize)).to be(true)
     end
   end
 
@@ -42,22 +42,22 @@ describe Investigation do
     end
     
     it "should not be public by default" do
-      @investigation.published?.should be(false)
+      expect(@investigation.published?).to be(false)
     end
     it "should be public if published" do
       @investigation.publish!
-      @investigation.public?.should be(true)
+      expect(@investigation.public?).to be(true)
     end
     
     it "should not be public if unpublished " do
       @investigation.publish!
-      @investigation.public?.should be(true)
+      expect(@investigation.public?).to be(true)
       @investigation.un_publish!
-      @investigation.public?.should_not be(true)
+      expect(@investigation.public?).not_to be(true)
     end
     
     it "should define a method for available_states" do
-      @investigation.should respond_to(:available_states)
+      expect(@investigation).to respond_to(:available_states)
     end
   end
   
@@ -72,7 +72,7 @@ describe Investigation do
         @user.roles.destroy_all
         @user.add_role(role.to_s)
         
-        @investigation.duplicateable?(@user).should be_false
+        expect(@investigation.duplicateable?(@user)).to be_falsey
       end
     end
     
@@ -81,7 +81,7 @@ describe Investigation do
         @user.roles.destroy_all
         @user.add_role(role.to_s)
         
-        @investigation.duplicateable?(@user).should be_true
+        expect(@investigation.duplicateable?(@user)).to be_truthy
       end
     end
   end
@@ -100,7 +100,7 @@ describe Investigation do
     end
 
     it "should find all grade 8 phsysics investigations, including drafts" do
-      pending "Equivalent spec suite elsewhere"
+      skip "Equivalent spec suite elsewhere"
       options = {
         :grade_span => [@eight],
         :domain_id  => [@physics.id],
@@ -108,83 +108,83 @@ describe Investigation do
       }
       found = Investigation.search_list(options)
       found.each do |inv|
-        inv.domain.should == @physics
-        inv.grade_span.should == @eight
+        expect(inv.domain).to eq(@physics)
+        expect(inv.grade_span).to eq(@eight)
       end
     end
 
   
     it "should find all grade phsysics investigations, including drafts" do
-      pending "Equivalent spec suite elsewhere"
+      skip "Equivalent spec suite elsewhere"
       options = {
         :domain_id  => [@physics.id],
         :include_drafts => true
       }
       found = Investigation.search_list(options)
       found.each do |inv|
-        inv.domain.should == @physics
+        expect(inv.domain).to eq(@physics)
       end
     end
 
     it "should find all public and draft investigations" do
-      pending "Equivalent spec suite elsewhere"
+      skip "Equivalent spec suite elsewhere"
       options = {
         :include_drafts => true
       }
       found = Investigation.search_list(options)
-      found.should include(*@drafts)
-      found.should include(*@published)
+      expect(found).to include(*@drafts)
+      expect(found).to include(*@published)
     end
 
     it "should find all public and draft NON-GSE investigations too" do
-      pending "Equivalent spec suite elsewhere"
+      skip "Equivalent spec suite elsewhere"
       options = {
         :include_drafts => true
       }
       found = Investigation.search_list(options)
-      found.should include(@public_non_gse)
-      found.should include(@draft_non_gse)
+      expect(found).to include(@public_non_gse)
+      expect(found).to include(@draft_non_gse)
     end
     
     it "should find only published, in grade 8 physics domain" do
-      pending "Equivalent spec suite elsewhere"
+      skip "Equivalent spec suite elsewhere"
       options = {
         :grade_span => [@eight],
         :domain_id  => [@physics.id],
         :include_drafts => false
       }
       found = Investigation.search_list(options)
-      found.size.should == 1
+      expect(found.size).to eq(1)
       found.each do |inv|
-        inv.should be_public
-        inv.domain.should == @physics
-        inv.grade_span.should == @eight
+        expect(inv).to be_public
+        expect(inv.domain).to eq(@physics)
+        expect(inv.grade_span).to eq(@eight)
       end
     end
 
     it "should find only published in physics domain" do
-      pending "Equivalent spec suite elsewhere"
+      skip "Equivalent spec suite elsewhere"
       options = {
         :domain_id  => [@physics.id],
         :include_drafts => false
       }
       found = Investigation.search_list(options)
-      found.should_not include(*@drafts)
+      expect(found).not_to include(*@drafts)
       found.each do |inv|
-        inv.should be_public
-        inv.domain.should == @physics
+        expect(inv).to be_public
+        expect(inv.domain).to eq(@physics)
       end
     end
     
     it "should find all published investigations" do
-      pending "Equivalent spec suite elsewhere"
+      skip "Equivalent spec suite elsewhere"
       options = {
         :include_drafts => false
       }
       found = Investigation.search_list(options)
-      found.should include(*@published)
-      found.should include(@public_non_gse)
-      found.should_not include(*@drafts)
+      expect(found).to include(*@published)
+      expect(found).to include(@public_non_gse)
+      expect(found).not_to include(*@drafts)
     end
   end 
 
@@ -199,30 +199,30 @@ describe Investigation do
 
     # We might want to have one activity in the future. 
     it "should have no activities initially" do
-      investigation.should have(0).activities
+      expect(investigation.activities.size).to eq(0)
     end
 
     it "should have one activity after it is added" do
       investigation.activities << activity_one
-      investigation.should have(1).activities
+      expect(investigation.activities.size).to eq(1)
     end
 
     it "the position of the first activity should be 1" do
       investigation.activities << activity_one
       activity_one.insert_at(1)
-      investigation.should have(1).activities
-      activity_one.position.should_not be_nil
-      activity_one.position.should eql 1
+      expect(investigation.activities.size).to eq(1)
+      expect(activity_one.position).not_to be_nil
+      expect(activity_one.position).to eql 1
     end
 
     it "the position of the second activity should be 2" do
       investigation.activities << activity_one
       investigation.activities << activity_two
-      investigation.should have(2).activities
+      expect(investigation.activities.size).to eq(2)
       activity_one.insert_at(1)
       activity_two.insert_at(2)
-      activity_one.position.should eql 1
-      activity_two.position.should eql 2
+      expect(activity_one.position).to eql 1
+      expect(activity_two.position).to eql 2
     end
 
     it "the activities honor the acts_as_list methods" do
@@ -232,20 +232,20 @@ describe Investigation do
       activity_two.insert_at(2)
       
       investigation.reload
-      investigation.activities.should eql([activity_one, activity_two])
+      expect(investigation.activities).to eql([activity_one, activity_two])
 
       activity_one.move_to_bottom
       investigation.reload
-      investigation.activities.should eql([activity_two, activity_one])
+      expect(investigation.activities).to eql([activity_two, activity_one])
       
       # must reload the other activity for updated position.
       activity_two.reload
-      activity_two.should be_before(activity_one)
-      activity_one.should be_after(activity_two)
+      expect(activity_two).to be_before(activity_one)
+      expect(activity_one).to be_after(activity_two)
       
       # more fragile, but worth checking:
-      activity_one.position.should eql 2
-      activity_two.position.should eql 1
+      expect(activity_one.position).to eql 2
+      expect(activity_two.position).to eql 1
     end
 
   end
@@ -267,9 +267,9 @@ describe Investigation do
     end
 
     it "should have 1 multiple choices" do
-      @investigation.should have(1).reportable_elements
+      expect(@investigation.reportable_elements.size).to eq(1)
       @investigation.reportable_elements.each do |elm|
-        elm[:embeddable].should be_a(Embeddable::MultipleChoice)
+        expect(elm[:embeddable]).to be_a(Embeddable::MultipleChoice)
       end
     end
   end
@@ -286,32 +286,32 @@ describe Investigation do
       @bad.stub(:page_elements => [@good_page_element, @bad_page_element, @good_page_element])
       @bad_with_learners.stub(:page_elements => [@good_page_element, @bad_page_element, @good_page_element])
       @bad_with_learners.stub(:offerings => [@offering])
-      Investigation.stub!(:all => [@good,@bad,@bad_with_learners])     
+      Investigation.stub(:all => [@good,@bad,@bad_with_learners])     
     end
 
     describe "broken investigations" do
       describe "broken_parts" do
         it "should return a list of a broken page_elements" do
-          @bad.broken_parts.should_not be_empty
-          @bad_with_learners.broken_parts.should_not be_empty
+          expect(@bad.broken_parts).not_to be_empty
+          expect(@bad_with_learners.broken_parts).not_to be_empty
         end
         it "should return an empty list if the investigation is fine" do
-          @good.broken_parts.should be_empty
+          expect(@good.broken_parts).to be_empty
         end
       end
       
       describe "broken?" do
         it "investigation with broken parts should be marked as broken" do
-          @good.should_not be_broken
-          @bad.should be_broken
-          @bad_with_learners.should be_broken
+          expect(@good).not_to be_broken
+          expect(@bad).to be_broken
+          expect(@bad_with_learners).to be_broken
         end
       end
 
       describe "Investigation#broken" do
         it "should return a list of broken investigations" do
-          Investigation.broken.should include @bad
-          Investigation.broken.should_not include @good
+          expect(Investigation.broken).to include @bad
+          expect(Investigation.broken).not_to include @good
         end
       end
     end #broken investigations
@@ -319,29 +319,29 @@ describe Investigation do
     describe "deleting broken investigations" do
       describe "can_be_modified?" do
         it "should return true for investigations without learners" do
-          @good.should be_can_be_modified
-          @bad.should be_can_be_modified
+          expect(@good).to be_can_be_modified
+          expect(@bad).to be_can_be_modified
         end
         it "should return false for investigations with learners" do
-          @bad_with_learners.should_not be_can_be_modified
+          expect(@bad_with_learners).not_to be_can_be_modified
         end
       end
 
       describe "can_be_deleted?" do
         it "should return true for investigations without learners" do
-          @good.can_be_deleted?.should == true
-          @bad.can_be_deleted?.should == true
+          expect(@good.can_be_deleted?).to eq(true)
+          expect(@bad.can_be_deleted?).to eq(true)
         end
         it "should return false for investigations with learners" do
-          @bad_with_learners.can_be_deleted?.should == false
+          expect(@bad_with_learners.can_be_deleted?).to eq(false)
         end
       end
 
       describe "delete_broken" do
         it "should send 'destroy' messages to broken investigations without learners" do
-          @bad_with_learners.should_not_receive(:destroy)
-          @good.should_not_receive(:destroy)
-          @bad.should_receive(:destroy)
+          expect(@bad_with_learners).not_to receive(:destroy)
+          expect(@good).not_to receive(:destroy)
+          expect(@bad).to receive(:destroy)
           Investigation.delete_broken
         end
       end
@@ -352,26 +352,26 @@ describe Investigation do
     let(:investigation)        { nil }
     let(:external_activities)  { [] }
     let(:activity_externals)    { [] }
-    let(:activity)             { mock(:external_activities => activity_externals) }
+    let(:activity)             { double(:external_activities => activity_externals) }
     let(:activities)           { [activity] }
     subject do
       s = Factory.create(:investigation)
-      s.stub!(:external_activities => external_activities)
-      s.stub!(:activities => activities)
+      s.stub(:external_activities => external_activities)
+      s.stub(:activities => activities)
       s.is_template
     end
     describe "when an investigation has an activity that is a template" do
       let(:activity_externals) { [1,2,3] }
-      it { should be_true }
+      it { is_expected.to be_truthy }
     end
     describe "when an investigation has an activity that is not a template" do
       describe "when an investigation has external_activities" do
         let(:external_activities) { [1,2,3]}
-        it { should be_true}
+        it { is_expected.to be_truthy}
       end
       describe "when an investigation has no external_activities" do
         let(:external_activities) {[]}
-        it { should be_false}
+        it { is_expected.to be_falsey}
       end
     end  
   end

--- a/spec/models/materials_collection_item_spec.rb
+++ b/spec/models/materials_collection_item_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
 describe MaterialsCollectionItem do
-  pending "add some examples to (or delete) #{__FILE__}"
+  skip "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/padlet_bookmark_spec.rb
+++ b/spec/models/padlet_bookmark_spec.rb
@@ -1,9 +1,9 @@
   require File.expand_path('../../spec_helper', __FILE__)
 
 describe Portal::PadletBookmark do
-  let(:bookmark_wrapper) { mock(:padlet_url => "http://fake_padlet.com") }
+  let(:bookmark_wrapper) { double(:padlet_url => "http://fake_padlet.com") }
   before(:each) do
-    PadletWrapper.stub!(:new) { bookmark_wrapper }
+    allow(PadletWrapper).to receive(:new) { bookmark_wrapper }
   end
 
   describe "Class methods" do
@@ -13,24 +13,24 @@ describe Portal::PadletBookmark do
         context "when none of the existing names contain ordinal numbers" do
           let(:user) {mock_model(User, :anonymous? => false, :email=>'k@gmail.com')}
           let(:found_items) do
-            [ mock(:name => 'foo'), mock(:name => 'bar'), mock(:name => 'baz')]
+            [ double(:name => 'foo'), double(:name => 'bar'), double(:name => 'baz')]
           end
 
           it "shuld use a name with an ordinal found-size + 1" do
-            Portal::PadletBookmark.stub!(:for_user => found_items)
-            Portal::PadletBookmark.create_for_user(user).name.should match(/my 4th padlet/i)
+            Portal::PadletBookmark.stub(:for_user => found_items)
+            expect(Portal::PadletBookmark.create_for_user(user).name).to match(/my 4th padlet/i)
           end
         end
 
         context "when some of the names contain ordinal numbers" do
           let(:user) {mock_model(User, :anonymous? => false, :email=>'k@gmail.com')}
           let(:found_items) do
-            [ mock(:name => 'my 3rd padlet'), mock(:name => 'bar'), mock(:name => 'my 7th padlet')]
+            [ double(:name => 'my 3rd padlet'), double(:name => 'bar'), double(:name => 'my 7th padlet')]
           end
 
           it "shuld use a name with existing max ordinal size + 1" do
-            Portal::PadletBookmark.stub!(:for_user => found_items)
-            Portal::PadletBookmark.create_for_user(user).name.should match(/my 8th padlet/i)
+            Portal::PadletBookmark.stub(:for_user => found_items)
+            expect(Portal::PadletBookmark.create_for_user(user).name).to match(/my 8th padlet/i)
           end
         end
       end
@@ -39,36 +39,36 @@ describe Portal::PadletBookmark do
     describe "user_can_make?(user)" do
       context "when the portal allows PadletBookmarks" do
         before(:each) do
-          Portal::Bookmark.stub!(:allowed_types => [Portal::PadletBookmark])
+          Portal::Bookmark.stub(:allowed_types => [Portal::PadletBookmark])
         end
 
         context "when the user is anonymous" do
           let(:user) { mock_model(User, :anonymous? => true)}
           it "shouldn't let the user make a PadletBookmark" do
-            Portal::PadletBookmark.user_can_make?(user).should be_false
+            expect(Portal::PadletBookmark.user_can_make?(user)).to be_falsey
           end
         end
         context "the user is a regular user" do
           let(:user) { mock_model(User, :anonymous? => false)}
           it "should let the user make a PadletBookmark" do
-            Portal::PadletBookmark.user_can_make?(user).should be_true
+            expect(Portal::PadletBookmark.user_can_make?(user)).to be_truthy
           end
         end
       end
       context "when the portal doesn't allow PadletBookmarks" do
         before(:each) do
-          Portal::Bookmark.stub!(:allowed_types => [])
+          Portal::Bookmark.stub(:allowed_types => [])
         end
         context "the user is a regular user" do
           let(:user) { mock_model(User, :anonymous? => false)}
           it "should let the user make a PadletBookmark" do
-            Portal::PadletBookmark.user_can_make?(user).should be_false
+            expect(Portal::PadletBookmark.user_can_make?(user)).to be_falsey
           end
         end
         context "the user is an anonymous user" do
           let(:user) { mock_model(User, :anonymous? => true)}
           it "should let the user make a PadletBookmark" do
-            Portal::PadletBookmark.user_can_make?(user).should be_false
+            expect(Portal::PadletBookmark.user_can_make?(user)).to be_falsey
           end
         end
       end

--- a/spec/models/page_element_spec.rb
+++ b/spec/models/page_element_spec.rb
@@ -8,29 +8,29 @@ describe PageElement do
   end
   
   it "should not be nil" do
-    @page_element.should_not be_nil
+    expect(@page_element).not_to be_nil
   end
   
   it "not original have an owner" do
-    @page_element.user.should be_nil
+    expect(@page_element.user).to be_nil
   end
   
   it "should let an onwer be assinged to it" do
     @page_element.user = @user
-    @page_element.user.should be(@user)
+    expect(@page_element.user).to be(@user)
   end
   
   it "should persist its owner information" do
     @page_element.user = @user
     @page_element.save
     @page_element.reload
-    @page_element.user.should_not be_nil
-    @page_element.user.should == @user
+    expect(@page_element.user).not_to be_nil
+    expect(@page_element.user).to eq(@user)
   end
   
   it "should be changable by its owner" do
     @page_element.user = @user
-    @page_element.should be_changeable(@user)
+    expect(@page_element).to be_changeable(@user)
   end
   
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -20,10 +20,10 @@ describe Page do
   end
 
   it 'has_many for all ALL_EMBEDDABLES' do
-    ALL_EMBEDDABLES.length.should be > 0
+    expect(ALL_EMBEDDABLES.length).to be > 0
     p = Page.create!(@valid_attributes)
     ALL_EMBEDDABLES.each do |e|
-      p.respond_to?(e[/::(\w+)$/, 1].underscore.pluralize).should be(true)
+      expect(p.respond_to?(e[/::(\w+)$/, 1].underscore.pluralize)).to be(true)
     end
   end
 
@@ -39,8 +39,8 @@ describe Page do
       @page2 = Page.create!(:name => "Page2", :description => "Page2 description")
       @page.reload
       @page2.reload
-      @page.position.should == 1
-      @page2.position.should == 2
+      expect(@page.position).to eq(1)
+      expect(@page2.position).to eq(2)
     end
   end
 end

--- a/spec/models/portal/clazzes_spec.rb
+++ b/spec/models/portal/clazzes_spec.rb
@@ -11,24 +11,24 @@ describe Portal::Clazz do
     it "under normal circumstances should say there is no reason admins cannot remove teachers" do
       admin_user = Factory.next(:admin_user)
       @existing_clazz.teachers = [@teacher1, @teacher2]
-      @existing_clazz.reason_user_cannot_remove_teacher_from_class(admin_user, @teacher1).should == nil
+      expect(@existing_clazz.reason_user_cannot_remove_teacher_from_class(admin_user, @teacher1)).to eq(nil)
     end
 
     it "under normal circumstances should say there is no reason authorized teachers cannot remove teachers" do
       @existing_clazz.teachers = [@teacher1, @teacher2]
-      @existing_clazz.reason_user_cannot_remove_teacher_from_class(@teacher1.user, @teacher2).should == nil
+      expect(@existing_clazz.reason_user_cannot_remove_teacher_from_class(@teacher1.user, @teacher2)).to eq(nil)
     end
 
     it "should say it is illegal for an unauthorized user to remove a teacher" do
       random_user = Factory.next(:anonymous_user)
       @existing_clazz.teachers = [@teacher1, @teacher2]
-      @existing_clazz.reason_user_cannot_remove_teacher_from_class(random_user, @teacher1).should == Portal::Clazz::ERROR_UNAUTHORIZED
+      expect(@existing_clazz.reason_user_cannot_remove_teacher_from_class(random_user, @teacher1)).to eq(Portal::Clazz::ERROR_UNAUTHORIZED)
     end
 
     it "should say it is illegal for a user to remove the last teacher" do
       admin_user = Factory.next(:admin_user)
       @existing_clazz.teachers = [@teacher1]
-      @existing_clazz.reason_user_cannot_remove_teacher_from_class(admin_user, @teacher1).should == Portal::Clazz::ERROR_REMOVE_TEACHER_LAST_TEACHER
+      expect(@existing_clazz.reason_user_cannot_remove_teacher_from_class(admin_user, @teacher1)).to eq(Portal::Clazz::ERROR_REMOVE_TEACHER_LAST_TEACHER)
     end
   end
 
@@ -39,25 +39,25 @@ describe Portal::Clazz do
 
     it "is true for admins" do
       admin_user = Factory.next(:admin_user)
-      @existing_clazz.changeable?(admin_user).should be_true
+      expect(@existing_clazz.changeable?(admin_user)).to be_truthy
     end
 
     it "is true for class teacher" do
       @teacher = Factory.create(:portal_teacher)
       @existing_clazz.teachers = [@teacher]
-      @existing_clazz.changeable?(@teacher.user).should be_true
+      expect(@existing_clazz.changeable?(@teacher.user)).to be_truthy
     end
 
     it "is true for second class teacher" do
       @teacher1 = Factory.create(:portal_teacher)
       @teacher2 = Factory.create(:portal_teacher)
       @existing_clazz.teachers = [@teacher1, @teacher2]
-      @existing_clazz.changeable?(@teacher2.user).should be_true
+      expect(@existing_clazz.changeable?(@teacher2.user)).to be_truthy
     end
 
     it "is false for non class teacher" do
       @teacher = Factory.create(:portal_teacher)
-      @existing_clazz.changeable?(@teacher.user).should be_false
+      expect(@existing_clazz.changeable?(@teacher.user)).to be_falsey
     end
   end
 
@@ -98,7 +98,7 @@ describe Portal::Clazz do
       })
 
       @new_clazz.name = ''
-      @new_clazz.valid?.should == false
+      expect(@new_clazz.valid?).to eq(false)
 
     end
 
@@ -118,7 +118,7 @@ describe Portal::Clazz do
 
       @new_clazz.class_word = ''
 
-      @new_clazz.valid?.should == false
+      expect(@new_clazz.valid?).to eq(false)
     end
 
   end
@@ -126,14 +126,14 @@ describe Portal::Clazz do
   describe ".default_class" do
     it "should return a portal clazz with default_class true" do
       default_class = Portal::Clazz.default_class
-      default_class.should be_an_instance_of Portal::Clazz
-      default_class.default_class.should be_true
+      expect(default_class).to be_an_instance_of Portal::Clazz
+      expect(default_class.default_class).to be_truthy
     end
 
     it "should return the same portal clazz on second call" do
       default_clazz = Portal::Clazz.default_class
-      default_clazz.should be_an_instance_of Portal::Clazz
-      Portal::Clazz.default_class.should == default_clazz
+      expect(default_clazz).to be_an_instance_of Portal::Clazz
+      expect(Portal::Clazz.default_class).to eq(default_clazz)
     end
   end
 
@@ -143,78 +143,78 @@ describe Portal::Clazz do
       @offerings         = []
       @default_offerings = []
       1.upto(10) do |i|
-        @offerings << mock(:offering,
+        @offerings << double(:offering,
                            :id => i,
                            :runnable_id => i,
                            :runnable_type => 'bogus',
                            :default => false)
 
-        @default_offerings << mock(:offering,
+        @default_offerings << double(:offering,
                                    :id => i,
                                    :runnable_id => i,
                                    :runnable_type => 'bogus',
                                    :default => true)
       end
-      @clazz.stub!(:active_offerings => @offerings)
+      @clazz.stub(:active_offerings => @offerings)
     end
 
     describe "when there are no default activities" do
       before(:each) do
         def_offerings = []
-        Portal::Offering.stub!(:find_all_by_runnable_id_and_runnable_type_and_default_offering).and_return { |a,b,c|
+        allow(Portal::Offering).to receive(:find_all_by_runnable_id_and_runnable_type_and_default_offering) { |a,b,c|
           def_offerings.select {|o| o.runnable_id == a}}
       end
       it "should have 10 offerings, zero default offerings" do
-        @clazz.offerings_including_default_class.size.should == 10
-        @clazz.offerings_including_default_class.select{ |i| i.default == true}.size.should == 0
+        expect(@clazz.offerings_including_default_class.size).to eq(10)
+        expect(@clazz.offerings_including_default_class.select{ |i| i.default == true}.size).to eq(0)
       end
     end
 
     describe "when there is 100% overlap with default activities" do
       before(:each) do
         def_offerings = @default_offerings
-        Portal::Offering.stub!(:find_all_by_runnable_id_and_runnable_type_and_default_offering).and_return { |a,b,c|
+        allow(Portal::Offering).to receive(:find_all_by_runnable_id_and_runnable_type_and_default_offering) { |a,b,c|
           def_offerings.select {|o| o.runnable_id == a}}
       end
       it "should have 10 offerings, 10 default offerings" do
-        @clazz.offerings_including_default_class.size.should == 10
-        @clazz.offerings_including_default_class.select{ |i| i.default == true}.size.should == 10
+        expect(@clazz.offerings_including_default_class.size).to eq(10)
+        expect(@clazz.offerings_including_default_class.select{ |i| i.default == true}.size).to eq(10)
       end
     end
 
     describe "the first half are default activities" do
       before(:each) do
         def_offerings = @default_offerings[0...5]
-        Portal::Offering.stub!(:find_all_by_runnable_id_and_runnable_type_and_default_offering).and_return { |a,b,c|
+        allow(Portal::Offering).to receive(:find_all_by_runnable_id_and_runnable_type_and_default_offering) { |a,b,c|
           def_offerings.select {|o| o.runnable_id == a}}
       end
       it "should have 10 offerings, 5 default offerings" do
-        @clazz.offerings_including_default_class.size.should == 10
-        @clazz.offerings_including_default_class.select{ |i| i.default == true}.size.should == 5
+        expect(@clazz.offerings_including_default_class.size).to eq(10)
+        expect(@clazz.offerings_including_default_class.select{ |i| i.default == true}.size).to eq(5)
       end
     end
 
     describe "the first half are default activities" do
       before(:each) do
         def_offerings = @default_offerings[5...10]
-        Portal::Offering.stub!(:find_all_by_runnable_id_and_runnable_type_and_default_offering).and_return { |a,b,c|
+        allow(Portal::Offering).to receive(:find_all_by_runnable_id_and_runnable_type_and_default_offering) { |a,b,c|
           def_offerings.select {|o| o.runnable_id == a}}
       end
       it "should have 10 offerings, 5 default offerings" do
-        @clazz.offerings_including_default_class.size.should == 10
-        @clazz.offerings_including_default_class.select{ |i| i.default == true}.size.should == 5
+        expect(@clazz.offerings_including_default_class.size).to eq(10)
+        expect(@clazz.offerings_including_default_class.select{ |i| i.default == true}.size).to eq(5)
       end
     end
 
     describe "every other activity is the default default" do
       before(:each) do
         def_offerings = @default_offerings.select { |i| i.runnable_id % 2 == 0 }
-        Portal::Offering.stub!(:find_all_by_runnable_id_and_runnable_type_and_default_offering).and_return { |a,b,c|
+        allow(Portal::Offering).to receive(:find_all_by_runnable_id_and_runnable_type_and_default_offering) { |a,b,c|
           def_offerings.select {|o| o.runnable_id == a}}
       end
       it "should have 10 offerings, 5 default offerings" do
-        @clazz.offerings_including_default_class.size.should == 10
-        @clazz.offerings_including_default_class.select{ |i| i.default == true}.size.should == 5
+        expect(@clazz.offerings_including_default_class.size).to eq(10)
+        expect(@clazz.offerings_including_default_class.select{ |i| i.default == true}.size).to eq(5)
       end
     end
   end
@@ -231,30 +231,30 @@ describe Portal::Clazz do
     end
     describe "called without a user" do
       it "should fall back to offerings_including_default_class" do
-        @clazz.should_receive(:offerings_including_default_class).and_return(true)
-        @clazz.offerings_with_default_classes.should == true
+        expect(@clazz).to receive(:offerings_including_default_class).and_return(true)
+        expect(@clazz.offerings_with_default_classes).to eq(true)
       end
     end
     describe "called without a student" do
       before(:each) do
-        @user = mock(:user, :portal_student => nil)
+        @user = double(:user, :portal_student => nil)
       end
       it "should fall back to offerings_including_default_class" do
-        @clazz.should_receive(:offerings_including_default_class).and_return(true)
-        @clazz.offerings_with_default_classes(@user).should == true
+        expect(@clazz).to receive(:offerings_including_default_class).and_return(true)
+        expect(@clazz.offerings_with_default_classes(@user)).to eq(true)
       end
     end
     describe "when not the default class" do
       before(:each) do
-        @offerings = [mock(:offering),mock(:offering)]
-        @clazzes = [mock(:clazz, :offerings => @offerings)]
-        @student = mock(:student, :clazzes => @clazzes)
-        @user = mock(:user, :portal_student => @student)
+        @offerings = [double(:offering),double(:offering)]
+        @clazzes = [double(:clazz, :offerings => @offerings)]
+        @student = double(:student, :clazzes => @clazzes)
+        @user = double(:user, :portal_student => @student)
       end
       it "should fall back to offerings_including_default_class" do
-        @clazz.should_receive(:default_class).and_return(false)
-        @clazz.should_receive(:offerings_including_default_class).and_return(true)
-        @clazz.offerings_with_default_classes(@user).should == true
+        expect(@clazz).to receive(:default_class).and_return(false)
+        expect(@clazz).to receive(:offerings_including_default_class).and_return(true)
+        expect(@clazz.offerings_with_default_classes(@user)).to eq(true)
       end
     end
     describe "when the default class, and when there is a user" do
@@ -262,44 +262,44 @@ describe Portal::Clazz do
         @offerings = []
         # these offerings belong to the "real" class
         0.upto(2) do |i|
-          @offerings << mock(:offering, :id => i, :runnable_type => 'fake', :runnable => i, :runnable_id => i)
+          @offerings << double(:offering, :id => i, :runnable_type => 'fake', :runnable => i, :runnable_id => i)
         end
         @student_offerings = @offerings[0..2]
 
         # these offerings belong to the default class but have the same runnable as the first 2 student offerings
         3.upto 4 do |i|
-          @offerings << mock(:offering, :id => i, :runnable_type => 'fake', :runnable => i-3, :runnable_id => i-3)
+          @offerings << double(:offering, :id => i, :runnable_type => 'fake', :runnable => i-3, :runnable_id => i-3)
         end
         @default_offerings_with_same_runnable_as_a_student_offering = @offerings[3..4]
 
         # these offerings belong only to the default class
         5.upto 8 do |i|
-          @offerings << mock(:offering, :id => i, :runnable_type => 'fake', :runnable => i, :runnable_id => i)
+          @offerings << double(:offering, :id => i, :runnable_type => 'fake', :runnable => i, :runnable_id => i)
         end
         @default_offerings_with_unique_runnable = @offerings[5..8]
         @default_offerings = @offerings[3..8]
 
-        @clazzes = [mock(:clazz, :active_offerings => @student_offerings, :default_class => false),@clazz]
-        @student = mock(:student, :clazzes => @clazzes)
-        @user = mock(:user, :portal_student => @student)
-        @clazz.stub!(:default_class => true)
-        @clazz.stub!(:active_offerings => @default_offerings)
+        @clazzes = [double(:clazz, :active_offerings => @student_offerings, :default_class => false),@clazz]
+        @student = double(:student, :clazzes => @clazzes)
+        @user = double(:user, :portal_student => @student)
+        @clazz.stub(:default_class => true)
+        @clazz.stub(:active_offerings => @default_offerings)
       end
       it "should not fall back to offerings_including_default_class" do
-        @clazz.should_not_receive(:offerings_including_default_class)
-        @clazz.offerings_with_default_classes(@user).should_not be_nil
+        expect(@clazz).not_to receive(:offerings_including_default_class)
+        expect(@clazz.offerings_with_default_classes(@user)).not_to be_nil
       end
       it "should not contain the offerings which use the same runnable as a student offering" do
         default_class_offerings = @clazz.offerings_with_default_classes(@user)
         @default_offerings_with_same_runnable_as_a_student_offering.each do |o|
-          default_class_offerings.should_not include(o)
+          expect(default_class_offerings).not_to include(o)
         end
       end
       it "should contain exactly the offerings which do not use the same runnable as a student offering" do
         default_class_offerings = @clazz.offerings_with_default_classes(@user)
-        default_class_offerings.should have(@default_offerings_with_unique_runnable.length).offerings
+        expect(default_class_offerings.size).to eq(@default_offerings_with_unique_runnable.length)
         @default_offerings_with_unique_runnable.each do |o|
-          default_class_offerings.should include(o)
+          expect(default_class_offerings).to include(o)
         end
       end
     end
@@ -315,31 +315,63 @@ describe Portal::Clazz do
 
     context "with no teachers" do
       subject do
-        @clazz.stub! :teachers => []
+        @clazz.stub :teachers => []
         @clazz
       end
-      its(:teachers_label) {should == "Teacher"      }
-      its(:teachers_listing){should == "no teachers" }
+
+      describe '#teachers_label' do
+        subject { super().teachers_label }
+        it {is_expected.to eq("Teacher")      }
+      end
+
+      describe '#teachers_listing' do
+        subject { super().teachers_listing }
+        it {is_expected.to eq("no teachers") }
+      end
     end
 
     context "With one teacher" do
       subject do
-        @clazz.stub! :teachers => [@joan]
+        @clazz.stub :teachers => [@joan]
         @clazz
       end
-      its(:teachers_label)  {should == "Teacher"         }
-      its(:teachers_listing){should match @joan.name      }
-      its(:teachers_listing){should_not match @bob.name }
+
+      describe '#teachers_label' do
+        subject { super().teachers_label }
+        it {is_expected.to eq("Teacher")         }
+      end
+
+      describe '#teachers_listing' do
+        subject { super().teachers_listing }
+        it {is_expected.to match @joan.name      }
+      end
+
+      describe '#teachers_listing' do
+        subject { super().teachers_listing }
+        it {is_expected.not_to match @bob.name }
+      end
     end
 
     context "With two teachers" do
       subject do
-        @clazz.stub! :teachers => [@bob,@joan]
+        @clazz.stub :teachers => [@bob,@joan]
         @clazz
       end
-      its(:teachers_label)  {should == "Teachers"    }
-      its(:teachers_listing){should match @bob.name  }
-      its(:teachers_listing){should match @joan.name }
+
+      describe '#teachers_label' do
+        subject { super().teachers_label }
+        it {is_expected.to eq("Teachers")    }
+      end
+
+      describe '#teachers_listing' do
+        subject { super().teachers_listing }
+        it {is_expected.to match @bob.name  }
+      end
+
+      describe '#teachers_listing' do
+        subject { super().teachers_listing }
+        it {is_expected.to match @joan.name }
+      end
     end
   end
 

--- a/spec/models/portal/courses_spec.rb
+++ b/spec/models/portal/courses_spec.rb
@@ -26,104 +26,104 @@ describe Portal::Course do
     [@course_with_number,@course_without_number].each do |course|
       inspect_course(course)
     end
-    @course_without_number.course_number.should be_nil
-    @course_with_number.course_number.should_not be_nil
+    expect(@course_without_number.course_number).to be_nil
+    expect(@course_with_number.course_number).not_to be_nil
   end
   
   describe "We should be able to find a course by course number and school id" do
     it "We should find a course for a valid course number and school id" do
       found = Portal::Course.find_by_course_number_and_school_id(@course_number,@school.id)
-      found.should_not be_nil
+      expect(found).not_to be_nil
     end
 
     it "We should not find a course for non-existant course numbers" do
       found = Portal::Course.find_by_course_number_and_school_id("PING_PONG",@school.id)
-      found.should be_nil
+      expect(found).to be_nil
       
       found = Portal::Course.find_by_course_number_and_school_id(@course_number,23)
-      found.should be_nil
+      expect(found).to be_nil
     end
   end
 
   describe "We should be able to find a course using a course number, name and school id" do
     it "We should be able to find a course with the same number,name and school_id" do
       found = Portal::Course.find_by_course_number_name_and_school_id(@course_number,"with number",@school.id)
-      found.should_not be_nil
-      found.id.should be(@course_with_number.id)
+      expect(found).not_to be_nil
+      expect(found.id).to be(@course_with_number.id)
     end
     it "We should be able to find a course with the same number,a new (differing) name and school_id" do
       found = Portal::Course.find_by_course_number_name_and_school_id(@course_number,"new name for the course",@school.id)
-      found.should_not be_nil
-      found.id.should be(@course_with_number.id)
+      expect(found).not_to be_nil
+      expect(found.id).to be(@course_with_number.id)
     end
     
     it "We should be able to find a course with no course number, but with the same name and school_id" do
       found = Portal::Course.find_by_course_number_name_and_school_id("NEW_COURSE_NUMBER","without number",@school.id)
-      found.should_not be_nil
-      found.id.should be(@course_without_number.id)
-      found.course_number.should be_nil
+      expect(found).not_to be_nil
+      expect(found.id).to be(@course_without_number.id)
+      expect(found.course_number).to be_nil
     end
     
     it "We should not find a course with found name, and schoold_id but differing course_number" do
       found = Portal::Course.find_by_course_number_name_and_school_id("BAD_COURSE_NUMBER","with number",@school.id)
-      found.should be_nil
+      expect(found).to be_nil
     end
   end
 
   describe "We should be able to find or create course using a course number, name and school id" do
     it "We should be able to find a course with the same number,name and school_id" do
       found = Portal::Course.find_or_create_by_course_number_name_and_school_id(@course_number,"with number",@school.id)
-      found.should_not be_nil
-      found.id.should be(@course_with_number.id)
+      expect(found).not_to be_nil
+      expect(found.id).to be(@course_with_number.id)
     end
     it "We should be able to find a course with the same number,and give it a new name" do
       new_name = "new name for the course"
       found = Portal::Course.find_or_create_by_course_number_name_and_school_id(@course_number,new_name,@school.id)
-      found.should_not be_nil
-      found.id.should be(@course_with_number.id)
-      found.name.should be(new_name)
+      expect(found).not_to be_nil
+      expect(found.id).to be(@course_with_number.id)
+      expect(found.name).to be(new_name)
     end
     
     it "We should be able to find a course with no previous course number, but with the same name, and assign the new number" do
       new_course_number="NEW_COURSE_NUMBER"
       found = Portal::Course.find_or_create_by_course_number_name_and_school_id(new_course_number,"without number",@school.id)
-      found.should_not be_nil
-      found.id.should be(@course_without_number.id)
-      found.course_number.should be(new_course_number)
+      expect(found).not_to be_nil
+      expect(found.id).to be(@course_without_number.id)
+      expect(found.course_number).to be(new_course_number)
     end
     
     it "We should create a new course with a new name and number schoold_id but differing course_number" do
       new_course_number="NEW_C_NMBR"
       new_course_name = "new course name"
       found = Portal::Course.find_or_create_by_course_number_name_and_school_id(new_course_number,new_course_name,@school.id)
-      found.should_not be_nil
-      found.id.should_not be(@course_without_number.id)
-      found.id.should_not be(@course_with_number.id)
-      found.name.should be(new_course_name)
-      found.course_number.should be(new_course_number)
+      expect(found).not_to be_nil
+      expect(found.id).not_to be(@course_without_number.id)
+      expect(found.id).not_to be(@course_with_number.id)
+      expect(found.name).to be(new_course_name)
+      expect(found.course_number).to be(new_course_number)
     end
     
     it "We should create a new course with a new name and number, even if the name matches an existing name" do
       new_course_number="NEW_C_NMBR"
       existing_name = "with number"
       found = Portal::Course.find_or_create_by_course_number_name_and_school_id(new_course_number,existing_name,@school.id)
-      found.should_not be_nil
-      found.id.should_not be(@course_without_number.id)
-      found.id.should_not be(@course_with_number.id)
-      found.name.should be(existing_name)
-      found.course_number.should be(new_course_number)
+      expect(found).not_to be_nil
+      expect(found.id).not_to be(@course_without_number.id)
+      expect(found.id).not_to be(@course_with_number.id)
+      expect(found.name).to be(existing_name)
+      expect(found.course_number).to be(new_course_number)
     end
     
     it "We should create a new course witht the SAME name and SAME number, but with a differing school.id" do
       new_course_number="NEW_C_NMBR"
       existing_name = "with number"
       found = Portal::Course.find_or_create_by_course_number_name_and_school_id(@course_with_number.course_number, @course_with_number.name, 777)
-      found.should_not be_nil
-      found.id.should_not equal(@course_without_number.id)
-      found.id.should_not equal(@course_with_number.id)
-      found.name.should equal(@course_with_number.name)
-      found.course_number.should equal(@course_with_number.course_number)
-      found.school_id.should equal(777)
+      expect(found).not_to be_nil
+      expect(found.id).not_to equal(@course_without_number.id)
+      expect(found.id).not_to equal(@course_with_number.id)
+      expect(found.name).to equal(@course_with_number.name)
+      expect(found.course_number).to equal(@course_with_number.course_number)
+      expect(found.school_id).to equal(777)
     end
     
     

--- a/spec/models/portal/district_spec.rb
+++ b/spec/models/portal/district_spec.rb
@@ -13,14 +13,14 @@ describe Portal::District do
   end
   
   it "should support virtual districts with no NCSES data" do
-    Portal::District.create!(@valid_attributes).should be_virtual
+    expect(Portal::District.create!(@valid_attributes)).to be_virtual
   end
     
   it "can create districts from NCES district data " do
     nces_district = Factory(:portal_nces06_district)
     new_district = Portal::District.find_or_create_by_nces_district(nces_district)
-    new_district.should_not be_nil
-    new_district.should be_real # meaning has a real nces school
+    expect(new_district).not_to be_nil
+    expect(new_district).to be_real # meaning has a real nces school
   end
   
   
@@ -39,26 +39,26 @@ describe Portal::District do
     describe "Given an NCES local district id that matches the STID field in an NCES district" do
       it "finds and returns the first district that is associated with the NCES district if one exists" do
         found = Portal::District.find_by_state_and_nces_local_id('RI', 39)
-        found.should_not be_nil
-        found.should eql(@district)
+        expect(found).not_to be_nil
+        expect(found).to eql(@district)
       end
       
       it "returns nil if there is no match" do
         found = Portal::District.find_by_state_and_nces_local_id('MA', 39)
-        found.should be_nil
+        expect(found).to be_nil
       end
     end
   
     describe "Given a district name that matches the NAME field in an NCES district" do
       it "finds and return the first district that is associated with the NCES district or nil." do
         found = Portal::District.find_by_state_and_district_name('RI', "Woonsocket")
-        found.should_not be_nil
-        found.should eql(@district)
+        expect(found).not_to be_nil
+        expect(found).to eql(@district)
       end
 
       it "If the district is a 'real' district return the NCES local district id" do
         found = Portal::District.find_by_state_and_district_name('MA', "Woonsocket")
-        found.should be_nil
+        expect(found).to be_nil
       end
     end
   end

--- a/spec/models/portal/learner_activity_feedback_spec.rb
+++ b/spec/models/portal/learner_activity_feedback_spec.rb
@@ -18,13 +18,13 @@ describe Portal::LearnerActivityFeedback do
 
   describe "learner_feedback" do
     it "should have an activity_feedback" do
-      learner_feedback.activity_feedback.should == activity_feedback
+      expect(learner_feedback.activity_feedback).to eq(activity_feedback)
     end
   end
 
   describe "the activity feedback" do
     it "should know about this learner feedback" do
-      activity_feedback.learner_activity_feedbacks.should include(learner_feedback)
+      expect(activity_feedback.learner_activity_feedbacks).to include(learner_feedback)
     end
   end
 
@@ -32,7 +32,7 @@ describe Portal::LearnerActivityFeedback do
     it "should return an array including our learner feedback" do
       ours = learner_feedback
       found = Portal::LearnerActivityFeedback.for_learner_and_activity_feedback(learner,activity_feedback)
-      found.should include(ours)
+      expect(found).to include(ours)
     end
   end
 

--- a/spec/models/portal/learner_spec.rb
+++ b/spec/models/portal/learner_spec.rb
@@ -9,7 +9,7 @@ describe Portal::Learner do
     :update_fields => true,
     # this is needed because of the inverse_of definition in the report_learner associtation
     # I think newer version of mock_model take care of this for you
-    :association => mock(:target= => nil) )
+    :association => double(:target= => nil) )
   }
   let(:attributes)  do
     {
@@ -22,7 +22,7 @@ describe Portal::Learner do
 
   describe "a bare instance" do
     it "should be valid" do
-      subject.should be_valid
+      expect(subject).to be_valid
     end
   end
 
@@ -30,14 +30,14 @@ describe Portal::Learner do
     it "should return lightweight blobs when they already exist" do
       blob = Dataservice::Blob.create(:learner_id => subject.id)
       subject.reload
-      subject.lightweight_blobs.should include(blob)
+      expect(subject.lightweight_blobs).to include(blob)
     end
     it "should return an empty set when no blobs exist" do
-      subject.lightweight_blobs.should be_empty
+      expect(subject.lightweight_blobs).to be_empty
     end
     it "should allow for creating a new blob" do
       subject.lightweight_blobs.create
-      subject.lightweight_blobs.should_not be_empty
+      expect(subject.lightweight_blobs).not_to be_empty
     end
   end
 end

--- a/spec/models/portal/offering_activity_feedback_spec.rb
+++ b/spec/models/portal/offering_activity_feedback_spec.rb
@@ -13,17 +13,17 @@ describe Portal::OfferingActivityFeedback do
     let(:activity_feedback){ Portal::OfferingActivityFeedback.create(feedback_params) }
 
     it "should have an activity" do
-     activity_feedback.activity.should == activity
+     expect(activity_feedback.activity).to eq(activity)
     end
 
     it "should have an offering" do
-      activity_feedback.portal_offering.should == offering
+      expect(activity_feedback.portal_offering).to eq(offering)
     end
 
     it "the defaults" do
-      activity_feedback.enable_text_feedback.should == false
-      activity_feedback.max_score.should == 10
-      activity_feedback.score_type.should == Portal::OfferingActivityFeedback::SCORE_NONE
+      expect(activity_feedback.enable_text_feedback).to eq(false)
+      expect(activity_feedback.max_score).to eq(10)
+      expect(activity_feedback.score_type).to eq(Portal::OfferingActivityFeedback::SCORE_NONE)
     end
 
     describe "#set_feedback_options" do
@@ -38,13 +38,13 @@ describe Portal::OfferingActivityFeedback do
         activity_feedback.set_feedback_options(options)
       end
       it "should have a max score of 12" do
-        activity_feedback.max_score.should == 12
+        expect(activity_feedback.max_score).to eq(12)
       end
       it "should be using manual scoring" do
-        activity_feedback.score_type.should == Portal::OfferingActivityFeedback::SCORE_MANUAL
+        expect(activity_feedback.score_type).to eq(Portal::OfferingActivityFeedback::SCORE_MANUAL)
       end
       it "should be using text feedback" do
-        activity_feedback.enable_text_feedback.should == true
+        expect(activity_feedback.enable_text_feedback).to eq(true)
       end
 
       describe "turning off text feedback" do
@@ -52,8 +52,16 @@ describe Portal::OfferingActivityFeedback do
           activity_feedback.set_feedback_options({enable_text_feedback: false})
         end
         subject { activity_feedback.reload }
-        its(:enable_text_feedback) { should be false }
-        its(:max_score) {should be 12 }
+
+        describe '#enable_text_feedback' do
+          subject { super().enable_text_feedback }
+          it { is_expected.to be false }
+        end
+
+        describe '#max_score' do
+          subject { super().max_score }
+          it {is_expected.to be 12 }
+        end
       end
     end
   end

--- a/spec/models/portal/offering_spec.rb
+++ b/spec/models/portal/offering_spec.rb
@@ -8,35 +8,35 @@ describe Portal::Offering do
     let(:offering) { Factory.create(:portal_offering, args) }
 
     it "should be active by default" do
-     offering.active.should be_true
-     offering.active?.should be_true
+     expect(offering.active).to be_truthy
+     expect(offering.active?).to be_truthy
     end
     
     it "can be deactivated" do
-     offering.active?.should be_true
+     expect(offering.active?).to be_truthy
      offering.deactivate!
       
-     offering.active.should be_false
-     offering.active?.should be_false
+     expect(offering.active).to be_falsey
+     expect(offering.active?).to be_falsey
     end
     
     it "can be activated" do
      offering.deactivate!
-     offering.active?.should be_false
+     expect(offering.active?).to be_falsey
       
      offering.activate!
-     offering.active?.should be_true
+     expect(offering.active?).to be_truthy
     end
 
     describe "should_be_shown" do
       describe "when the runable is archived" do
-        before(:each) { runnable.stub(:archived?).and_return(true) }
+        before(:each) { allow(runnable).to receive(:archived?).and_return(true) }
         it "should always be deactivated" do
-          offering.should_show?.should be_false
+          expect(offering.should_show?).to be_falsey
         end
         it "should still be deactivated after activating" do
           offering.activate!
-          offering.should_show?.should be_false
+          expect(offering.should_show?).to be_falsey
         end
       end
     end
@@ -44,26 +44,26 @@ describe Portal::Offering do
     describe "delegates whether the student report" do
       it "is enabled" do
         runnable.student_report_enabled = true
-        offering.student_report_enabled?.should be_true
+        expect(offering.student_report_enabled?).to be_truthy
       end
 
       it "is disabled" do
         runnable.student_report_enabled = false
-        offering.student_report_enabled?.should be_false
+        expect(offering.student_report_enabled?).to be_falsey
       end
     end
 
     describe "an offering with learners" do
       let(:learner) { Factory.build(:portal_learner) }
       let(:args)    { {runnable: runnable, learners: [learner]} }
-      before(:each) { learner.stub(:valid?).and_return(true) }
+      before(:each) { allow(learner).to receive(:valid?).and_return(true) }
 
       # this is probably not a good approach, it makes it heard for cleaning up learner data
       # and assignments when we really want to. It blocks all of the dependent destroy definitions
       # from being used
       it "can not be destroyed" do
-       offering.destroy.should be false
-        lambda {offering.destroy!}.should raise_exception()
+       expect(offering.destroy).to be false
+        expect {offering.destroy!}.to raise_exception()
       end
 
     end

--- a/spec/models/portal/school_selector_spec.rb
+++ b/spec/models/portal/school_selector_spec.rb
@@ -9,15 +9,15 @@ describe Portal::SchoolSelector do
   before(:each) do
     @adhoc = mock_model(Admin::Settings,    {:allow_adhoc_schools => true })
     @no_adhoc = mock_model(Admin::Settings, {:allow_adhoc_schools => false })
-    Admin::Settings.stub!(:default_settings).and_return(@adhoc)
+    allow(Admin::Settings).to receive(:default_settings).and_return(@adhoc)
     @district1 = Factory(:portal_district, {:state => "MA", :name => "no district"} )
   end
   describe "when presented for the first time (no query params)" do
     it "needs a state" do
-      new_selector({}).needs.should == :state
+      expect(new_selector({}).needs).to eq(:state)
     end
     it "provides state options" do
-      new_selector({}).choices[:state].should include "MA"
+      expect(new_selector({}).choices[:state]).to include "MA"
     end
   end
 
@@ -26,12 +26,12 @@ describe Portal::SchoolSelector do
       @selector = new_selector({:country => 'England'})
     end
     it "does not require state or district information" do
-      @selector.needs.should_not == :country
-      @selector.needs.should_not == :state
-      @selector.needs.should_not == :district
+      expect(@selector.needs).not_to eq(:country)
+      expect(@selector.needs).not_to eq(:state)
+      expect(@selector.needs).not_to eq(:district)
     end
     it "provides a list of schools in England" do
-      pending # how do we do this?
+      skip # how do we do this?
     end
   end
 
@@ -45,18 +45,18 @@ describe Portal::SchoolSelector do
       @school3   = Factory(:portal_school, {:district => @district2})
 
       @default_district = Factory(:portal_district,  {:state => nil} )
-      Portal::District.stub!(:default).and_return(@default_district)
+      allow(Portal::District).to receive(:default).and_return(@default_district)
       @selector = new_selector({:country => Portal::SchoolSelector::USA})
     end
     it "no longer requires a country" do
-      @selector.needs.should_not == :country
+      expect(@selector.needs).not_to eq(:country)
     end
     it "requires a state" do
-      @selector.needs.should == :state
+      expect(@selector.needs).to eq(:state)
     end
     it "presents a list of available states" do
-      @selector.choices[:state].should include "MA"
-      @selector.choices[:state].should include "NY"
+      expect(@selector.choices[:state]).to include "MA"
+      expect(@selector.choices[:state]).to include "NY"
     end
 
     describe "when the user has selected Massachussetts as the state" do
@@ -65,13 +65,13 @@ describe Portal::SchoolSelector do
       end
 
       it "still requires a district" do
-        @selector.needs.should == :district
+        expect(@selector.needs).to eq(:district)
       end
 
       it "presents choices for the districts in Massachussetts" do
-        @selector.choices[:district].map { |d| d[1] }.should     include @district1.id
-        @selector.choices[:district].map { |d| d[1] }.should     include @district2.id
-        @selector.choices[:district].map { |d| d[1] }.should_not include @district3.id
+        expect(@selector.choices[:district].map { |d| d[1] }).to     include @district1.id
+        expect(@selector.choices[:district].map { |d| d[1] }).to     include @district2.id
+        expect(@selector.choices[:district].map { |d| d[1] }).not_to include @district3.id
       end
 
       describe "when the user has picked the first district in Massachussetts" do
@@ -80,17 +80,17 @@ describe Portal::SchoolSelector do
         end
 
         it "no longer requires a district" do
-          @selector.needs.should_not == :district
+          expect(@selector.needs).not_to eq(:district)
         end
 
         it "should still reqruire a school" do
-          @selector.needs.should == :school
+          expect(@selector.needs).to eq(:school)
         end
 
         it "presents a list of schools in Massachussetts in district1" do
-          @selector.choices[:school].map { |s| s[1]}.should     include @school1.id
-          @selector.choices[:school].map { |s| s[1]}.should     include @school2.id
-          @selector.choices[:school].map { |s| s[1]}.should_not include @school3.id
+          expect(@selector.choices[:school].map { |s| s[1]}).to     include @school1.id
+          expect(@selector.choices[:school].map { |s| s[1]}).to     include @school2.id
+          expect(@selector.choices[:school].map { |s| s[1]}).not_to include @school3.id
         end
       end
 
@@ -103,14 +103,14 @@ describe Portal::SchoolSelector do
           })
         end
         it "should indicate the selection is not complete" do
-          @selector.should_not be_valid
+          expect(@selector).not_to be_valid
         end
       end
 
       describe "checking if teachers can add districts and schools" do
         describe "when the portal allows adhoc schools" do
           before(:each) do
-            Admin::Settings.stub!(:default_settings).and_return(@adhoc)
+            allow(Admin::Settings).to receive(:default_settings).and_return(@adhoc)
             @selector = new_selector({
             :country => Portal::SchoolSelector::USA,
             :state => 'MA',
@@ -118,15 +118,15 @@ describe Portal::SchoolSelector do
           })
           end
           it "should let teachers add new schools" do
-            @selector.allow_teacher_creation.should be_true
+            expect(@selector.allow_teacher_creation).to be_truthy
           end
         end
         describe "when the portal doesnt adhoc schools" do
           before(:each) do
-            Admin::Settings.stub!(:default_settings).and_return(@no_adhoc)
+            allow(Admin::Settings).to receive(:default_settings).and_return(@no_adhoc)
           end
           it "shouldn't let teachers add new district" do
-            @selector.allow_teacher_creation(:district).should be_false
+            expect(@selector.allow_teacher_creation(:district)).to be_falsey
           end
         end
       end
@@ -155,31 +155,31 @@ describe Portal::SchoolSelector do
 
           describe "when the settings lets teacher create new schools" do
             before(:each) do
-              Admin::Settings.stub!(:default_settings).and_return(@adhoc)
+              allow(Admin::Settings).to receive(:default_settings).and_return(@adhoc)
               @selector = new_selector(@params)
             end
             it "should have a district" do
-              @selector.district.should_not be_nil
+              expect(@selector.district).not_to be_nil
             end
             it "should have a school (id) set" do
-              @selector.school.should_not be_nil
-              @selector.school.should be_a_kind_of Portal::School
+              expect(@selector.school).not_to be_nil
+              expect(@selector.school).to be_a_kind_of Portal::School
             end
             it "should be comeplete" do
-              @selector.should be_valid
+              expect(@selector).to be_valid
             end
           end
 
           describe "when the settings prevents teachers from creating new schools" do
             before(:each) do
-              Admin::Settings.stub!(:default_settings).and_return(@no_adhoc)
+              allow(Admin::Settings).to receive(:default_settings).and_return(@no_adhoc)
               @selector = new_selector(@params)
             end
             it "should remove the invalid school" do
-              @selector.school.should be_nil
+              expect(@selector.school).to be_nil
             end
             it "should not be comeplete" do
-              @selector.should_not be_valid
+              expect(@selector).not_to be_valid
             end
           end
 
@@ -207,13 +207,13 @@ describe Portal::SchoolSelector do
         @selector = new_selector(@params)
       end
       it "sould invalidate the district" do
-        @selector.state.should == 'MA'
+        expect(@selector.state).to eq('MA')
       end
       it "should invalidate the district" do
-        @selector.district.should be_nil
+        expect(@selector.district).to be_nil
       end
       it "should invlidate the school" do
-        @selector.school.should be_nil
+        expect(@selector.school).to be_nil
       end
     end
     describe "changing the district" do
@@ -229,14 +229,14 @@ describe Portal::SchoolSelector do
         @selector = new_selector(@params)
       end
       it "the state should still be valid" do
-        @selector.state.should == "ME"
+        expect(@selector.state).to eq("ME")
       end
 
       it "the district should be changed" do
-        @selector.district.should == @changed_district
+        expect(@selector.district).to eq(@changed_district)
       end
       it "should invlidate the school" do
-        @selector.school.should be_nil
+        expect(@selector.school).to be_nil
       end
     end
   end

--- a/spec/models/portal/school_spec.rb
+++ b/spec/models/portal/school_spec.rb
@@ -28,42 +28,42 @@ describe Portal::School do
   it "can create schools from NCES school data " do
     nces_school = Factory(:portal_nces06_school)
     new_school = Portal::School.find_or_create_by_nces_school(nces_school)
-    new_school.should_not be_nil
-    new_school.should be_real # meaning has a real nces school
+    expect(new_school).not_to be_nil
+    expect(new_school).to be_real # meaning has a real nces school
   end
   
   it "should not allow a teacher to be added more than once" do
     school = Factory(:portal_school)
-    school.members.should be_empty
+    expect(school.members).to be_empty
     teacher = Factory(:portal_teacher)
     school.add_member(teacher)
     school.reload
-    school.members.size.should eql(1)
+    expect(school.members.size).to eql(1)
     school.add_member(teacher)
     
-    school.members.size.should eql(1)
+    expect(school.members.size).to eql(1)
     school.reload
-    school.members.size.should eql(1)
+    expect(school.members.size).to eql(1)
   end
 
   describe "#portal_teachers" do
     it "should be writable" do
       school = Factory(:portal_school)
-      school.members.should be_empty
+      expect(school.members).to be_empty
       teacher = Factory.create(:portal_teacher, :user => Factory.create(:user, :login => "authorized_teacher"))
 
       school.portal_teachers << teacher
 
-      school.members.size.should == 1
-      school.portal_teachers.size.should == 1
+      expect(school.members.size).to eq(1)
+      expect(school.portal_teachers.size).to eq(1)
       school.reload
-      school.members.size.should == 1
-      school.portal_teachers.size.should == 1
+      expect(school.members.size).to eq(1)
+      expect(school.portal_teachers.size).to eq(1)
     end
 
     it "should only return teachers" do
       school = Factory(:portal_school)
-      school.members.should be_empty
+      expect(school.members).to be_empty
       teacher = Factory.create(:portal_teacher, :user => Factory.create(:user, :login => "authorized_teacher"), :schools => [school])
 
       # we actually don't add students to schools anymore but in case we start doing it again
@@ -71,8 +71,8 @@ describe Portal::School do
       Portal::SchoolMembership.create(:school => school, :member => student)
 
       school.reload
-      school.members.size.should == 2
-      school.portal_teachers.size.should == 1
+      expect(school.members.size).to eq(2)
+      expect(school.portal_teachers.size).to eq(1)
     end
   end
   
@@ -91,23 +91,23 @@ describe Portal::School do
     describe "Given an NCES local school id that matches the SEASCH field in an NCES school" do
       it "finds and return the first school that is associated with the NCES school if one exists" do
         found = Portal::School.find_by_state_and_nces_local_id('RI', 39123)
-        found.should_not be_nil
-        found.should eql(@school)
+        expect(found).not_to be_nil
+        expect(found).to eql(@school)
       end
       it "returns nil if there is no matching school" do
         found = Portal::School.find_by_state_and_nces_local_id('MA', 39123)
-        found.should be_nil
+        expect(found).to be_nil
       end
     end
     describe "Given a school name that matches the SEASCH field in an NCES school " do
       it "finds and returns the first school that is associated with the NCES school name." do
         found = Portal::School.find_by_state_and_school_name('RI', "Woonsocket High School")
-        found.should_not be_nil
-        found.should eql(@school)
+        expect(found).not_to be_nil
+        expect(found).to eql(@school)
       end
       it "if there is no matching school, it should return nil" do
         found = Portal::School.find_by_state_and_school_name('RI', "Amherst Regional High School")
-        found.should be_nil
+        expect(found).to be_nil
       end
     end
   end

--- a/spec/models/portal/state_or_province_spec.rb
+++ b/spec/models/portal/state_or_province_spec.rb
@@ -11,17 +11,17 @@ describe Portal::StateOrProvince do
 
   it "should return all states if :all is configured" do
     APP_CONFIG[:states_and_provinces] = 'all'
-    Portal::StateOrProvince.configured.length.should == Portal::StateOrProvince::STATES_AND_PROVINCES.length
+    expect(Portal::StateOrProvince.configured.length).to eq(Portal::StateOrProvince::STATES_AND_PROVINCES.length)
   end
 
   it "should return no states if nil is configured" do
     APP_CONFIG[:states_and_provinces] = nil
-    Portal::StateOrProvince.configured.should be_empty
+    expect(Portal::StateOrProvince.configured).to be_empty
   end
 
   it "should return the specific states if they are configured" do
     APP_CONFIG[:states_and_provinces] = ['MA', 'RI']
-    Portal::StateOrProvince.configured.should == ['MA', 'RI']
+    expect(Portal::StateOrProvince.configured).to eq(['MA', 'RI'])
   end
 
 end

--- a/spec/models/portal/student_spec.rb
+++ b/spec/models/portal/student_spec.rb
@@ -8,28 +8,28 @@ describe Portal::Student do
   describe "when a clazz is added to a students list of clazzes" do
     it "the students clazz list increases by one if the student is not already enrolled in that class" do
       clazz = Factory(:portal_clazz)
-      @student.clazzes.should be_empty
+      expect(@student.clazzes).to be_empty
       @student.add_clazz(clazz)
       @student.reload
-      @student.clazzes.should_not be_empty
-      @student.clazzes.should include(clazz)
-      @student.should have(1).clazzes
+      expect(@student.clazzes).not_to be_empty
+      expect(@student.clazzes).to include(clazz)
+      expect(@student.clazzes.size).to eq(1)
     end
     
     it "the students clazz list should stay the same if the same clazz is added multiple times" do
       clazz = Factory(:portal_clazz)
-      @student.clazzes.should be_empty
+      expect(@student.clazzes).to be_empty
       @student.add_clazz(clazz)
       @student.add_clazz(clazz)
       @student.reload
-      @student.clazzes.should_not be_empty
-      @student.clazzes.should include(clazz)
-      @student.should have(1).clazzes
+      expect(@student.clazzes).not_to be_empty
+      expect(@student.clazzes).to include(clazz)
+      expect(@student.clazzes.size).to eq(1)
     end
   end
   
   it "should generate a user name by first initial and last name" do
-    Portal::Student.generate_user_login("test", "user").should == "tuser"
+    expect(Portal::Student.generate_user_login("test", "user")).to eq("tuser")
     
     first_name = "Nametest"
     last_name  = "Testuser"
@@ -41,8 +41,8 @@ describe Portal::Student do
       :password_confirmation => "password",
       :email => "test@test.com"
     })
-    @student.user.login.should == "ntestuser"
-    Portal::Student.generate_user_login(@student.first_name, @student.last_name).should == @student.user.login + "1"
+    expect(@student.user.login).to eq("ntestuser")
+    expect(Portal::Student.generate_user_login(@student.first_name, @student.last_name)).to eq(@student.user.login + "1")
   end
 
 end

--- a/spec/models/portal/teacher_clazz_spec.rb
+++ b/spec/models/portal/teacher_clazz_spec.rb
@@ -11,7 +11,7 @@ describe Portal::TeacherClazz do
       clazz = Factory :portal_clazz
       teacher.add_clazz(clazz)
       teacher.reload
-      teacher.clazzes.should include(clazz)
+      expect(teacher.clazzes).to include(clazz)
     end
     it "there should be no double enrollment if a teacher adds a class twice" do
       teacher = Factory :portal_teacher, {:clazzes => []}
@@ -20,8 +20,8 @@ describe Portal::TeacherClazz do
       teacher.add_clazz(clazz)
       teacher.add_clazz(clazz)
       teacher.reload
-      teacher.clazzes.should include(clazz)
-      teacher.clazzes.should have(1).things
+      expect(teacher.clazzes).to include(clazz)
+      expect(teacher.clazzes.size).to eq(1)
     end
     
     it "clazzes should be alble to have more than one teacher" do
@@ -33,10 +33,10 @@ describe Portal::TeacherClazz do
       teacher.reload
       second_teacher.reload
       clazz.reload
-      teacher.clazzes.should include(clazz)
-      second_teacher.clazzes.should include(clazz)
-      clazz.teachers.should include(teacher)
-      clazz.teachers.should include(second_teacher)
+      expect(teacher.clazzes).to include(clazz)
+      expect(second_teacher.clazzes).to include(clazz)
+      expect(clazz.teachers).to include(teacher)
+      expect(clazz.teachers).to include(second_teacher)
     end
     
     it "clazzes which have multiple teachers are owned by both teachers" do
@@ -48,20 +48,20 @@ describe Portal::TeacherClazz do
       teacher.reload
       second_teacher.reload
       clazz.reload
-      clazz.should be_virtual
-      clazz.should be_changeable(teacher.user)
-      clazz.should be_changeable(second_teacher.user)
-      clazz.should be_changeable(teacher)
-      clazz.should be_changeable(second_teacher)
+      expect(clazz).to be_virtual
+      expect(clazz).to be_changeable(teacher.user)
+      expect(clazz).to be_changeable(second_teacher.user)
+      expect(clazz).to be_changeable(teacher)
+      expect(clazz).to be_changeable(second_teacher)
     end
     
     it "should remove this teacher from the specified class" do
       clazz = Factory :portal_clazz
       teacher = Factory :portal_teacher, {:clazzes => [clazz]}
-      teacher.clazzes.should include(clazz)
+      expect(teacher.clazzes).to include(clazz)
       teacher.remove_clazz(clazz)
       teacher.reload
-      teacher.clazzes.should_not include(clazz)
+      expect(teacher.clazzes).not_to include(clazz)
     end
   end
   
@@ -71,7 +71,7 @@ describe Portal::TeacherClazz do
       clazz = Factory :portal_clazz
       clazz.teacher = teacher
       teacher.reload
-      teacher.clazzes.should include(clazz)
+      expect(teacher.clazzes).to include(clazz)
     end
     
     it "clazz.teacher=@teacher assignment shouldn't make a duplicate teacher entry" do
@@ -81,13 +81,13 @@ describe Portal::TeacherClazz do
       clazz.teacher = teacher
       clazz.teacher = teacher
       teacher.reload
-      teacher.clazzes.should include(clazz)
-      teacher.clazzes.should have(1).things
+      expect(teacher.clazzes).to include(clazz)
+      expect(teacher.clazzes.size).to eq(1)
     end
     
     it "clazz.teacher should return nil if there isn't a teacher" do
       clazz = Factory :portal_clazz
-      clazz.teacher.should be_nil
+      expect(clazz.teacher).to be_nil
     end
     
   end

--- a/spec/models/portal/teacher_spec.rb
+++ b/spec/models/portal/teacher_spec.rb
@@ -8,44 +8,44 @@ describe Portal::Teacher do
   end
   
   it "should support nces teachers" do
-    @nces_teacher.should_not be_nil
+    expect(@nces_teacher).not_to be_nil
   end
   
   it "nces teachers should have at least one class" do
-    @nces_teacher.clazzes.should_not be_nil
+    expect(@nces_teacher.clazzes).not_to be_nil
     @nces_teacher.clazzes.size > 0
   end
   
   it "nces teachers class should be 'real'" do 
-    @nces_teacher.clazzes[0].should be_real
+    expect(@nces_teacher.clazzes[0]).to be_real
   end
   
   it "virtual teachers should have virtual classes" do
-    @virtual_teacher.clazzes[0].should be_virtual
+    expect(@virtual_teacher.clazzes[0]).to be_virtual
   end
   
   # new policy: Teachers CAN change their real clazzes
   # TODO: If we want to lock classes we need to implement a different mechanism
   it "teachers with real clazzes should be able to change them" do
-    @nces_teacher.clazzes[0].should be_changeable(@nces_teacher)
+    expect(@nces_teacher.clazzes[0]).to be_changeable(@nces_teacher)
   end
   
   it "should support virtual teachers" do
-    @virtual_teacher.should_not be_nil
+    expect(@virtual_teacher).not_to be_nil
   end
   
   it "virtual teachers can have classes" do
-    @virtual_teacher.clazzes.should_not be_nil
-    @virtual_teacher.clazzes.size.should_not be(0)
+    expect(@virtual_teacher.clazzes).not_to be_nil
+    expect(@virtual_teacher.clazzes.size).not_to be(0)
   end
   
   it "virtual teachers class should not be real" do 
-    @virtual_teacher.clazzes[0].real?.should_not be_true
-    @virtual_teacher.clazzes[0].virtual?.should be_true
+    expect(@virtual_teacher.clazzes[0].real?).not_to be_truthy
+    expect(@virtual_teacher.clazzes[0].virtual?).to be_truthy
   end
   
   it "Teachers in virtual schools should be able to change their clazzes" do
-    @virtual_teacher.clazzes[0].should be_changeable(@virtual_teacher)
+    expect(@virtual_teacher.clazzes[0]).to be_changeable(@virtual_teacher)
   end
 
   # Should we enforce the school requirement via a validation, or should it be done in the controller at registration? -- Cantina-CMH 6/9/10
@@ -62,19 +62,19 @@ describe Portal::Teacher do
   describe "possibly_add_authoring_role" do
     describe "when the portal allows teachers to author" do
       it "should add the authoring role to teachers when they are created" do
-        Admin::Settings.stub!(:teachers_can_author? => true)
+        Admin::Settings.stub(:teachers_can_author? => true)
         teacher = Factory.create(:portal_teacher)
         teacher.possibly_add_authoring_role
-        teacher.user.should have_role('author')
+        expect(teacher.user).to have_role('author')
       end
     end
 
     describe "when the portal doesn't allow the teacher to author" do
       it "should not add the authoring role to teachers when they are created" do
-        Admin::Settings.stub!(:teachers_can_author? => false)
+        Admin::Settings.stub(:teachers_can_author? => false)
         teacher = Factory.create(:portal_teacher)
         teacher.possibly_add_authoring_role
-        teacher.user.should_not have_role('author')
+        expect(teacher.user).not_to have_role('author')
       end
     end
   end
@@ -83,7 +83,7 @@ describe Portal::Teacher do
     let(:settings) { Factory.create(:admin_settings) }
     let(:teacher) { Factory(:portal_teacher) }
     before(:each) do
-      Admin::Settings.stub!(:default_settings).and_return(settings)
+      allow(Admin::Settings).to receive(:default_settings).and_return(settings)
     end
 
     describe 'when default cohort is not specified in portal settings' do

--- a/spec/models/report/embeddable_filter_spec.rb
+++ b/spec/models/report/embeddable_filter_spec.rb
@@ -18,7 +18,7 @@ describe Report::EmbeddableFilter do
   describe "#embeddables" do
     let(:embeddables)    { all_embeddables }
     it "should set the instance variable @embeddables_internal" do
-      subject.instance_variable_get(:@embeddables_internal).should eq all_embeddables
+      expect(subject.instance_variable_get(:@embeddables_internal)).to eq all_embeddables
     end
   end
 
@@ -26,13 +26,13 @@ describe Report::EmbeddableFilter do
     let(:embeddables)    { mc_questions }
     # this is a cheat because our subject is calling #embeddables=
     it "should set the instance variable @embeddables_internal" do
-      subject.instance_variable_get(:@embeddables_internal).should eq mc_questions
+      expect(subject.instance_variable_get(:@embeddables_internal)).to eq mc_questions
     end
     it "should set AR attribute embeddables to a serialized hash" do
       hashes = subject.read_attribute(:embeddables)
       hashes.each do |hash| 
-        hash.should have_key(:type) 
-        hash.should have_key(:id)
+        expect(hash).to have_key(:type) 
+        expect(hash).to have_key(:id)
       end
     end
   end
@@ -41,14 +41,14 @@ describe Report::EmbeddableFilter do
     let(:embeddables) { mc_questions }
     describe "filtering all_embeddables using a mc_questions filter" do  
       it "should only return the multiplechoice embeddables" do
-        subject.filter(all_embeddables).should eq mc_questions
+        expect(subject.filter(all_embeddables)).to eq mc_questions
       end
     end
 
     describe "filtering all embeddables using an empty filter" do
       let(:embeddables) { [] }
       it "should return all the embeddables" do
-        subject.filter(all_embeddables).should eq all_embeddables
+        expect(subject.filter(all_embeddables)).to eq all_embeddables
       end
     end
   end
@@ -59,10 +59,10 @@ describe Report::EmbeddableFilter do
       subject.clear
     end
     it "shouldn't filter anything" do
-      subject.instance_variable_get(:@embeddables_internal).should be_nil
+      expect(subject.instance_variable_get(:@embeddables_internal)).to be_nil
     end
     it "serialized embeddables should be empty" do
-      subject.read_attribute(:embeddables).should be_empty
+      expect(subject.read_attribute(:embeddables)).to be_empty
     end
   end
 

--- a/spec/models/report/learner/selector_spec.rb
+++ b/spec/models/report/learner/selector_spec.rb
@@ -4,7 +4,7 @@ include ReportLearnerSpecHelper # defines : saveable_for : answers_for : add_ans
 
 describe Report::Learner::Selector do
 
-  # assign the student permission_form_b to complicate the tests …
+  # assign the student permission_form_b to complicate the tests
   before(:each) {
     learner.student.permission_forms << students_p_forms
   }
@@ -26,7 +26,7 @@ describe Report::Learner::Selector do
                               :save_path => "/path/to/save",
                             } )  }
 
-  before (:each) do
+  before(:each) do
     es_response = {
           "hits" => {
             "hits" => [

--- a/spec/models/report/learner_spec.rb
+++ b/spec/models/report/learner_spec.rb
@@ -187,12 +187,8 @@ describe Report::Learner do
           report_learner.update_answers()
         end
 
-        describe '#answers' do
-          subject { super().answers }
-
-          it 'has 2 answers' do
-            expect(subject.answers.size).to eq(2)
-          end
+        it 'has 2 answers' do
+          expect(subject.answers.size).to eq(2)
         end
 
         describe "the feedback" do

--- a/spec/models/report/learner_spec.rb
+++ b/spec/models/report/learner_spec.rb
@@ -44,9 +44,9 @@ describe Report::Learner do
       :periodic_bundle_contents => [@periodic_bundle_content]
     )
 
-    @last_contents   = mock(:updated_at => nil)
-    @bucket_contents = mock(:last => @last_contents)
-    @bucket_logger   = mock(:bucket_contents => @bucket_contents)
+    @last_contents   = double(:updated_at => nil)
+    @bucket_contents = double(:last => @last_contents)
+    @bucket_logger   = double(:bucket_contents => @bucket_contents)
 
     @learner  = mock_model(Portal::Learner,
       :student  => @student,
@@ -56,7 +56,7 @@ describe Report::Learner do
       :bucket_logger => @bucket_logger,
       # this is needed because of the inverse_of definition in the report_learner associtation
       # I think newer version of mock_model take care of this for you
-      :association => mock(:target= => nil)
+      :association => double(:target= => nil)
     )
   end
 
@@ -66,76 +66,76 @@ describe Report::Learner do
 
   describe "with no bundle_loggers" do
     before(:each) do
-      @learner.stub!(:periodic_bundle_logger => nil)
-      @bundle_logger.stub!(:last_non_empty_bundle_content => nil)
+      @learner.stub(:periodic_bundle_logger => nil)
+      @bundle_logger.stub(:last_non_empty_bundle_content => nil)
     end
 
     it "the last_run time should be nil" do
       report = Report::Learner.create(:learner => @learner)
-      report.last_run.should be_nil
+      expect(report.last_run).to be_nil
     end
 
     it "the last_run time should be preserved" do
       report = Report::Learner.create(:learner => @learner)
-      report.last_run.should be_nil
+      expect(report.last_run).to be_nil
       now = DateTime.now
       report.last_run = now
       report.calculate_last_run
-      report.last_run.should == now
+      expect(report.last_run).to eq(now)
     end
   end
 
   describe "with only old type bundle loggers" do
     before(:each) do
-      @learner.stub!(:periodic_bundle_logger => nil)
-      @bundle_content.stub!(:updated_at => Time.now)
+      @learner.stub(:periodic_bundle_logger => nil)
+      @bundle_content.stub(:updated_at => Time.now)
     end
 
     it "should use the last bundle contents update time" do
       report = Report::Learner.create(:learner => @learner)
-      report.last_run.should == @bundle_content.updated_at
+      expect(report.last_run).to eq(@bundle_content.updated_at)
     end
   end
 
   describe "with only periodic bundle loggers" do
     before(:each) do
-      @learner.stub!(:bundle_logger => nil)
-      @periodic_bundle_content.stub!(:updated_at => Time.now)
-      @periodic_bundle_logger.stub!(:periodic_bundle_contents => [@periodic_bundle_content])
+      @learner.stub(:bundle_logger => nil)
+      @periodic_bundle_content.stub(:updated_at => Time.now)
+      @periodic_bundle_logger.stub(:periodic_bundle_contents => [@periodic_bundle_content])
     end
 
     it "should use the last bundle contents update time" do
       report = Report::Learner.create(:learner => @learner)
-      report.last_run.should == @periodic_bundle_content.updated_at
+      expect(report.last_run).to eq(@periodic_bundle_content.updated_at)
     end
   end
 
   describe "with both preiodic and standard loggers" do
     describe "when the periodic logger is the most recent" do
       before(:each) do
-        @bundle_content.stub!(:updated_at => Time.now - 2.hours)
-        @bundle_logger.stub!(:last_non_empty_bundle_content => @bundle_content)
-        @periodic_bundle_content.stub!(:updated_at => Time.now)
-        @periodic_bundle_logger.stub!(:periodic_bundle_contents => [@periodic_bundle_content])
+        @bundle_content.stub(:updated_at => Time.now - 2.hours)
+        @bundle_logger.stub(:last_non_empty_bundle_content => @bundle_content)
+        @periodic_bundle_content.stub(:updated_at => Time.now)
+        @periodic_bundle_logger.stub(:periodic_bundle_contents => [@periodic_bundle_content])
       end
 
       it "should use the periodic update time" do
         report = Report::Learner.create(:learner => @learner)
-        report.last_run.should == @periodic_bundle_content.updated_at
+        expect(report.last_run).to eq(@periodic_bundle_content.updated_at)
       end
     end
     describe "when the periodic logger is the most recent" do
       before(:each) do
-        @bundle_content.stub!(:updated_at => Time.now)
-        @bundle_logger.stub!(:last_non_empty_bundle_content => @bundle_content)
+        @bundle_content.stub(:updated_at => Time.now)
+        @bundle_logger.stub(:last_non_empty_bundle_content => @bundle_content)
 
-        @periodic_bundle_content.stub!(:updated_at => Time.now - 2.hours)
-        @periodic_bundle_logger.stub!(:periodic_bundle_contents => [@periodic_bundle_content])
+        @periodic_bundle_content.stub(:updated_at => Time.now - 2.hours)
+        @periodic_bundle_logger.stub(:periodic_bundle_contents => [@periodic_bundle_content])
       end
 
       it "should use the bundle update time" do
         report = Report::Learner.create(:learner => @learner)
-        report.last_run.should == @bundle_content.updated_at
+        expect(report.last_run).to eq(@bundle_content.updated_at)
       end
     end
 
@@ -148,15 +148,15 @@ describe Report::Learner do
 
     describe "basic test setup" do
       subject {report_learner}
-      it { should_not be_nil}
+      it { is_expected.not_to be_nil}
 
       describe "answers" do
         subject { report_learner.answers }
-        it { should_not be_nil}
+        it { is_expected.not_to be_nil}
       end
       describe "offering" do
         subject { offering }
-        it { should_not be_nil}
+        it { is_expected.not_to be_nil}
       end
     end
 
@@ -176,7 +176,9 @@ describe Report::Learner do
         stub_all_reportables(Investigation, embeddables)
       end
 
-      it { should have(0).answers }
+      it 'has no answers' do
+        expect(subject.answers.size).to eq(0)
+      end
 
       describe "when the learner answers something" do
         before(:each) do
@@ -184,13 +186,20 @@ describe Report::Learner do
           add_answer(image_question, {blob: Dataservice::Blob.create(), note: "note"} )
           report_learner.update_answers()
         end
-        its(:answers) { should have(2).answers }
+
+        describe '#answers' do
+          subject { super().answers }
+
+          it 'has 2 answers' do
+            expect(subject.answers.size).to eq(2)
+          end
+        end
 
         describe "the feedback" do
           it "should have feedback entries for each answer" do
             subject.answers.each do |answer|
               qkey,a = answer
-              a[:feedbacks].should_not be_nil
+              expect(a[:feedbacks]).not_to be_nil
             end
           end
 
@@ -206,7 +215,7 @@ describe Report::Learner do
             end
 
             it "should no longer require feedback for the open response item" do
-              open_response_saveable[1][:needs_review].should be_false
+              expect(open_response_saveable[1][:needs_review]).to be_falsey
             end
 
             describe "adding a new answer" do

--- a/spec/models/report/offering_student_status_spec.rb
+++ b/spec/models/report/offering_student_status_spec.rb
@@ -18,7 +18,10 @@ describe Report::OfferingStudentStatus do
     end
     
     describe "last_run" do
-      its(:last_run){should == @run_date}
+      describe '#last_run' do
+        subject { super().last_run }
+        it {is_expected.to eq(@run_date)}
+      end
     end
 
     describe "complete_percent" do
@@ -26,15 +29,19 @@ describe Report::OfferingStudentStatus do
       context "when the offering isn't reportable" do
         let :offering do
           _offering = Object.new
-          _offering.stub!(:individual_reportable?).and_return(false)
+          allow(_offering).to receive(:individual_reportable?).and_return(false)
           _offering
         end
-        its(:complete_percent){should == 100}
+
+        describe '#complete_percent' do
+          subject { super().complete_percent }
+          it {is_expected.to eq(100)}
+        end
       end
       context "when the offering is reportable" do
         let :offering do
           _offering = Object.new
-          _offering.stub!(:individual_reportable?).and_return(true)
+          allow(_offering).to receive(:individual_reportable?).and_return(true)
           _offering
         end
         context "without a complete_percent in report_learner" do
@@ -43,7 +50,11 @@ describe Report::OfferingStudentStatus do
             _learner.stub_chain(:report_learner,:complete_percent).and_return(nil)
             _learner
           end
-          its(:complete_percent){should == 0}
+
+          describe '#complete_percent' do
+            subject { super().complete_percent }
+            it {is_expected.to eq(0)}
+          end
       
         end
         context "with a 50% complete_percent in report_learner" do
@@ -52,17 +63,27 @@ describe Report::OfferingStudentStatus do
             _learner.stub_chain(:report_learner,:complete_percent).and_return(50)
             _learner
           end
-          its(:complete_percent){should == 50}
+
+          describe '#complete_percent' do
+            subject { super().complete_percent }
+            it {is_expected.to eq(50)}
+          end
         end
       end
     end
 
     describe "never_run" do
-      its(:never_run){ should == false }
+      describe '#never_run' do
+        subject { super().never_run }
+        it { is_expected.to eq(false) }
+      end
     end
 
     describe "last_run_string" do
-      its(:last_run_string) { should == "Last run Dec 23, 1970"}
+      describe '#last_run_string' do
+        subject { super().last_run_string }
+        it { is_expected.to eq("Last run Dec 23, 1970")}
+      end
     end
   end
 
@@ -76,15 +97,24 @@ describe Report::OfferingStudentStatus do
     
     # TODO: What kind of behavior do we want without a learner?
     describe "last_run" do
-      its(:last_run){should be_nil}
+      describe '#last_run' do
+        subject { super().last_run }
+        it {is_expected.to be_nil}
+      end
     end
     
     describe "never_run" do
-      its(:never_run){ should == true }
+      describe '#never_run' do
+        subject { super().never_run }
+        it { is_expected.to eq(true) }
+      end
     end
 
     describe "last_run_string" do
-      its(:last_run_string) { should == "not yet started"}
+      describe '#last_run_string' do
+        subject { super().last_run_string }
+        it { is_expected.to eq("not yet started")}
+      end
     end
   end
  

--- a/spec/models/ri_gse/expectation_spec.rb
+++ b/spec/models/ri_gse/expectation_spec.rb
@@ -21,7 +21,7 @@ describe RiGse::Expectation do
     gse = RiGse::GradeSpanExpectation.new
     gse.save
     @expectation.grade_span_expectation = gse
-    @expectation.grade_span_expectation.should_not be_nil
+    expect(@expectation.grade_span_expectation).not_to be_nil
     @expectation.save
   end
   
@@ -29,7 +29,7 @@ describe RiGse::Expectation do
     stem = RiGse::ExpectationStem.new
     stem.save
     @expectation.expectation_stem = stem
-    @expectation.expectation_stem.should_not be_nil
+    expect(@expectation.expectation_stem).not_to be_nil
     @expectation.save
   end
   
@@ -42,7 +42,7 @@ describe RiGse::Expectation do
     two.save
     @expectation.expectation_indicators << one
     @expectation.expectation_indicators << two
-    @expectation.expectation_indicators.size.should be(2) 
+    expect(@expectation.expectation_indicators.size).to be(2) 
     @expectation.save
   end
   

--- a/spec/models/saveable/image_question_spec.rb
+++ b/spec/models/saveable/image_question_spec.rb
@@ -15,19 +15,19 @@ describe Saveable::ImageQuestion do
   subject {Saveable::ImageQuestion.create(:learner => learner, :image_question => image_q )}
   describe "valid instance as a basis for testing" do
     it "should be valid" do
-      subject.should be_valid
+      expect(subject).to be_valid
     end
   end
 
   describe "add_external_answer" do
     it "should create new answer with a blob" do
       blob = Dataservice::Blob.create()
-      Dataservice::Blob.should_receive(:for_learner_and_url).and_return(blob)
+      expect(Dataservice::Blob).to receive(:for_learner_and_url).and_return(blob)
       note = "this is the note"
       url  = "http://somelace.com/example.jgp"
       subject.add_external_answer(note, url)
-      subject.answers.size.should == 1
-      subject.answers.first.blob.should == blob
+      expect(subject.answers.size).to eq(1)
+      expect(subject.answers.first.blob).to eq(blob)
     end
   end
 

--- a/spec/models/saveable/saveable_standin_spec.rb
+++ b/spec/models/saveable/saveable_standin_spec.rb
@@ -10,16 +10,16 @@ describe Saveable::SaveableStandin do
   end
 
   it "should resond to embeddable" do
-    @nil_standin.should respond_to :embeddable
+    expect(@nil_standin).to respond_to :embeddable
   end
 
   it "should respond to submitted?" do
-    @nil_standin.should respond_to :submitted?
+    expect(@nil_standin).to respond_to :submitted?
   end
 
   it "should optionally return its embeddable" do
-    @nil_standin.embeddable.should be_nil
-    @real_standin.embeddable.should == @multiple_choice
+    expect(@nil_standin.embeddable).to be_nil
+    expect(@real_standin.embeddable).to eq(@multiple_choice)
   end
 
 end

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -20,37 +20,37 @@ describe Search do
   describe "parameter cleaning" do
     describe "clean_search_terms" do
       it "should remove normal dashes" do
-        Search.clean_search_terms("balrgs-bonk").should == "balrgs bonk"
+        expect(Search.clean_search_terms("balrgs-bonk")).to eq("balrgs bonk")
       end
       it "should remove pluses" do
-        Search.clean_search_terms("balrgs+bonk").should == "balrgs bonk"
+        expect(Search.clean_search_terms("balrgs+bonk")).to eq("balrgs bonk")
       end
       it "should remove pluses" do
-        Search.clean_search_terms("balrgs+bonk").should == "balrgs bonk"
+        expect(Search.clean_search_terms("balrgs+bonk")).to eq("balrgs bonk")
       end
       it "should leave white spaces in the middle" do
-        Search.clean_search_terms("balrgs bonk").should == "balrgs bonk"
+        expect(Search.clean_search_terms("balrgs bonk")).to eq("balrgs bonk")
       end
       it "should strip whitespace at the start" do
-        Search.clean_search_terms(" balrgs bonk").should == "balrgs bonk"
+        expect(Search.clean_search_terms(" balrgs bonk")).to eq("balrgs bonk")
       end
 
       it "should not remove single quote strings" do
-        Search.clean_search_terms("This is Sarah's test sequence").should == "This is Sarah's test sequence"
+        expect(Search.clean_search_terms("This is Sarah's test sequence")).to eq("This is Sarah's test sequence")
       end
 
     end
 
     describe "clean_domain_id" do
       it "returns the defaults when passed nil" do
-        Search.clean_domain_id(nil).should == Search::NoDomainID
+        expect(Search.clean_domain_id(nil)).to eq(Search::NoDomainID)
       end
       it "wraps bare strings in an array" do
-        Search.clean_domain_id("1").should == ["1"]
+        expect(Search.clean_domain_id("1")).to eq(["1"])
       end
 
       it "leaves arrays alone" do
-        Search.clean_domain_id([1,2,3]).should == [1,2,3]
+        expect(Search.clean_domain_id([1,2,3])).to eq([1,2,3])
       end
     end
 
@@ -60,31 +60,31 @@ describe Search do
       describe "when types is nil" do
         let(:types){nil}
         it "should return AllMaterials" do
-          subject.should == Search::AllMaterials
+          expect(subject).to eq(Search::AllMaterials)
         end
       end
       describe "when types is blank" do
         let(:types){""}
         it "should return AllMaterials" do
-          subject.should == Search::AllMaterials
+          expect(subject).to eq(Search::AllMaterials)
         end
       end
       describe "when types is empty" do
         let(:types){[]}
         it "should return AllMaterials" do
-          subject.should == Search::AllMaterials
+          expect(subject).to eq(Search::AllMaterials)
         end
       end
       describe "when types is a string" do
         let(:types){Search::InvestigationMaterial}
         it "should return an array" do
-          subject.should == [Search::InvestigationMaterial]
+          expect(subject).to eq([Search::InvestigationMaterial])
         end
       end
       describe "when types is an array" do
         let(:types){[Search::InvestigationMaterial, Search::ActivityMaterial]}
         it "should return an array" do
-          subject.should == [Search::InvestigationMaterial, Search::ActivityMaterial]
+          expect(subject).to eq([Search::InvestigationMaterial, Search::ActivityMaterial])
         end
       end
     end
@@ -152,19 +152,19 @@ describe Search do
           describe "searching for '2013'" do
             let(:search_term)      { "2013" }
             it "should be found" do
-              subject.results[:all].should include funny_activity
+              expect(subject.results[:all]).to include funny_activity
             end
           end
           describe "searching for '(2013-2014)'" do
             let(:search_term)      { "(2013-2014)" }
             it "should be found" do
-              subject.results[:all].should include funny_activity
+              expect(subject.results[:all]).to include funny_activity
             end
           end
           describe "searching for 'BLARG' " do
             let(:search_term)      { "BLARG" }
             it "should NOT be found" do
-              subject.results[:all].should_not include funny_activity
+              expect(subject.results[:all]).not_to include funny_activity
             end
           end
         end
@@ -173,19 +173,19 @@ describe Search do
           describe "searching for 'Noah's'" do
             let(:search_term)      { "Noah's" }
             it "should be found" do
-              subject.results[:all].should include funny_activity
+              expect(subject.results[:all]).to include funny_activity
             end
           end
           describe "searching for 'Noah'" do
             let(:search_term)      { "Noah*" }
             it "should be found" do
-              subject.results[:all].should include funny_activity
+              expect(subject.results[:all]).to include funny_activity
             end
           end
           describe "searching for 'Soup'" do
             let(:search_term)      { "Soup" }
             it "should be found" do
-              subject.results[:all].should include funny_activity
+              expect(subject.results[:all]).to include funny_activity
             end
           end
         end
@@ -195,7 +195,7 @@ describe Search do
         let(:materials)     { [public_items, assessment_activities].flatten }
         let(:search_opts)   {{ :user_id => mock_user.id }}
         before(:each) do
-          User.stub!(:find => mock_user)
+          User.stub(:find => mock_user)
         end
         describe "a teacher" do
           let(:user_stubs) {{
@@ -207,7 +207,7 @@ describe Search do
 
           it "should see the assessment items" do
             assessment_activities.each do |act|
-              subject.results[:all].should include act
+              expect(subject.results[:all]).to include act
             end
           end
         end
@@ -221,7 +221,7 @@ describe Search do
           }}
           it "should not see the assessment items" do
             assessment_activities.each do |act|
-              subject.results[:all].should_not include act
+              expect(subject.results[:all]).not_to include act
             end
           end
         end
@@ -234,7 +234,7 @@ describe Search do
           }}
           it "should not see the assment items" do
             assessment_activities.each do |act|
-              subject.results[:all].should_not include act
+              expect(subject.results[:all]).not_to include act
             end
           end
 
@@ -247,13 +247,13 @@ describe Search do
         let(:materials)     { [public_items, template_ivs, template_acts].flatten }
         it "results should not include any of the template activities" do
           template_acts.each do |act|
-            subject.results[:all].should_not include act
+            expect(subject.results[:all]).not_to include act
           end
         end
 
         it "results should not include any of the template investigations" do
           template_ivs.each do |inv|
-            subject.results[:all].should_not include inv
+            expect(subject.results[:all]).not_to include inv
           end
         end
       end
@@ -261,11 +261,11 @@ describe Search do
       describe "searching public items" do
         let(:search_opts) { {:private => false } }
         it "results should include 4 public external_activities" do
-          subject.results[:all].should have(4).entries
+          expect(subject.results[:all].entries.size).to eq(4)
           # Sequence externals
-          subject.results[Search::InvestigationMaterial].should have(2).entries
+          expect(subject.results[Search::InvestigationMaterial].entries.size).to eq(2)
           # Actvitiy externals
-          subject.results[Search::ActivityMaterial].should have(2).entries
+          expect(subject.results[Search::ActivityMaterial].entries.size).to eq(2)
         end
       end
 
@@ -278,16 +278,16 @@ describe Search do
         let(:materials) { [archived_activity, unarchived_activity] }
         describe "with default search options" do
           it "results should include not include archived activities" do
-            subject.results[:all].should have(1).entries
-            subject.results[:all].should include(unarchived_activity)
+            expect(subject.results[:all].entries.size).to eq(1)
+            expect(subject.results[:all]).to include(unarchived_activity)
           end
         end
         describe "when searching for archived items" do
           let(:search_opts) { {:show_archived => true } }
           it "results should include only archived activities" do
             # TBD: I think we decided to only show archived with this option
-            subject.results[:all].should have(1).entries
-            subject.results[:all].should include(archived_activity)
+            expect(subject.results[:all].entries.size).to eq(1)
+            expect(subject.results[:all]).to include(archived_activity)
           end
         end
       end
@@ -295,16 +295,16 @@ describe Search do
       describe "searching all items" do
         let(:search_opts) { {:private => true, :include_templates => true} }
         it "results should include 4 external activities and 4 external sequences" do
-          subject.results[Search::InvestigationMaterial].should have(4).entries
-          subject.results[Search::ActivityMaterial].should have(4).entries
+          expect(subject.results[Search::InvestigationMaterial].entries.size).to eq(4)
+          expect(subject.results[Search::ActivityMaterial].entries.size).to eq(4)
         end
       end
 
       describe "searching only public Sequences" do
         let(:search_opts) { {:private  => false, :material_types => ["Investigation"]} }
         it "results should include 4 investigations" do
-          subject.results[:all].should have(2).entries
-          subject.results[Search::InvestigationMaterial].should have(2).entries
+          expect(subject.results[:all].entries.size).to eq(2)
+          expect(subject.results[Search::InvestigationMaterial].entries.size).to eq(2)
         end
       end
 
@@ -322,8 +322,8 @@ describe Search do
         describe "when the template type is an Investigation" do
           let(:external_activity){FactoryGirl.create(:external_activity, external_seq.merge(public_opts).merge(official))}
           it "should be listed in the investigations results" do
-            subject.results[Search::InvestigationMaterial].should include(external_activity)
-            subject.results[Search::ActivityMaterial].should_not include(external_activity)
+            expect(subject.results[Search::InvestigationMaterial]).to include(external_activity)
+            expect(subject.results[Search::ActivityMaterial]).not_to include(external_activity)
 
           end
         end
@@ -333,8 +333,8 @@ describe Search do
           describe "when its an offical activity" do
             let(:external_activity){FactoryGirl.create(:external_activity, external_act.merge(public_opts).merge(official))}
             it "should be listed in the activity results" do
-              subject.results[Search::InvestigationMaterial].should_not include(external_activity)
-              subject.results[Search::ActivityMaterial].should include(external_activity)
+              expect(subject.results[Search::InvestigationMaterial]).not_to include(external_activity)
+              expect(subject.results[Search::ActivityMaterial]).to include(external_activity)
             end
           end
 
@@ -343,16 +343,16 @@ describe Search do
             describe "when the search doesn't include contributed items" do
               let(:search_opts) { {:include_official => true } }
               it "should not be listed in the results" do
-                subject.results[Search::InvestigationMaterial].should_not include(external_activity)
-                subject.results[Search::ActivityMaterial].should_not include(external_activity)
+                expect(subject.results[Search::InvestigationMaterial]).not_to include(external_activity)
+                expect(subject.results[Search::ActivityMaterial]).not_to include(external_activity)
               end
             end
 
             describe "when the search includes contributed items" do
               let(:search_opts) { {:include_contributed => true } }
               it "should not be listed in the activity results" do
-                subject.results[Search::InvestigationMaterial].should_not include(external_activity)
-                subject.results[Search::ActivityMaterial].should include(external_activity)
+                expect(subject.results[Search::InvestigationMaterial]).not_to include(external_activity)
+                expect(subject.results[Search::ActivityMaterial]).to include(external_activity)
               end
             end
           end
@@ -362,8 +362,8 @@ describe Search do
         describe "When there is no template" do
           let(:external_activity){FactoryGirl.create(:external_activity, external_base.merge(public_opts).merge(official).merge({:material_type => 'Activity'}))}
           it "should be listed in the Activity results" do
-            subject.results[Search::InvestigationMaterial].should_not include(external_activity)
-            subject.results[Search::ActivityMaterial].should include(external_activity)
+            expect(subject.results[Search::InvestigationMaterial]).not_to include(external_activity)
+            expect(subject.results[Search::ActivityMaterial]).to include(external_activity)
           end
         end
       end
@@ -376,16 +376,16 @@ describe Search do
         let(:public_items)   { collection(:external_activity, 2, public_opts)}
         let(:search_opts)     {{ :private => false, :user_id => my_id }}
         before(:each) do
-          User.stub!(:find => mock_user)
+          User.stub(:find => mock_user)
         end
         it "should return public items" do
           public_items.each do |act|
-            subject.results[Search::ActivityMaterial].should include(act)
+            expect(subject.results[Search::ActivityMaterial]).to include(act)
           end
         end
 
         it "should return the my_activity" do
-          subject.results[Search::ActivityMaterial].should include(my_activity)
+          expect(subject.results[Search::ActivityMaterial]).to include(my_activity)
           # subject.results[:users].should include(my_activity)
         end
       end
@@ -405,7 +405,7 @@ describe Search do
         }}
         let(:search_opts){{ :private => false, :user_id => mock_user.id }}
         before(:each) do
-          User.stub!(:find => mock_user)
+          User.stub(:find => mock_user)
         end
         describe "With two defined cohorts"  do
           describe "With activities in every combination of cohorts " do
@@ -445,10 +445,10 @@ describe Search do
               describe "Searching all material types" do
 
                 it "Includes all only blank sequences" do
-                  subject.results[Search::InvestigationMaterial].should have(1).items
+                  expect(subject.results[Search::InvestigationMaterial].size).to eq(1)
                 end
                 it "Includes blank activities and blank externals" do
-                  subject.results[Search::ActivityMaterial].should have(2).items
+                  expect(subject.results[Search::ActivityMaterial].size).to eq(2)
                 end
               end
             end
@@ -459,10 +459,10 @@ describe Search do
               describe "Searching all material types" do
 
                 it "Includes all only blank sequences" do
-                  subject.results[Search::InvestigationMaterial].should have(1).items
+                  expect(subject.results[Search::InvestigationMaterial].size).to eq(1)
                 end
                 it "Includes blank activities and blank externals" do
-                  subject.results[Search::ActivityMaterial].should have(2).items
+                  expect(subject.results[Search::ActivityMaterial].size).to eq(2)
                 end
               end
             end
@@ -473,15 +473,15 @@ describe Search do
               describe "Searching all material types" do
 
                 it "Includes sequences for cohort1(2), both(1), and unlabled(2)" do
-                  subject.results[Search::InvestigationMaterial].should have(4).items
+                  expect(subject.results[Search::InvestigationMaterial].size).to eq(4)
                 end
                 it "Includes activities for cohort1(4), both(1), and unlabled(2)" do
-                  subject.results[Search::ActivityMaterial].should have(7).items
+                  expect(subject.results[Search::ActivityMaterial].size).to eq(7)
                 end
                 it "should be not cohort tagged, or include a cohort1 tag" do
                   subject.results[:all].each do |r|
                     unless r.cohorts.empty?
-                      r.cohorts.should include(cohort1)
+                      expect(r.cohorts).to include(cohort1)
                     end
                   end
                 end
@@ -494,15 +494,15 @@ describe Search do
               describe "Searching all material types" do
 
               it "Includes sequences for cohort2(2), both(1), and unlabled(2)" do
-                  subject.results[Search::InvestigationMaterial].should have(4).items
+                  expect(subject.results[Search::InvestigationMaterial].size).to eq(4)
                 end
                 it "Includes activities for cohort2(4), both(1), and unlabled(2)" do
-                  subject.results[Search::ActivityMaterial].should have(7).items
+                  expect(subject.results[Search::ActivityMaterial].size).to eq(7)
                 end
                 it "should be not cohort tagged, or include a cohort2 tag" do
                   subject.results[:all].each do |r|
                     unless r.cohorts.empty?
-                      r.cohorts.should include(cohort2)
+                      expect(r.cohorts).to include(cohort2)
                     end
                   end
                 end
@@ -515,10 +515,10 @@ describe Search do
               describe "Searching all material types" do
 
                 it "Includes sequences for cohort1(2) cohort2(2), and unlabled(2)" do
-                  subject.results[Search::InvestigationMaterial].should have(6).items
+                  expect(subject.results[Search::InvestigationMaterial].size).to eq(6)
                 end
                 it "Includes activities for cohort2(4), cohort1(4), and unlabled(2)" do
-                  subject.results[Search::ActivityMaterial].should have(10).items
+                  expect(subject.results[Search::ActivityMaterial].size).to eq(10)
                 end
               end
             end
@@ -528,15 +528,15 @@ describe Search do
               let(:cohort2_opts) {{:publication_status=>'published', :cohorts => [cohort2], :user_id => mock_user.id} }
 
               it "Includes sequences for cohort2(2), and unlabled(2)" do
-                subject.results[Search::InvestigationMaterial].should have(3).items
+                expect(subject.results[Search::InvestigationMaterial].size).to eq(3)
               end
               it "Includes activities for cohort2(4), and unlabled(2)" do
-                subject.results[Search::ActivityMaterial].should have(6).items
+                expect(subject.results[Search::ActivityMaterial].size).to eq(6)
               end
               it "should be not cohort tagged, or include a cohort2 tag" do
                 subject.results[:all].each do |r|
                   unless r.cohorts.empty?
-                    r.cohorts.should include(cohort2)
+                    expect(r.cohorts).to include(cohort2)
                   end
                 end
               end
@@ -551,10 +551,10 @@ describe Search do
                   has_role?: true }}
               describe "Searching all material types" do
                 it "Includes sequences for cohort1(2) cohort2(2), and unlabled(2)" do
-                  subject.results[Search::InvestigationMaterial].should have(6).items
+                  expect(subject.results[Search::InvestigationMaterial].size).to eq(6)
                 end
                 it "Includes activities for cohort2(4), cohort1(4), and unlabled(2)" do
-                  subject.results[Search::ActivityMaterial].should have(10).items
+                  expect(subject.results[Search::ActivityMaterial].size).to eq(10)
                 end
               end
             end
@@ -598,16 +598,16 @@ describe Search do
 
           describe "Search::Newest" do
             it "the collection should be sorted by updated_at newest ➙ oldest" do
-              subject.results[Search::InvestigationMaterial].should be_ordered_by(:updated_at_desc)
-              subject.results[Search::ActivityMaterial].should be_ordered_by(:updated_at_desc)
+              expect(subject.results[Search::InvestigationMaterial]).to be_ordered_by(:updated_at_desc)
+              expect(subject.results[Search::ActivityMaterial]).to be_ordered_by(:updated_at_desc)
             end
           end
 
           describe "Search::Oldest" do
             let(:search_opts) { {:private => false, :sort_order => Search::Oldest} }
             it "the collection should be sorted by updated_at oldest ➙ newest" do
-              subject.results[Search::InvestigationMaterial].should be_ordered_by(:updated_at)
-              subject.results[Search::ActivityMaterial].should be_ordered_by(:updated_at)
+              expect(subject.results[Search::InvestigationMaterial]).to be_ordered_by(:updated_at)
+              expect(subject.results[Search::ActivityMaterial]).to be_ordered_by(:updated_at)
             end
           end
         end # by date
@@ -632,8 +632,8 @@ describe Search do
             ].flatten
           end
           it "the collection should be sotred by offerings_count desc" do
-            subject.results[Search::InvestigationMaterial].should be_ordered_by(:offerings_count_desc)
-            subject.results[Search::ActivityMaterial].should be_ordered_by(:offerings_count_desc)
+            expect(subject.results[Search::InvestigationMaterial]).to be_ordered_by(:offerings_count_desc)
+            expect(subject.results[Search::ActivityMaterial]).to be_ordered_by(:offerings_count_desc)
           end
         end
       end
@@ -661,34 +661,34 @@ describe Search do
       let(:materials) { [public_with_temperature_sensor, public_with_force_sensor,
         public_with_force_and_temperature_sensor, public_ext_act]}
       it "the temperature activity is returned" do
-        subject.results[:all].should include(public_with_temperature_sensor)
+        expect(subject.results[:all]).to include(public_with_temperature_sensor)
       end
       describe "with the temperature sensor selected" do
         let(:search_opts)      { {:sensors => ["Temperature"]} }
         it "only returns activities with a temperature sensor" do
-          subject.results[:all].should have(2).entries
-          subject.results[:all].should include(public_with_temperature_sensor)
-          subject.results[:all].should include(public_with_force_and_temperature_sensor)
+          expect(subject.results[:all].entries.size).to eq(2)
+          expect(subject.results[:all]).to include(public_with_temperature_sensor)
+          expect(subject.results[:all]).to include(public_with_force_and_temperature_sensor)
         end
       end
       describe "with the 'no sensors' option selected" do
         let(:search_opts)      { {:no_sensors => true} }
         it "only returns activities without sensors" do
           # public_ext_act is an array so we need to turn it into set parameters
-          subject.results[:all].should include(*public_ext_act)
-          subject.results[:all].should_not include(public_with_temperature_sensor)
-          subject.results[:all].should_not include(public_with_force_sensor)
-          subject.results[:all].should_not include(public_with_force_and_temperature_sensor)
+          expect(subject.results[:all]).to include(*public_ext_act)
+          expect(subject.results[:all]).not_to include(public_with_temperature_sensor)
+          expect(subject.results[:all]).not_to include(public_with_force_sensor)
+          expect(subject.results[:all]).not_to include(public_with_force_and_temperature_sensor)
         end
       end
       describe "with the 'no sensors' option selected and temperature sensor selected" do
         let(:search_opts)      { {:no_sensors => true, :sensors => ["Temperature"]} }
         it "returns activities with no sensors and with temperature sensors" do
           # public_ext_act is an array so we need to turn it into set parameters
-          subject.results[:all].should include(*public_ext_act)
-          subject.results[:all].should include(public_with_temperature_sensor)
-          subject.results[:all].should include(public_with_force_and_temperature_sensor)
-          subject.results[:all].should_not include(public_with_force_sensor)
+          expect(subject.results[:all]).to include(*public_ext_act)
+          expect(subject.results[:all]).to include(public_with_temperature_sensor)
+          expect(subject.results[:all]).to include(public_with_force_and_temperature_sensor)
+          expect(subject.results[:all]).not_to include(public_with_force_sensor)
         end
       end
     end

--- a/spec/models/security_question_spec.rb
+++ b/spec/models/security_question_spec.rb
@@ -28,10 +28,10 @@ describe SecurityQuestion do
     it "makes a new set of questions according to provided information" do
       new_questions = SecurityQuestion.make_questions_from_hash_and_user(@hash)
       
-      new_questions.size.should == 3
+      expect(new_questions.size).to eq(3)
       
       @hash.each do |k, v|
-        new_questions.select { |q| q.question == SecurityQuestion::QUESTIONS[v[:question_idx]] && q.answer == v[:answer] }.size.should == 1
+        expect(new_questions.select { |q| q.question == SecurityQuestion::QUESTIONS[v[:question_idx]] && q.answer == v[:answer] }.size).to eq(1)
       end
     end
     
@@ -44,13 +44,13 @@ describe SecurityQuestion do
       
       new_questions = SecurityQuestion.make_questions_from_hash_and_user(@hash, @user)
       
-      new_questions.size.should == 3
+      expect(new_questions.size).to eq(3)
       
-      new_questions.select { |q| q.question == SecurityQuestion::QUESTIONS[@hash[:question0][:question_idx]] && q.answer == @hash[:question0][:answer] }.size.should == 1
-      new_questions.select { |q| q.question == SecurityQuestion::QUESTIONS[@hash[:question1][:question_idx]] && q.answer == @hash[:question1][:answer] }.size.should == 1
+      expect(new_questions.select { |q| q.question == SecurityQuestion::QUESTIONS[@hash[:question0][:question_idx]] && q.answer == @hash[:question0][:answer] }.size).to eq(1)
+      expect(new_questions.select { |q| q.question == SecurityQuestion::QUESTIONS[@hash[:question1][:question_idx]] && q.answer == @hash[:question1][:answer] }.size).to eq(1)
       
       # The question should remain the same, but the answer should be updated with the one received in the hash.
-      new_questions.select { |q| q.question == question.question && q.answer == @hash[:question2][:answer] }.size.should == 1
+      expect(new_questions.select { |q| q.question == question.question && q.answer == @hash[:question2][:answer] }.size).to eq(1)
     end
   end
   
@@ -68,7 +68,7 @@ describe SecurityQuestion do
       
       errors = SecurityQuestion.errors_for_questions_list!(@questions)
       
-      errors.should include(SecurityQuestion::ERROR_DUPLICATE_QUESTIONS)
+      expect(errors).to include(SecurityQuestion::ERROR_DUPLICATE_QUESTIONS)
     end
     
     it "does not accept fewer than three questions" do
@@ -76,7 +76,7 @@ describe SecurityQuestion do
       
       errors = SecurityQuestion.errors_for_questions_list!(@questions)
       
-      errors.should include(SecurityQuestion::ERROR_TOO_FEW_QUESTIONS)
+      expect(errors).to include(SecurityQuestion::ERROR_TOO_FEW_QUESTIONS)
     end
     
     it "does not accept empty answers" do
@@ -84,7 +84,7 @@ describe SecurityQuestion do
       
       errors = SecurityQuestion.errors_for_questions_list!(@questions)
       
-      errors.should include(SecurityQuestion::ERROR_BLANK_ANSWER)
+      expect(errors).to include(SecurityQuestion::ERROR_BLANK_ANSWER)
     end
   end
   

--- a/spec/models/standard_document_spec.rb
+++ b/spec/models/standard_document_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
 describe StandardDocument do
-  pending "add some examples to (or delete) #{__FILE__}"
+  skip "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/standard_statement_spec.rb
+++ b/spec/models/standard_statement_spec.rb
@@ -20,7 +20,7 @@ describe StandardStatement do
       end
       it "should save and load description array" do
         subject2 = StandardStatement.find_by_id(subject.id)
-        subject2.description.size.should eq 2
+        expect(subject2.description.size).to eq 2
       end
     end
 
@@ -47,10 +47,10 @@ describe StandardStatement do
       end
       it "should save and load parent" do
         subject2 = StandardStatement.find_by_id(subject.id)
-        subject2.parents[0][:uri].should eq "http://foo.com/ID123"
-        subject2.parents[0][:notation].should eq "A-1"
-        subject2.parents[1][:uri].should eq "http://foo.com/ID456"
-        subject2.parents[1][:notation].should eq "B-2"
+        expect(subject2.parents[0][:uri]).to eq "http://foo.com/ID123"
+        expect(subject2.parents[0][:notation]).to eq "A-1"
+        expect(subject2.parents[1][:uri]).to eq "http://foo.com/ID456"
+        expect(subject2.parents[1][:notation]).to eq "B-2"
       end
     end
 

--- a/spec/models/student_roster_row_spec.rb
+++ b/spec/models/student_roster_row_spec.rb
@@ -34,10 +34,10 @@ describe StudentRosterRow do
 
   describe "A student without a valid user" do
     it "should use default values" do
-      roster_item.name.should eql "No Name"
-      roster_item.login.should eql "No Username"
-      roster_item.last_login.should eql "Unknown"
-      roster_item.assignments_started.should eql "Unknown"
+      expect(roster_item.name).to eql "No Name"
+      expect(roster_item.login).to eql "No Username"
+      expect(roster_item.last_login).to eql "Unknown"
+      expect(roster_item.assignments_started).to eql "Unknown"
     end
   end
 
@@ -46,14 +46,14 @@ describe StudentRosterRow do
     let(:learners) { [] }
 
     it "should use user attributes for fields" do
-      roster_item.name.should eql "Malfoy, Draco"
-      roster_item.login.should eql "dmalfoy"
+      expect(roster_item.name).to eql "Malfoy, Draco"
+      expect(roster_item.login).to eql "dmalfoy"
     end
 
     describe "When the student has not done any work" do
       it "should list 0 assingments started" do
-        roster_item.assignments_started.should eql 0
-          roster_item.last_login.should eql "Never"
+        expect(roster_item.assignments_started).to eql 0
+          expect(roster_item.last_login).to eql "Never"
       end
     end
 
@@ -61,8 +61,8 @@ describe StudentRosterRow do
       let(:learners)   { [Object.new]    }
       let(:login_time) { good_login_time }
       it "should list 0 assingments started" do
-        roster_item.assignments_started.should eql "Unknown"
-        roster_item.last_login.should eql "about 1 hour ago"
+        expect(roster_item.assignments_started).to eql "Unknown"
+        expect(roster_item.last_login).to eql "about 1 hour ago"
       end
     end
     describe "when the student has started 2 activities in this class, and 1 in another class" do
@@ -74,7 +74,7 @@ describe StudentRosterRow do
         item1.stub_chain(:offering, :clazz_id).and_return(clazz.id)
         item2.stub_chain(:offering, :clazz_id).and_return(clazz.id)
         item3.stub_chain(:offering, :clazz_id).and_return(404)
-        roster_item.assignments_started.should eql 2
+        expect(roster_item.assignments_started).to eql 2
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,13 +14,13 @@ describe User do
     end
 
     it 'increments User#count' do
-      @creating_user.should change(User, :count).by(1)
+      expect(@creating_user).to change(User, :count).by(1)
     end
 
     it 'initializes #activation_code' do
       @creating_user.call
       @user.reload
-      @user.confirmation_token.should_not be_nil
+      expect(@user.confirmation_token).not_to be_nil
     end
 
     it 'starts in pending state' do
@@ -35,20 +35,20 @@ describe User do
   #
 
   it 'requires login' do
-    lambda do
+    expect do
       u = create_user(:login => nil)
-      u.errors[:login].should_not be_nil
-    end.should_not change(User, :count)
+      expect(u.errors[:login]).not_to be_nil
+    end.not_to change(User, :count)
   end
 
   describe 'allows legitimate logins:' do
     ['123', '1234567890_234567890_234567890_234567890',
      'hello.-_there@funnychar.com'].each do |login_str|
       it "'#{login_str}'" do
-        lambda do
+        expect do
           u = create_user(:login => login_str)
-          u.errors[:login].should == []
-        end.should change(User, :count).by(1)
+          expect(u.errors[:login]).to eq([])
+        end.to change(User, :count).by(1)
       end
     end
   end
@@ -58,33 +58,33 @@ describe User do
      "Iñtërnâtiônàlizætiøn hasn't happened to ruby 1.8 yet",
      'semicolon;', 'quote"', 'backtick`', 'percent%'].each do |login_str|
       it "'#{login_str}'" do
-        lambda do
+        expect do
           u = create_user(:login => login_str)
-          u.errors[:login].should_not be_nil
-        end.should_not change(User, :count)
+          expect(u.errors[:login]).not_to be_nil
+        end.not_to change(User, :count)
       end
     end
   end
 
   it 'requires password' do
-    lambda do
+    expect do
       u = create_user(:password => nil)
-      u.errors[:password].should_not be_nil
-    end.should_not change(User, :count)
+      expect(u.errors[:password]).not_to be_nil
+    end.not_to change(User, :count)
   end
 
   it 'requires password confirmation' do
-    lambda do
+    expect do
       u = create_user(:password_confirmation => nil)
-      u.errors[:password_confirmation].should_not be_nil
-    end.should_not change(User, :count)
+      expect(u.errors[:password_confirmation]).not_to be_nil
+    end.not_to change(User, :count)
   end
 
   it 'requires email' do
-    lambda do
+    expect do
       u = create_user(:email => nil)
-      u.errors[:email].should_not be_nil
-    end.should_not change(User, :count)
+      expect(u.errors[:email]).not_to be_nil
+    end.not_to change(User, :count)
   end
 
   describe 'allows legitimate emails:' do
@@ -94,10 +94,10 @@ describe User do
      'domain@can.haz.many.sub.doma.in', 'student.name@university.edu'
     ].each do |email_str|
       it "'#{email_str}'" do
-        lambda do
+        expect do
           u = create_user(:email => email_str)
-          u.errors[:email].should == []
-        end.should change(User, :count).by(1)
+          expect(u.errors[:email]).to eq([])
+        end.to change(User, :count).by(1)
       end
     end
   end
@@ -113,10 +113,10 @@ describe User do
      'uucp!addr@gmail.com', 'semicolon;@gmail.com', 'quote"@gmail.com', 'backtick`@gmail.com', 'space @gmail.com', 'bracket<@gmail.com', 'bracket>@gmail.com'
     ].each do |email_str|
       it "'#{email_str}'" do
-        lambda do
+        expect do
           u = create_user(:email => email_str)
-          u.errors[:email].should_not be_nil
-        end.should_not change(User, :count)
+          expect(u.errors[:email]).not_to be_nil
+        end.not_to change(User, :count)
       end
     end
   end
@@ -127,10 +127,10 @@ describe User do
      '1234567890k',
     ].each do |name_str|
       it "'#{name_str}'" do
-        lambda do
+        expect do
           u = create_user(:first_name => name_str)
-          u.errors[:first_name].should == []
-        end.should change(User, :count).by(1)
+          expect(u.errors[:first_name]).to eq([])
+        end.to change(User, :count).by(1)
       end
     end
   end
@@ -138,22 +138,22 @@ describe User do
     ['1234567890_234567890_234567890_234567890_234567890_234567890_234567890_234567890_234567890_234567890_',
      ].each do |name_str|
       it "'#{name_str}'" do
-        lambda do
+        expect do
           u = create_user(:first_name => name_str)
-          u.errors[:first_name].should_not be_nil
-        end.should_not change(User, :count)
+          expect(u.errors[:first_name]).not_to be_nil
+        end.not_to change(User, :count)
       end
     end
   end
 
   it 'resets password' do
     users(:quentin).update_attributes({:password => 'new password', :password_confirmation => 'new password'})
-    User.authenticate('quentin', 'new password').should == users(:quentin)
+    expect(User.authenticate('quentin', 'new password')).to eq(users(:quentin))
   end
 
   it 'does not rehash password' do
     users(:quentin).update_attributes({:login => 'quentin2'})
-    User.authenticate('quentin2', 'monkey').should == users(:quentin)
+    expect(User.authenticate('quentin2', 'monkey')).to eq(users(:quentin))
   end
 
   #
@@ -161,11 +161,11 @@ describe User do
   #
 
   it 'authenticates user' do
-    User.authenticate('quentin', 'monkey').should == users(:quentin)
+    expect(User.authenticate('quentin', 'monkey')).to eq(users(:quentin))
   end
 
   it "doesn't authenticate user with bad password" do
-    User.authenticate('quentin', 'invalid_password').should be_nil
+    expect(User.authenticate('quentin', 'invalid_password')).to be_nil
   end
 
   #
@@ -174,41 +174,41 @@ describe User do
 
   it 'sets remember token' do
     users(:quentin).remember_me!
-    users(:quentin).remember_token.should_not be_nil
-    users(:quentin).remember_created_at.should_not be_nil
+    expect(users(:quentin).remember_token).not_to be_nil
+    expect(users(:quentin).remember_created_at).not_to be_nil
   end
 
   it 'unsets remember token' do
     users(:quentin).remember_me!
-    users(:quentin).remember_token.should_not be_nil
+    expect(users(:quentin).remember_token).not_to be_nil
     users(:quentin).forget_me
-    users(:quentin).remember_token.should be_nil
+    expect(users(:quentin).remember_token).to be_nil
   end
 
   it 'remembers me for one week' do
     before = 1.week.ago.utc
     users(:quentin).remember_me_for 1.week
     after = 1.week.from_now.utc
-    users(:quentin).remember_token.should_not be_nil
-    users(:quentin).remember_created_at.should_not be_nil
-    users(:quentin).remember_created_at.between?(before, after).should be_true
+    expect(users(:quentin).remember_token).not_to be_nil
+    expect(users(:quentin).remember_created_at).not_to be_nil
+    expect(users(:quentin).remember_created_at.between?(before, after)).to be_truthy
   end
 
   it 'remembers me until one week' do
     time = 1.week.from_now.utc
     users(:quentin).remember_me_until time
-    users(:quentin).remember_token.should_not be_nil
-    users(:quentin).remember_created_at.should_not be_nil
-    users(:quentin).remember_created_at.utc.to_s(:db).should == time.to_s(:db)
+    expect(users(:quentin).remember_token).not_to be_nil
+    expect(users(:quentin).remember_created_at).not_to be_nil
+    expect(users(:quentin).remember_created_at.utc.to_s(:db)).to eq(time.to_s(:db))
   end
 
   it 'remembers me default two weeks' do
     before = 2.weeks.ago.utc
     users(:quentin).remember_me!
     after = 2.weeks.from_now.utc
-    users(:quentin).remember_token.should_not be_nil
-    users(:quentin).remember_created_at.should_not be_nil
-    users(:quentin).remember_created_at.between?(before, after).should be_true
+    expect(users(:quentin).remember_token).not_to be_nil
+    expect(users(:quentin).remember_created_at).not_to be_nil
+    expect(users(:quentin).remember_created_at.between?(before, after)).to be_truthy
   end
 
   it 'registers passive user' do
@@ -227,13 +227,13 @@ describe User do
 
   it 'does not authenticate suspended user' do
     users(:quentin).suspend!
-    User.authenticate('quentin', 'monkey').should_not == users(:quentin)
+    expect(User.authenticate('quentin', 'monkey')).not_to eq(users(:quentin))
   end
 
   it 'deletes user' do
-    users(:quentin).deleted_at.should be_nil
+    expect(users(:quentin).deleted_at).to be_nil
     users(:quentin).delete!
-    users(:quentin).deleted_at.should_not be_nil
+    expect(users(:quentin).deleted_at).not_to be_nil
     expect(users(:quentin).state).to eq('disabled')
   end
 
@@ -292,13 +292,13 @@ describe User do
     it "updates security questions" do
       questions = Array.new(3) { |i| SecurityQuestion.new({ :question => "test #{i}", :answer => "test" }) }
 
-      @user.security_questions.should be_empty
+      expect(@user.security_questions).to be_empty
 
       @user.update_security_questions!(questions)
 
-      @user.security_questions.size.should == 3
+      expect(@user.security_questions.size).to eq(3)
       questions.each do |v|
-        @user.security_questions.select { |q| q.question == v.question && q.answer == v.answer }.size.should == 1
+        expect(@user.security_questions.select { |q| q.question == v.question && q.answer == v.answer }.size).to eq(1)
       end
     end
   end
@@ -306,19 +306,19 @@ describe User do
   describe "checking for logins" do
     describe "when available" do
       before(:each) do
-        User.should_receive(:login_exists?).with("hpotter").and_return(false)
+        expect(User).to receive(:login_exists?).with("hpotter").and_return(false)
       end
       it "should return the first initial and last name" do
-        User.suggest_login('Harry','Potter').should == "hpotter"
+        expect(User.suggest_login('Harry','Potter')).to eq("hpotter")
       end
     end
     describe "when not available" do
       it "should append a counter number to the default login" do
-        User.should_receive(:login_exists?).once.with("hpotter").ordered.and_return(true)
-        User.should_receive(:login_exists?).once.with("hpotter1").ordered.and_return(true)
-        User.should_receive(:login_exists?).once.with("hpotter2").ordered.and_return(true)
-        User.should_receive(:login_exists?).once.with("hpotter3").ordered.and_return(false)
-        User.suggest_login('Harry','Potter').should == "hpotter3"
+        expect(User).to receive(:login_exists?).once.with("hpotter").ordered.and_return(true)
+        expect(User).to receive(:login_exists?).once.with("hpotter1").ordered.and_return(true)
+        expect(User).to receive(:login_exists?).once.with("hpotter2").ordered.and_return(true)
+        expect(User).to receive(:login_exists?).once.with("hpotter3").ordered.and_return(false)
+        expect(User.suggest_login('Harry','Potter')).to eq("hpotter3")
       end
     end
   end
@@ -329,7 +329,7 @@ describe User do
     end
     describe "freshly minted user" do
       it "will not require the password to be reset" do
-        @user.require_password_reset.should be_false
+        expect(@user.require_password_reset).to be_falsey
       end
     end
   end
@@ -343,7 +343,7 @@ describe User do
     end
 
     it "should be a project admin for the project now " do
-      user.is_project_admin?(project).should eq true
+      expect(user.is_project_admin?(project)).to eq true
     end
 
     describe "when a user was previously an admin for the project" do
@@ -351,10 +351,10 @@ describe User do
         user.add_role_for_project('admin', project)
       end
       it "should still be an admin of the project " do
-        user.is_project_admin?(project).should eq true
+        expect(user.is_project_admin?(project)).to eq true
       end
       it "should only be admin for one project" do
-        user.admin_for_projects.should have(1).item
+        expect(user.admin_for_projects.size).to eq(1)
       end
     end
   end
@@ -369,17 +369,17 @@ describe User do
       end
       it "the user is no longer an admin for the project" do
         user.remove_role_for_project("admin",project)
-        user.is_project_admin?(project).should eq false
+        expect(user.is_project_admin?(project)).to eq false
       end
     end
 
     describe "when a user wasnt previously an admin for the project" do
       it "the user is still not an admin for the project" do
         user.remove_role_for_project("admin",project)
-        user.is_project_admin?(project).should eq false
+        expect(user.is_project_admin?(project)).to eq false
       end
       it "should only be admin for no projects" do
-        user.admin_for_projects.should have(0).item
+        expect(user.admin_for_projects.size).to eq(0)
       end
     end
   end
@@ -394,12 +394,12 @@ describe User do
     end
 
     it "should be a project admin for the first project now " do
-      user.is_project_admin?(projects.first).should eq true
+      expect(user.is_project_admin?(projects.first)).to eq true
     end
 
     it "should list one admin_project" do
-      user.admin_for_projects.should have(1).item
-      user.admin_for_projects.should include(projects.first)
+      expect(user.admin_for_projects.size).to eq(1)
+      expect(user.admin_for_projects).to include(projects.first)
     end
 
   end
@@ -430,7 +430,7 @@ describe User do
       end
       context "when the user isn't a student" do
         it "creates an authentication if one doesn't exist" do
-          expect(user.authentications).to have(0).items
+          expect(user.authentications.size).to eq(0)
           found_user = User.find_for_omniauth(mock_auth)
           expect(found_user).to eq user
           new_authentication = found_user.authentications.first

--- a/spec/policies/commons_license_policy_spec.rb
+++ b/spec/policies/commons_license_policy_spec.rb
@@ -6,37 +6,37 @@ describe CommonsLicensePolicy do
   let(:commons_license)   { FactoryGirl.create(:commons_license)                   }
 
   context "for anonymous" do
-    it { should_not permit(:index)   }
-    it { should_not permit(:show)    }
-    it { should_not permit(:new)     }
-    it { should_not permit(:edit)    }
-    it { should_not permit(:create)  }
-    it { should_not permit(:update)  }
-    it { should_not permit(:destroy) }
+    it { is_expected.not_to permit(:index)   }
+    it { is_expected.not_to permit(:show)    }
+    it { is_expected.not_to permit(:new)     }
+    it { is_expected.not_to permit(:edit)    }
+    it { is_expected.not_to permit(:create)  }
+    it { is_expected.not_to permit(:update)  }
+    it { is_expected.not_to permit(:destroy) }
   end
 
   context "for a normal user" do
     let(:active_user) { FactoryGirl.create(:user) }
 
-    it { should_not permit(:index)   }
-    it { should_not permit(:show)    }
-    it { should_not permit(:new)     }
-    it { should_not permit(:edit)    }
-    it { should_not permit(:create)  }
-    it { should_not permit(:update)  }
-    it { should_not permit(:destroy) }
+    it { is_expected.not_to permit(:index)   }
+    it { is_expected.not_to permit(:show)    }
+    it { is_expected.not_to permit(:new)     }
+    it { is_expected.not_to permit(:edit)    }
+    it { is_expected.not_to permit(:create)  }
+    it { is_expected.not_to permit(:update)  }
+    it { is_expected.not_to permit(:destroy) }
   end
 
   context "for an admin" do
     let(:active_user) { Factory.next(:admin_user)   }
 
-    it { should permit(:index)   }
-    it { should permit(:show)    }
-    it { should permit(:new)     }
-    it { should permit(:edit)    }
-    it { should permit(:create)  }
-    it { should permit(:update)  }
-    it { should permit(:destroy) }
+    it { is_expected.to permit(:index)   }
+    it { is_expected.to permit(:show)    }
+    it { is_expected.to permit(:new)     }
+    it { is_expected.to permit(:edit)    }
+    it { is_expected.to permit(:create)  }
+    it { is_expected.to permit(:update)  }
+    it { is_expected.to permit(:destroy) }
   end
 
   context "for a manager" do
@@ -44,13 +44,13 @@ describe CommonsLicensePolicy do
     before(:each) do
       active_user.add_role('manager')
     end
-    it { should permit(:index)   }
-    it { should permit(:show)    }
-    it { should permit(:new)     }
-    it { should permit(:edit)    }
-    it { should permit(:create)  }
-    it { should permit(:update)  }
-    it { should permit(:destroy) }
+    it { is_expected.to permit(:index)   }
+    it { is_expected.to permit(:show)    }
+    it { is_expected.to permit(:new)     }
+    it { is_expected.to permit(:edit)    }
+    it { is_expected.to permit(:create)  }
+    it { is_expected.to permit(:update)  }
+    it { is_expected.to permit(:destroy) }
   end
 
 end

--- a/spec/policies/external_activity_policy_spec.rb
+++ b/spec/policies/external_activity_policy_spec.rb
@@ -6,34 +6,34 @@ describe ExternalActivityPolicy do
   let(:activity)          { FactoryGirl.create(:external_activity)              }
 
   context "for anonymous" do
-    it { should permit(:preview_index)           }
-    it { should_not permit(:publish)             }
-    it { should_not permit(:duplicate)           }
-    it { should_not permit(:matedit)             }
-    it { should_not permit(:duplicate)           }
-    it { should_not permit(:copy)                }
-    it { should_not permit(:edit_basic)          }
-    it { should_not permit(:update)              }
-    it { should_not permit(:archive)             }
-    it { should_not permit(:unarchive)           }
-    it { should_not permit(:edit_credits)        }
+    it { is_expected.to permit(:preview_index)           }
+    it { is_expected.not_to permit(:publish)             }
+    it { is_expected.not_to permit(:duplicate)           }
+    it { is_expected.not_to permit(:matedit)             }
+    it { is_expected.not_to permit(:duplicate)           }
+    it { is_expected.not_to permit(:copy)                }
+    it { is_expected.not_to permit(:edit_basic)          }
+    it { is_expected.not_to permit(:update)              }
+    it { is_expected.not_to permit(:archive)             }
+    it { is_expected.not_to permit(:unarchive)           }
+    it { is_expected.not_to permit(:edit_credits)        }
   end
 
 
   context "for a normal user" do
     let(:active_user) { FactoryGirl.create(:user) }
 
-    it { should permit(:preview_index)            }
-    it { should permit(:copy)                     }
-    it { should_not permit(:publish)              }
-    it { should_not permit(:duplicate)            }
-    it { should_not permit(:matedit)              }
-    it { should_not permit(:duplicate)            }
-    it { should_not permit(:edit_basic)           }
-    it { should_not permit(:update)               }
-    it { should_not permit(:archive)              }
-    it { should_not permit(:unarchive)            }
-    it { should_not permit(:edit_credits)        }
+    it { is_expected.to permit(:preview_index)            }
+    it { is_expected.to permit(:copy)                     }
+    it { is_expected.not_to permit(:publish)              }
+    it { is_expected.not_to permit(:duplicate)            }
+    it { is_expected.not_to permit(:matedit)              }
+    it { is_expected.not_to permit(:duplicate)            }
+    it { is_expected.not_to permit(:edit_basic)           }
+    it { is_expected.not_to permit(:update)               }
+    it { is_expected.not_to permit(:archive)              }
+    it { is_expected.not_to permit(:unarchive)            }
+    it { is_expected.not_to permit(:edit_credits)        }
   end
 
   context "for the owner" do
@@ -44,32 +44,32 @@ describe ExternalActivityPolicy do
       active_user.add_role('author')
     end
 
-    it { should permit(:preview_index)            }
-    it { should permit(:copy)                     }
-    it { should permit(:publish)                  }
-    it { should permit(:matedit)                  }
-    it { should permit(:edit_basic)               }
-    it { should permit(:archive)                  }
-    it { should permit(:unarchive)                }
+    it { is_expected.to permit(:preview_index)            }
+    it { is_expected.to permit(:copy)                     }
+    it { is_expected.to permit(:publish)                  }
+    it { is_expected.to permit(:matedit)                  }
+    it { is_expected.to permit(:edit_basic)               }
+    it { is_expected.to permit(:archive)                  }
+    it { is_expected.to permit(:unarchive)                }
 
     # not sure why. Just documenting:
-    it { should_not permit(:duplicate)            }
+    it { is_expected.not_to permit(:duplicate)            }
 
-    it { should_not permit(:edit_credits)         }
+    it { is_expected.not_to permit(:edit_credits)         }
   end
 
   context "for an admin" do
     let(:active_user) { Factory.next(:admin_user)   }
 
-    it { should permit(:preview_index)            }
-    it { should permit(:copy)                     }
-    it { should permit(:publish)                  }
-    it { should permit(:matedit)                  }
-    it { should permit(:edit_basic)               }
-    it { should permit(:archive)                  }
-    it { should permit(:unarchive)                }
-    it { should permit(:duplicate)                }
-    it { should permit(:edit_credits)             }
+    it { is_expected.to permit(:preview_index)            }
+    it { is_expected.to permit(:copy)                     }
+    it { is_expected.to permit(:publish)                  }
+    it { is_expected.to permit(:matedit)                  }
+    it { is_expected.to permit(:edit_basic)               }
+    it { is_expected.to permit(:archive)                  }
+    it { is_expected.to permit(:unarchive)                }
+    it { is_expected.to permit(:duplicate)                }
+    it { is_expected.to permit(:edit_credits)             }
   end
 
 
@@ -80,15 +80,15 @@ describe ExternalActivityPolicy do
     before(:each) do
       active_user.add_role_for_project('admin', project_a)
     end
-    it { should permit(:preview_index)            }
-    it { should permit(:copy)                     }
-    it { should permit(:publish)                  }
-    it { should permit(:matedit)                  }
-    it { should permit(:edit_basic)               }
-    it { should permit(:archive)                  }
-    it { should permit(:unarchive)                }
-    it { should permit(:duplicate)                }
-    it { should permit(:edit_credits)             }
+    it { is_expected.to permit(:preview_index)            }
+    it { is_expected.to permit(:copy)                     }
+    it { is_expected.to permit(:publish)                  }
+    it { is_expected.to permit(:matedit)                  }
+    it { is_expected.to permit(:edit_basic)               }
+    it { is_expected.to permit(:archive)                  }
+    it { is_expected.to permit(:unarchive)                }
+    it { is_expected.to permit(:duplicate)                }
+    it { is_expected.to permit(:edit_credits)             }
   end
 
   context "for an admin of a project that is not one of the material's projects" do
@@ -97,12 +97,12 @@ describe ExternalActivityPolicy do
     before(:each) do
       active_user.add_role_for_project('admin', project_a)
     end
-    it { should permit(:edit_projects)            }
-    it { should permit(:edit_cohorts)             }
-    it { should permit(:edit)                     }
+    it { is_expected.to permit(:edit_projects)            }
+    it { is_expected.to permit(:edit_cohorts)             }
+    it { is_expected.to permit(:edit)                     }
     # this type of user needs to be able to update the activity so that it can make a
     # material part of a project that isn't already part of the project.
-    it { should permit(:update)                   }
+    it { is_expected.to permit(:update)                   }
   end
 
 end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -6,60 +6,60 @@ describe UserPolicy do
   let(:user)        { FactoryGirl.create(:user)            }
 
   context "for anonymous" do
-    it { should_not permit(:limited_edit)           }
-    it { should_not permit(:limited_update)         }
-    it { should_not permit(:index)                  }
-    it { should_not permit(:show)                   }
-    it { should_not permit(:update)                 }
-    it { should_not permit(:destroy)                }
-    it { should_not permit(:edit)                   }
-    it { should_not permit(:make_admin)             }
-    it { should_not permit(:switch)                 }
-    it { should_not permit(:confirm)                }
-    it { should_not permit(:preferences)            }
-    it { should_not permit(:reset_password)         }
+    it { is_expected.not_to permit(:limited_edit)           }
+    it { is_expected.not_to permit(:limited_update)         }
+    it { is_expected.not_to permit(:index)                  }
+    it { is_expected.not_to permit(:show)                   }
+    it { is_expected.not_to permit(:update)                 }
+    it { is_expected.not_to permit(:destroy)                }
+    it { is_expected.not_to permit(:edit)                   }
+    it { is_expected.not_to permit(:make_admin)             }
+    it { is_expected.not_to permit(:switch)                 }
+    it { is_expected.not_to permit(:confirm)                }
+    it { is_expected.not_to permit(:preferences)            }
+    it { is_expected.not_to permit(:reset_password)         }
     # Documenting current behavior:
-    it { should_not permit(:create)                 }
-    it { should_not permit(:new)                    }
+    it { is_expected.not_to permit(:create)                 }
+    it { is_expected.not_to permit(:new)                    }
   end
 
   context "for a normal user" do
     let(:active_user) { FactoryGirl.create(:user) }
-    it { should_not permit(:limited_edit)           }
-    it { should_not permit(:limited_update)         }
-    it { should_not permit(:index)                  }
-    it { should_not permit(:show)                   }
-    it { should_not permit(:update)                 }
-    it { should_not permit(:destroy)                }
-    it { should_not permit(:edit)                   }
-    it { should_not permit(:make_admin)             }
-    it { should_not permit(:switch)                 }
-    it { should_not permit(:preferences)            }
-    it { should_not permit(:confirm)                }
-    it { should_not permit(:reset_password)         }
+    it { is_expected.not_to permit(:limited_edit)           }
+    it { is_expected.not_to permit(:limited_update)         }
+    it { is_expected.not_to permit(:index)                  }
+    it { is_expected.not_to permit(:show)                   }
+    it { is_expected.not_to permit(:update)                 }
+    it { is_expected.not_to permit(:destroy)                }
+    it { is_expected.not_to permit(:edit)                   }
+    it { is_expected.not_to permit(:make_admin)             }
+    it { is_expected.not_to permit(:switch)                 }
+    it { is_expected.not_to permit(:preferences)            }
+    it { is_expected.not_to permit(:confirm)                }
+    it { is_expected.not_to permit(:reset_password)         }
     # Documenting current behavior:
-    it { should permit(:create)                     }
-    it { should permit(:new)                        }
+    it { is_expected.to permit(:create)                     }
+    it { is_expected.to permit(:new)                        }
   end
 
   context "for an admin" do
     let(:active_user) { Factory.next(:admin_user)   }
-    it { should permit(:limited_edit)               }
-    it { should permit(:limited_update)             }
-    it { should permit(:index)                      }
-    it { should permit(:show)                       }
-    it { should permit(:update)                     }
-    it { should permit(:destroy)                    }
-    it { should permit(:create)                     }
-    it { should permit(:new)                        }
-    it { should permit(:edit)                       }
-    it { should permit(:make_admin)                 }
-    it { should permit(:switch)                     }
-    it { should permit(:confirm)                    }
-    it { should permit(:preferences)                }
-    it { should permit(:reset_password)             }
-    it { should permit(:student_page)               }
-    it { should permit(:teacher_page)               }
+    it { is_expected.to permit(:limited_edit)               }
+    it { is_expected.to permit(:limited_update)             }
+    it { is_expected.to permit(:index)                      }
+    it { is_expected.to permit(:show)                       }
+    it { is_expected.to permit(:update)                     }
+    it { is_expected.to permit(:destroy)                    }
+    it { is_expected.to permit(:create)                     }
+    it { is_expected.to permit(:new)                        }
+    it { is_expected.to permit(:edit)                       }
+    it { is_expected.to permit(:make_admin)                 }
+    it { is_expected.to permit(:switch)                     }
+    it { is_expected.to permit(:confirm)                    }
+    it { is_expected.to permit(:preferences)                }
+    it { is_expected.to permit(:reset_password)             }
+    it { is_expected.to permit(:student_page)               }
+    it { is_expected.to permit(:teacher_page)               }
   end
 
   context "for a teacher" do
@@ -68,11 +68,11 @@ describe UserPolicy do
 
     context "working with their own student" do
       let(:user)     { FactoryGirl.create(:full_portal_student, clazzes: [clazz]).user}
-      it { should permit(:reset_password)             }
+      it { is_expected.to permit(:reset_password)             }
     end
     context "working with some other student" do
       let(:user)     { FactoryGirl.create(:full_portal_student).user}
-      it { should_not permit(:reset_password)         }
+      it { is_expected.not_to permit(:reset_password)         }
     end
   end
 
@@ -90,44 +90,44 @@ describe UserPolicy do
     end
 
     it "the active user should be a project admin" do
-      active_user.admin_for_projects.should include(project_a)
+      expect(active_user.admin_for_projects).to include(project_a)
     end
 
     context "acting on a generic portal teacher" do
       let(:user) { regular_teacher.user }
-      it { should permit(:limited_edit)               }
-      it { should permit(:limited_update)             }
-      it { should permit(:index)                      }
-      it { should permit(:show)                       }
-      it { should_not permit(:update)                 }
-      it { should_not permit(:destroy)                }
-      it { should_not permit(:edit)                   }
-      it { should_not permit(:make_admin)             }
-      it { should_not permit(:confirm)                }
-      it { should_not permit(:preferences)            }
-      it { should_not permit(:reset_password)         }
-      it { should_not permit(:student_page)           }
-      it { should_not permit(:teacher_page)           }
+      it { is_expected.to permit(:limited_edit)               }
+      it { is_expected.to permit(:limited_update)             }
+      it { is_expected.to permit(:index)                      }
+      it { is_expected.to permit(:show)                       }
+      it { is_expected.not_to permit(:update)                 }
+      it { is_expected.not_to permit(:destroy)                }
+      it { is_expected.not_to permit(:edit)                   }
+      it { is_expected.not_to permit(:make_admin)             }
+      it { is_expected.not_to permit(:confirm)                }
+      it { is_expected.not_to permit(:preferences)            }
+      it { is_expected.not_to permit(:reset_password)         }
+      it { is_expected.not_to permit(:student_page)           }
+      it { is_expected.not_to permit(:teacher_page)           }
       # Documenting current behavior:
-      it { should permit(:create)                     }
-      it { should permit(:new)                        }
+      it { is_expected.to permit(:create)                     }
+      it { is_expected.to permit(:new)                        }
     end
 
     context "acting on a portal teacher in hir project cohort" do
       let(:user) { a_teacher.user }
-      it { should permit(:index)                      }
-      it { should permit(:show)                       }
-      it { should permit(:confirm)                    }
-      it { should_not permit(:preferences)            }
-      it { should permit(:reset_password)             }
-      it { should permit(:update)                     }
-      it { should_not permit(:destroy)                }
-      it { should permit(:edit)                       }
-      it { should_not permit(:make_admin)             }
-      it { should permit(:switch)                     }
+      it { is_expected.to permit(:index)                      }
+      it { is_expected.to permit(:show)                       }
+      it { is_expected.to permit(:confirm)                    }
+      it { is_expected.not_to permit(:preferences)            }
+      it { is_expected.to permit(:reset_password)             }
+      it { is_expected.to permit(:update)                     }
+      it { is_expected.not_to permit(:destroy)                }
+      it { is_expected.to permit(:edit)                       }
+      it { is_expected.not_to permit(:make_admin)             }
+      it { is_expected.to permit(:switch)                     }
       # Documenting current behavior:
-      it { should permit(:create)                     }
-      it { should permit(:new)                        }
+      it { is_expected.to permit(:create)                     }
+      it { is_expected.to permit(:new)                        }
     end
 
     context "acting on a portal administrator" do
@@ -135,55 +135,55 @@ describe UserPolicy do
         user.add_role("admin")
       end
       let(:user) { a_teacher.user }
-      it { should permit(:index)                      }
-      it { should_not permit(:make_admin)             }
-      it { should permit(:show)                       }
-      it { should permit(:confirm)                }
-      it { should_not permit(:reset_password)         }
-      it { should_not permit(:preferences)            }
-      it { should_not permit(:switch)                 }
-      it { should_not permit(:update)                 }
-      it { should_not permit(:destroy)                }
-      it { should_not permit(:edit)                   }
+      it { is_expected.to permit(:index)                      }
+      it { is_expected.not_to permit(:make_admin)             }
+      it { is_expected.to permit(:show)                       }
+      it { is_expected.to permit(:confirm)                }
+      it { is_expected.not_to permit(:reset_password)         }
+      it { is_expected.not_to permit(:preferences)            }
+      it { is_expected.not_to permit(:switch)                 }
+      it { is_expected.not_to permit(:update)                 }
+      it { is_expected.not_to permit(:destroy)                }
+      it { is_expected.not_to permit(:edit)                   }
       # Documenting current behavior:
-      it { should permit(:create)                     }
-      it { should permit(:new)                        }
+      it { is_expected.to permit(:create)                     }
+      it { is_expected.to permit(:new)                        }
     end
 
     context "acting on a regular student" do
       let(:user) { regular_student.user }
-      it { should permit(:index)                      }
-      it { should_not permit(:limited_edit)           }
-      it { should_not permit(:limited_update)         }
-      it { should_not permit(:make_admin)             }
-      it { should_not permit(:show)                   }
-      it { should_not permit(:confirm)                }
-      it { should_not permit(:reset_password)         }
-      it { should_not permit(:preferences)            }
-      it { should_not permit(:switch)                 }
-      it { should_not permit(:update)                 }
-      it { should_not permit(:destroy)                }
-      it { should_not permit(:edit)                   }
+      it { is_expected.to permit(:index)                      }
+      it { is_expected.not_to permit(:limited_edit)           }
+      it { is_expected.not_to permit(:limited_update)         }
+      it { is_expected.not_to permit(:make_admin)             }
+      it { is_expected.not_to permit(:show)                   }
+      it { is_expected.not_to permit(:confirm)                }
+      it { is_expected.not_to permit(:reset_password)         }
+      it { is_expected.not_to permit(:preferences)            }
+      it { is_expected.not_to permit(:switch)                 }
+      it { is_expected.not_to permit(:update)                 }
+      it { is_expected.not_to permit(:destroy)                }
+      it { is_expected.not_to permit(:edit)                   }
       # Documenting current behavior:
-      it { should permit(:create)                     }
-      it { should permit(:new)                        }
+      it { is_expected.to permit(:create)                     }
+      it { is_expected.to permit(:new)                        }
     end
 
     context "acting on a student in hir project cohort" do
       let(:user) { a_student.user }
-      it { should permit(:index)                      }
-      it { should_not permit(:make_admin)             }
-      it { should permit(:show)                       }
-      it { should permit(:confirm)                    }
-      it { should permit(:reset_password)             }
-      it { should_not permit(:preferences)            }
-      it { should permit(:switch)                     }
-      it { should permit(:update)                     }
-      it { should_not permit(:destroy)                }
-      it { should permit(:edit)                       }
+      it { is_expected.to permit(:index)                      }
+      it { is_expected.not_to permit(:make_admin)             }
+      it { is_expected.to permit(:show)                       }
+      it { is_expected.to permit(:confirm)                    }
+      it { is_expected.to permit(:reset_password)             }
+      it { is_expected.not_to permit(:preferences)            }
+      it { is_expected.to permit(:switch)                     }
+      it { is_expected.to permit(:update)                     }
+      it { is_expected.not_to permit(:destroy)                }
+      it { is_expected.to permit(:edit)                       }
       # Documenting current behavior:
-      it { should permit(:create)                     }
-      it { should permit(:new)                        }
+      it { is_expected.to permit(:create)                     }
+      it { is_expected.to permit(:new)                        }
     end
   end
 

--- a/spec/routing/admin/settings_routing_spec.rb
+++ b/spec/routing/admin/settings_routing_spec.rb
@@ -3,31 +3,31 @@ require File.expand_path('../../../spec_helper', __FILE__)
 describe Admin::SettingsController do
   describe "routing" do
     it "recognizes and generates #index" do
-      { :get => "admin/settings" }.should route_to(:controller => "admin/settings", :action => "index")
+      expect({ :get => "admin/settings" }).to route_to(:controller => "admin/settings", :action => "index")
     end
 
     it "recognizes and generates #new" do
-      { :get => "admin/settings/new" }.should route_to(:controller => "admin/settings", :action => "new")
+      expect({ :get => "admin/settings/new" }).to route_to(:controller => "admin/settings", :action => "new")
     end
 
     it "recognizes and generates #show" do
-      { :get => "admin/settings/1" }.should route_to(:controller => "admin/settings", :action => "show", :id => "1")
+      expect({ :get => "admin/settings/1" }).to route_to(:controller => "admin/settings", :action => "show", :id => "1")
     end
 
     it "recognizes and generates #edit" do
-      { :get => "admin/settings/1/edit" }.should route_to(:controller => "admin/settings", :action => "edit", :id => "1")
+      expect({ :get => "admin/settings/1/edit" }).to route_to(:controller => "admin/settings", :action => "edit", :id => "1")
     end
 
     it "recognizes and generates #create" do
-      { :post => "admin/settings" }.should route_to(:controller => "admin/settings", :action => "create") 
+      expect({ :post => "admin/settings" }).to route_to(:controller => "admin/settings", :action => "create") 
     end
 
     it "recognizes and generates #update" do
-      { :put => "admin/settings/1" }.should route_to(:controller => "admin/settings", :action => "update", :id => "1") 
+      expect({ :put => "admin/settings/1" }).to route_to(:controller => "admin/settings", :action => "update", :id => "1") 
     end
 
     it "recognizes and generates #destroy" do
-      { :delete => "admin/settings/1" }.should route_to(:controller => "admin/settings", :action => "destroy", :id => "1") 
+      expect({ :delete => "admin/settings/1" }).to route_to(:controller => "admin/settings", :action => "destroy", :id => "1") 
     end
   end
 end

--- a/spec/routing/admin/tags_routing_spec.rb
+++ b/spec/routing/admin/tags_routing_spec.rb
@@ -3,31 +3,31 @@ require 'spec_helper'
 describe Admin::TagsController do
   describe "routing" do
     it "recognizes and generates #index" do
-      { :get => "/admin/tags" }.should route_to(:controller => "admin/tags", :action => "index")
+      expect({ :get => "/admin/tags" }).to route_to(:controller => "admin/tags", :action => "index")
     end
 
     it "recognizes and generates #new" do
-      { :get => "/admin/tags/new" }.should route_to(:controller => "admin/tags", :action => "new")
+      expect({ :get => "/admin/tags/new" }).to route_to(:controller => "admin/tags", :action => "new")
     end
 
     it "recognizes and generates #show" do
-      { :get => "/admin/tags/1" }.should route_to(:controller => "admin/tags", :action => "show", :id => "1")
+      expect({ :get => "/admin/tags/1" }).to route_to(:controller => "admin/tags", :action => "show", :id => "1")
     end
 
     it "recognizes and generates #edit" do
-      { :get => "/admin/tags/1/edit" }.should route_to(:controller => "admin/tags", :action => "edit", :id => "1")
+      expect({ :get => "/admin/tags/1/edit" }).to route_to(:controller => "admin/tags", :action => "edit", :id => "1")
     end
 
     it "recognizes and generates #create" do
-      { :post => "/admin/tags" }.should route_to(:controller => "admin/tags", :action => "create")
+      expect({ :post => "/admin/tags" }).to route_to(:controller => "admin/tags", :action => "create")
     end
 
     it "recognizes and generates #update" do
-      { :put => "/admin/tags/1" }.should route_to(:controller => "admin/tags", :action => "update", :id => "1")
+      expect({ :put => "/admin/tags/1" }).to route_to(:controller => "admin/tags", :action => "update", :id => "1")
     end
 
     it "recognizes and generates #destroy" do
-      { :delete => "/admin/tags/1" }.should route_to(:controller => "admin/tags", :action => "destroy", :id => "1")
+      expect({ :delete => "/admin/tags/1" }).to route_to(:controller => "admin/tags", :action => "destroy", :id => "1")
     end
   end
 end

--- a/spec/routing/dataservice/blobs_routing_spec.rb
+++ b/spec/routing/dataservice/blobs_routing_spec.rb
@@ -3,35 +3,35 @@ require File.expand_path('../../../spec_helper', __FILE__)
 describe Dataservice::BlobsController do
   describe "routing" do
     it "recognizes and generates #index" do
-      { :get => "/dataservice/blobs" }.should route_to(:controller => "dataservice/blobs", :action => "index")
+      expect({ :get => "/dataservice/blobs" }).to route_to(:controller => "dataservice/blobs", :action => "index")
     end
 
     it "recognizes and generates #new" do
-      { :get => "/dataservice/blobs/new" }.should route_to(:controller => "dataservice/blobs", :action => "new")
+      expect({ :get => "/dataservice/blobs/new" }).to route_to(:controller => "dataservice/blobs", :action => "new")
     end
 
     it "recognizes and generates #show" do
-      { :get => "/dataservice/blobs/1" }.should route_to(:controller => "dataservice/blobs", :action => "show", :id => "1")
+      expect({ :get => "/dataservice/blobs/1" }).to route_to(:controller => "dataservice/blobs", :action => "show", :id => "1")
     end
     
     it "recognizes and generates the raw #show with a valid token" do
-      { :get => "/dataservice/blobs/1.blob/8ad04a50ba96463d80407cd119173b86"}.should route_to(:controller => "dataservice/blobs", :action => "show", :format => "blob", :id => "1", :token => "8ad04a50ba96463d80407cd119173b86")
+      expect({ :get => "/dataservice/blobs/1.blob/8ad04a50ba96463d80407cd119173b86"}).to route_to(:controller => "dataservice/blobs", :action => "show", :format => "blob", :id => "1", :token => "8ad04a50ba96463d80407cd119173b86")
     end
 
     it "recognizes and generates #edit" do
-      { :get => "/dataservice/blobs/1/edit" }.should route_to(:controller => "dataservice/blobs", :action => "edit", :id => "1")
+      expect({ :get => "/dataservice/blobs/1/edit" }).to route_to(:controller => "dataservice/blobs", :action => "edit", :id => "1")
     end
 
     it "recognizes and generates #create" do
-      { :post => "/dataservice/blobs" }.should route_to(:controller => "dataservice/blobs", :action => "create") 
+      expect({ :post => "/dataservice/blobs" }).to route_to(:controller => "dataservice/blobs", :action => "create") 
     end
 
     it "recognizes and generates #update" do
-      { :put => "/dataservice/blobs/1" }.should route_to(:controller => "dataservice/blobs", :action => "update", :id => "1") 
+      expect({ :put => "/dataservice/blobs/1" }).to route_to(:controller => "dataservice/blobs", :action => "update", :id => "1") 
     end
 
     it "recognizes and generates #destroy" do
-      { :delete => "/dataservice/blobs/1" }.should route_to(:controller => "dataservice/blobs", :action => "destroy", :id => "1") 
+      expect({ :delete => "/dataservice/blobs/1" }).to route_to(:controller => "dataservice/blobs", :action => "destroy", :id => "1") 
     end
   end
 end

--- a/spec/routing/dataservice/bundle_contents_routing_spec.rb
+++ b/spec/routing/dataservice/bundle_contents_routing_spec.rb
@@ -3,31 +3,31 @@ require File.expand_path('../../../spec_helper', __FILE__)
 describe Dataservice::BundleContentsController do
   describe "routing" do
     it "recognizes and generates #index" do
-      { :get => "dataservice/bundle_contents" }.should route_to(:controller => "dataservice/bundle_contents", :action => "index")
+      expect({ :get => "dataservice/bundle_contents" }).to route_to(:controller => "dataservice/bundle_contents", :action => "index")
     end
 
     it "recognizes and generates #new" do
-      { :get => "dataservice/bundle_contents/new" }.should route_to(:controller => "dataservice/bundle_contents", :action => "new")
+      expect({ :get => "dataservice/bundle_contents/new" }).to route_to(:controller => "dataservice/bundle_contents", :action => "new")
     end
 
     it "recognizes and generates #show" do
-      { :get => "dataservice/bundle_contents/1" }.should route_to(:controller => "dataservice/bundle_contents", :action => "show", :id => "1")
+      expect({ :get => "dataservice/bundle_contents/1" }).to route_to(:controller => "dataservice/bundle_contents", :action => "show", :id => "1")
     end
 
     it "recognizes and generates #edit" do
-      { :get => "dataservice/bundle_contents/1/edit" }.should route_to(:controller => "dataservice/bundle_contents", :action => "edit", :id => "1")
+      expect({ :get => "dataservice/bundle_contents/1/edit" }).to route_to(:controller => "dataservice/bundle_contents", :action => "edit", :id => "1")
     end
 
     it "recognizes and generates #create" do
-      { :post => "dataservice/bundle_contents" }.should route_to(:controller => "dataservice/bundle_contents", :action => "create") 
+      expect({ :post => "dataservice/bundle_contents" }).to route_to(:controller => "dataservice/bundle_contents", :action => "create") 
     end
 
     it "recognizes and generates #update" do
-      { :put => "dataservice/bundle_contents/1" }.should route_to(:controller => "dataservice/bundle_contents", :action => "update", :id => "1") 
+      expect({ :put => "dataservice/bundle_contents/1" }).to route_to(:controller => "dataservice/bundle_contents", :action => "update", :id => "1") 
     end
 
     it "recognizes and generates #destroy" do
-      { :delete => "dataservice/bundle_contents/1" }.should route_to(:controller => "dataservice/bundle_contents", :action => "destroy", :id => "1") 
+      expect({ :delete => "dataservice/bundle_contents/1" }).to route_to(:controller => "dataservice/bundle_contents", :action => "destroy", :id => "1") 
     end
   end
 end

--- a/spec/routing/dataservice/bundle_loggers_routing_spec.rb
+++ b/spec/routing/dataservice/bundle_loggers_routing_spec.rb
@@ -3,31 +3,31 @@ require File.expand_path('../../../spec_helper', __FILE__)
 describe Dataservice::BundleContentsController do
   describe "routing" do
     it "recognizes and generates #index" do
-      { :get => "dataservice/bundle_loggers" }.should route_to(:controller => "dataservice/bundle_loggers", :action => "index")
+      expect({ :get => "dataservice/bundle_loggers" }).to route_to(:controller => "dataservice/bundle_loggers", :action => "index")
     end
 
     it "recognizes and generates #new" do
-      { :get => "dataservice/bundle_loggers/new" }.should route_to(:controller => "dataservice/bundle_loggers", :action => "new")
+      expect({ :get => "dataservice/bundle_loggers/new" }).to route_to(:controller => "dataservice/bundle_loggers", :action => "new")
     end
 
     it "recognizes and generates #show" do
-      { :get => "dataservice/bundle_loggers/1" }.should route_to(:controller => "dataservice/bundle_loggers", :action => "show", :id => "1")
+      expect({ :get => "dataservice/bundle_loggers/1" }).to route_to(:controller => "dataservice/bundle_loggers", :action => "show", :id => "1")
     end
 
     it "recognizes and generates #edit" do
-      { :get => "dataservice/bundle_loggers/1/edit" }.should route_to(:controller => "dataservice/bundle_loggers", :action => "edit", :id => "1")
+      expect({ :get => "dataservice/bundle_loggers/1/edit" }).to route_to(:controller => "dataservice/bundle_loggers", :action => "edit", :id => "1")
     end
 
     it "recognizes and generates #create" do
-      { :post => "dataservice/bundle_loggers" }.should route_to(:controller => "dataservice/bundle_loggers", :action => "create") 
+      expect({ :post => "dataservice/bundle_loggers" }).to route_to(:controller => "dataservice/bundle_loggers", :action => "create") 
     end
 
     it "recognizes and generates #update" do
-      { :put => "dataservice/bundle_loggers/1" }.should route_to(:controller => "dataservice/bundle_loggers", :action => "update", :id => "1") 
+      expect({ :put => "dataservice/bundle_loggers/1" }).to route_to(:controller => "dataservice/bundle_loggers", :action => "update", :id => "1") 
     end
 
     it "recognizes and generates #destroy" do
-      { :delete => "dataservice/bundle_loggers/1" }.should route_to(:controller => "dataservice/bundle_loggers", :action => "destroy", :id => "1") 
+      expect({ :delete => "dataservice/bundle_loggers/1" }).to route_to(:controller => "dataservice/bundle_loggers", :action => "destroy", :id => "1") 
     end
   end
 end

--- a/spec/routing/dataservice/console_contents_routing_spec.rb
+++ b/spec/routing/dataservice/console_contents_routing_spec.rb
@@ -3,31 +3,31 @@ require File.expand_path('../../../spec_helper', __FILE__)
 describe Dataservice::BundleContentsController do
   describe "routing" do
     it "recognizes and generates #index" do
-      { :get => "dataservice/console_contents" }.should route_to(:controller => "dataservice/console_contents", :action => "index")
+      expect({ :get => "dataservice/console_contents" }).to route_to(:controller => "dataservice/console_contents", :action => "index")
     end
 
     it "recognizes and generates #new" do
-      { :get => "dataservice/console_contents/new" }.should route_to(:controller => "dataservice/console_contents", :action => "new")
+      expect({ :get => "dataservice/console_contents/new" }).to route_to(:controller => "dataservice/console_contents", :action => "new")
     end
 
     it "recognizes and generates #show" do
-      { :get => "dataservice/console_contents/1" }.should route_to(:controller => "dataservice/console_contents", :action => "show", :id => "1")
+      expect({ :get => "dataservice/console_contents/1" }).to route_to(:controller => "dataservice/console_contents", :action => "show", :id => "1")
     end
 
     it "recognizes and generates #edit" do
-      { :get => "dataservice/console_contents/1/edit" }.should route_to(:controller => "dataservice/console_contents", :action => "edit", :id => "1")
+      expect({ :get => "dataservice/console_contents/1/edit" }).to route_to(:controller => "dataservice/console_contents", :action => "edit", :id => "1")
     end
 
     it "recognizes and generates #create" do
-      { :post => "dataservice/console_contents" }.should route_to(:controller => "dataservice/console_contents", :action => "create") 
+      expect({ :post => "dataservice/console_contents" }).to route_to(:controller => "dataservice/console_contents", :action => "create") 
     end
 
     it "recognizes and generates #update" do
-      { :put => "dataservice/console_contents/1" }.should route_to(:controller => "dataservice/console_contents", :action => "update", :id => "1") 
+      expect({ :put => "dataservice/console_contents/1" }).to route_to(:controller => "dataservice/console_contents", :action => "update", :id => "1") 
     end
 
     it "recognizes and generates #destroy" do
-      { :delete => "dataservice/console_contents/1" }.should route_to(:controller => "dataservice/console_contents", :action => "destroy", :id => "1") 
+      expect({ :delete => "dataservice/console_contents/1" }).to route_to(:controller => "dataservice/console_contents", :action => "destroy", :id => "1") 
     end
   end
 end

--- a/spec/routing/dataservice/console_loggers_routing_spec.rb
+++ b/spec/routing/dataservice/console_loggers_routing_spec.rb
@@ -3,31 +3,31 @@ require File.expand_path('../../../spec_helper', __FILE__)
 describe Dataservice::BundleContentsController do
   describe "routing" do
     it "recognizes and generates #index" do
-      { :get => "dataservice/console_loggers" }.should route_to(:controller => "dataservice/console_loggers", :action => "index")
+      expect({ :get => "dataservice/console_loggers" }).to route_to(:controller => "dataservice/console_loggers", :action => "index")
     end
 
     it "recognizes and generates #new" do
-      { :get => "dataservice/console_loggers/new" }.should route_to(:controller => "dataservice/console_loggers", :action => "new")
+      expect({ :get => "dataservice/console_loggers/new" }).to route_to(:controller => "dataservice/console_loggers", :action => "new")
     end
 
     it "recognizes and generates #show" do
-      { :get => "dataservice/console_loggers/1" }.should route_to(:controller => "dataservice/console_loggers", :action => "show", :id => "1")
+      expect({ :get => "dataservice/console_loggers/1" }).to route_to(:controller => "dataservice/console_loggers", :action => "show", :id => "1")
     end
 
     it "recognizes and generates #edit" do
-      { :get => "dataservice/console_loggers/1/edit" }.should route_to(:controller => "dataservice/console_loggers", :action => "edit", :id => "1")
+      expect({ :get => "dataservice/console_loggers/1/edit" }).to route_to(:controller => "dataservice/console_loggers", :action => "edit", :id => "1")
     end
 
     it "recognizes and generates #create" do
-      { :post => "dataservice/console_loggers" }.should route_to(:controller => "dataservice/console_loggers", :action => "create") 
+      expect({ :post => "dataservice/console_loggers" }).to route_to(:controller => "dataservice/console_loggers", :action => "create") 
     end
 
     it "recognizes and generates #update" do
-      { :put => "dataservice/console_loggers/1" }.should route_to(:controller => "dataservice/console_loggers", :action => "update", :id => "1") 
+      expect({ :put => "dataservice/console_loggers/1" }).to route_to(:controller => "dataservice/console_loggers", :action => "update", :id => "1") 
     end
 
     it "recognizes and generates #destroy" do
-      { :delete => "dataservice/console_loggers/1" }.should route_to(:controller => "dataservice/console_loggers", :action => "destroy", :id => "1") 
+      expect({ :delete => "dataservice/console_loggers/1" }).to route_to(:controller => "dataservice/console_loggers", :action => "destroy", :id => "1") 
     end
   end
 end

--- a/spec/routing/images_routing_spec.rb
+++ b/spec/routing/images_routing_spec.rb
@@ -3,31 +3,31 @@ require File.expand_path('../../spec_helper', __FILE__)
 describe  ImagesController do
   describe "routing" do
     it "recognizes and generates #index" do
-      { :get => "images" }.should route_to(:controller => "images", :action => "index")
+      expect({ :get => "images" }).to route_to(:controller => "images", :action => "index")
     end
 
     it "recognizes and generates #new" do
-      { :get => "images/new" }.should route_to(:controller => "images", :action => "new")
+      expect({ :get => "images/new" }).to route_to(:controller => "images", :action => "new")
     end
 
     it "recognizes and generates #show" do
-      { :get => "images/1" }.should route_to(:controller => "images", :action => "show", :id => "1")
+      expect({ :get => "images/1" }).to route_to(:controller => "images", :action => "show", :id => "1")
     end
 
     it "recognizes and generates #edit" do
-      { :get => "images/1/edit" }.should route_to(:controller => "images", :action => "edit", :id => "1")
+      expect({ :get => "images/1/edit" }).to route_to(:controller => "images", :action => "edit", :id => "1")
     end
 
     it "recognizes and generates #create" do
-      { :post => "images" }.should route_to(:controller => "images", :action => "create") 
+      expect({ :post => "images" }).to route_to(:controller => "images", :action => "create") 
     end
 
     it "recognizes and generates #update" do
-      { :put => "images/1" }.should route_to(:controller => "images", :action => "update", :id => "1") 
+      expect({ :put => "images/1" }).to route_to(:controller => "images", :action => "update", :id => "1") 
     end
 
     it "recognizes and generates #destroy" do
-      { :delete => "images/1" }.should route_to(:controller => "images", :action => "destroy", :id => "1") 
+      expect({ :delete => "images/1" }).to route_to(:controller => "images", :action => "destroy", :id => "1") 
     end
   end
 end

--- a/spec/routing/materials_collections_routing_spec.rb
+++ b/spec/routing/materials_collections_routing_spec.rb
@@ -4,39 +4,39 @@ describe MaterialsCollectionsController do
   describe "routing" do
 
     it "routes to #index" do
-      get("/materials_collections").should route_to("materials_collections#index")
+      expect(get("/materials_collections")).to route_to("materials_collections#index")
     end
 
     it "routes to #new" do
-      get("/materials_collections/new").should route_to("materials_collections#new")
+      expect(get("/materials_collections/new")).to route_to("materials_collections#new")
     end
 
     it "routes to #show" do
-      get("/materials_collections/1").should route_to("materials_collections#show", :id => "1")
+      expect(get("/materials_collections/1")).to route_to("materials_collections#show", :id => "1")
     end
 
     it "routes to #edit" do
-      get("/materials_collections/1/edit").should route_to("materials_collections#edit", :id => "1")
+      expect(get("/materials_collections/1/edit")).to route_to("materials_collections#edit", :id => "1")
     end
 
     it "routes to #create" do
-      post("/materials_collections").should route_to("materials_collections#create")
+      expect(post("/materials_collections")).to route_to("materials_collections#create")
     end
 
     it "routes to #update" do
-      put("/materials_collections/1").should route_to("materials_collections#update", :id => "1")
+      expect(put("/materials_collections/1")).to route_to("materials_collections#update", :id => "1")
     end
 
     it "routes to #destroy" do
-      delete("/materials_collections/1").should route_to("materials_collections#destroy", :id => "1")
+      expect(delete("/materials_collections/1")).to route_to("materials_collections#destroy", :id => "1")
     end
 
     it "routes to #sort_materials" do
-      post("/materials_collections/1/sort_materials").should route_to("materials_collections#sort_materials", :id => "1")
+      expect(post("/materials_collections/1/sort_materials")).to route_to("materials_collections#sort_materials", :id => "1")
     end
 
     it "routes to #remove_material" do
-      post("/materials_collections/1/remove_material").should route_to("materials_collections#remove_material", :id => "1")
+      expect(post("/materials_collections/1/remove_material")).to route_to("materials_collections#remove_material", :id => "1")
     end
 
   end

--- a/spec/routing/portal/grade_levels_routing_spec.rb
+++ b/spec/routing/portal/grade_levels_routing_spec.rb
@@ -3,31 +3,31 @@ require File.expand_path('../../../spec_helper', __FILE__)
 describe  Portal::GradeLevelsController do
   describe "routing" do
     it "recognizes and generates #index" do
-      { :get => "portal/grade_levels" }.should route_to(:controller => "portal/grade_levels", :action => "index")
+      expect({ :get => "portal/grade_levels" }).to route_to(:controller => "portal/grade_levels", :action => "index")
     end
 
     it "recognizes and generates #new" do
-      { :get => "portal/grade_levels/new" }.should route_to(:controller => "portal/grade_levels", :action => "new")
+      expect({ :get => "portal/grade_levels/new" }).to route_to(:controller => "portal/grade_levels", :action => "new")
     end
 
     it "recognizes and generates #show" do
-      { :get => "portal/grade_levels/1" }.should route_to(:controller => "portal/grade_levels", :action => "show", :id => "1")
+      expect({ :get => "portal/grade_levels/1" }).to route_to(:controller => "portal/grade_levels", :action => "show", :id => "1")
     end
 
     it "recognizes and generates #edit" do
-      { :get => "portal/grade_levels/1/edit" }.should route_to(:controller => "portal/grade_levels", :action => "edit", :id => "1")
+      expect({ :get => "portal/grade_levels/1/edit" }).to route_to(:controller => "portal/grade_levels", :action => "edit", :id => "1")
     end
 
     it "recognizes and generates #create" do
-      { :post => "portal/grade_levels" }.should route_to(:controller => "portal/grade_levels", :action => "create") 
+      expect({ :post => "portal/grade_levels" }).to route_to(:controller => "portal/grade_levels", :action => "create") 
     end
 
     it "recognizes and generates #update" do
-      { :put => "portal/grade_levels/1" }.should route_to(:controller => "portal/grade_levels", :action => "update", :id => "1") 
+      expect({ :put => "portal/grade_levels/1" }).to route_to(:controller => "portal/grade_levels", :action => "update", :id => "1") 
     end
 
     it "recognizes and generates #destroy" do
-      { :delete => "portal/grade_levels/1" }.should route_to(:controller => "portal/grade_levels", :action => "destroy", :id => "1") 
+      expect({ :delete => "portal/grade_levels/1" }).to route_to(:controller => "portal/grade_levels", :action => "destroy", :id => "1") 
     end
   end
 end

--- a/spec/routing/portal/grades_routing_spec.rb
+++ b/spec/routing/portal/grades_routing_spec.rb
@@ -3,31 +3,31 @@ require File.expand_path('../../../spec_helper', __FILE__)
 describe  Portal::GradesController do
   describe "routing" do
     it "recognizes and generates #index" do
-      { :get => "portal/grades" }.should route_to(:controller => "portal/grades", :action => "index")
+      expect({ :get => "portal/grades" }).to route_to(:controller => "portal/grades", :action => "index")
     end
 
     it "recognizes and generates #new" do
-      { :get => "portal/grades/new" }.should route_to(:controller => "portal/grades", :action => "new")
+      expect({ :get => "portal/grades/new" }).to route_to(:controller => "portal/grades", :action => "new")
     end
 
     it "recognizes and generates #show" do
-      { :get => "portal/grades/1" }.should route_to(:controller => "portal/grades", :action => "show", :id => "1")
+      expect({ :get => "portal/grades/1" }).to route_to(:controller => "portal/grades", :action => "show", :id => "1")
     end
 
     it "recognizes and generates #edit" do
-      { :get => "portal/grades/1/edit" }.should route_to(:controller => "portal/grades", :action => "edit", :id => "1")
+      expect({ :get => "portal/grades/1/edit" }).to route_to(:controller => "portal/grades", :action => "edit", :id => "1")
     end
 
     it "recognizes and generates #create" do
-      { :post => "portal/grades" }.should route_to(:controller => "portal/grades", :action => "create") 
+      expect({ :post => "portal/grades" }).to route_to(:controller => "portal/grades", :action => "create") 
     end
 
     it "recognizes and generates #update" do
-      { :put => "portal/grades/1" }.should route_to(:controller => "portal/grades", :action => "update", :id => "1") 
+      expect({ :put => "portal/grades/1" }).to route_to(:controller => "portal/grades", :action => "update", :id => "1") 
     end
 
     it "recognizes and generates #destroy" do
-      { :delete => "portal/grades/1" }.should route_to(:controller => "portal/grades", :action => "destroy", :id => "1") 
+      expect({ :delete => "portal/grades/1" }).to route_to(:controller => "portal/grades", :action => "destroy", :id => "1") 
     end
   end
 end

--- a/spec/routing/portal/schools_routing_spec.rb
+++ b/spec/routing/portal/schools_routing_spec.rb
@@ -3,31 +3,31 @@ require File.expand_path('../../../spec_helper', __FILE__)
 describe  Portal::SchoolsController do
   describe "routing" do
     it "recognizes and generates #index" do
-      { :get => "portal/schools" }.should route_to(:controller => "portal/schools", :action => "index")
+      expect({ :get => "portal/schools" }).to route_to(:controller => "portal/schools", :action => "index")
     end
 
     it "recognizes and generates #new" do
-      { :get => "portal/schools/new" }.should route_to(:controller => "portal/schools", :action => "new")
+      expect({ :get => "portal/schools/new" }).to route_to(:controller => "portal/schools", :action => "new")
     end
 
     it "recognizes and generates #show" do
-      { :get => "portal/schools/1" }.should route_to(:controller => "portal/schools", :action => "show", :id => "1")
+      expect({ :get => "portal/schools/1" }).to route_to(:controller => "portal/schools", :action => "show", :id => "1")
     end
 
     it "recognizes and generates #edit" do
-      { :get => "portal/schools/1/edit" }.should route_to(:controller => "portal/schools", :action => "edit", :id => "1")
+      expect({ :get => "portal/schools/1/edit" }).to route_to(:controller => "portal/schools", :action => "edit", :id => "1")
     end
 
     it "recognizes and generates #create" do
-      { :post => "portal/schools" }.should route_to(:controller => "portal/schools", :action => "create") 
+      expect({ :post => "portal/schools" }).to route_to(:controller => "portal/schools", :action => "create") 
     end
 
     it "recognizes and generates #update" do
-      { :put => "portal/schools/1" }.should route_to(:controller => "portal/schools", :action => "update", :id => "1") 
+      expect({ :put => "portal/schools/1" }).to route_to(:controller => "portal/schools", :action => "update", :id => "1") 
     end
 
     it "recognizes and generates #destroy" do
-      { :delete => "portal/schools/1" }.should route_to(:controller => "portal/schools", :action => "destroy", :id => "1") 
+      expect({ :delete => "portal/schools/1" }).to route_to(:controller => "portal/schools", :action => "destroy", :id => "1") 
     end
   end
 end

--- a/spec/routing/ri_gse/assessment_targets_routing_spec.rb
+++ b/spec/routing/ri_gse/assessment_targets_routing_spec.rb
@@ -3,31 +3,31 @@ require File.expand_path('../../../spec_helper', __FILE__)
 describe  RiGse::AssessmentTargetsController do
   describe "routing" do
     it "recognizes and generates #index" do
-      { :get => "ri_gse/assessment_targets" }.should route_to(:controller => "ri_gse/assessment_targets", :action => "index")
+      expect({ :get => "ri_gse/assessment_targets" }).to route_to(:controller => "ri_gse/assessment_targets", :action => "index")
     end
 
     it "recognizes and generates #new" do
-      { :get => "ri_gse/assessment_targets/new" }.should route_to(:controller => "ri_gse/assessment_targets", :action => "new")
+      expect({ :get => "ri_gse/assessment_targets/new" }).to route_to(:controller => "ri_gse/assessment_targets", :action => "new")
     end
 
     it "recognizes and generates #show" do
-      { :get => "ri_gse/assessment_targets/1" }.should route_to(:controller => "ri_gse/assessment_targets", :action => "show", :id => "1")
+      expect({ :get => "ri_gse/assessment_targets/1" }).to route_to(:controller => "ri_gse/assessment_targets", :action => "show", :id => "1")
     end
 
     it "recognizes and generates #edit" do
-      { :get => "ri_gse/assessment_targets/1/edit" }.should route_to(:controller => "ri_gse/assessment_targets", :action => "edit", :id => "1")
+      expect({ :get => "ri_gse/assessment_targets/1/edit" }).to route_to(:controller => "ri_gse/assessment_targets", :action => "edit", :id => "1")
     end
 
     it "recognizes and generates #create" do
-      { :post => "ri_gse/assessment_targets" }.should route_to(:controller => "ri_gse/assessment_targets", :action => "create") 
+      expect({ :post => "ri_gse/assessment_targets" }).to route_to(:controller => "ri_gse/assessment_targets", :action => "create") 
     end
 
     it "recognizes and generates #update" do
-      { :put => "ri_gse/assessment_targets/1" }.should route_to(:controller => "ri_gse/assessment_targets", :action => "update", :id => "1") 
+      expect({ :put => "ri_gse/assessment_targets/1" }).to route_to(:controller => "ri_gse/assessment_targets", :action => "update", :id => "1") 
     end
 
     it "recognizes and generates #destroy" do
-      { :delete => "ri_gse/assessment_targets/1" }.should route_to(:controller => "ri_gse/assessment_targets", :action => "destroy", :id => "1") 
+      expect({ :delete => "ri_gse/assessment_targets/1" }).to route_to(:controller => "ri_gse/assessment_targets", :action => "destroy", :id => "1") 
     end
   end
 end

--- a/spec/routing/ri_gse/big_ideas_routing_spec.rb
+++ b/spec/routing/ri_gse/big_ideas_routing_spec.rb
@@ -3,31 +3,31 @@ require File.expand_path('../../../spec_helper', __FILE__)
 describe  RiGse::BigIdeasController do
   describe "routing" do
     it "recognizes and generates #index" do
-      { :get => "ri_gse/big_ideas" }.should route_to(:controller => "ri_gse/big_ideas", :action => "index")
+      expect({ :get => "ri_gse/big_ideas" }).to route_to(:controller => "ri_gse/big_ideas", :action => "index")
     end
 
     it "recognizes and generates #new" do
-      { :get => "ri_gse/big_ideas/new" }.should route_to(:controller => "ri_gse/big_ideas", :action => "new")
+      expect({ :get => "ri_gse/big_ideas/new" }).to route_to(:controller => "ri_gse/big_ideas", :action => "new")
     end
 
     it "recognizes and generates #show" do
-      { :get => "ri_gse/big_ideas/1" }.should route_to(:controller => "ri_gse/big_ideas", :action => "show", :id => "1")
+      expect({ :get => "ri_gse/big_ideas/1" }).to route_to(:controller => "ri_gse/big_ideas", :action => "show", :id => "1")
     end
 
     it "recognizes and generates #edit" do
-      { :get => "ri_gse/big_ideas/1/edit" }.should route_to(:controller => "ri_gse/big_ideas", :action => "edit", :id => "1")
+      expect({ :get => "ri_gse/big_ideas/1/edit" }).to route_to(:controller => "ri_gse/big_ideas", :action => "edit", :id => "1")
     end
 
     it "recognizes and generates #create" do
-      { :post => "ri_gse/big_ideas" }.should route_to(:controller => "ri_gse/big_ideas", :action => "create") 
+      expect({ :post => "ri_gse/big_ideas" }).to route_to(:controller => "ri_gse/big_ideas", :action => "create") 
     end
 
     it "recognizes and generates #update" do
-      { :put => "ri_gse/big_ideas/1" }.should route_to(:controller => "ri_gse/big_ideas", :action => "update", :id => "1") 
+      expect({ :put => "ri_gse/big_ideas/1" }).to route_to(:controller => "ri_gse/big_ideas", :action => "update", :id => "1") 
     end
 
     it "recognizes and generates #destroy" do
-      { :delete => "ri_gse/big_ideas/1" }.should route_to(:controller => "ri_gse/big_ideas", :action => "destroy", :id => "1") 
+      expect({ :delete => "ri_gse/big_ideas/1" }).to route_to(:controller => "ri_gse/big_ideas", :action => "destroy", :id => "1") 
     end
   end
 end

--- a/spec/routing/ri_gse/domains_routing_spec.rb
+++ b/spec/routing/ri_gse/domains_routing_spec.rb
@@ -3,31 +3,31 @@ require File.expand_path('../../../spec_helper', __FILE__)
 describe  RiGse::DomainsController do
   describe "routing" do
     it "recognizes and generates #index" do
-      { :get => "ri_gse/domains" }.should route_to(:controller => "ri_gse/domains", :action => "index")
+      expect({ :get => "ri_gse/domains" }).to route_to(:controller => "ri_gse/domains", :action => "index")
     end
 
     it "recognizes and generates #new" do
-      { :get => "ri_gse/domains/new" }.should route_to(:controller => "ri_gse/domains", :action => "new")
+      expect({ :get => "ri_gse/domains/new" }).to route_to(:controller => "ri_gse/domains", :action => "new")
     end
 
     it "recognizes and generates #show" do
-      { :get => "ri_gse/domains/1" }.should route_to(:controller => "ri_gse/domains", :action => "show", :id => "1")
+      expect({ :get => "ri_gse/domains/1" }).to route_to(:controller => "ri_gse/domains", :action => "show", :id => "1")
     end
 
     it "recognizes and generates #edit" do
-      { :get => "ri_gse/domains/1/edit" }.should route_to(:controller => "ri_gse/domains", :action => "edit", :id => "1")
+      expect({ :get => "ri_gse/domains/1/edit" }).to route_to(:controller => "ri_gse/domains", :action => "edit", :id => "1")
     end
 
     it "recognizes and generates #create" do
-      { :post => "ri_gse/domains" }.should route_to(:controller => "ri_gse/domains", :action => "create") 
+      expect({ :post => "ri_gse/domains" }).to route_to(:controller => "ri_gse/domains", :action => "create") 
     end
 
     it "recognizes and generates #update" do
-      { :put => "ri_gse/domains/1" }.should route_to(:controller => "ri_gse/domains", :action => "update", :id => "1") 
+      expect({ :put => "ri_gse/domains/1" }).to route_to(:controller => "ri_gse/domains", :action => "update", :id => "1") 
     end
 
     it "recognizes and generates #destroy" do
-      { :delete => "ri_gse/domains/1" }.should route_to(:controller => "ri_gse/domains", :action => "destroy", :id => "1") 
+      expect({ :delete => "ri_gse/domains/1" }).to route_to(:controller => "ri_gse/domains", :action => "destroy", :id => "1") 
     end
   end
 end

--- a/spec/routing/ri_gse/expectation_stems_routing_spec.rb
+++ b/spec/routing/ri_gse/expectation_stems_routing_spec.rb
@@ -3,31 +3,31 @@ require File.expand_path('../../../spec_helper', __FILE__)
 describe  RiGse::ExpectationStemsController do
   describe "routing" do
     it "recognizes and generates #index" do
-      { :get => "ri_gse/expectation_stems" }.should route_to(:controller => "ri_gse/expectation_stems", :action => "index")
+      expect({ :get => "ri_gse/expectation_stems" }).to route_to(:controller => "ri_gse/expectation_stems", :action => "index")
     end
 
     it "recognizes and generates #new" do
-      { :get => "ri_gse/expectation_stems/new" }.should route_to(:controller => "ri_gse/expectation_stems", :action => "new")
+      expect({ :get => "ri_gse/expectation_stems/new" }).to route_to(:controller => "ri_gse/expectation_stems", :action => "new")
     end
 
     it "recognizes and generates #show" do
-      { :get => "ri_gse/expectation_stems/1" }.should route_to(:controller => "ri_gse/expectation_stems", :action => "show", :id => "1")
+      expect({ :get => "ri_gse/expectation_stems/1" }).to route_to(:controller => "ri_gse/expectation_stems", :action => "show", :id => "1")
     end
 
     it "recognizes and generates #edit" do
-      { :get => "ri_gse/expectation_stems/1/edit" }.should route_to(:controller => "ri_gse/expectation_stems", :action => "edit", :id => "1")
+      expect({ :get => "ri_gse/expectation_stems/1/edit" }).to route_to(:controller => "ri_gse/expectation_stems", :action => "edit", :id => "1")
     end
 
     it "recognizes and generates #create" do
-      { :post => "ri_gse/expectation_stems" }.should route_to(:controller => "ri_gse/expectation_stems", :action => "create") 
+      expect({ :post => "ri_gse/expectation_stems" }).to route_to(:controller => "ri_gse/expectation_stems", :action => "create") 
     end
 
     it "recognizes and generates #update" do
-      { :put => "ri_gse/expectation_stems/1" }.should route_to(:controller => "ri_gse/expectation_stems", :action => "update", :id => "1") 
+      expect({ :put => "ri_gse/expectation_stems/1" }).to route_to(:controller => "ri_gse/expectation_stems", :action => "update", :id => "1") 
     end
 
     it "recognizes and generates #destroy" do
-      { :delete => "ri_gse/expectation_stems/1" }.should route_to(:controller => "ri_gse/expectation_stems", :action => "destroy", :id => "1") 
+      expect({ :delete => "ri_gse/expectation_stems/1" }).to route_to(:controller => "ri_gse/expectation_stems", :action => "destroy", :id => "1") 
     end
   end
 end

--- a/spec/routing/ri_gse/expectations_routing_spec.rb
+++ b/spec/routing/ri_gse/expectations_routing_spec.rb
@@ -3,31 +3,31 @@ require File.expand_path('../../../spec_helper', __FILE__)
 describe  RiGse::ExpectationsController do
   describe "routing" do
     it "recognizes and generates #index" do
-      { :get => "ri_gse/expectations" }.should route_to(:controller => "ri_gse/expectations", :action => "index")
+      expect({ :get => "ri_gse/expectations" }).to route_to(:controller => "ri_gse/expectations", :action => "index")
     end
 
     it "recognizes and generates #new" do
-      { :get => "ri_gse/expectations/new" }.should route_to(:controller => "ri_gse/expectations", :action => "new")
+      expect({ :get => "ri_gse/expectations/new" }).to route_to(:controller => "ri_gse/expectations", :action => "new")
     end
 
     it "recognizes and generates #show" do
-      { :get => "ri_gse/expectations/1" }.should route_to(:controller => "ri_gse/expectations", :action => "show", :id => "1")
+      expect({ :get => "ri_gse/expectations/1" }).to route_to(:controller => "ri_gse/expectations", :action => "show", :id => "1")
     end
 
     it "recognizes and generates #edit" do
-      { :get => "ri_gse/expectations/1/edit" }.should route_to(:controller => "ri_gse/expectations", :action => "edit", :id => "1")
+      expect({ :get => "ri_gse/expectations/1/edit" }).to route_to(:controller => "ri_gse/expectations", :action => "edit", :id => "1")
     end
 
     it "recognizes and generates #create" do
-      { :post => "ri_gse/expectations" }.should route_to(:controller => "ri_gse/expectations", :action => "create") 
+      expect({ :post => "ri_gse/expectations" }).to route_to(:controller => "ri_gse/expectations", :action => "create") 
     end
 
     it "recognizes and generates #update" do
-      { :put => "ri_gse/expectations/1" }.should route_to(:controller => "ri_gse/expectations", :action => "update", :id => "1") 
+      expect({ :put => "ri_gse/expectations/1" }).to route_to(:controller => "ri_gse/expectations", :action => "update", :id => "1") 
     end
 
     it "recognizes and generates #destroy" do
-      { :delete => "ri_gse/expectations/1" }.should route_to(:controller => "ri_gse/expectations", :action => "destroy", :id => "1") 
+      expect({ :delete => "ri_gse/expectations/1" }).to route_to(:controller => "ri_gse/expectations", :action => "destroy", :id => "1") 
     end
   end
 end

--- a/spec/routing/ri_gse/grade_span_expectations_routing_spec.rb
+++ b/spec/routing/ri_gse/grade_span_expectations_routing_spec.rb
@@ -3,31 +3,31 @@ require File.expand_path('../../../spec_helper', __FILE__)
 describe  RiGse::GradeSpanExpectationsController do
   describe "routing" do
     it "recognizes and generates #index" do
-      { :get => "ri_gse/grade_span_expectations" }.should route_to(:controller => "ri_gse/grade_span_expectations", :action => "index")
+      expect({ :get => "ri_gse/grade_span_expectations" }).to route_to(:controller => "ri_gse/grade_span_expectations", :action => "index")
     end
 
     it "recognizes and generates #new" do
-      { :get => "ri_gse/grade_span_expectations/new" }.should route_to(:controller => "ri_gse/grade_span_expectations", :action => "new")
+      expect({ :get => "ri_gse/grade_span_expectations/new" }).to route_to(:controller => "ri_gse/grade_span_expectations", :action => "new")
     end
 
     it "recognizes and generates #show" do
-      { :get => "ri_gse/grade_span_expectations/1" }.should route_to(:controller => "ri_gse/grade_span_expectations", :action => "show", :id => "1")
+      expect({ :get => "ri_gse/grade_span_expectations/1" }).to route_to(:controller => "ri_gse/grade_span_expectations", :action => "show", :id => "1")
     end
 
     it "recognizes and generates #edit" do
-      { :get => "ri_gse/grade_span_expectations/1/edit" }.should route_to(:controller => "ri_gse/grade_span_expectations", :action => "edit", :id => "1")
+      expect({ :get => "ri_gse/grade_span_expectations/1/edit" }).to route_to(:controller => "ri_gse/grade_span_expectations", :action => "edit", :id => "1")
     end
 
     it "recognizes and generates #create" do
-      { :post => "ri_gse/grade_span_expectations" }.should route_to(:controller => "ri_gse/grade_span_expectations", :action => "create") 
+      expect({ :post => "ri_gse/grade_span_expectations" }).to route_to(:controller => "ri_gse/grade_span_expectations", :action => "create") 
     end
 
     it "recognizes and generates #update" do
-      { :put => "ri_gse/grade_span_expectations/1" }.should route_to(:controller => "ri_gse/grade_span_expectations", :action => "update", :id => "1") 
+      expect({ :put => "ri_gse/grade_span_expectations/1" }).to route_to(:controller => "ri_gse/grade_span_expectations", :action => "update", :id => "1") 
     end
 
     it "recognizes and generates #destroy" do
-      { :delete => "ri_gse/grade_span_expectations/1" }.should route_to(:controller => "ri_gse/grade_span_expectations", :action => "destroy", :id => "1") 
+      expect({ :delete => "ri_gse/grade_span_expectations/1" }).to route_to(:controller => "ri_gse/grade_span_expectations", :action => "destroy", :id => "1") 
     end
   end
 end

--- a/spec/routing/ri_gse/knowledge_statements_routing_spec.rb
+++ b/spec/routing/ri_gse/knowledge_statements_routing_spec.rb
@@ -3,31 +3,31 @@ require File.expand_path('../../../spec_helper', __FILE__)
 describe  RiGse::KnowledgeStatementsController do
   describe "routing" do
     it "recognizes and generates #index" do
-      { :get => "ri_gse/knowledge_statements" }.should route_to(:controller => "ri_gse/knowledge_statements", :action => "index")
+      expect({ :get => "ri_gse/knowledge_statements" }).to route_to(:controller => "ri_gse/knowledge_statements", :action => "index")
     end
 
     it "recognizes and generates #new" do
-      { :get => "ri_gse/knowledge_statements/new" }.should route_to(:controller => "ri_gse/knowledge_statements", :action => "new")
+      expect({ :get => "ri_gse/knowledge_statements/new" }).to route_to(:controller => "ri_gse/knowledge_statements", :action => "new")
     end
 
     it "recognizes and generates #show" do
-      { :get => "ri_gse/knowledge_statements/1" }.should route_to(:controller => "ri_gse/knowledge_statements", :action => "show", :id => "1")
+      expect({ :get => "ri_gse/knowledge_statements/1" }).to route_to(:controller => "ri_gse/knowledge_statements", :action => "show", :id => "1")
     end
 
     it "recognizes and generates #edit" do
-      { :get => "ri_gse/knowledge_statements/1/edit" }.should route_to(:controller => "ri_gse/knowledge_statements", :action => "edit", :id => "1")
+      expect({ :get => "ri_gse/knowledge_statements/1/edit" }).to route_to(:controller => "ri_gse/knowledge_statements", :action => "edit", :id => "1")
     end
 
     it "recognizes and generates #create" do
-      { :post => "ri_gse/knowledge_statements" }.should route_to(:controller => "ri_gse/knowledge_statements", :action => "create") 
+      expect({ :post => "ri_gse/knowledge_statements" }).to route_to(:controller => "ri_gse/knowledge_statements", :action => "create") 
     end
 
     it "recognizes and generates #update" do
-      { :put => "ri_gse/knowledge_statements/1" }.should route_to(:controller => "ri_gse/knowledge_statements", :action => "update", :id => "1") 
+      expect({ :put => "ri_gse/knowledge_statements/1" }).to route_to(:controller => "ri_gse/knowledge_statements", :action => "update", :id => "1") 
     end
 
     it "recognizes and generates #destroy" do
-      { :delete => "ri_gse/knowledge_statements/1" }.should route_to(:controller => "ri_gse/knowledge_statements", :action => "destroy", :id => "1") 
+      expect({ :delete => "ri_gse/knowledge_statements/1" }).to route_to(:controller => "ri_gse/knowledge_statements", :action => "destroy", :id => "1") 
     end
   end
 end

--- a/spec/routing/ri_gse/unifying_themes_routing_spec.rb
+++ b/spec/routing/ri_gse/unifying_themes_routing_spec.rb
@@ -3,31 +3,31 @@ require File.expand_path('../../../spec_helper', __FILE__)
 describe  RiGse::UnifyingThemesController do
   describe "routing" do
     it "recognizes and generates #index" do
-      { :get => "ri_gse/unifying_themes" }.should route_to(:controller => "ri_gse/unifying_themes", :action => "index")
+      expect({ :get => "ri_gse/unifying_themes" }).to route_to(:controller => "ri_gse/unifying_themes", :action => "index")
     end
 
     it "recognizes and generates #new" do
-      { :get => "ri_gse/unifying_themes/new" }.should route_to(:controller => "ri_gse/unifying_themes", :action => "new")
+      expect({ :get => "ri_gse/unifying_themes/new" }).to route_to(:controller => "ri_gse/unifying_themes", :action => "new")
     end
 
     it "recognizes and generates #show" do
-      { :get => "ri_gse/unifying_themes/1" }.should route_to(:controller => "ri_gse/unifying_themes", :action => "show", :id => "1")
+      expect({ :get => "ri_gse/unifying_themes/1" }).to route_to(:controller => "ri_gse/unifying_themes", :action => "show", :id => "1")
     end
 
     it "recognizes and generates #edit" do
-      { :get => "ri_gse/unifying_themes/1/edit" }.should route_to(:controller => "ri_gse/unifying_themes", :action => "edit", :id => "1")
+      expect({ :get => "ri_gse/unifying_themes/1/edit" }).to route_to(:controller => "ri_gse/unifying_themes", :action => "edit", :id => "1")
     end
 
     it "recognizes and generates #create" do
-      { :post => "ri_gse/unifying_themes" }.should route_to(:controller => "ri_gse/unifying_themes", :action => "create") 
+      expect({ :post => "ri_gse/unifying_themes" }).to route_to(:controller => "ri_gse/unifying_themes", :action => "create") 
     end
 
     it "recognizes and generates #update" do
-      { :put => "ri_gse/unifying_themes/1" }.should route_to(:controller => "ri_gse/unifying_themes", :action => "update", :id => "1") 
+      expect({ :put => "ri_gse/unifying_themes/1" }).to route_to(:controller => "ri_gse/unifying_themes", :action => "update", :id => "1") 
     end
 
     it "recognizes and generates #destroy" do
-      { :delete => "ri_gse/unifying_themes/1" }.should route_to(:controller => "ri_gse/unifying_themes", :action => "destroy", :id => "1") 
+      expect({ :delete => "ri_gse/unifying_themes/1" }).to route_to(:controller => "ri_gse/unifying_themes", :action => "destroy", :id => "1") 
     end
   end
 end

--- a/spec/services/api/v1/create_collaboration_spec.rb
+++ b/spec/services/api/v1/create_collaboration_spec.rb
@@ -39,17 +39,17 @@ describe API::V1::CreateCollaboration do
 
     describe "missing owner" do
       before { params.delete('owner_id') }
-      it { should have(1).error_on :owner_id }
+      it { is_expected.to have(1).error_on :owner_id }
     end
 
     describe "missing offering" do
       before { params.delete('offering_id') }
-      it { should have(1).error_on :offering_id }
+      it { is_expected.to have(1).error_on :offering_id }
     end
 
     describe "incorrect student ID" do
       before { params['students'][1]['id'] = 99999999 }
-      it { should have(1).error_on :"students[1]" }
+      it { is_expected.to have(1).error_on :"students[1]" }
     end
   end
 
@@ -71,11 +71,11 @@ describe API::V1::CreateCollaboration do
       end
       describe "http" do
         let (:protocol) { 'http://' }
-        it { should start_with(domain) }
+        it { is_expected.to start_with(domain) }
       end
       describe "https" do
         let (:protocol) { 'https://' }
-        it { should start_with(domain) }
+        it { is_expected.to start_with(domain) }
       end
     end
 

--- a/spec/services/navigation_service_spec.rb
+++ b/spec/services/navigation_service_spec.rb
@@ -56,29 +56,29 @@ describe NavigationService do
 
   describe "basics" do
     it "should have some sections" do
-      nav_service.sections.should have(4).sections
+      expect(nav_service.sections.size).to eq(4)
     end
     it "should have 2 links" do
-      nav_service.links.should have(3).links
+      expect(nav_service.links.size).to eq(3)
     end
   end
 
   describe "nested structure" do
     describe "schema validation" do
       subject { nav_service.to_json }
-      it { should match_response_schema("navigation")}
+      it { is_expected.to match_response_schema("navigation")}
     end
     describe "values" do
       let(:greeting) { "bonjour" }
       subject { nav_service.to_hash }
-      it { should include(name:  name )}
-      it { should include(greeting: "bonjour") }
-      it { should include(:help) }
-      it { should include(:links) }
-      it { should_not include("xxx") }
+      it { is_expected.to include(name:  name )}
+      it { is_expected.to include(greeting: "bonjour") }
+      it { is_expected.to include(:help) }
+      it { is_expected.to include(:links) }
+      it { is_expected.not_to include("xxx") }
       describe "nested links" do
         it "should have /classes/2/assign link" do
-          subject[:links].first()[:children].first()[:children].first()[:id].should eq("/classes/2/assign")
+          expect(subject[:links].first()[:children].first()[:children].first()[:id]).to eq("/classes/2/assign")
         end
       end
     end
@@ -101,13 +101,13 @@ describe NavigationService do
       describe "with roster using lower sort value" do
         let(:sort) { 0 }
         it "should have /classes/2/assign should appear after /casses/2/roster" do
-          subject[:links].first()[:children].first()[:children].first()[:id].should eq("/classes/2/roster")
+          expect(subject[:links].first()[:children].first()[:children].first()[:id]).to eq("/classes/2/roster")
         end
       end
       describe "with roster using higher sort value" do
         let(:sort) { 7 }
         it "should have /classes/2/assign should appear before /casses/2/roster" do
-          subject[:links].first()[:children].first()[:children].first()[:id].should eq("/classes/2/assign")
+          expect(subject[:links].first()[:children].first()[:children].first()[:id]).to eq("/classes/2/assign")
         end
       end
       describe "supressing items" do
@@ -118,15 +118,15 @@ describe NavigationService do
         describe "supressing a non existant item" do
           let(:supress_path) { "/foo" }
           it "it should still have all sections, such as resources and classes" do
-            gather_item_values(subject[:links], :id).should include("/resources")
-            gather_item_values(subject[:links], :id).should include("/classes")
+            expect(gather_item_values(subject[:links], :id)).to include("/resources")
+            expect(gather_item_values(subject[:links], :id)).to include("/classes")
           end
         end
 
         describe "supressing the resources section" do
           let(:supress_path) { "/resources" }
           it "should no longer have a resources section" do
-            gather_item_values(subject[:links], :id).should_not include("/resources")
+            expect(gather_item_values(subject[:links], :id)).not_to include("/resources")
           end
         end
       end

--- a/spec/spec_helper_common.rb
+++ b/spec/spec_helper_common.rb
@@ -88,6 +88,17 @@ RSpec.configure do |config|
   config.include Devise::TestHelpers, :type => :controller
   config.include VerifyAndResetHelpers
 
+
+  # rspec-rails 3 will no longer automatically infer an example group's spec type
+  # from the file location. You can explicitly opt-in to the feature using this
+  # config option.
+  # To explicitly tag specs without using automatic inference, set the `:type`
+  # metadata manually:
+  #
+  #     describe ThingsController, :type => :controller do
+  #       # Equivalent to being in spec/controllers
+  #     end
+  config.infer_spec_type_from_file_location!
 end
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.

--- a/spec/support/api_registration_helper.rb
+++ b/spec/support/api_registration_helper.rb
@@ -17,12 +17,12 @@ shared_examples_for 'user registration' do
 
       describe "With valid user parameters" do
         subject { test_class.new(good_params) }
-        it { should be_valid }
+        it { is_expected.to be_valid }
       end
       
       describe "Missing some required parameter" do
         let(:bad_params) { Hash[good_params.to_a.sample(4)]}
-        it { should_not be_valid }
+        it { is_expected.not_to be_valid }
       end
 
     end

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -83,7 +83,7 @@ def generate_default_settings_and_jnlps_with_mocks
     :enabled_bookmark_types         => []
   )
 
-  Admin::Settings.stub!(:default_settings).and_return(@mock_settings)
+  allow(Admin::Settings).to receive(:default_settings).and_return(@mock_settings)
   @mock_settings
 end
 

--- a/spec/support/embeddable_controller_helper.rb
+++ b/spec/support/embeddable_controller_helper.rb
@@ -39,7 +39,7 @@ shared_examples_for 'an embeddable controller' do
   describe "GET index" do
     it "runs without error" do
       get :index
-      response.should be_success
+      expect(response).to be_success
     end
 
   end
@@ -47,24 +47,24 @@ shared_examples_for 'an embeddable controller' do
   describe "GET show" do
 
     it "assigns the requested #{model_ivar_name_lambda.call} as @#{model_ivar_name_lambda.call}" do
-      @model_class.stub!(:find).with("37").and_return(@model_ivar)
+      allow(@model_class).to receive(:find).with("37").and_return(@model_ivar)
       get :show, :id => "37"
-      assigns[@model_ivar_name].should equal(@model_ivar)
+      expect(assigns[@model_ivar_name]).to equal(@model_ivar)
     end
 
     it "assigns the requested #{model_ivar_name_lambda.call} as @#{model_ivar_name_lambda.call} when called with Ajax" do
-      @model_class.stub!(:find).with("37").and_return(@model_ivar)
+      allow(@model_class).to receive(:find).with("37").and_return(@model_ivar)
       xhr :get, :show, :id => "37"
-      assigns[@model_ivar_name].should equal(@model_ivar)
+      expect(assigns[@model_ivar_name]).to equal(@model_ivar)
     end
 
     describe "with mime type of jnlp" do
 
       it "renders the requested #{model_ivar_name_lambda.call} as jnlp without error" do
-        @model_class.stub!(:find).with("37").and_return(@model_ivar)
+        allow(@model_class).to receive(:find).with("37").and_return(@model_ivar)
         get :show, :id => "37", :format => 'jnlp'
-        assigns[@model_ivar_name].should equal(@model_ivar)
-        response.should render_template("shared/_installer")
+        expect(assigns[@model_ivar_name]).to equal(@model_ivar)
+        expect(response).to render_template("shared/_installer")
         assert_select('jnlp') do
           assert_select('information')
           assert_select('security')

--- a/spec/support/projects_listing_shared_examples.rb
+++ b/spec/support/projects_listing_shared_examples.rb
@@ -6,8 +6,8 @@ shared_examples 'projects listing' do
 
   context 'when user is an admin' do
     before(:each) do
-      view.stub!(:current_visitor).and_return(Factory.next(:admin_user))
-      view.stub!(:current_user).and_return(Factory.next(:admin_user))
+      allow(view).to receive(:current_visitor).and_return(Factory.next(:admin_user))
+      allow(view).to receive(:current_user).and_return(Factory.next(:admin_user))
     end
     it 'should be visible' do
       render
@@ -17,8 +17,8 @@ shared_examples 'projects listing' do
 
   context 'when user is an author' do
     before(:each) do
-      view.stub!(:current_visitor).and_return(Factory.next(:author_user))
-      view.stub!(:current_user).and_return(Factory.next(:author_user))
+      allow(view).to receive(:current_visitor).and_return(Factory.next(:author_user))
+      allow(view).to receive(:current_user).and_return(Factory.next(:author_user))
     end
     it 'should not be visible' do
       render

--- a/spec/support/report_learner_helper.rb
+++ b/spec/support/report_learner_helper.rb
@@ -1,7 +1,7 @@
 module ReportLearnerSpecHelper
 
   def stub_all_reportables(runnableClass, embeddables)
-    runnableClass.any_instance.stub(:reportable_elements).and_return( embeddables.map { |e| {embeddable: e} } )
+    allow_any_instance_of(runnableClass).to receive(:reportable_elements).and_return( embeddables.map { |e| {embeddable: e} } )
   end
 
   # must have a learner in scenario's setup

--- a/spec/support/runnables_link_matcher.rb
+++ b/spec/support/runnables_link_matcher.rb
@@ -1,24 +1,13 @@
+# require 'rspec/expectations'
+
 module RunnablesLinkMatcher
-  class BeLinkLike
-    def initialize(href, css_class, image, link_text)
-      @href, @css_class, @image, @link_text = href, css_class, image, link_text
-    end
+  extend RSpec::Matchers::DSL
 
-    def matches?(target)
-      @target = target
-      @target.should =~ /(.*)#{@href}(.*)#{@css_class}(.*)#{@image}(.*)(#{@link_text}(.*))?/i
+  matcher :be_link_like do |href, css_class, image, link_text|
+    match do |actual|
+      actual =~ /(.*)#{@href}(.*)#{@css_class}(.*)#{@image}(.*)(#{@link_text}(.*))?/i
     end
-
-    def failure_message
-      "Expected a properly formed link."
-    end
-
-    def negative_failure_message
-      "Expected an improperly formed link."
-    end
-  end
-
-  def be_link_like(href, css_class, image, link_text="")
-    BeLinkLike.new(href, css_class, image, link_text)
+    failure_message_for_should { 'Expected a properly formed link.' }
+    failure_message_for_should_not { 'Expected an improperly formed link.' }
   end
 end

--- a/spec/support/saveable_helper.rb
+++ b/spec/support/saveable_helper.rb
@@ -53,7 +53,7 @@ shared_examples_for 'a saveable' do
     describe "#needs_review?" do
       subject { saveable.needs_review? }
       describe "with no answers" do
-        it { should be_false }
+        it { is_expected.to be_falsey }
       end
       describe "with an answer" do
         before(:each) do
@@ -61,14 +61,14 @@ shared_examples_for 'a saveable' do
         end
 
         describe "when no feedback has been given" do
-          it { should  be_true }
+          it { is_expected.to  be_truthy }
         end
 
         describe "when the answer has been reviewed" do
           before(:each) do
             review_answer
           end
-          it { should be_false }
+          it { is_expected.to be_falsey }
         end
 
       end
@@ -77,7 +77,7 @@ shared_examples_for 'a saveable' do
     describe "#current_feedback" do
       subject { saveable.current_feedback }
       describe "with no answers" do
-        it { should be_nil }
+        it { is_expected.to be_nil }
       end
       describe "with an answer" do
         before(:each) do
@@ -85,7 +85,7 @@ shared_examples_for 'a saveable' do
         end
 
         describe "when no feedback has been given" do
-          it { should  be_nil }
+          it { is_expected.to  be_nil }
         end
 
         describe "when we give feeback" do
@@ -93,7 +93,7 @@ shared_examples_for 'a saveable' do
           before(:each) do
             add_feedback(feedback)
           end
-          it { should eq feedback }
+          it { is_expected.to eq feedback }
         end
 
       end
@@ -102,7 +102,7 @@ shared_examples_for 'a saveable' do
     describe "#current_score" do
       subject { saveable.current_score }
       describe "with no answers" do
-        it { should be_nil }
+        it { is_expected.to be_nil }
       end
       describe "with an answer" do
         before(:each) do
@@ -110,7 +110,7 @@ shared_examples_for 'a saveable' do
         end
 
         describe "when no score has been given" do
-          it { should  be_nil }
+          it { is_expected.to  be_nil }
         end
 
         describe "when we score the work" do
@@ -118,7 +118,7 @@ shared_examples_for 'a saveable' do
           before(:each) do
             add_score(score)
           end
-          it { should eq score }
+          it { is_expected.to eq score }
         end
 
       end

--- a/spec/views/admin/settings/edit.html.haml_spec.rb
+++ b/spec/views/admin/settings/edit.html.haml_spec.rb
@@ -7,16 +7,16 @@ describe "/admin/settings/edit.html.haml" do
     @pub_interval = 30000;
     @settings = Admin::Settings.new(:pub_interval => @pub_interval)
     assign(:admin_settings,@settings)
-    view.stub!(:current_visitor).and_return(Factory.next(:admin_user))
+    allow(view).to receive(:current_visitor).and_return(Factory.next(:admin_user))
     render
   end
 
   it "should show the pub interval form label" do
-    rendered.should match(/pub interval/i)
+    expect(rendered).to match(/pub interval/i)
   end
 
   it "should show the pub interval field value" do
-    rendered.should have_selector("input#admin_settings_pub_interval")
+    expect(rendered).to have_selector("input#admin_settings_pub_interval")
   end
 
 end

--- a/spec/views/admin/settings/show.html.haml_spec.rb
+++ b/spec/views/admin/settings/show.html.haml_spec.rb
@@ -7,13 +7,13 @@ describe "/admin/settings/show.html.haml" do
     @pub_interval = 30000;
     @settings = Admin::Settings.new(:pub_interval => @pub_interval)
     assign(:admin_settings,@settings)
-    view.stub!(:current_visitor).and_return(Factory.next(:admin_user))
+    allow(view).to receive(:current_visitor).and_return(Factory.next(:admin_user))
     render
   end
 
   it "should show the pub interval" do
-    rendered.should match(/pub interval/i)
-    rendered.should match(/#{@pub_interval.to_s}/)
+    expect(rendered).to match(/pub interval/i)
+    expect(rendered).to match(/#{@pub_interval.to_s}/)
   end
 
 end

--- a/spec/views/admin/tags/edit.html.haml_spec.rb
+++ b/spec/views/admin/tags/edit.html.haml_spec.rb
@@ -5,7 +5,7 @@ describe "/admin/tags/edit.html.haml" do
 
   before(:each) do
     power_user = stub_model(User, :has_role? => true)
-    view.stub!(:current_visitor).and_return(power_user)
+    allow(view).to receive(:current_visitor).and_return(power_user)
     assign(:admin_tag, @admin_tag = stub_model(Admin::Tag,
       :new_record? => false,
       :scope => "value for scope",

--- a/spec/views/admin/tags/index.html.haml_spec.rb
+++ b/spec/views/admin/tags/index.html.haml_spec.rb
@@ -5,7 +5,7 @@ describe "/admin/tags/index.html.haml" do
 
   before(:each) do
     power_user = stub_model(User, :has_role? => true)
-    view.stub!(:current_visitor).and_return(power_user)
+    allow(view).to receive(:current_visitor).and_return(power_user)
     assigns[:admin_tags] = [
       stub_model(Admin::Tag,
         :scope => "value for scope",
@@ -19,9 +19,9 @@ describe "/admin/tags/index.html.haml" do
   end
 
   it "renders a list of admin_tags" do
-    pending "Make this test compatible with pagination"
+    skip "Make this test compatible with pagination"
     render
-    response.should have_selector("tr>td", "value for scope".to_s, 2)
-    response.should have_selector("tr>td", "value for tag".to_s, 2)
+    expect(response).to have_selector("tr>td", "value for scope".to_s, 2)
+    expect(response).to have_selector("tr>td", "value for tag".to_s, 2)
   end
 end

--- a/spec/views/admin/tags/new.html.haml_spec.rb
+++ b/spec/views/admin/tags/new.html.haml_spec.rb
@@ -5,7 +5,7 @@ describe "/admin/tags/new.html.haml" do
 
   before(:each) do
     power_user = stub_model(User, :has_role? => true)
-    view.stub!(:current_visitor).and_return(power_user)
+    allow(view).to receive(:current_visitor).and_return(power_user)
     assign(:admin_tag, Factory.build(:admin_tag,
       :scope => "value for scope",
       :tag => "value for tag"

--- a/spec/views/admin/tags/show.html.haml_spec.rb
+++ b/spec/views/admin/tags/show.html.haml_spec.rb
@@ -4,7 +4,7 @@ describe "/admin/tags/show.html.haml" do
   include Admin::TagsHelper
   before(:each) do
     power_user = stub_model(User, :has_role? => true)
-    view.stub!(:current_visitor).and_return(power_user)
+    allow(view).to receive(:current_visitor).and_return(power_user)
     @admin_tag = stub_model(Admin::Tag,
       :scope => "value for scope",
       :tag => "value for tag")
@@ -13,7 +13,7 @@ describe "/admin/tags/show.html.haml" do
 
   it "renders attributes in <p>" do
     render
-    rendered.should match(/value for scope/)
-    rendered.should match(/value for tag/)
+    expect(rendered).to match(/value for scope/)
+    expect(rendered).to match(/value for tag/)
   end
 end

--- a/spec/views/browse/external_activities/show.html.haml_spec.rb
+++ b/spec/views/browse/external_activities/show.html.haml_spec.rb
@@ -6,19 +6,19 @@ describe "browse/external_activities/show" do
   let (:search_material) { Search::SearchMaterial.new(ext_act, user) }
 
   before(:each) do
-    view.stub!(:current_visitor).and_return(user)
-    view.stub!(:current_user).and_return(user)
+    allow(view).to receive(:current_visitor).and_return(user)
+    allow(view).to receive(:current_user).and_return(user)
     assigns[:search_material] = @search_material = search_material
   end
 
   it 'should present an external activity long description' do
     render
-    rendered.should match /desc foo bar/
+    expect(rendered).to match /desc foo bar/
   end
 
   it 'should remove hazardous HTML tags from the description' do
     render
-    rendered.should match /<p>desc foo bar<\/p>/
-    rendered.should_not match /&lt;p&gt;desc foo bar&lt;\/p&gt;/
+    expect(rendered).to match /<p>desc foo bar<\/p>/
+    expect(rendered).not_to match /&lt;p&gt;desc foo bar&lt;\/p&gt;/
   end
 end

--- a/spec/views/dataservice/blobs/edit.html.haml_spec.rb
+++ b/spec/views/dataservice/blobs/edit.html.haml_spec.rb
@@ -5,7 +5,7 @@ describe "/dataservice/blobs/edit.html.haml" do
 
   before(:each) do
     # cut off the edit_menu_for helper which traverses lots of other code
-    view.stub!(:edit_menu_for).and_return("edit menu")
+    allow(view).to receive(:edit_menu_for).and_return("edit menu")
     assign(:dataservice_blob, @dataservice_blob = stub_model(Dataservice::Blob,
       :new_record? => false, :id => 1, :token => "8ad04a50ba96463d80407cd119173b86", :content => ""
     ))
@@ -14,7 +14,7 @@ describe "/dataservice/blobs/edit.html.haml" do
   it "renders the edit blob form" do
     render
 
-    rendered.should have_selector("form[action='#{dataservice_blob_path(@dataservice_blob)}'][method=post]") do
+    expect(rendered).to have_selector("form[action='#{dataservice_blob_path(@dataservice_blob)}'][method=post]") do
     end
   end
 end

--- a/spec/views/dataservice/blobs/index.html.haml_spec.rb
+++ b/spec/views/dataservice/blobs/index.html.haml_spec.rb
@@ -5,10 +5,10 @@ describe "/dataservice/blobs/index.html.haml" do
 
   before(:each) do
     # cut off the show_menu_for helper which traverses lots of other code
-    view.stub!(:show_menu_for).and_return("show menu")
+    allow(view).to receive(:show_menu_for).and_return("show menu")
 
     power_user = stub_model(User, :has_role? => true)
-    view.stub!(:current_visitor).and_return(power_user)
+    allow(view).to receive(:current_visitor).and_return(power_user)
 
     # the changeable? => true prevents a current_visitor lookup, but will test if editing links correctly wrap the passed block
     collection = WillPaginate::Collection.create(1,10) do |coll|

--- a/spec/views/dataservice/blobs/show.html.haml_spec.rb
+++ b/spec/views/dataservice/blobs/show.html.haml_spec.rb
@@ -4,10 +4,10 @@ describe "/dataservice/blobs/show.html.haml" do
   include Dataservice::BlobsHelper
   before(:each) do
     # cut off the show_menu_for helper which traverses lots of other code
-    view.stub!(:show_menu_for).and_return("show menu")
+    allow(view).to receive(:show_menu_for).and_return("show menu")
 
     power_user = stub_model(User, :has_role? => true)
-    view.stub!(:current_visitor).and_return(power_user)
+    allow(view).to receive(:current_visitor).and_return(power_user)
 
     # :changeable? => true prevents a current_visitor lookup, but will test if editing links correctly wrap the passed block
     @dataservice_blob = stub_model(Dataservice::Blob, :id => 1, :token => "8ad04a50ba96463d80407cd119173b86", 

--- a/spec/views/dynamic_scripts/_all.html.haml_spec.rb
+++ b/spec/views/dynamic_scripts/_all.html.haml_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe "dynamic_scripts/_all.html.haml" do
   before(:each) do
-    view.stub(:current_user).and_return(nil)
-    ENV.stub(:[]).and_return('')
+    allow(view).to receive(:current_user).and_return(nil)
+    allow(ENV).to receive(:[]).and_return('')
   end
 
   context "when ENEWS_API_KEY is not set" do
@@ -15,7 +15,7 @@ describe "dynamic_scripts/_all.html.haml" do
 
   context "when ENEWS_API_KEY is set" do
     it "sets Portal.enewsSubscriptionEnabled to false" do
-      ENV.stub(:[]).with("ENEWS_API_KEY").and_return('12345')
+      allow(ENV).to receive(:[]).with("ENEWS_API_KEY").and_return('12345')
       render partial: 'dynamic_scripts/all'
       expect(rendered).to match 'Portal.enewsSubscriptionEnabled = true'
     end

--- a/spec/views/embeddables/open_responses/edit.html.haml_spec.rb
+++ b/spec/views/embeddables/open_responses/edit.html.haml_spec.rb
@@ -4,8 +4,8 @@ describe "/embeddable/open_responses/edit.html.haml" do
 
   before(:each) do
     power_user = stub_model(User, :has_role? => true)
-    view.stub!(:edit_menu_for).and_return("edit menu")
-    view.stub!(:current_visitor).and_return(power_user)
+    allow(view).to receive(:edit_menu_for).and_return("edit menu")
+    allow(view).to receive(:current_visitor).and_return(power_user)
     assign(:open_response, @open_response = stub_model(Embeddable::OpenResponse,
       :new_record? => false, 
       :id => 1,
@@ -19,15 +19,15 @@ describe "/embeddable/open_responses/edit.html.haml" do
 
   it "renders the edit form" do
     render
-    rendered.should have_selector("form[action='#{embeddable_open_response_path(@open_response)}'][method=post]")
+    expect(rendered).to have_selector("form[action='#{embeddable_open_response_path(@open_response)}'][method=post]")
   end
   it "should have a prompt tag" do
     render
-    rendered.should have_selector("textarea[name='embeddable_open_response[prompt]']")
+    expect(rendered).to have_selector("textarea[name='embeddable_open_response[prompt]']")
   end
   it "should have a rows field" do
     render
-    rendered.should have_selector("input[name='embeddable_open_response[rows]']")
+    expect(rendered).to have_selector("input[name='embeddable_open_response[rows]']")
   end
   # No one has asked for these yet, but they are in the model:
   # it "should have a columns field" do

--- a/spec/views/embeddables/open_responses/show.html.haml_spec.rb
+++ b/spec/views/embeddables/open_responses/show.html.haml_spec.rb
@@ -4,8 +4,8 @@ describe "/embeddable/open_responses/show.html.haml" do
 
   before(:each) do
     power_user = stub_model(User, :has_role? => true)
-    view.stub!(:edit_menu_for).and_return("edit menu")
-    view.stub!(:current_visitor).and_return(power_user)
+    allow(view).to receive(:edit_menu_for).and_return("edit menu")
+    allow(view).to receive(:current_visitor).and_return(power_user)
     assign(:open_response, @open_response = stub_model(Embeddable::OpenResponse,
       :new_record? => false, 
       :id => 1,
@@ -19,10 +19,10 @@ describe "/embeddable/open_responses/show.html.haml" do
 
   it "should have a rows field" do
     render
-    rendered.should have_selector("textarea[rows='#{@open_response.rows.to_s}']")
+    expect(rendered).to have_selector("textarea[rows='#{@open_response.rows.to_s}']")
   end
   it "should have a columns field" do
     render
-    rendered.should have_selector("textarea[cols='#{@open_response.columns.to_s}']")
+    expect(rendered).to have_selector("textarea[cols='#{@open_response.columns.to_s}']")
   end
 end

--- a/spec/views/external_activities/edit.html.haml_spec.rb
+++ b/spec/views/external_activities/edit.html.haml_spec.rb
@@ -5,7 +5,7 @@ describe "/external_activities/edit.html.haml" do
 
   before(:each) do
     assigns[:external_activity] = @external_activity = ext_act
-    view.stub!(:current_user).and_return(Factory.next(:admin_user))
+    allow(view).to receive(:current_user).and_return(Factory.next(:admin_user))
   end
 
   it 'should have an is_official check box to designate official activities' do
@@ -14,7 +14,7 @@ describe "/external_activities/edit.html.haml" do
   end
 
   it 'should not show the is_official check box to users without permissions' do
-    view.stub!(:current_user).and_return(Factory.next(:author_user))
+    allow(view).to receive(:current_user).and_return(Factory.next(:author_user))
     render
     assert_select "input[id=?]", 'external_activity_is_official', false
   end
@@ -22,9 +22,9 @@ describe "/external_activities/edit.html.haml" do
   it 'should show the offical checkbox to project admins of the project material' do
     common_projects = [mock_model(Admin::Project, cohorts: [])]
     auth_user = Factory.next(:author_user)
-    auth_user.stub!(admin_for_projects: common_projects)
-    ext_act.stub!(projects: common_projects)
-    view.stub!(:current_user).and_return(auth_user)
+    auth_user.stub(admin_for_projects: common_projects)
+    ext_act.stub(projects: common_projects)
+    allow(view).to receive(:current_user).and_return(auth_user)
     render
     assert_select "input[id=?]", 'external_activity_is_official'
   end

--- a/spec/views/home/authoring.html.haml_spec.rb
+++ b/spec/views/home/authoring.html.haml_spec.rb
@@ -6,7 +6,7 @@ describe "home/authoring.html.haml" do
     @external_activities = [mock_model(ExternalActivity, :id => 1, :name => "RP1"),mock_model(ExternalActivity, :id => 2, :name => "RP2")]
     @interactives = [mock_model(Interactive, :id => 1, :name => "interactive1"),mock_model(ExternalActivity, :id => 2, :name => "interactive2")]
     @authoring_sites = [mock_model(Admin::AuthoringSite, :id => 1, :name => "site1", :url => "http://site1.com/"),mock_model(Admin::AuthoringSite, :id => 2, :name => "site2", :url => "http://site2.com/")]
-    @user = mock(
+    @user = double(
       :id => 1,
       :investigations  => @investigations,
       :external_activities => @external_activities,
@@ -14,7 +14,7 @@ describe "home/authoring.html.haml" do
       :has_role?       => true
     )
 
-    view.stub!(:current_visitor).and_return(@user)
+    allow(view).to receive(:current_visitor).and_return(@user)
   end
 
   it "renders without error" do

--- a/spec/views/images/edit.html.haml_spec.rb
+++ b/spec/views/images/edit.html.haml_spec.rb
@@ -19,11 +19,11 @@ describe "/images/edit.html.haml" do
       width: 10,
       height: 20
     )
-    @user = mock(
+    @user = double(
       :has_role?       => true
     )
 
-    view.stub!(:current_user).and_return(@user)
+    allow(view).to receive(:current_user).and_return(@user)
   end
 
   it "should render edit form without error" do

--- a/spec/views/images/index.html.haml_spec.rb
+++ b/spec/views/images/index.html.haml_spec.rb
@@ -7,10 +7,10 @@ describe "/images/index.html.haml" do
       stub_model(Image),
       stub_model(Image)
     ]
-    @user = mock(
+    @user = double(
       :has_role?       => true
     )
-    view.stub!(:current_visitor).and_return(@user)
+    allow(view).to receive(:current_visitor).and_return(@user)
   end
 
   it "should render list of images without error" do

--- a/spec/views/images/show.html.haml_spec.rb
+++ b/spec/views/images/show.html.haml_spec.rb
@@ -5,17 +5,17 @@ describe "/images/show.html.haml" do
   before(:each) do
     @image = stub_model(Image, :name => "my secret image")
     assigns[:image] = @image
-    @user = mock(
+    @user = double(
       :has_role?       => true,
       :anonymous?      => false
     )
-    view.stub!(:current_visitor).and_return(@user)
+    allow(view).to receive(:current_visitor).and_return(@user)
   end
 
 
   it "should render without error" do
     render
-    rendered.should match /my secret image/
+    expect(rendered).to match /my secret image/
   end
 end
 

--- a/spec/views/layouts/application.html.haml_spec.rb
+++ b/spec/views/layouts/application.html.haml_spec.rb
@@ -5,11 +5,11 @@ describe "rendering application.html.haml" do
   let(:roles) {['first-role']}
 
   before do
-    view.stub(:current_visitor).and_return(fake_visitor)
-    view.stub(:current_user).and_return(fake_visitor)
-    view.stub(:calpicker_includes).and_return('')
-    fake_visitor.stub(:authenticate).and_return(true)
-    fake_visitor.stub(:role_names).and_return(roles)
+    allow(view).to receive(:current_visitor).and_return(fake_visitor)
+    allow(view).to receive(:current_user).and_return(fake_visitor)
+    allow(view).to receive(:calpicker_includes).and_return('')
+    allow(fake_visitor).to receive(:authenticate).and_return(true)
+    allow(fake_visitor).to receive(:role_names).and_return(roles)
   end
 
   it "applies the correct role classes" do
@@ -18,7 +18,7 @@ describe "rendering application.html.haml" do
       :text => "nothing",
       :layout => "layouts/application"
     )
-    rendered.should have_selector("body.first-role-visitor")
+    expect(rendered).to have_selector("body.first-role-visitor")
   end
 end
 

--- a/spec/views/materials_collections/edit.html.haml_spec.rb
+++ b/spec/views/materials_collections/edit.html.haml_spec.rb
@@ -9,7 +9,7 @@ describe "materials_collections/edit" do
     ))
 
     @admin_user = Factory.next(:admin_user)
-    controller.stub!(:current_user).and_return(@admin_user)
+    allow(controller).to receive(:current_user).and_return(@admin_user)
   end
 
   it "renders the edit materials_collection form" do

--- a/spec/views/materials_collections/index.html.haml_spec.rb
+++ b/spec/views/materials_collections/index.html.haml_spec.rb
@@ -9,7 +9,7 @@ describe "materials_collections/index" do
     assign(:materials_collections, MaterialsCollection.search(nil, nil, nil))
 
     @admin_user = Factory.next(:admin_user)
-    controller.stub!(:current_user).and_return(@admin_user)
+    allow(controller).to receive(:current_user).and_return(@admin_user)
   end
 
   it "renders a list of materials_collections" do

--- a/spec/views/materials_collections/new.html.haml_spec.rb
+++ b/spec/views/materials_collections/new.html.haml_spec.rb
@@ -9,7 +9,7 @@ describe "materials_collections/new" do
     ).as_new_record)
 
     @admin_user = Factory.next(:admin_user)
-    controller.stub!(:current_user).and_return(@admin_user)
+    allow(controller).to receive(:current_user).and_return(@admin_user)
   end
 
   it "renders new materials_collection form" do

--- a/spec/views/materials_collections/show.html.haml_spec.rb
+++ b/spec/views/materials_collections/show.html.haml_spec.rb
@@ -4,7 +4,7 @@ describe "materials_collections/show" do
   before(:each) do
 
     @admin_user = Factory.next(:admin_user)
-    controller.stub!(:current_user).and_return(@admin_user)
+    allow(controller).to receive(:current_user).and_return(@admin_user)
   end
 
   it "renders attributes in accordion (no materials)" do

--- a/spec/views/ri_gse/grade_span_expectations/index.html.haml_spec.rb
+++ b/spec/views/ri_gse/grade_span_expectations/index.html.haml_spec.rb
@@ -3,8 +3,8 @@ require File.expand_path('../../../../spec_helper', __FILE__)
 describe "/ri_gse/grade_span_expectations/index.html.haml" do
   
   before(:each) do
-    target = mock('target', :number => 1, :description => "nothing here", :knowledge_statement => nil, :unifying_themes => [])
-    domain = mock('domain')
+    target = double('target', :number => 1, :description => "nothing here", :knowledge_statement => nil, :unifying_themes => [])
+    domain = double('domain')
     canned_responses = {
       :assessment_target => target,
       :domain => domain,
@@ -18,9 +18,9 @@ describe "/ri_gse/grade_span_expectations/index.html.haml" do
       mock_model(RiGse::GradeSpanExpectation,canned_responses)
     ];
     # do this so will_paginate handles this array, there is probably a better approach
-    @gses.stub(:total_pages).and_return(1)
-    @gses.stub(:total_entries).and_return(@gses.length)
-    RiGse::GradeSpanExpectation.stub!(:paginate).and_return(@gses)
+    allow(@gses).to receive(:total_pages).and_return(1)
+    allow(@gses).to receive(:total_entries).and_return(@gses.length)
+    allow(RiGse::GradeSpanExpectation).to receive(:paginate).and_return(@gses)
     assign(:grade_span_expectations, @gses)
   end
 

--- a/spec/views/ri_gse/grade_span_expectations/show.html.haml_spec.rb
+++ b/spec/views/ri_gse/grade_span_expectations/show.html.haml_spec.rb
@@ -3,8 +3,8 @@ require File.expand_path('../../../../spec_helper', __FILE__)
 describe "/ri_gse/grade_span_expectations/show.html.haml" do
   
   before(:each) do
-    target = mock('target', :number => 1, :description => "nothing here", :knowledge_statement => nil, :unifying_themes => [])
-    domain = mock('domain')
+    target = double('target', :number => 1, :description => "nothing here", :knowledge_statement => nil, :unifying_themes => [])
+    domain = double('domain')
     canned_responses = {
       :assessment_target => target,
       :domain => domain,


### PR DESCRIPTION
This PR updates rspec 2.x syntax (should) to rspec 3.x (expect). It also adds the gem `rspec-activemodel-mocks` which was extracted out of rspec-mocks in 3.x.