### PR TITLE
Update ExternalActivity#duplicate

### DIFF
--- a/app/models/external_activity.rb
+++ b/app/models/external_activity.rb
@@ -206,7 +206,9 @@ class ExternalActivity < ActiveRecord::Base
   # New activity will have a new owner and publication status set to private.
   # Returns a new activity or nil in case of error.
   def duplicate(new_owner, root_url = nil)
-    clone = ExternalActivity.new(attributes.except('id', 'uuid', 'created_at', 'updated_at', 'template_id', 'template_type'))
+    # Copy all the attributes except ones listed here.
+    duplicated_attrs =  attributes.except('id', 'uuid', 'created_at', 'updated_at', 'template_id', 'template_type', 'is_official', 'is_featured')
+    clone = ExternalActivity.new(duplicated_attrs)
     clone.name = "Copy of #{name}"
     clone.user = new_owner
     clone.publication_status = 'private'

--- a/app/models/external_activity.rb
+++ b/app/models/external_activity.rb
@@ -207,11 +207,15 @@ class ExternalActivity < ActiveRecord::Base
   # Returns a new activity or nil in case of error.
   def duplicate(new_owner, root_url = nil)
     # Copy all the attributes except ones listed here.
-    duplicated_attrs =  attributes.except('id', 'uuid', 'created_at', 'updated_at', 'template_id', 'template_type', 'is_official', 'is_featured')
+    duplicated_attrs =  attributes.except('id', 'uuid', 'created_at', 'updated_at', 'template_id', 'template_type',
+      'is_official', 'is_featured', 'logging')
     clone = ExternalActivity.new(duplicated_attrs)
     clone.name = "Copy of #{name}"
     clone.user = new_owner
     clone.publication_status = 'private'
+    admin_or_proj_admin = new_owner.has_role?('admin') || projects.any? { |p| new_owner.is_project_admin?(p) }
+    # Logging is copied only if the new owner is an admin or a project admin for given material.
+    clone.logging = admin_or_proj_admin ? logging : false
     clone.save
 
     # This section triggers remote duplication if necessary.

--- a/spec/models/external_activity_spec.rb
+++ b/spec/models/external_activity_spec.rb
@@ -10,6 +10,7 @@ describe ExternalActivity do
       :publication_status => "value for publication_status",
       :is_featured => true,
       :is_official => true,
+      :logging => true,
       :url => "http://www.concord.org/"
   } }
 
@@ -92,8 +93,9 @@ describe ExternalActivity do
     let(:template) { FactoryGirl.create(:investigation) }
     let(:activity) { a = ExternalActivity.create(valid_attributes); a.user = user1; a.save; a }
     # List of attributes that shouldn't match the original activity after duplication is done.
-    let(:unique_attrs) do  [ 'id', 'uuid', 'created_at', 'updated_at', 'name', 'user_id', 'publication_status',
-      'template_id', 'template_type', 'is_official', 'is_featured' ]
+    let(:unique_attrs) do
+      [ 'id', 'uuid', 'created_at', 'updated_at', 'name', 'user_id', 'publication_status',
+        'template_id', 'template_type', 'is_official', 'is_featured', 'logging' ]
     end
     # Automatically generate all the attributes. This will let us test new automatically things when they are added.
     let(:attrs) { activity.attributes.except(*unique_attrs).keys }
@@ -135,11 +137,21 @@ describe ExternalActivity do
       expect(clone.publication_status).to eq("private")
       expect(clone.is_official).to eq(false)
       expect(clone.is_featured).to eq(false)
+      expect(clone.logging).to eq(true) # because user is a project admin
       expect(clone.user).to eq(user2)
       expect(clone.name).to eq("Copy of " + activity.name)
       # Automatically check all the attributes.
       attrs.each do |attr|
         expect(clone.send(attr)).to eq(activity.send(attr))
+      end
+    end
+
+    describe "when user is not an admin or project admin" do
+      before(:each) do
+        user2.remove_role_for_project('admin', project1)
+      end
+      it "should NOT copy logging option" do
+        expect(clone.logging).to eq(false)
       end
     end
 

--- a/spec/models/external_activity_spec.rb
+++ b/spec/models/external_activity_spec.rb
@@ -8,6 +8,7 @@ describe ExternalActivity do
       :long_description => "value for description",
       :long_description_for_teacher => "value for description for teachers",
       :publication_status => "value for publication_status",
+      :is_featured => true,
       :is_official => true,
       :url => "http://www.concord.org/"
   } }
@@ -91,7 +92,9 @@ describe ExternalActivity do
     let(:template) { FactoryGirl.create(:investigation) }
     let(:activity) { a = ExternalActivity.create(valid_attributes); a.user = user1; a.save; a }
     # List of attributes that shouldn't match the original activity after duplication is done.
-    let(:unique_attrs) { [ 'id', 'uuid', 'created_at', 'updated_at', 'name', 'user_id', 'publication_status', 'template_id', 'template_type' ] }
+    let(:unique_attrs) do  [ 'id', 'uuid', 'created_at', 'updated_at', 'name', 'user_id', 'publication_status',
+      'template_id', 'template_type', 'is_official', 'is_featured' ]
+    end
     # Automatically generate all the attributes. This will let us test new automatically things when they are added.
     let(:attrs) { activity.attributes.except(*unique_attrs).keys }
     let(:clone) { activity.duplicate(user2) }
@@ -128,8 +131,10 @@ describe ExternalActivity do
       activity.save!
     end
 
-    it "should copy basic attributes, sets publication status to private and assign a new user" do
+    it "should copy basic attributes (except small subset) and assign a new user" do
       expect(clone.publication_status).to eq("private")
+      expect(clone.is_official).to eq(false)
+      expect(clone.is_featured).to eq(false)
       expect(clone.user).to eq(user2)
       expect(clone.name).to eq("Copy of " + activity.name)
       # Automatically check all the attributes.


### PR DESCRIPTION
- is_official is never copied 
- is_featured is never copied
- logging is copied only if new owner is admin or project admin for one of the activity's projects