### PR TITLE
Comment out tests creating files in project directory

### DIFF
--- a/spec/libs/app_settings_spec.rb
+++ b/spec/libs/app_settings_spec.rb
@@ -89,7 +89,7 @@ describe "A class with the AppSettings module included" do
 
   # TODO: auto-generated
   describe '#save_settings' do
-    it 'save_settings' do
+    xit 'save_settings' do
       app_settings = ClassWithAppSettings.new
       result = app_settings.save_settings({}, 'path')
 

--- a/spec/libs/app_settings_spec.rb
+++ b/spec/libs/app_settings_spec.rb
@@ -5,16 +5,16 @@ class ClassWithAppSettings
 end
 
 describe "A class with the AppSettings module included" do
-  
+
   before(:each) do
     @class_with_app_settings = ClassWithAppSettings.new
     @settings_with_symbol_keys_path = "#{::Rails.root.to_s}/spec/fixtures/settings_with_symbol_keys.yml"
     @settings_with_string_keys_path = "#{::Rails.root.to_s}/spec/fixtures/settings_with_string_keys.yml"
     @settings_with_mixed_keys_path = "#{::Rails.root.to_s}/spec/fixtures/settings_with_mixed_keys.yml"
   end
-  
+
   describe "ClassWithAppSettings#load_and_symbolize_settings" do
-    
+
     it "should set return a recursively symbolized hash when given a path to a YAML settings file with symbolized keys" do
       @class_with_app_settings.load_all_app_settings(@settings_with_symbol_keys_path)
     end
@@ -28,7 +28,7 @@ describe "A class with the AppSettings module included" do
     end
 
   end
-  
+
 
   # TODO: auto-generated
   describe '#settings_exists?' do
@@ -77,7 +77,7 @@ describe "A class with the AppSettings module included" do
 
   # TODO: auto-generated
   describe '#save_app_settings' do
-    it 'save_app_settings' do
+    xit 'save_app_settings' do
       app_settings = ClassWithAppSettings.new
       new_app_settings = {}
       path = double('path')

--- a/spec/services/reports/book_spec.rb
+++ b/spec/services/reports/book_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Reports::Book do
 
   # TODO: auto-generated
   describe '#save' do
-    it 'save' do
+    xit 'save' do
       options = {}
       book = described_class.new(options)
       filename = 'filename'


### PR DESCRIPTION
Found three specs (created en masse) responsible for inexplicably creating files in the project directory. This PR comments them out. I will create an issue for these for future investigation.

File called "path" being created by spec/libs/app_settings_spec.rb lines 79 and 91
```
  # TODO: auto-generated
  describe '#save_app_settings' do
    it 'save_app_settings' do
      app_settings = ClassWithAppSettings.new
      new_app_settings = {}
      path = double('path')
      result = app_settings.save_app_settings(new_app_settings, 'path')

      expect(result).not_to be_nil
    end
  end
```
```
  # TODO: auto-generated
  describe '#save_settings' do
    it 'save_settings' do
      app_settings = ClassWithAppSettings.new
      result = app_settings.save_settings({}, 'path')

      expect(result).not_to be_nil
    end
  end
```

File called "filename" being created by spec/services/reports/book_spec.rb:42
```
  # TODO: auto-generated
  describe '#save' do
    it 'save' do
      options = {}
      book = described_class.new(options)
      filename = 'filename'
      result = book.save(filename)

      expect(result).not_to be_nil
    end
  end
```