### PR TITLE
Reorder configuration to resolve cucumber mysql errors

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -7,7 +7,6 @@
 require 'rubygems'
 
 ENV['RAILS_ENV'] = 'cucumber'
-require File.expand_path('../../../spec/spec_helper_common.rb', __FILE__)
 
 require 'cucumber/rails'
 require 'cucumber/rails/capybara/javascript_emulation' # Lets you click links with onclick javascript handlers without using @culerity or @javascript
@@ -29,11 +28,6 @@ Capybara::Screenshot.register_filename_prefix_formatter(:cucumber) do |scenario|
   "screenshot_#{scenario.title.gsub(' ', '-').gsub(/^.*\/spec\//,'')}"
 end
 
-include SolrSpecHelper
-solr_setup
-clean_solar_index
-reindex_all
-
 # so we can use things like dom_id_for
 include ApplicationHelper
 
@@ -47,3 +41,10 @@ World(RSpec::Mocks::ExampleMethods)
 
 # Make visible for testing
 ApplicationController.send(:public, :logged_in?, :current_visitor)
+
+require File.expand_path('../../../spec/spec_helper_common.rb', __FILE__)
+
+include SolrSpecHelper
+solr_setup
+clean_solar_index
+reindex_all


### PR DESCRIPTION
We recently started seeing some features fail in
teacher_searches_groups_and_previews_instructional_materials.feature.
The errors were related to [database connection sharing](https://github.com/concord-consortium/rigse/blob/master/spec/spec_helper_common.rb#L68) between
threads (mysql errors).

I believe the problem started recently when [I moved configuration around](https://github.com/concord-consortium/rigse/pull/556/files).
However, it appears these features may have failed in the past too because
[some of them have the tag `@with_mysql_failures`](https://github.com/concord-consortium/rigse/blob/master/features/teacher_searches_groups_and_previews_instructional_materials.feature#L38).

I believe the problem is that Cucumber::Rails is [enacting its own connection
sharing strategy](https://github.com/cucumber/cucumber-rails/blob/master/lib/cucumber/rails/database.rb#L89) which is similar to ours (same intent) when the configuration
option `javascript_strategy` is set to `transaction`. If [our own strategy](https://github.com/concord-consortium/rigse/blob/master/spec/spec_helper_common.rb#L68)
(now in the common helper) comes before it, then we have problems.

I tried completely removing the `javascript_strategy` configuration,
unfortunately that's not an option because it then [defaults to truncation](https://github.com/cucumber/cucumber-rails/blob/master/lib/cucumber/rails/database.rb#L109)
which we do not want (and doesn't work at all with seed data).

So, I've opted to reorder some things in cucumbers .env file such that
the order of operations is similar to what it was before these issues
popped up.