### PR TITLE
Move SimpleCov config to env file and to top of spec helper file

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -5,6 +5,24 @@
 # files.
 
 require 'rubygems'
+require 'simplecov'
+SimpleCov.start do
+  merge_timeout 3600
+
+  add_filter '/spec/'
+  add_filter '/initializers/'
+  add_filter '/features/'
+  add_filter '/factories/'
+  add_filter '/config/'
+
+  add_group 'Controllers', 'app/controllers'
+  add_group 'Models', 'app/models'
+  add_group 'Helpers', 'app/helpers'
+  add_group 'Views', 'app/views'
+  add_group 'Policies', 'app/policies'
+  add_group 'Services', 'app/services'
+  add_group 'Lib', 'lib'
+end
 
 ENV['RAILS_ENV'] = 'cucumber'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,21 @@
+require 'simplecov'
+SimpleCov.start do
+  merge_timeout 3600
+
+  add_filter '/spec/'
+  add_filter '/initializers/'
+  add_filter '/features/'
+  add_filter '/factories/'
+  add_filter '/config/'
+
+  add_group 'Controllers', 'app/controllers'
+  add_group 'Models', 'app/models'
+  add_group 'Helpers', 'app/helpers'
+  add_group 'Views', 'app/views'
+  add_group 'Policies', 'app/policies'
+  add_group 'Services', 'app/services'
+  add_group 'Lib', 'lib'
+end
 require_relative 'spec_helper_common'
 require_relative 'spec_helper_pundit'
 

--- a/spec/spec_helper_common.rb
+++ b/spec/spec_helper_common.rb
@@ -1,4 +1,3 @@
-require 'simplecov'
 require File.expand_path("../../config/environment", __FILE__)
 require 'factory_girl'
 require 'rspec/rails'
@@ -10,23 +9,6 @@ require 'capybara-screenshot/rspec'
 require 'remarkable_activerecord'
 Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
 
-SimpleCov.start do
-  merge_timeout 3600
-  
-  add_filter '/spec/'
-  add_filter '/initializers/'
-  add_filter '/features/'
-  add_filter '/factories/'
-  add_filter '/config/'
-
-  add_group 'Controllers', 'app/controllers'
-  add_group 'Models', 'app/models'
-  add_group 'Helpers', 'app/helpers'
-  add_group 'Views', 'app/views'
-  add_group 'Policies', 'app/policies'
-  add_group 'Services', 'app/services'
-  add_group 'Lib', 'lib'
-end
 
 # Mute FactoryGirl deprecation warnings...
 ActiveSupport::Deprecation.behavior = lambda do |msg, stack|


### PR DESCRIPTION
It was pointed out that the coverage report after running the rspec suite was lower than expected after Tim's work - `601 / 1196 LOC (50.25%) covered`. In PR #556 some configuration was changed that moved SimpleCov config below all of the require statements, affecting its reporting. 

It was moved into features/support/env.rb and at the top of the main spec helper file. Coverage is now being reported more accurately.