### PR TITLE
Fix failing cucumber tests

### DIFF
--- a/features/manager_updates_account_information.feature
+++ b/features/manager_updates_account_information.feature
@@ -36,7 +36,7 @@ Feature: A manager updates account information for another user
     When I log out
     And I login with username: <userlogin> password: <new_password>
     Then I should see "Welcome"
-    And I should see "Settings"
+    And I should see "SETTINGS"
 
     Examples:
       | username      | userlogin | new_password |

--- a/features/step_definitions/project_links_steps.rb
+++ b/features/step_definitions/project_links_steps.rb
@@ -26,13 +26,15 @@ Given /^the "([^"]*)" user is added to the default project$/ do |username|
 end
 
 Then /^I should see a project link labeled "([^"]*)" linking to "([^"]*)"$/ do |link, href|
-  bin_name = "Resources"
-  page.find(:xpath,"//*[text()='#{bin_name}']").click
   expect(page).to have_link link
   expect(find_link(link)[:href]).to eq href
+end
+
+Then /^I expand the "([^"]*)" section$/ do |section_name|
+  # Note: if the section is already expanded this will fail.
+  page.find(:xpath,"//*[@id='clazzes_nav']//*[text()='#{section_name}'][not(contains(@class,'open'))]").click
 end
 
 Then /^I should not see a project link labeled "([^"]*)"$/ do |link|
   expect(page).to have_no_link link
 end
-

--- a/features/teacher_sees_project_specific_links.feature
+++ b/features/teacher_sees_project_specific_links.feature
@@ -20,6 +20,6 @@ Feature: Teacher can see project specific links
   Scenario: Teacher in project visits homepage
     Given the "teacher" user is added to the default project
     When I am on getting started page
+    And I expand the "Resources" section
     Then I should see a project link labeled "Foo Project Link" linking to "http://foo.com/"
-      And I should see a project link labeled "Bar Project Link" linking to "http://bar.com/"
-
+    And I should see a project link labeled "Bar Project Link" linking to "http://bar.com/"


### PR DESCRIPTION
There were 3 tests that started failing after changes to portal-pages master.
2 are the same because some change in the way the css capitalized the Settings menu item
required the cucumber matcher to also be capitalized.
The last was broken because the Resources section changed so once it was expanded
clicking on it again would navigate to the link instead of re-expanding the section.

It would be great if changes to portal-pages would not get deployed if the rigse tests failed. Currently it is easy to make a change in portal pages which then breaks the rigse tests, and when this happens it isn't obvious. I don't know of a quick way to set that up though.