### PR TITLE
Rename Recent Activity page to Recent Updates.

### DIFF
--- a/app/views/home/recent_activity.html.haml
+++ b/app/views/home/recent_activity.html.haml
@@ -1,4 +1,4 @@
-%h1 Recent Activity
+%h1=I18n.t('recent_activity.title')
 = render :partial => "notice"
 #recent-activity
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,7 @@ en:
   instructional_materials: Instructional Materials
   assignments: Assignments
   recent_activity:
+    title: Recent Updates
     no_offerings: 'You need to assign investigations to your classes.'
     no_students:  'You have not yet assigned students to your classes.'
     no_activity:  'As your students get started, their progress will be displayed here.'


### PR DESCRIPTION
Change the `Recent Activity` Page label to `Recent Updates`

[#159960718]
https://www.pivotaltracker.com/story/show/159960718