### PR TITLE
Undefined steps that fail on upgrade

### DIFF
--- a/features/step_definitions/materials_search_steps.rb
+++ b/features/step_definitions/materials_search_steps.rb
@@ -1,6 +1,6 @@
 Then /I search for my own materials/ do
-  search_mine_string = I18n.translate("Search.only_mine")
-  step "I should see #{search_mine_string}"
+  search_mine_string = I18n.translate("search.only_mine")
+  step "I should see \"#{search_mine_string}\""
 end
 
 When /^I wait for the search to be ready$/ do


### PR DESCRIPTION
While working on upgrading cucumber, some tests that previously returned as undefined are now failing. It looks like they were always a little broken, but not causing the suite to fail until the upgrade. 
```
Undefined step: "I should see translation missing: en.Search.only_mine" (Cucumber::Undefined)
./features/step_definitions/materials_search_steps.rb:3:in `/I search for my own materials/'
features/authors_can_filter_their_own_material.feature:33:in `And I search for my own materials'
```

Above, the translation is incorrect. When the capitalization is corrected, the error becomes:
```
Undefined step: "I should see Show only materials authored by me" (Cucumber::Undefined)
```
The step itself is `And I should see "interactive_1”`, so when the quotes are corrected in the step definition, the now fatal error becomes:
```
expected to find text "interactive_1" in "Learn about the Concord Consortium Home… etc
```
It’s a little unclear how cucumber is meant to be working here and why it's not passing. @scytacki @knowuh please advise.