### PR TITLE
🐞Fix: Navigation not updated on 'Manage Class' pages.

### DIFF
--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -192,7 +192,7 @@ module NavigationHelper
     clazz_links << {
       id: "/classes/manage",
       label: "Manage Classes",
-      url: manage_portal_clazzes_url,
+      url: manage_portal_clazzes_path,
       sort: 11
       # link_to 'Manage Classes', manage_portal_clazzes_url, :class=>"pie", :id=>"btn_manage_classes"
     }

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -70,7 +70,7 @@ module NavigationHelper
         url: '/help',
         small: true,
         sort: -1,
-        iconName:'icon-search',
+        iconName:'icon-help',
       }
     else
       false


### PR DESCRIPTION
Navigation items should use relative links for matching current location.

In order to match the selected navigation item, we need to use relative paths in our links.

manage_portal_clazzes_url wasn't matching our request path because it included the server url.