### PR TITLE
Cleanup test output

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,6 +1,4 @@
 class Image < ActiveRecord::Base
-  UseUploadedByInAttribution = false
-
   attr_accessor :is_reprocessing
 
   belongs_to :user
@@ -144,13 +142,4 @@ class Image < ActiveRecord::Base
     end
     size
   end
-
-  # NOTE: user_id and user are nil here. (??)
-  def uploaded_by_attribution
-    if (self.user && UseUploadedByInAttribution)
-      return "Uploaded by: #{self.user.login}"
-    end
-    return ""
-  end
-
 end

--- a/app/models/report/util.rb
+++ b/app/models/report/util.rb
@@ -154,7 +154,6 @@ class Report::Util
     old = @saveables - current
     if old.size > 0
       warning = "WARNING: missing #{old.size} removed reportables in report for #{assignable.name}"
-      puts warning
       Rails.logger.info(warning)
       @saveables = current
     end

--- a/app/models/report/util_learner.rb
+++ b/app/models/report/util_learner.rb
@@ -35,7 +35,6 @@ class Report::UtilLearner
     old = @saveables - current
     if old.size > 0
       warning = "WARNING: missing #{old.size} removed reportables in report for #{assignable.name}"
-      puts warning
       Rails.logger.info(warning)
       @saveables = current
     end

--- a/app/views/dynamic_scripts/_current_user.html.haml
+++ b/app/views/dynamic_scripts/_current_user.html.haml
@@ -20,11 +20,11 @@
     },
     get isTeacher() {
       // portal_teacher can return nil which is interpolated to "" string.
-      return "#{current_visitor.portal_teacher}" != "";
+      return "#{current_visitor.portal_teacher.present?}" === "true";
     },
     get isStudent() {
       // portal_student can return nil which is interpolated to "" string.
-      return "#{current_visitor.portal_student}" != "";
+      return "#{current_visitor.portal_student.present?}" === "true";
     },
     get firstName() {
       return "#{current_visitor.first_name}";

--- a/lib/padlet_wrapper.rb
+++ b/lib/padlet_wrapper.rb
@@ -22,8 +22,7 @@ class PadletWrapper
     yaml_config = YAML.load_file(yaml_file_path).symbolize_keys
     OPTS.merge!(yaml_config)
   rescue Exception => e
-    puts "Error: #{e} loading yaml: #{yaml_file_path}"
-    puts "Using defaults (see padlet_wrapper.rb)"
+    Rails.logger.info("Error: #{e} loading yaml: #{yaml_file_path}. Using defaults (see padlet_wrapper.rb)")
   end
 
   def initialize

--- a/lib/paperclip_processors/attributor_overlay.rb
+++ b/lib/paperclip_processors/attributor_overlay.rb
@@ -6,12 +6,6 @@ class AttributorOverlay < Paperclip::Processor
     @attach = attachment.instance
     @attribution = @attach.attribution.dup || " "
 
-
-    if (@attach.respond_to? :uploaded_by_attribution)
-      @attribution << "\n" unless @attribution.blank?
-      @attribution << @attach.uploaded_by_attribution
-    end
-
     @current_format = File.extname(@file.path)
     @basename =  File.basename(@file.path, @current_format)
     @source_geometry = Paperclip::Geometry.from_file(@file)

--- a/spec/models/admin/settings_spec.rb
+++ b/spec/models/admin/settings_spec.rb
@@ -24,7 +24,6 @@ describe Admin::Settings do
       it "should fail validations" do
         @new_valid_settings.pub_interval = Admin::Settings::MinPubInterval - 1
         expect(@new_valid_settings).not_to be_valid
-        puts @new_valid_settings.errors
       end
     end
 

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -169,25 +169,6 @@ describe Image do
       expect(subject.image_size).to eq(0)
     end
   end
-
-  describe "uploaded_by_attribution" do
-    context "when UseUploadedByInAttribution is set to true" do
-      before(:each) do
-        Image::UseUploadedByInAttribution = true
-      end
-      it "should return the users login" do
-        expect(subject.uploaded_by_attribution).to eq("Uploaded by: testuser")
-      end
-    end
-    context "when UseUploadedByInAttribution is set to false" do
-      before(:each) do
-        Image::UseUploadedByInAttribution = false
-      end
-      it "should return an empty string" do
-        expect(subject.uploaded_by_attribution).to be_blank
-      end
-    end
-  end
 end
 
 


### PR DESCRIPTION
Related: #455

Cleans up rspec test output, removing warnings and puts messages.

![image](https://user-images.githubusercontent.com/1232531/43922192-dccd7280-9bd2-11e8-9552-3d98abb9f3b8.png)

The first two commits are the most significant. Review the commit message on each of those commits for an explanation. Is spoke with @knowuh about the removal of `Image::UseUploadedByInAttribution` on slack. I told him I'd tag him in the commit, so I'm also assigning him as a reviewer.

Let me know if you have any questions!
