### PR TITLE
Clean up spec output (part 2)

### DIFF
--- a/app/models/admin/settings.rb
+++ b/app/models/admin/settings.rb
@@ -145,7 +145,7 @@ ut = User.find_by_login('teacher'); us = User.find_by_login('student')
 t = ut.portal_teacher; s = us.portal_student; c = t.clazzes.first; o = c.offerings.first
 
 HEREDOC
-    puts summary
+    Rails.logger.info summary
     summary
   end
 

--- a/lib/national_district_importer.rb
+++ b/lib/national_district_importer.rb
@@ -25,12 +25,12 @@ class NationalDistrictImporter
     existing_districts    = Portal::District.find(:all, :conditions => {:nces_district_id => nces_district_ids})
     existing_district_ids = existing_districts.map { |d| d.nces_district_id }
 
-    puts "found    : #{nces_districts.size} national districts to import"
-    puts "rejecting: #{existing_district_ids.size} pre-imported districts"
+    Rails.logger.info "found    : #{nces_districts.size} national districts to import"
+    Rails.logger.info "rejecting: #{existing_district_ids.size} pre-imported districts"
 
     nces_districts.reject! { |d| existing_district_ids.include? d.id }
 
-    puts "leaves   : #{nces_districts.size} remaining districts to import"
+    Rails.logger.info "leaves   : #{nces_districts.size} remaining districts to import"
 
     district_values = []
     nces_districts.each_with_index do |nces_district,count|
@@ -40,8 +40,8 @@ class NationalDistrictImporter
       existing_district ||= Portal::District.find(:first,
                                                   :conditions => {:state => nces_district.LSTATE, :name => nces_district.NAME})
       if existing_district
-        puts "district similar already exists:#{existing_district.state} #{existing_district.name} #{existing_district.id}"
-        puts "updating."
+        Rails.logger.info "district similar already exists:#{existing_district.state} #{existing_district.name} #{existing_district.id}"
+        Rails.logger.info "updating."
         existing_district.nces_district = nces_district
         existing_district.leaid = nces_district.LEAID
         existing_district.save
@@ -74,9 +74,9 @@ class NationalDistrictImporter
                                               :select => "id, nces_school_id")
     existing_school_ids = existing_schools.map { |s| s.nces_school_id }
     import_count = nces_schools.size - existing_school_ids.size
-    puts "found    : #{nces_schools.size} national schools to import"
-    puts "found    : #{existing_school_ids.size} pre-imported schools"
-    puts "         : #{import_count} schools will be imported"
+    Rails.logger.info "found    : #{nces_schools.size} national schools to import"
+    Rails.logger.info "found    : #{existing_school_ids.size} pre-imported schools"
+    Rails.logger.info "         : #{import_count} schools will be imported"
 
     school_values = []
     added = 0
@@ -98,8 +98,8 @@ class NationalDistrictImporter
                                               :district_id => district_id,
                                               :name        => nces_school.SCHNAM})
       if existing_school
-        puts "similar school already exists:#{existing_school.state} #{existing_school.name} #{existing_school.id}"
-        puts "updating."
+        Rails.logger.info "similar school already exists:#{existing_school.state} #{existing_school.name} #{existing_school.id}"
+        Rails.logger.info "updating."
         existing_school.nces_school = nces_school
         existing_school.save
       else

--- a/lib/parent_investigation.rb
+++ b/lib/parent_investigation.rb
@@ -15,7 +15,7 @@ class ParentInvestigation
     i.name = activity.name
     i.user = activity.user
     i.description = activity.description
-    puts "creating investigation #{i.name} : #{i.description}"
+    Rails.logger.info "creating investigation #{i.name} : #{i.description}"
     i.save
     activity.investigation = i
     activity.save

--- a/lib/tree_node.rb
+++ b/lib/tree_node.rb
@@ -64,7 +64,7 @@ module TreeNode
     set_user = lambda { |thing|
       unless thing.user == new_user
         old_login = thing.user ? thing.user.login : "<nil>"
-        puts "changing ownership of #{thing.name} from #{old_login} to #{new_user.login}" if logging
+        Rails.logger.info "changing ownership of #{thing.name} from #{old_login} to #{new_user.login}" if logging
         thing.user = new_user
         thing.save
       end
@@ -82,7 +82,7 @@ module TreeNode
         thing.teacher_notes.each do |note|
           unless note.user == new_user
             old_login = note.user ? note.user.login : "<nil>"
-            puts "changing ownership of #{note} from #{old_login} to #{new_user.login}" if logging
+            Rails.logger.info "changing ownership of #{note} from #{old_login} to #{new_user.login}" if logging
             note.user = new_user
             note.save
           end
@@ -91,7 +91,7 @@ module TreeNode
       if thing.respond_to? 'author_notes'
         thing.author_notes.each do |note|
           unless note.user == new_user
-            puts "changing ownership of #{note} from #{note.user} to #{new_user}" if logging
+            Rails.logger.info "changing ownership of #{note} from #{note.user} to #{new_user}" if logging
             note.user = new_user
             note.save
           end

--- a/lib/user_deleter.rb
+++ b/lib/user_deleter.rb
@@ -58,7 +58,7 @@ class UserDeleter
   def delete_user_list(user_list=User.find(:all, :conditions => "login like '%rinet_sakai%'"))
     user_list = user_list - self.keep_list
     user_list.each do |user|
-      print "Removing user: #{user.login} #{user.email}::::"
+      Rails.logger.info "Removing user: #{user.login} #{user.email}::::"
       delete_user(user)
       puts "\n"
     end
@@ -67,7 +67,7 @@ class UserDeleter
   def reown_investigations(user)
     user.investigations.each { |i|
       i.deep_set_user(self.default_owner)
-      print "I"
+      Rails.logger.info "I"
     }
   end
   
@@ -82,7 +82,7 @@ class UserDeleter
   def delete_student(user)
     if user.portal_student
       user.portal_student.destroy
-      print "S"
+      Rails.logger.info "S"
     end
   end
   
@@ -91,11 +91,11 @@ class UserDeleter
       if user.portal_teacher.clazzes
         user.portal_teacher.clazzes.each do |clazz|
           clazz.destroy
-          print "C"
+          Rails.logger.info "C"
         end
       end
       user.portal_teacher.destroy
-      print "T"
+      Rails.logger.info "T"
     end
   end
 

--- a/spec/libs/app_settings_spec.rb
+++ b/spec/libs/app_settings_spec.rb
@@ -77,11 +77,10 @@ describe "A class with the AppSettings module included" do
 
   # TODO: auto-generated
   describe '#save_app_settings' do
-    xit 'save_app_settings' do
+    it 'save_app_settings' do
       app_settings = ClassWithAppSettings.new
       new_app_settings = {}
-      path = double('path')
-      result = app_settings.save_app_settings(new_app_settings, 'path')
+      result = app_settings.save_app_settings(new_app_settings, 'tmp/path')
 
       expect(result).not_to be_nil
     end

--- a/spec/libs/national_district_importer_spec.rb
+++ b/spec/libs/national_district_importer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe NationalDistrictImporter do
       national_district_importer = described_class.new
       count = 1
       interval = 1
-      string = ('string')
+      string = ('')
       result = national_district_importer.tick(count, interval, string)
 
       expect(result).not_to be_nil

--- a/spec/models/ri_gse/grade_span_expectation_spec.rb
+++ b/spec/models/ri_gse/grade_span_expectation_spec.rb
@@ -57,6 +57,7 @@ describe RiGse::GradeSpanExpectation do
   # TODO: auto-generated
   describe '.default' do
     it 'default' do
+      FactoryGirl.create :rigse_grade_span_expectation, grade_span: '9-11'
       result = described_class.default
 
       expect(result).not_to be_nil

--- a/spec/services/reports/book_spec.rb
+++ b/spec/services/reports/book_spec.rb
@@ -40,11 +40,10 @@ RSpec.describe Reports::Book do
 
   # TODO: auto-generated
   describe '#save' do
-    xit 'save' do
+    it 'save' do
       options = {}
       book = described_class.new(options)
-      filename = 'filename'
-      result = book.save(filename)
+      result = book.save('tmp/filename')
 
       expect(result).not_to be_nil
     end


### PR DESCRIPTION
After @tjchambers added test coverage, we ended up with some additional puts/print statements in rspec output. This PR converts those statements to use `Rails.logger`.

I've also taken the opportunity to fix #568 and another [flaky test ](
5a837d7).