### PR TITLE
Deprecate prototype usage

### DIFF
--- a/config/initializers/00_deprecate_prototype.rb
+++ b/config/initializers/00_deprecate_prototype.rb
@@ -20,14 +20,16 @@ end
 # prototype_rails has its own engine initializer
 # that runs after local/app initializers.
 Rails.application.config.after_initialize do
-  namespaces = [
-    ActionView::Helpers::PrototypeHelper,
-    ActionView::Helpers::ScriptaculousHelper,
-    PrototypeHelper,
-    ActionView::Helpers::JavaScriptHelper
-  ]
-  namespaces.each do |namespace|
-    methods = namespace.public_instance_methods
-    deprecate_methods(namespace, *methods)
+  if ENV.fetch('DEPRECATE_PROTOTYPE', true) != 'false'
+    namespaces = [
+      ActionView::Helpers::PrototypeHelper,
+      ActionView::Helpers::ScriptaculousHelper,
+      PrototypeHelper,
+      ActionView::Helpers::JavaScriptHelper
+    ]
+    namespaces.each do |namespace|
+      methods = namespace.public_instance_methods
+      deprecate_methods(namespace, *methods)
+    end
   end
 end

--- a/config/initializers/00_deprecate_prototype.rb
+++ b/config/initializers/00_deprecate_prototype.rb
@@ -5,6 +5,7 @@ def deprecate_methods(target_module, *method_names)
   method_names += options.keys
 
   method_names.each do |method_name|
+    next if %i[[] <<].include? method_name
     target_module.alias_method_chain(method_name, :deprecation) do |target, punctuation|
       target_module.module_eval(<<-end_eval, __FILE__, __LINE__ + 1)
         def #{target}_with_deprecation#{punctuation}(*args, &block)

--- a/config/initializers/00_deprecate_prototype.rb
+++ b/config/initializers/00_deprecate_prototype.rb
@@ -1,0 +1,33 @@
+# Mostly copied from:
+# https://github.com/rails/rails/blob/3-2-stable/activesupport/lib/active_support/deprecation/method_wrappers.rb
+def deprecate_methods(target_module, *method_names)
+  options = method_names.extract_options!
+  method_names += options.keys
+
+  method_names.each do |method_name|
+    target_module.alias_method_chain(method_name, :deprecation) do |target, punctuation|
+      target_module.module_eval(<<-end_eval, __FILE__, __LINE__ + 1)
+        def #{target}_with_deprecation#{punctuation}(*args, &block)
+          ::ActiveSupport::Deprecation.warn("Prototype Usage: #{method_name}", caller)
+          send(:#{target}_without_deprecation#{punctuation}, *args, &block)
+        end
+      end_eval
+    end
+  end
+end
+
+# This must be done after_initialize because
+# prototype_rails has its own engine initializer
+# that runs after local/app initializers.
+Rails.application.config.after_initialize do
+  namespaces = [
+    ActionView::Helpers::PrototypeHelper,
+    ActionView::Helpers::ScriptaculousHelper,
+    PrototypeHelper,
+    ActionView::Helpers::JavaScriptHelper
+  ]
+  namespaces.each do |namespace|
+    methods = namespace.public_instance_methods
+    deprecate_methods(namespace, *methods)
+  end
+end

--- a/config/initializers/00_deprecate_prototype.rb
+++ b/config/initializers/00_deprecate_prototype.rb
@@ -24,8 +24,9 @@ Rails.application.config.after_initialize do
     namespaces = [
       ActionView::Helpers::PrototypeHelper,
       ActionView::Helpers::ScriptaculousHelper,
-      PrototypeHelper,
-      ActionView::Helpers::JavaScriptHelper
+      ActionView::Helpers::JavaScriptHelper,
+      ActionView::Helpers::PrototypeHelper::JavaScriptGenerator::GeneratorMethods,
+      PrototypeHelper
     ]
     namespaces.each do |namespace|
       methods = namespace.public_instance_methods


### PR DESCRIPTION
This PR deprecates all public methods for several prototype related modules.

Deprecating usage will help us to safely remove all traces from the app.