### PR TITLE
Convert scopes to callable

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -92,18 +92,15 @@ class Activity < ActiveRecord::Base
     }
   }
 
-  scope :investigation, ->
-  {
+  scope :investigation, -> {
     joins("left outer JOIN investigations ON investigations.id = activities.investigation_id")
   }
 
-  scope :published, ->
-  {
+  scope :published, -> {
     where('activities.publication_status = "published" OR (investigations.publication_status = "published" AND investigations.allow_activity_assignment = 1)')
   }
 
-  scope :directly_published, ->
-  {
+  scope :directly_published, -> {
     where('activities.publication_status = "published"')
   }
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -60,12 +60,12 @@ class Activity < ActiveRecord::Base
   delegate :domain_id, :grade_span, :to => :investigation, :allow_nil => true
 
   # TODO: Which of these scopes can be removed?
-  scope :with_gse, {
-    :joins => "left outer JOIN ri_gse_grade_span_expectations on (ri_gse_grade_span_expectations.id = investigations.grade_span_expectation_id) JOIN ri_gse_assessment_targets ON (ri_gse_assessment_targets.id = ri_gse_grade_span_expectations.assessment_target_id) JOIN ri_gse_knowledge_statements ON (ri_gse_knowledge_statements.id = ri_gse_assessment_targets.knowledge_statement_id)"
+  scope :with_gse, -> {
+    joins("left outer JOIN ri_gse_grade_span_expectations on (ri_gse_grade_span_expectations.id = investigations.grade_span_expectation_id) JOIN ri_gse_assessment_targets ON (ri_gse_assessment_targets.id = ri_gse_grade_span_expectations.assessment_target_id) JOIN ri_gse_knowledge_statements ON (ri_gse_knowledge_statements.id = ri_gse_assessment_targets.knowledge_statement_id)")
   }
 
-  scope :without_teacher_only,{
-    :conditions =>['activities.teacher_only = 0']
+  scope :without_teacher_only, -> {
+    where('activities.teacher_only = 0')
   }
 
   scope :domain, lambda { |domain_id|
@@ -81,8 +81,8 @@ class Activity < ActiveRecord::Base
     }
   }
 
-  scope :activity_group, {
-      :group => "#{self.table_name}.id"
+  scope :activity_group, -> {
+      group("#{self.table_name}.id")
     }
 
   scope :like, lambda { |name|
@@ -92,22 +92,22 @@ class Activity < ActiveRecord::Base
     }
   }
 
-  scope :investigation,
+  scope :investigation, ->
   {
-    :joins => "left outer JOIN investigations ON investigations.id = activities.investigation_id",
+    joins("left outer JOIN investigations ON investigations.id = activities.investigation_id")
   }
 
-  scope :published,
+  scope :published, ->
   {
-    :conditions =>['activities.publication_status = "published" OR (investigations.publication_status = "published" AND investigations.allow_activity_assignment = 1)']
+    where('activities.publication_status = "published" OR (investigations.publication_status = "published" AND investigations.allow_activity_assignment = 1)')
   }
 
-  scope :directly_published,
+  scope :directly_published, ->
   {
-    :conditions =>['activities.publication_status = "published"']
+    where('activities.publication_status = "published"')
   }
 
-  scope :assigned, where('offerings_count > 0')
+  scope :assigned, -> { where('offerings_count > 0') }
 
   scope :ordered_by, lambda { |order| { :order => order } }
 

--- a/app/models/commons_license.rb
+++ b/app/models/commons_license.rb
@@ -9,7 +9,7 @@ class CommonsLicense < ActiveRecord::Base
   DeedFormat  =   "http://#{Site}/licenses/%{code}/%{version}/"
   LegalFormat =   "http://#{Site}/licenses/%{code}/%{version}/legalcode"
 
-  default_scope :order => 'number ASC'
+  default_scope { order('number ASC') }
 
   def default_paths
     self.deed  ||= CommonsLicense.deed(self)

--- a/app/models/external_activity.rb
+++ b/app/models/external_activity.rb
@@ -137,25 +137,25 @@ class ExternalActivity < ActiveRecord::Base
     errors.add(:url, 'must be a valid url') if validated_url.nil?
   end
 
-  scope :published,
+  scope :published, ->
   {
-    :conditions =>{:publication_status => "published"}
+    where(publication_status: "published")
   }
 
-  scope :assigned, where('offerings_count > 0')
+  scope :assigned, -> { where('offerings_count > 0') }
 
-  scope :not_private,
+  scope :not_private, ->
   {
-    :conditions => "#{self.table_name}.publication_status IN ('published', 'draft')"
+    where("#{self.table_name}.publication_status IN ('published', 'draft')")
   }
 
   scope :by_user, proc { |u| { :conditions => {:user_id => u.id} } }
 
   scope :ordered_by, lambda { |order| { :order => order } }
 
-  scope :official, where(:is_official => true)
-  scope :contributed, where(:is_official => false)
-  scope :archived, where(:is_archived => true)
+  scope :official, -> { where(is_official: true) }
+  scope :contributed, -> { where(is_official: false) }
+  scope :archived, -> { where(is_archived: true) }
 
   def url(learner = nil, domain = nil)
     begin

--- a/app/models/external_activity.rb
+++ b/app/models/external_activity.rb
@@ -137,17 +137,11 @@ class ExternalActivity < ActiveRecord::Base
     errors.add(:url, 'must be a valid url') if validated_url.nil?
   end
 
-  scope :published, ->
-  {
-    where(publication_status: "published")
-  }
+  scope :published, -> { where(publication_status: "published") }
 
   scope :assigned, -> { where('offerings_count > 0') }
 
-  scope :not_private, ->
-  {
-    where("#{self.table_name}.publication_status IN ('published', 'draft')")
-  }
+  scope :not_private, -> { where("#{self.table_name}.publication_status IN ('published', 'draft')") }
 
   scope :by_user, proc { |u| { :conditions => {:user_id => u.id} } }
 

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -22,12 +22,12 @@ class Image < ActiveRecord::Base
 
   validates_presence_of :user_id, :name, :publication_status
 
-  scope :published, :conditions => { :publication_status => 'published' }
-  scope :private_status, :conditions => { :publication_status => 'private' }
-  scope :draft_status, :conditions => { :publication_status => 'draft' }
+  scope :published, -> { where(publication_status: 'published') }
+  scope :private_status, -> { where(publication_status:'private') }
+  scope :draft_status, -> { where(publication_status: 'draft') }
   scope :by_user, proc { |u| { :conditions => {:user_id => u.id} } }
   scope :with_status, proc { |s| { :conditions => { :publication_status => s } } }
-  scope :not_private, { :conditions => "#{self.table_name}.publication_status IN ('published', 'draft')" }
+  scope :not_private, -> { where("#{self.table_name}.publication_status IN ('published', 'draft')") }
 
   scope :visible_to_user, proc { |u| { :conditions =>
     [ "#{self.table_name}.publication_status = 'published' OR
@@ -38,7 +38,7 @@ class Image < ActiveRecord::Base
     [ "#{self.table_name}.publication_status IN ('published', 'draft') OR
       (#{self.table_name}.publication_status = 'private' AND #{self.table_name}.user_id = ?)", u.nil? ? u : u.id ]
   }}
-  scope :no_drafts, :conditions => "#{self.table_name}.publication_status NOT IN ('draft')"
+  scope :no_drafts, -> { where("#{self.table_name}.publication_status NOT IN ('draft')") }
 
   scope :like, lambda { |name|
     name = "%#{name}%"

--- a/app/models/interactive.rb
+++ b/app/models/interactive.rb
@@ -101,7 +101,7 @@ class Interactive < ActiveRecord::Base
 
   end
 
-  scope :published, where(publication_status: 'published')
+  scope :published, -> { where(publication_status: 'published') }
 
   def is_official
     true

--- a/app/models/investigation.rb
+++ b/app/models/investigation.rb
@@ -74,14 +74,14 @@ class Investigation < ActiveRecord::Base
   # for convenience (will not work in find_by_* &etc.)
   delegate :grade_span, :domain, :to => :grade_span_expectation, :allow_nil => true
 
-  scope :assigned, where('investigations.offerings_count > 0')
+  scope :assigned, -> { where('investigations.offerings_count > 0') }
   #
   # IMPORTANT: Use with_gse if you are also going to use domain and grade params... eg:
   # Investigation.with_gse.grade('9-11') == good
   # Investigation.grade('9-11') == bad
   #
-  scope :with_gse, {
-    :joins => "left outer JOIN ri_gse_grade_span_expectations on (ri_gse_grade_span_expectations.id = investigations.grade_span_expectation_id) JOIN ri_gse_assessment_targets ON (ri_gse_assessment_targets.id = ri_gse_grade_span_expectations.assessment_target_id) JOIN ri_gse_knowledge_statements ON (ri_gse_knowledge_statements.id = ri_gse_assessment_targets.knowledge_statement_id)"
+  scope :with_gse, -> {
+    joins("left outer JOIN ri_gse_grade_span_expectations on (ri_gse_grade_span_expectations.id = investigations.grade_span_expectation_id) JOIN ri_gse_assessment_targets ON (ri_gse_assessment_targets.id = ri_gse_grade_span_expectations.assessment_target_id) JOIN ri_gse_knowledge_statements ON (ri_gse_knowledge_statements.id = ri_gse_assessment_targets.knowledge_statement_id)")
   }
 
   scope :domain, lambda { |domain_id|
@@ -105,8 +105,8 @@ class Investigation < ActiveRecord::Base
     }
   }
 
-  scope :activity_group, {
-    :group => "#{self.table_name}.id"
+  scope :activity_group, -> {
+    group("#{self.table_name}.id")
   }
 
   scope :ordered_by, lambda { |order| { :order => order } }

--- a/app/models/portal/bookmark.rb
+++ b/app/models/portal/bookmark.rb
@@ -12,7 +12,7 @@ class Portal::Bookmark < ActiveRecord::Base
   # Global filtering of scope, based on Admin Project settings. Note that {} block
   # is required so the expression is evaluated lazily and current settings are used.
   default_scope { where(:type => self.enabled_bookmark_types) }
-  default_scope :order => 'position'
+  default_scope { order('position') }
   acts_as_list
 
   def self.available_types

--- a/app/models/portal/bookmark_visit.rb
+++ b/app/models/portal/bookmark_visit.rb
@@ -4,5 +4,5 @@ class Portal::BookmarkVisit < ActiveRecord::Base
   belongs_to :user
   belongs_to :bookmark
 
-  scope :recent, limit(100).order("created_at DESC")
+  scope :recent, -> { limit(100).order("created_at DESC") }
 end

--- a/app/models/portal/district.rb
+++ b/app/models/portal/district.rb
@@ -6,8 +6,8 @@ class Portal::District < ActiveRecord::Base
   has_many :schools, :dependent => :destroy, :class_name => "Portal::School", :foreign_key => "district_id", :order => "name"
   belongs_to :nces_district, :class_name => "Portal::Nces06District", :foreign_key => "nces_district_id"
 
-  scope :real,    { :conditions => 'nces_district_id is NOT NULL', :include => :schools, :order => "name" }
-  scope :virtual, { :conditions => 'nces_district_id is NULL', :include => :schools, :order => "name" }
+  scope :real,    -> { where('nces_district_id is NOT NULL').include(:schools).order("name") }
+  scope :virtual, -> { where('nces_district_id is NULL').include(:schools).order("name") }
 
   include Changeable
 

--- a/app/models/portal/district.rb
+++ b/app/models/portal/district.rb
@@ -6,8 +6,8 @@ class Portal::District < ActiveRecord::Base
   has_many :schools, :dependent => :destroy, :class_name => "Portal::School", :foreign_key => "district_id", :order => "name"
   belongs_to :nces_district, :class_name => "Portal::Nces06District", :foreign_key => "nces_district_id"
 
-  scope :real,    -> { where('nces_district_id is NOT NULL').include(:schools).order("name") }
-  scope :virtual, -> { where('nces_district_id is NULL').include(:schools).order("name") }
+  scope :real,    -> { where('nces_district_id is NOT NULL').includes(:schools).order("name") }
+  scope :virtual, -> { where('nces_district_id is NULL').includes(:schools).order("name") }
 
   include Changeable
 

--- a/app/models/portal/generic_bookmark.rb
+++ b/app/models/portal/generic_bookmark.rb
@@ -1,3 +1,3 @@
 class Portal::GenericBookmark < Portal::Bookmark
-  default_scope :order => 'position'
+  default_scope { order('position') }
 end

--- a/app/models/portal/grade.rb
+++ b/app/models/portal/grade.rb
@@ -4,7 +4,7 @@ class Portal::Grade < ActiveRecord::Base
   acts_as_list
   acts_as_replicatable
 
-  scope :active, { :conditions => { :active => true } }  
+  scope :active, -> { where(active: true) }
   has_many :grade_levels, :dependent => :destroy,:class_name => "Portal::GradeLevel"
   
   include Changeable

--- a/app/models/portal/learner.rb
+++ b/app/models/portal/learner.rb
@@ -3,7 +3,7 @@ class Portal::Learner < ActiveRecord::Base
 
   self.table_name = :portal_learners
   
-  default_scope :order => 'portal_learners.student_id ASC'
+  default_scope { order('portal_learners.student_id ASC') }
   
   acts_as_replicatable
   

--- a/app/models/portal/learner_activity_feedback.rb
+++ b/app/models/portal/learner_activity_feedback.rb
@@ -13,7 +13,7 @@ class Portal::LearnerActivityFeedback < ActiveRecord::Base
 
   serialize :rubric_feedback, JSON
 
-  default_scope :order => 'created_at DESC'
+  default_scope { order('created_at DESC') }
 
   def self._attribute_ids(*attributes)
     results = []

--- a/app/models/portal/padlet_bookmark.rb
+++ b/app/models/portal/padlet_bookmark.rb
@@ -1,5 +1,5 @@
 class Portal::PadletBookmark < Portal::Bookmark
-  default_scope :order => 'position'
+  default_scope { order('position') }
 
   def self.create_for_user(user, clazz = nil)
     return false if user.anonymous?

--- a/app/models/portal/school.rb
+++ b/app/models/portal/school.rb
@@ -33,9 +33,9 @@ class Portal::School < ActiveRecord::Base
   # has_many_polymorphs :members, :from => [:"portal/teachers", :"portal/students"], :through => :"portal/members"
   has_many :portal_teachers, :through => :members, :source => 'member', :source_type => "Portal::Teacher"
   alias :teachers :portal_teachers
-  scope :real,    { :conditions => 'nces_school_id is NOT NULL' }  
-  scope :virtual, { :conditions => 'nces_school_id is NULL' }  
-  scope :has_teachers, joins(:members).group(:school_id)
+  scope :real,    -> { where('nces_school_id is NOT NULL') }
+  scope :virtual, -> { where('nces_school_id is NULL') }
+  scope :has_teachers, -> { joins(:members).group(:school_id) }
 
   # TODO: Maybe this?  But also maybe nces_id.nil? technique instead??
   [:virtual?, :real?].each {|method| delegate method, :to=> :district }

--- a/app/models/portal/teacher_clazz.rb
+++ b/app/models/portal/teacher_clazz.rb
@@ -6,7 +6,7 @@ class Portal::TeacherClazz < ActiveRecord::Base
   
   belongs_to :clazz, :class_name => "Portal::Clazz", :foreign_key => "clazz_id"
   belongs_to :teacher, :class_name => "Portal::Teacher", :foreign_key => "teacher_id"
-  default_scope :order => 'position ASC'
+  default_scope { order('position ASC') }
   
   [:name, :description].each { |m| delegate m, :to => :clazz }
   

--- a/app/models/report/learner.rb
+++ b/app/models/report/learner.rb
@@ -11,10 +11,10 @@ class Report::Learner < ActiveRecord::Base
   serialize    :answers, Hash
   belongs_to   :runnable, :polymorphic => true
 
-  scope :after,  lambda         { |date|         {:conditions => ["last_run > ?", date]} }
-  scope :before, lambda         { |date|         {:conditions => ["last_run < ?", date]} }
-  scope :in_schools, lambda     { |school_ids|   {:conditions => {:school_id   => school_ids   }}}
-  scope :in_classes, lambda     { |class_ids|    {:conditions => {:class_id    => class_ids    }}}
+  scope :after,  lambda         { |date|         where("last_run > ?", date)  }
+  scope :before, lambda         { |date|         where("last_run < ?", date) }
+  scope :in_schools, lambda     { |school_ids|   where(:school_id   => school_ids) }
+  scope :in_classes, lambda     { |class_ids|    where(:class_id    => class_ids) }
 
   scope :with_permission_ids, lambda { |ids|
     includes(student: :portal_student_permission_forms)

--- a/app/models/ri_gse/grade_span_expectation.rb
+++ b/app/models/ri_gse/grade_span_expectation.rb
@@ -26,11 +26,9 @@ class RiGse::GradeSpanExpectation < ActiveRecord::Base
   acts_as_replicatable
 
   # brittle;,because we must know too much about table names ...
-  scope :grade_and_domain, lambda { |gs,domain_id|
-    {
-      :joins => "JOIN ri_gse_assessment_targets ON (ri_gse_assessment_targets.id = ri_gse_grade_span_expectations.assessment_target_id) JOIN ri_gse_knowledge_statements ON (ri_gse_knowledge_statements.id = ri_gse_assessment_targets.knowledge_statement_id)",
-      :conditions => ['ri_gse_knowledge_statements.domain_id = ? and ri_gse_grade_span_expectations.grade_span LIKE ?', domain_id, gs ]
-    }
+  scope :grade_and_domain, lambda { |gs, domain_id|
+      joins("JOIN ri_gse_assessment_targets ON (ri_gse_assessment_targets.id = ri_gse_grade_span_expectations.assessment_target_id) JOIN ri_gse_knowledge_statements ON (ri_gse_knowledge_statements.id = ri_gse_assessment_targets.knowledge_statement_id)").
+      where('ri_gse_knowledge_statements.domain_id = ? and ri_gse_grade_span_expectations.grade_span LIKE ?', domain_id, gs)
   }
   
   # 

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -5,6 +5,6 @@ class Role < ActiveRecord::Base
   acts_as_list
   acts_as_replicatable
 
-  default_scope :order => 'position ASC'
+  default_scope { order('position ASC') }
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,7 @@ class User < ActiveRecord::Base
          :recoverable,:timeoutable, :rememberable, :trackable, :validatable,:encryptable, :encryptor => :restful_authentication_sha1
   devise :omniauthable, :omniauth_providers => Devise.omniauth_providers
   self.token_authentication_key = "access_token"
-  default_scope where(User.arel_table[:state].not_in(['disabled']))
+  default_scope { where(User.arel_table[:state].not_in(['disabled'])) }
 
   def apply_omniauth(omniauth)
     authentications.build(:provider => omniauth['provider'], :uid => omniauth['uid'])
@@ -57,12 +57,12 @@ class User < ActiveRecord::Base
 
   has_one :notice_user_display_status, :dependent => :destroy ,:class_name => "Admin::NoticeUserDisplayStatus", :foreign_key => "user_id"
 
-  scope :all_users, { :conditions => {}}
-  scope :active, { :conditions => { :state => 'active' } }
-  scope :suspended, {:conditions => { :state => 'suspended'}}
-  scope :no_email, { :conditions => "email LIKE '#{NO_EMAIL_STRING}%'" }
-  scope :email, { :conditions => "email NOT LIKE '#{NO_EMAIL_STRING}%'" }
-  scope :default, { :conditions => { :default_user => true } }
+  scope :all_users, -> { where(nil) }
+  scope :active, -> { where(state: 'active') }
+  scope :suspended, -> { where(state: 'suspended') }
+  scope :no_email, -> { where("email LIKE '#{NO_EMAIL_STRING}%'") }
+  scope :email, -> { where("email NOT LIKE '#{NO_EMAIL_STRING}%'") }
+  scope :default, -> { where(default_user: true) }
   scope :with_role, lambda { | role_name |
     { :include => :roles, :conditions => ['roles.title = ?',role_name]}
   }

--- a/lib/publishable.rb
+++ b/lib/publishable.rb
@@ -34,8 +34,7 @@ module Publishable
         transitions :to => :draft, :from => [:published]
       end
 
-      scope :published, ->
-      {
+      scope :published, -> {
         where(:publication_status => "published")
       }
 

--- a/lib/publishable.rb
+++ b/lib/publishable.rb
@@ -34,9 +34,9 @@ module Publishable
         transitions :to => :draft, :from => [:published]
       end
 
-      scope :published,
+      scope :published, ->
       {
-        :conditions =>{:publication_status => "published"}
+        where(:publication_status => "published")
       }
 
       def available_states(who_wants_to_know)

--- a/spec/models/portal/district_spec.rb
+++ b/spec/models/portal/district_spec.rb
@@ -72,10 +72,13 @@ describe Portal::District do
       expect(described_class.limit(3).real).to all(be_a(described_class))
     end
   end
+  
   # TODO: auto-generated
   describe '.virtual' do # scope test
     it 'supports named scope virtual' do
+      Portal::District.create!(@valid_attributes)
       expect(described_class.limit(3).virtual).to all(be_a(described_class))
+      expect(described_class.limit(3).virtual).to have(1).entry
     end
   end
 


### PR DESCRIPTION
Fixes #473 in advance of Rails 4.0 upgrade where scopes must be callable objects.