### PR TITLE
Adjust regex to avoid multiline anchors on simple strings

### DIFF
--- a/app/models/password.rb
+++ b/app/models/password.rb
@@ -8,7 +8,7 @@ class Password < ActiveRecord::Base
   
   # Validations
   validates_presence_of :email, :user
-  validates_format_of :email, :with => /^([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})$/i, :message => 'is not a valid email address'
+  validates_format_of :email, :with => /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, :message => 'is not a valid email address'
 
   protected
   

--- a/spec/models/password_spec.rb
+++ b/spec/models/password_spec.rb
@@ -2,8 +2,28 @@
 
 require 'spec_helper'
 
-
 RSpec.describe Password, type: :model do
+  let(:user) {FactoryGirl.create(:user)}
+  let(:password) {Password.new(user: user)}
 
+  describe '#initialize_reset_code_and_expiration' do
+    it 'does not create with missing email' do
+      expect(password).not_to be_valid
+    end
 
+    it 'does not create with improper email' do
+      password.email = 'abcexample.com'
+      expect(password).not_to be_valid
+    end
+
+    it 'does  create with proper email' do
+      password.email = 'abc@example.com'
+      expect(password).to be_valid
+
+      password.save!
+
+      expect(password.reset_code).not_to be_empty
+      expect(password.expiration_date).to be > 13.days.from_now
+    end
+  end
 end


### PR DESCRIPTION
Fixes #471 to using `\A` in place of `^` and `\z` for `$` to avoid assumption of multiline regex matching.