### PR TITLE
Convert find(:all...) references to Rails 4 syntax

### DIFF
--- a/app/controllers/admin/clients_controller.rb
+++ b/app/controllers/admin/clients_controller.rb
@@ -11,7 +11,7 @@ class Admin::ClientsController < ApplicationController
   # GET /admin/clients
   def index
     authorize Client
-    @clients = Client.find(:all).paginate(:per_page => 20, :page => params[:page])
+    @clients = Client.all.paginate(:per_page => 20, :page => params[:page])
   end
 
   # GET /admin/client/1

--- a/app/controllers/admin/commons_licenses_controller.rb
+++ b/app/controllers/admin/commons_licenses_controller.rb
@@ -10,7 +10,7 @@ class Admin::CommonsLicensesController < ApplicationController
 
   def index
     authorize CommonsLicense
-    @licenses = CommonsLicense.find(:all).paginate(:per_page => 20, :page => params[:page])
+    @licenses = CommonsLicense.all.paginate(:per_page => 20, :page => params[:page])
   end
 
   def show

--- a/app/controllers/admin/external_reports_controller.rb
+++ b/app/controllers/admin/external_reports_controller.rb
@@ -11,7 +11,7 @@ class Admin::ExternalReportsController < ApplicationController
   # GET /admin/reports
   def index
     authorize ExternalReport
-    @reports = ExternalReport.find(:all).paginate(:per_page => 20, :page => params[:page])
+    @reports = ExternalReport.all.paginate(:per_page => 20, :page => params[:page])
   end
 
   # GET /admin/report/1

--- a/app/controllers/admin/site_notices_controller.rb
+++ b/app/controllers/admin/site_notices_controller.rb
@@ -70,7 +70,7 @@ class Admin::SiteNoticesController < ApplicationController
   def index
     #authorize Admin::SiteNotice
     #@all_notices = policy_scope(Admin::SiteNotice).order('updated_at desc')
-    @all_notices = Admin::SiteNotice.find(:all,:order=> 'updated_at desc')
+    @all_notices = Admin::SiteNotice.find(:yall,:order=> 'updated_at desc')
   end
 
   def edit

--- a/app/controllers/admin/site_notices_controller.rb
+++ b/app/controllers/admin/site_notices_controller.rb
@@ -70,7 +70,7 @@ class Admin::SiteNoticesController < ApplicationController
   def index
     #authorize Admin::SiteNotice
     #@all_notices = policy_scope(Admin::SiteNotice).order('updated_at desc')
-    @all_notices = Admin::SiteNotice.find(:yall,:order=> 'updated_at desc')
+    @all_notices = Admin::SiteNotice.order('updated_at desc')
   end
 
   def edit

--- a/app/controllers/import/imports_controller.rb
+++ b/app/controllers/import/imports_controller.rb
@@ -126,7 +126,7 @@ class Import::ImportsController < ApplicationController
     # authorize Import::Import, :new_or_create?
     # authorize @import, :update_edit_or_destroy?
     user_import = Import::Import.find(:last, :conditions => {:import_type => Import::Import::IMPORT_TYPE_USER})
-    duplicate_users = Import::DuplicateUser.find(:all, :conditions => {:import_id => user_import.id})
+    duplicate_users = Import::DuplicateUser.find(:yall, :conditions => {:import_id => user_import.id})
     if duplicate_users.length == 0
       flash[:alert] = "No duplicate users found in the import."
       redirect_to :back

--- a/app/controllers/import/imports_controller.rb
+++ b/app/controllers/import/imports_controller.rb
@@ -11,8 +11,9 @@ class Import::ImportsController < ApplicationController
     # authorize @import
     # authorize Import::Import, :new_or_create?
     # authorize @import, :update_edit_or_destroy?
-    file_data = params[:import][:import].read
     begin
+      file_data = params[:import][:import].read
+
       json_data = JSON.parse file_data, :symbolize_names => true
       if json_data[:districts].nil? || json_data[:schools].nil?
         raise "Invalid JSON"
@@ -38,8 +39,9 @@ class Import::ImportsController < ApplicationController
     # authorize @import
     # authorize Import::Import, :new_or_create?
     # authorize @import, :update_edit_or_destroy?
-    file_data = params[:import][:import].read
     begin
+      file_data = params[:import][:import].read
+
       json_data = JSON.parse file_data, :symbolize_names => true
       if json_data[:users].nil?
         raise "Invalid JSON"
@@ -126,7 +128,7 @@ class Import::ImportsController < ApplicationController
     # authorize Import::Import, :new_or_create?
     # authorize @import, :update_edit_or_destroy?
     user_import = Import::Import.find(:last, :conditions => {:import_type => Import::Import::IMPORT_TYPE_USER})
-    duplicate_users = Import::DuplicateUser.find(:yall, :conditions => {:import_id => user_import.id})
+    duplicate_users = Import::DuplicateUser.where(:import_id => user_import.id)
     if duplicate_users.length == 0
       flash[:alert] = "No duplicate users found in the import."
       redirect_to :back

--- a/app/controllers/portal/nces06_districts_controller.rb
+++ b/app/controllers/portal/nces06_districts_controller.rb
@@ -32,12 +32,12 @@ class Portal::Nces06DistrictsController < ApplicationController
     # authorize Portal::Nces06District
     select = "id, NAME"
     if params[:state_or_province]
-      @nces06_districts = Portal::Nces06District.find(:all, :conditions => ["MSTATE = ?", params[:state_or_province]], :select => select, :order => 'NAME')
+      @nces06_districts = Portal::Nces06District.find(:yall, :conditions => ["MSTATE = ?", params[:state_or_province]], :select => select, :order => 'NAME')
     # PUNDIT_REVIEW_SCOPE
     # PUNDIT_CHECK_SCOPE (found instance)
     # @nces06_districts = policy_scope(Portal::Nces06District)
     else
-      @nces06_districts = Portal::Nces06District.find(:all, :select => select, :order => 'NAME')
+      @nces06_districts = Portal::Nces06District.find(:yall, :select => select, :order => 'NAME')
     end
 
     respond_to do |format|

--- a/app/controllers/portal/nces06_districts_controller.rb
+++ b/app/controllers/portal/nces06_districts_controller.rb
@@ -32,12 +32,12 @@ class Portal::Nces06DistrictsController < ApplicationController
     # authorize Portal::Nces06District
     select = "id, NAME"
     if params[:state_or_province]
-      @nces06_districts = Portal::Nces06District.find(:yall, :conditions => ["MSTATE = ?", params[:state_or_province]], :select => select, :order => 'NAME')
+      @nces06_districts = Portal::Nces06District.where("MSTATE = ?", params[:state_or_province]).select(select).order('NAME')
     # PUNDIT_REVIEW_SCOPE
     # PUNDIT_CHECK_SCOPE (found instance)
     # @nces06_districts = policy_scope(Portal::Nces06District)
     else
-      @nces06_districts = Portal::Nces06District.find(:yall, :select => select, :order => 'NAME')
+      @nces06_districts = Portal::Nces06District.select(select).order('NAME')
     end
 
     respond_to do |format|

--- a/app/controllers/portal/nces06_schools_controller.rb
+++ b/app/controllers/portal/nces06_schools_controller.rb
@@ -32,14 +32,14 @@ class Portal::Nces06SchoolsController < ApplicationController
     # authorize Portal::Nces06School
     select = "id, SCHNAM"
     if params[:state_or_province]
-      @nces06_schools = Portal::Nces06School.find(:all, :conditions => ["MSTATE = ?", params[:state_or_province]], :select => select, :order => 'SCHNAM')
+      @nces06_schools = Portal::Nces06School.find(:yall, :conditions => ["MSTATE = ?", params[:state_or_province]], :select => select, :order => 'SCHNAM')
     # PUNDIT_REVIEW_SCOPE
     # PUNDIT_CHECK_SCOPE (found instance)
     # @nces06_schools = policy_scope(Portal::Nces06School)
     elsif params[:nces_district_id]
-      @nces06_schools = Portal::Nces06School.find(:all, :conditions => ["nces_district_id = ?", params[:nces_district_id]], :select => select, :order => 'SCHNAM')
+      @nces06_schools = Portal::Nces06School.find(:yall, :conditions => ["nces_district_id = ?", params[:nces_district_id]], :select => select, :order => 'SCHNAM')
     else
-      @nces06_schools = Portal::Nces06School.find(:all, :select => select, :order => 'SCHNAM')
+      @nces06_schools = Portal::Nces06School.find(:yall, :select => select, :order => 'SCHNAM')
     end
     respond_to do |format|
       format.html # index.html.erb

--- a/app/controllers/portal/nces06_schools_controller.rb
+++ b/app/controllers/portal/nces06_schools_controller.rb
@@ -32,14 +32,14 @@ class Portal::Nces06SchoolsController < ApplicationController
     # authorize Portal::Nces06School
     select = "id, SCHNAM"
     if params[:state_or_province]
-      @nces06_schools = Portal::Nces06School.find(:yall, :conditions => ["MSTATE = ?", params[:state_or_province]], :select => select, :order => 'SCHNAM')
+      @nces06_schools = Portal::Nces06School.where("MSTATE = ?", params[:state_or_province]).select(select).order('SCHNAM')
     # PUNDIT_REVIEW_SCOPE
     # PUNDIT_CHECK_SCOPE (found instance)
     # @nces06_schools = policy_scope(Portal::Nces06School)
     elsif params[:nces_district_id]
-      @nces06_schools = Portal::Nces06School.find(:yall, :conditions => ["nces_district_id = ?", params[:nces_district_id]], :select => select, :order => 'SCHNAM')
+      @nces06_schools = Portal::Nces06School.where("nces_district_id = ?", params[:nces_district_id]).select(select).order('SCHNAM')
     else
-      @nces06_schools = Portal::Nces06School.find(:yall, :select => select, :order => 'SCHNAM')
+      @nces06_schools = Portal::Nces06School.select(select).order('SCHNAM')
     end
     respond_to do |format|
       format.html # index.html.erb

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -19,7 +19,7 @@ class Activity < ActiveRecord::Base
 
   has_many :sections, :order => :position, :dependent => :destroy do
     def student_only
-      find(:all, :conditions => {'teacher_only' => false})
+      where('teacher_only' => false)
     end
   end
   has_many :pages, :through => :sections

--- a/app/models/admin/settings.rb
+++ b/app/models/admin/settings.rb
@@ -132,10 +132,10 @@ Dataservice::BundleContent: #{Dataservice::BundleContent.count}
 Dataservice::ConsoleLogger:  #{Dataservice::ConsoleLogger.count}
 Dataservice::ConsoleContent: #{Dataservice::ConsoleContent.count}
 
-There are #{Portal::Teacher.find(:all).select {|t| t.user == nil}.size} Teachers without Users
-There are #{Portal::Student.find(:all).select {|s| s.user == nil}.size} Students which no longer have Teachers
-There are #{Portal::Clazz.find(:all).select {|i| i.teacher == nil}.size} Classes which no longer have Teachers
-There are #{Portal::Learner.find(:all).select {|i| i.student == nil}.size} Learners which are no longer associated with Students
+There are #{Portal::Teacher.select {|t| t.user == nil}.size} Teachers without Users
+There are #{Portal::Student.select {|s| s.user == nil}.size} Students which no longer have Teachers
+There are #{Portal::Clazz.select {|i| i.teacher == nil}.size} Classes which no longer have Teachers
+There are #{Portal::Learner.select {|i| i.student == nil}.size} Learners which are no longer associated with Students
 
 If these numbers are large you may want to consider cleaning up the database.
 
@@ -152,6 +152,4 @@ HEREDOC
   def available_bookmark_types
     Portal::Bookmark.available_types.map { |t| t.name }
   end
-
-
 end

--- a/app/models/embeddable/multiple_choice.rb
+++ b/app/models/embeddable/multiple_choice.rb
@@ -16,7 +16,7 @@ class Embeddable::MultipleChoice < ActiveRecord::Base
       where(:learner_id => learner.id)
     end
     def first_by_learner(learner)
-      where(:learner_id => learner.id).first
+      by_learner(learner).first
     end
   end
 

--- a/app/models/embeddable/multiple_choice.rb
+++ b/app/models/embeddable/multiple_choice.rb
@@ -10,13 +10,13 @@ class Embeddable::MultipleChoice < ActiveRecord::Base
 
   has_many :saveables, :class_name => "Saveable::MultipleChoice", :foreign_key => :multiple_choice_id do
     def by_offering(offering)
-      find(:all, :conditions => { :offering_id => offering.id })
+      where(:offering_id => offering.id)
     end
     def by_learner(learner)
-      find(:all, :conditions => { :learner_id => learner.id })
+      where(:learner_id => learner.id)
     end
     def first_by_learner(learner)
-      find(:first, :conditions => { :learner_id => learner.id })
+      where(:learner_id => learner.id).first
     end
   end
 

--- a/app/models/embeddable/open_response.rb
+++ b/app/models/embeddable/open_response.rb
@@ -15,13 +15,13 @@ class Embeddable::OpenResponse < ActiveRecord::Base
 
   has_many :saveables, :class_name => "Saveable::OpenResponse", :foreign_key => :open_response_id do
     def by_offering(offering)
-      find(:all, :conditions => { :offering_id => offering.id })
+      where(:offering_id => offering.id)
     end
     def by_learner(learner)
-      find(:all, :conditions => { :learner_id => learner.id })
+      where(:learner_id => learner.id)
     end
     def first_by_learner(learner)
-      find(:first, :conditions => { :learner_id => learner.id })
+      where(:learner_id => learner.id)
     end
   end
 

--- a/app/models/embeddable/open_response.rb
+++ b/app/models/embeddable/open_response.rb
@@ -21,7 +21,7 @@ class Embeddable::OpenResponse < ActiveRecord::Base
       where(:learner_id => learner.id)
     end
     def first_by_learner(learner)
-      where(:learner_id => learner.id)
+      by_learner(learner).first
     end
   end
 

--- a/app/models/investigation.rb
+++ b/app/models/investigation.rb
@@ -8,7 +8,7 @@ class Investigation < ActiveRecord::Base
   belongs_to :grade_span_expectation, :class_name => 'RiGse::GradeSpanExpectation'
   has_many :activities, :order => :position, :dependent => :destroy do
     def student_only
-      find(:all, :conditions => {'teacher_only' => false})
+      where('teacher_only' => false)
     end
   end
   has_many :teacher_notes, :dependent => :destroy, :as => :authored_entity

--- a/app/models/portal/learner.rb
+++ b/app/models/portal/learner.rb
@@ -18,7 +18,7 @@ class Portal::Learner < ActiveRecord::Base
 
   has_many :open_responses, :dependent => :destroy , :class_name => "Saveable::OpenResponse" do
     def answered
-      find(:all).select { |question| question.answered? }
+      all.select { |question| question.answered? }
     end
   end
   
@@ -26,28 +26,28 @@ class Portal::Learner < ActiveRecord::Base
   
   has_many :image_questions, :dependent => :destroy, :class_name => "Saveable::ImageQuestion" do
     def answered
-      find(:all).select { |question| question.answered? }
+      all.select { |question| question.answered? }
     end
   end
 
   has_many :multiple_choices, :dependent => :destroy, :class_name => "Saveable::MultipleChoice" do
     def answered
-      find(:all).select { |question| question.answered? }
+      all.select { |question| question.answered? }
     end
     def answered_correctly
-      find(:all).select { |question| question.answered? }.select{ |item| item.answered_correctly? }
+      all.select { |question| question.answered? }.select{ |item| item.answered_correctly? }
     end
   end
 
   has_many :external_links, :dependent => :destroy , :class_name => "Saveable::ExternalLink" do
     def answered
-      find(:all).select { |question| question.answered? }
+      all.select { |question| question.answered? }
     end
   end
 
   has_many :interactives, :dependent => :destroy , :class_name => "Saveable::Interactive" do
     def answered
-      find(:all).select { |question| question.answered? }
+      all.select { |question| question.answered? }
     end
   end
 

--- a/app/models/portal/offering.rb
+++ b/app/models/portal/offering.rb
@@ -29,16 +29,16 @@ class Portal::Offering < ActiveRecord::Base
 
   has_many :open_responses, :dependent => :destroy, :class_name => "Saveable::OpenResponse", :foreign_key => "offering_id" do
     def answered
-      find(:all).select { |question| question.answered? }
+      all.select { |question| question.answered? }
     end
   end
 
   has_many :multiple_choices, :dependent => :destroy, :class_name => "Saveable::MultipleChoice", :foreign_key => "offering_id" do
     def answered
-      find(:all).select { |question| question.answered? }
+      all.select { |question| question.answered? }
     end
     def answered_correctly
-      find(:all).select { |question| question.answered? }.select{ |item| item.answered_correctly? }
+      all.select { |question| question.answered? }.select{ |item| item.answered_correctly? }
     end
   end
 

--- a/app/models/portal/school_selector.rb
+++ b/app/models/portal/school_selector.rb
@@ -230,18 +230,18 @@ class Portal::SchoolSelector
 
   def district_choices
     if @state
-      districts = Portal::District.find(:all, :conditions => {:state => @state })
+      districts = Portal::District.where(:state => @state)
       return districts.sort{ |a,b| a.name <=> b.name}.map { |d| [d.name, d.id] }
     end
     # return [default_district].map { |d| [d.name, d.id] }
-    return []
+    []
   end
 
 
   def school_choices
     if @district && (@district.kind_of? Portal::District)
-      schools = Portal::School.find(:all, :conditions => {:district_id => @district.id })
-      return schools.sort{ |a,b| a.name <=> b.name}.map { |s| [s.name, s.id] }
+      schools = Portal::School.where(:district_id => @district.id)
+      schools.sort{ |a,b| a.name <=> b.name}.map { |s| [s.name, s.id] }
     end
   end
 

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -12,7 +12,7 @@ class Section < ActiveRecord::Base
 
   has_many :pages ,:order => :position, :dependent => :destroy do
     def student_only
-      find(:all, :conditions => {'teacher_only' => false})
+      where('teacher_only' => false)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -192,7 +192,7 @@ class User < ActiveRecord::Base
     end
 
     def default_users
-      User.find(:all, :conditions => { :default_user => true })
+      User.where(:default_user => true)
     end
 
     def suspend_default_users

--- a/lib/clipboard.rb
+++ b/lib/clipboard.rb
@@ -31,7 +31,7 @@ module Clipboard
     if clipboard_data_type && clipboard_data_type != 'null' && clipboard_data_id
       begin
         clazz = clipboard_data_type.de_clipboardify.classify.constantize
-        obj_array = clazz.find(:all, :conditions => {:id => clipboard_data_id})
+        obj_array = clazz.where(:id => clipboard_data_id)
         results = obj_array.empty? ? nil : obj_array.first
       rescue NameError
         error_message = "unknown object in clipboard #{clipboard_data_type} (id:#{clipboard_data_id})"

--- a/lib/multiteacher_clazzes.rb
+++ b/lib/multiteacher_clazzes.rb
@@ -1,7 +1,7 @@
 class MultiteacherClazzes
 
   def self.make_all_multi_teacher
-    clazzes = Portal::Clazz.find(:all)  
+    clazzes = Portal::Clazz.all
     clazzes.each do |clazz|
       make_multi_teacher(clazz)
     end

--- a/lib/parent_investigation.rb
+++ b/lib/parent_investigation.rb
@@ -1,8 +1,7 @@
 class ParentInvestigation
 
   def self.parent_activities()
-    activities = Activity.find(:all)
-    activities.each do |a|
+    Activity.all.each do |a|
       parent_activity(a)
     end
   end

--- a/lib/tasks/data_load_and_save.rake
+++ b/lib/tasks/data_load_and_save.rake
@@ -61,7 +61,7 @@ namespace :db do
         interesting_tables.each do |tbl|
           klass = tbl.classify.constantize
           File.open("#{tbl}.yaml", 'w') do |f| 
-            attributes = klass.find(:all).collect { |m| m.attributes }
+            attributes = klass.all.collect { |m| m.attributes }
             f.write YAML.dump(attributes)
           end
         end
@@ -110,7 +110,7 @@ namespace :db do
         tables.each do |tbl|
           puts "writing #{dir}/#{tbl}.yaml"
           File.open("#{tbl}.yaml", 'w') do |f| 
-            attributes = tbl.gsub(/^ri_gse_/, "ri_gse/").classify.constantize.find(:all).collect { |m| m.attributes }
+            attributes = tbl.gsub(/^ri_gse_/, "ri_gse/").classify.constantize.all.collect { |m| m.attributes }
             f.write YAML.dump(attributes)
           end
         end

--- a/lib/tasks/fixups.rake
+++ b/lib/tasks/fixups.rake
@@ -32,7 +32,7 @@ namespace :app do
 
     desc 'Add the author role to all users who have authored an Investigation'
     task :add_author_role_to_authors => :environment do
-      User.find(:all).each do |user|
+      User.all.each do |user|
         if user.has_investigations?
           print '.'
           STDOUT.flush
@@ -44,7 +44,7 @@ namespace :app do
 
     desc 'Remove the author role from users who have not authored an Investigation'
     task :remove_author_role_from_non_authors => :environment do
-      User.find(:all).each do |user|
+      User.all.each do |user|
         unless user.has_investigations?
           print '.'
           STDOUT.flush
@@ -73,7 +73,7 @@ namespace :app do
 
     desc 'ensure investigations have publication_status'
     task :pub_status => :environment do
-      Investigation.find(:all).each do |i|
+      Investigation.all.each do |i|
         if i.publication_status.nil?
           i.update_attribute(:publication_status,'draft')
         end
@@ -106,7 +106,7 @@ namespace :app do
     
     desc "Create bundle and console loggers for learners"
     task :create_bundle_and_console_loggers_for_learners => :environment do
-      Portal::Learner.find(:all).each do |learner|
+      Portal::Learner.all.each do |learner|
         learner.console_logger = Dataservice::ConsoleLogger.create! unless learner.console_logger
         learner.bundle_logger = Dataservice::BundleLogger.create! unless learner.bundle_logger
         learner.periodic_bundle_logger = Dataservice::PeriodicBundleLogger.create! unless learner.periodic_bundle_logger
@@ -220,8 +220,8 @@ namespace :app do
     task :activity_positon_bug_report, [:file_name] => :environment do |t,args|
       args.with_defaults(:file_name => 'position_bug_activity_report.csv')
       file_name = args.file_name
-      suspect_activities = Activity.find(:all, :conditions => "position is null and investigation_id is not null")
-      good_activities =  Activity.find(:all, :conditions => "position is not null and investigation_id is not null")
+      suspect_activities = Activity.where("position is null and investigation_id is not null")
+      good_activities =  Activity.where("position is not null and investigation_id is not null")
       puts "#{suspect_activities.size} without positions & #{good_activities.size} with good positions" 
       bad_hash = suspect_activities.map do |a|
         {

--- a/lib/tasks/nces_importer.rake
+++ b/lib/tasks/nces_importer.rake
@@ -184,14 +184,14 @@ The following codes were calculated from the school's corresponding GSLO and GSH
         school_values = []
         district_values = []
         state_province_str = "#{state}, #{Portal::StateOrProvince::STATES_AND_PROVINCES[state]}"
-        nces_districts = Portal::Nces06District.find(:all, :conditions => { :MSTATE => state }, :select => "id, NAME, LEAID, LZIP, LSTATE")
+        nces_districts = Portal::Nces06District.where(:MSTATE => state).select("id, NAME, LEAID, LZIP, LSTATE")
         if nces_districts.empty?
           puts "\n*** No NCES districts found in state/province: #{state_province_str}"
         else
           puts "\n*** Processing #{nces_districts.length} NCES districts in: #{state_province_str}"
           count = 0
           nces_districts.each do |nces_district|
-            nces_schools = Portal::Nces06School.find(:all, :conditions => { :nces_district_id => nces_district.id }, :select => "LEVEL")
+            nces_schools = Portal::Nces06School.where(:nces_district_id => nces_district.id).select("LEVEL")
             nces_school_levels = nces_schools.collect { |s| s.LEVEL }
             count += 1
             if count % 25 == 0
@@ -208,11 +208,11 @@ The following codes were calculated from the school's corresponding GSLO and GSH
           end
           # portal_districts = Portal::District.import(new_districts, :synchronize => new_districts)
           Portal::District.import(portal_district_field_names, district_values, import_options)
-          portal_districts = Portal::District.find(:all, :conditions => { :state => state }, :select => "id, nces_district_id, state")
+          portal_districts = Portal::District.where(:state => state).select("id, nces_district_id, state")
           puts "\ncreated #{portal_districts.length} districts"
           count = 0
           portal_districts.each do |portal_district|
-            nces_schools = Portal::Nces06School.find(:all, :conditions => { :nces_district_id => portal_district.nces_district_id }, :select => "id, nces_district_id, NCESSCH, LZIP,SCHNAM, LEVEL")
+            nces_schools = Portal::Nces06School.where(:nces_district_id => portal_district.nces_district_id ).select("id, nces_district_id, NCESSCH, LZIP,SCHNAM, LEVEL")
             nces_school_levels = nces_schools.collect { |s| s.LEVEL }
             if count % 10 == 0
               print '.'
@@ -225,7 +225,7 @@ The following codes were calculated from the school's corresponding GSLO and GSH
             end
           end
           Portal::School.import(portal_school_field_names, school_values, import_options)
-          portal_schools = Portal::School.find(:all, :conditions => { :state => state }, :select => "id")
+          portal_schools = Portal::School.where(:state => state).select("id")
           puts "\ncreated #{portal_schools.length} schools"
         end
       end

--- a/lib/tasks/reclaim_elements.rake
+++ b/lib/tasks/reclaim_elements.rake
@@ -19,14 +19,13 @@ namespace :app do
     
     desc 'remove teacher notes without an authored entity. reclaim ownership of '
     task :clean_teacher_notes => :environment do
-      TeacherNote.find(:all).each do |note|
-        dirty = false
+      TeacherNote.all.each do |note|
         if note.authored_entity
           if note.authored_entity.user
             unless note.authored_entity.user == note.user
-              puts "chaing owner of teacher note #{note.id} to #{note.authored_entity.user.login}"
+              puts "changing owner of teacher note #{note.id} to #{note.authored_entity.user.login}"
               note.user = note.authored_entity.user
-              note.save
+              note.save!
             end
           end
         end

--- a/lib/user_deleter.rb
+++ b/lib/user_deleter.rb
@@ -23,17 +23,17 @@ class UserDeleter
       manager teacher student anonymous guest admin].split
 
 
-    self.keep_list = User.find(:all, :conditions => ["login in (?)", save_these_logins]);
-    concord_users =  User.find(:all, :conditions => "email like '%concord.org'")
-    no_email_users = User.find(:all, :conditions => "email like 'no-email%'")
+    self.keep_list = User.where("login in (?)", save_these_logins)
+    concord_users =  User.where("email like '%concord.org'")
+    no_email_users = User.where("email like 'no-email%'")
     published_authors = Investigation.published.map { |i| i.user }
 
-    # new_users = User.find(:all, :conditions => "created_at > '#{new_date}'")
+    # new_users = User.where("created_at > '#{new_date}'")
     admin_users =  User.with_role('admin')
     manager_users = User.with_role('manager')
-    report_users = User.find(:all, :conditions => "login like 'report%'")
-    sakai_users =  User.find(:all, :conditions => "login like '%_rinet_sakai'")
-    team_users = User.find(:all, :conditions => "last_name like '%team%'")
+    report_users = User.where("login like 'report%'")
+    sakai_users =  User.where("login like '%_rinet_sakai'")
+    team_users = User.where("last_name like '%team%'")
 
     # build a keep list:
     self.keep_list = self.keep_list + manager_users
@@ -52,10 +52,10 @@ class UserDeleter
   end
   
   def delete_all
-    delete_user_list(User.find(:all))
+    delete_user_list(User.all)
   end
 
-  def delete_user_list(user_list=User.find(:all, :conditions => "login like '%rinet_sakai%'"))
+  def delete_user_list(user_list=User.where("login like '%rinet_sakai%'"))
     user_list = user_list - self.keep_list
     user_list.each do |user|
       Rails.logger.info "Removing user: #{user.login} #{user.email}::::"

--- a/spec/controllers/import/imports_controller_spec.rb
+++ b/spec/controllers/import/imports_controller_spec.rb
@@ -4,9 +4,18 @@ require 'spec_helper'
 
 RSpec.describe Import::ImportsController, type: :controller do
 
+  before(:each) do
+    @admin_user = Factory.next(:admin_user)
+    allow(controller).to receive(:current_visitor).and_return(@admin_user)
+    
+    login_admin
+  end
+
   # TODO: auto-generated
   describe '#import_school_district_json' do
     it 'GET import_school_district_json' do
+      login_anonymous
+      
       get :import_school_district_json, {}, {}
 
       expect(response).to have_http_status(:redirect)
@@ -27,7 +36,7 @@ RSpec.describe Import::ImportsController, type: :controller do
     it 'GET import_school_district_status' do
       get :import_school_district_status, {}, {}
 
-      expect(response).to have_http_status(:redirect)
+      expect(response).to have_http_status(:ok)
     end
   end
 
@@ -36,13 +45,16 @@ RSpec.describe Import::ImportsController, type: :controller do
     it 'GET import_user_status' do
       get :import_user_status, {}, {}
 
-      expect(response).to have_http_status(:redirect)
+      expect(response).to have_http_status(:ok)
     end
   end
 
   # TODO: auto-generated
   describe '#download' do
     it 'GET download' do
+      request.env["HTTP_REFERER"] = "https://foo.bar.com/some/path.html"
+      Import::Import.new(:import_type => Import::Import::IMPORT_TYPE_USER, import_data: {}).save!
+
       get :download, {}, {}
 
       expect(response).to have_http_status(:redirect)
@@ -54,7 +66,7 @@ RSpec.describe Import::ImportsController, type: :controller do
     it 'GET import_activity_status' do
       get :import_activity_status, {}, {}
 
-      expect(response).to have_http_status(:redirect)
+      expect(response).to have_http_status(:ok)
     end
   end
 
@@ -63,16 +75,14 @@ RSpec.describe Import::ImportsController, type: :controller do
     it 'GET import_activity' do
       get :import_activity, {}, {}
 
-      expect(response).to have_http_status(:redirect)
+      expect(response).to have_http_status(:ok)
     end
   end
 
   # TODO: auto-generated
   describe '#import_activity_progress' do
     it 'GET import_activity_progress' do
-      get :import_activity_progress, {}, {}
-
-      expect(response).to have_http_status(:redirect)
+      expect { get :import_activity_progress, {}, {} }.to raise_error(ActionController::RoutingError)
     end
   end
 
@@ -81,7 +91,7 @@ RSpec.describe Import::ImportsController, type: :controller do
     it 'GET activity_clear_job' do
       get :activity_clear_job, {}, {}
 
-      expect(response).to have_http_status(:redirect)
+      expect(response).to have_http_status(:ok)
     end
   end
 
@@ -90,16 +100,16 @@ RSpec.describe Import::ImportsController, type: :controller do
     it 'GET batch_import_status' do
       get :batch_import_status, {}, {}
 
-      expect(response).to have_http_status(:redirect)
+      expect(response).to have_http_status(:ok)
     end
   end
 
   # TODO: auto-generated
   describe '#batch_import_data' do
     it 'GET batch_import_data' do
-      get :batch_import_data, {}, {}
+      Import::Import.new(:import_type => Import::Import::IMPORT_TYPE_BATCH_ACTIVITY, import_data: {}).save!
 
-      expect(response).to have_http_status(:redirect)
+      expect{ get :batch_import_data, {}, {}  }.to raise_error(ActionController::RoutingError)
     end
   end
 
@@ -115,9 +125,10 @@ RSpec.describe Import::ImportsController, type: :controller do
   # TODO: auto-generated
   describe '#failed_batch_import' do
     it 'GET failed_batch_import' do
+      Import::Import.new(:import_type => Import::Import::IMPORT_TYPE_BATCH_ACTIVITY, import_data: {}).save!
       get :failed_batch_import, {}, {}
 
-      expect(response).to have_http_status(:redirect)
+      expect(response).to have_http_status(:ok)
     end
   end
 

--- a/spec/controllers/portal/nces06_districts_controller_spec.rb
+++ b/spec/controllers/portal/nces06_districts_controller_spec.rb
@@ -6,17 +6,30 @@ RSpec.describe Portal::Nces06DistrictsController, type: :controller do
 
   # TODO: auto-generated
   describe '#index' do
+    before(:each) do
+      @manager_user = Factory.next(:manager_user)
+      allow(controller).to receive(:current_visitor).and_return(@manager_user)
+
+      login_manager
+    end
+
     it 'GET index' do
       get :index, {}, {}
 
-      expect(response).to have_http_status(:redirect)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'GET index for state' do
+      get :index, state_or_province: 'WA'
+
+      expect(response).to have_http_status(:ok)
     end
   end
 
   # TODO: auto-generated
   describe '#show' do
     it 'GET show' do
-      get :show, {}, {}
+      get :show, id: 123
 
       expect(response).to have_http_status(:redirect)
     end

--- a/spec/controllers/portal/nces06_schools_controller_spec.rb
+++ b/spec/controllers/portal/nces06_schools_controller_spec.rb
@@ -6,10 +6,29 @@ RSpec.describe Portal::Nces06SchoolsController, type: :controller do
 
   # TODO: auto-generated
   describe '#index' do
+    before(:each) do
+      @manager_user = Factory.next(:manager_user)
+      allow(controller).to receive(:current_visitor).and_return(@manager_user)
+
+      login_manager
+    end
+
     it 'GET index' do
       get :index, {}, {}
 
-      expect(response).to have_http_status(:redirect)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'GET index for state' do
+      get :index, state_or_province: 'WA'
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'GET index for id' do
+      get :index, nces_district_id: 123
+
+      expect(response).to have_http_status(:ok)
     end
   end
 

--- a/spec/models/admin/settings_spec.rb
+++ b/spec/models/admin/settings_spec.rb
@@ -258,7 +258,10 @@ describe Admin::Settings do
       settings = described_class.new
       result = settings.summary_info
 
-      expect(result).not_to be_nil
+      expect(result).to match(/There are 0 Teachers without Users
+There are 0 Students which no longer have Teachers
+There are 0 Classes which no longer have Teachers
+There are 0 Learners which are no longer associated with Students/)
     end
   end
 

--- a/spec/models/embeddable/multiple_choice_spec.rb
+++ b/spec/models/embeddable/multiple_choice_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe Embeddable::MultipleChoice, type: :model do
 
   # TODO: auto-generated
   describe '#by_offering' do
-    xit 'by_offering' do
+    it 'by_offering' do
       multiple_choice = described_class.new
-      offering = Factory.create(:portal_offering)
-      result = multiple_choice.by_offering(offering)
+      offering = FactoryGirl.create(:portal_offering)
+      result = multiple_choice.saveables.by_offering(offering)
 
       expect(result).not_to be_nil
     end
@@ -20,10 +20,10 @@ RSpec.describe Embeddable::MultipleChoice, type: :model do
 
   # TODO: auto-generated
   describe '#by_learner' do
-    xit 'by_learner' do
+    it 'by_learner' do
       multiple_choice = described_class.new
-      learner = double('learner')
-      result = multiple_choice.by_learner(learner)
+      learner = Portal::Learner.new
+      result = multiple_choice.saveables.by_learner(learner)
 
       expect(result).not_to be_nil
     end
@@ -31,12 +31,12 @@ RSpec.describe Embeddable::MultipleChoice, type: :model do
 
   # TODO: auto-generated
   describe '#first_by_learner' do
-    xit 'first_by_learner' do
+    it 'first_by_learner' do
       multiple_choice = described_class.new
-      learner = double('learner')
-      result = multiple_choice.first_by_learner(learner)
+      learner = Portal::Learner.new
+      result = multiple_choice.saveables.first_by_learner(learner)
 
-      expect(result).not_to be_nil
+      expect(result).to be_nil
     end
   end
 

--- a/spec/models/embeddable/open_response_spec.rb
+++ b/spec/models/embeddable/open_response_spec.rb
@@ -34,10 +34,10 @@ describe Embeddable::OpenResponse do
 
   # TODO: auto-generated
   describe '#by_offering' do
-    xit 'by_offering' do
+    it 'by_offering' do
       open_response = described_class.new
-      offering = Factory.create(:portal_offering)
-      result = open_response.by_offering(offering)
+      offering = FactoryGirl.create(:portal_offering)
+      result = open_response.saveables.by_offering(offering)
 
       expect(result).not_to be_nil
     end
@@ -45,10 +45,10 @@ describe Embeddable::OpenResponse do
 
   # TODO: auto-generated
   describe '#by_learner' do
-    xit 'by_learner' do
+    it 'by_learner' do
       open_response = described_class.new
-      learner = double('learner')
-      result = open_response.by_learner(learner)
+      learner = Portal::Learner.new
+      result = open_response.saveables.by_learner(learner)
 
       expect(result).not_to be_nil
     end
@@ -56,12 +56,12 @@ describe Embeddable::OpenResponse do
 
   # TODO: auto-generated
   describe '#first_by_learner' do
-    xit 'first_by_learner' do
+    it 'first_by_learner' do
       open_response = described_class.new
-      learner = double('learner')
-      result = open_response.first_by_learner(learner)
+      learner = Portal::Learner.new
+      result = open_response.saveables.first_by_learner(learner)
 
-      expect(result).not_to be_nil
+      expect(result).to be_nil
     end
   end
 

--- a/spec/models/portal/learner_spec.rb
+++ b/spec/models/portal/learner_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path('../../../spec_helper', __FILE__)
 
 describe Portal::Learner do
   let(:student)        { mock_model(Portal::Student)     }
-  let(:offering)       { mock_model(Portal::Offering)    }
+  let(:offering)       { FactoryGirl.create(:portal_offering)   }
   let(:report_learner) { mock_model(Report::Learner,
     :[]= => nil,
     :save => true,
@@ -38,6 +38,118 @@ describe Portal::Learner do
     it "should allow for creating a new blob" do
       subject.lightweight_blobs.create
       expect(subject.lightweight_blobs).not_to be_empty
+    end
+  end
+
+  describe '#answered' do
+    it 'answered for open responses' do
+      result = subject.open_responses.answered
+
+      expect(result).to be_empty
+    end
+  end
+
+  describe '#answered' do
+    it 'answered for image_questions' do
+      result = subject.image_questions.answered
+
+      expect(result).to be_empty
+    end
+  end
+
+  describe '#answered' do
+    it 'answered for external_links' do
+      result = subject.external_links.answered
+
+      expect(result).to be_empty
+    end
+  end
+
+  describe '#answered' do
+    it 'answered for interactives' do
+      result = subject.interactives.answered
+
+      expect(result).to be_empty
+    end
+  end
+
+  describe '#answered' do
+    it 'answered for multiple_choices' do
+      result = subject.multiple_choices.answered
+
+      expect(result).to be_empty
+    end
+  end
+
+  describe '#answered_correctly' do
+    it 'answered for multiple_choices' do
+      result = subject.multiple_choices.answered_correctly
+
+      expect(result).to be_empty
+    end
+  end
+
+  describe '#sessions' do
+    it 'sessions' do
+      result = subject.sessions
+
+      expect(result).not_to be_nil
+    end
+  end
+
+  describe '#valid_loggers?' do
+    it 'valid_loggers?' do
+      result = subject.valid_loggers?
+
+      expect(result).not_to be_nil
+    end
+  end
+
+  describe '#create_new_loggers' do
+    it 'create_new_loggers' do
+      result = subject.create_new_loggers
+
+      expect(result).not_to be_nil
+    end
+  end
+
+  describe '#user' do
+    xit 'user' do
+      result = subject.user
+
+      expect(result).not_to be_nil
+    end
+  end
+
+  describe '#name' do
+    xit 'name' do
+      result = subject.name
+
+      expect(result).not_to be_nil
+    end
+  end
+
+  describe '#run_format' do
+    xit 'run_format' do
+      result = subject.run_format
+
+      expect(result).not_to be_nil
+    end
+  end
+
+  describe '#saveable_count' do
+    it 'saveable_count' do
+      result = subject.saveable_count
+
+      expect(result).not_to be_nil
+    end
+  end
+
+  describe '#saveable_answered' do
+    it 'saveable_answered' do
+      result = subject.saveable_answered
+
+      expect(result).not_to be_nil
     end
   end
 end

--- a/spec/models/portal/offering_spec.rb
+++ b/spec/models/portal/offering_spec.rb
@@ -67,5 +67,107 @@ describe Portal::Offering do
       end
     end
   end
-  
+
+  describe '#answered' do
+    it 'answered for open responses' do
+      offering = described_class.new
+      result = offering.open_responses.answered
+
+      expect(result).to be_empty
+    end
+  end
+
+  describe '#answered' do
+    it 'answered for multiple_choices' do
+      offering = described_class.new
+      result = offering.multiple_choices.answered
+
+      expect(result).to be_empty
+    end
+  end
+
+  describe '#answered_correctly' do
+    it 'answered for multiple_choices' do
+      offering = described_class.new
+      result = offering.multiple_choices.answered_correctly
+
+      expect(result).to be_empty
+    end
+  end
+
+  describe '#for_embeddable' do
+    it 'answered for metadata' do
+      offering = described_class.new
+      dummy = offering
+      result = offering.metadata.for_embeddable(dummy)
+
+      expect(result).to be_nil
+    end
+  end
+
+  describe '#sessions' do
+    it 'sessions' do
+      offering = described_class.new
+      result = offering.sessions
+
+      expect(result).not_to be_nil
+    end
+  end
+
+  describe '#saveables' do
+    it 'saveables' do
+      offering = described_class.new
+      result = offering.saveables
+
+      expect(result).to be_empty
+    end
+  end
+
+  describe '#printable_report?' do
+    it 'printable_report?' do
+      offering = described_class.new
+      result = offering.printable_report?
+
+      expect(result).not_to be_nil
+    end
+  end
+
+  describe '#completed_students_count' do
+    it 'completed_students_count' do
+      offering = described_class.new
+      offering.clazz = Portal::Clazz.new
+      result = offering.completed_students_count
+
+      expect(result).not_to be_nil
+    end
+  end
+
+  describe '#inprogress_students_count' do
+    it 'inprogress_students_count' do
+      offering = described_class.new
+      offering.clazz = Portal::Clazz.new
+      result = offering.inprogress_students_count
+
+      expect(result).not_to be_nil
+    end
+  end
+
+  describe '#notstarted_students_count' do
+    it 'notstarted_students_count' do
+      offering = described_class.new
+      offering.clazz = Portal::Clazz.new
+      result = offering.notstarted_students_count
+
+      expect(result).not_to be_nil
+    end
+  end
+
+  describe '.searchable_attributes' do
+    it 'searchable_attributes' do
+      offering = described_class
+      result = offering.searchable_attributes
+
+      expect(result).not_to be_nil
+    end
+  end
 end

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -13,13 +13,12 @@ RSpec.describe Section, type: :model do
     end
   end
 
-  # TODO: auto-generated
   describe '#student_only' do
-    xit 'student_only' do
+    it 'student_only' do
       section = described_class.new
-      result = section.student_only
+      result = section.pages.student_only
 
-      expect(result).not_to be_nil
+      expect(result).to be_empty
     end
   end
 


### PR DESCRIPTION
Address the `find(:all`syntax by transforming it to `all` or `where...` usage which is Rails 4 compatible.