### PR TITLE
Only show active classes in the left menu

### DIFF
--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -138,8 +138,7 @@ module NavigationHelper
   end
 
   def clazz_links_for_teacher
-    # TODO Omit inactive classes?
-    clazzes = current_visitor.portal_teacher.teacher_clazzes.map { |c| c.clazz }
+    clazzes = current_visitor.portal_teacher.teacher_clazzes.where(active: true).map { |c| c.clazz }
     clazz_links = [
       {
         id: "/classes",

--- a/config/initializers/00_deprecate_prototype.rb
+++ b/config/initializers/00_deprecate_prototype.rb
@@ -5,7 +5,7 @@ def deprecate_methods(target_module, *method_names)
   method_names += options.keys
 
   method_names.each do |method_name|
-    next if %i[[] << javascript_tag j escape_javascript javascript_cdata_section].include? method_name
+    next if %i[[] << javascript_tag j escape_javascript javascript_cdata_section to_s call].include? method_name
     target_module.alias_method_chain(method_name, :deprecation) do |target, punctuation|
       target_module.module_eval(<<-end_eval, __FILE__, __LINE__ + 1)
         def #{target}_with_deprecation#{punctuation}(*args, &block)

--- a/features/step_definitions/student_steps.rb
+++ b/features/step_definitions/student_steps.rb
@@ -64,10 +64,6 @@ Then /^the student "([^"]*)" should belong to the class "([^"]*)"$/ do |student_
   expect(student.clazzes).to include clazz
 end
 
-When /^I reload the page$/ do
-  visit [ current_path, page.driver.request.env['QUERY_STRING'] ].reject(&:blank?).join('?')
-end
-
 When /^(?:|I )run the (?:investigation|activity|external activity)$/ do
   # make sure the current user is a student
   user = User.find_by_login(@cuke_current_username)

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -313,3 +313,7 @@ And /^(?:|I )fill "(.*)" in the tinyMCE editor with id "(.*)"$/ do |html, editor
   expect(page).to have_css("##{editor_id}", visible: false)
   execute_script("tinyMCE.getInstanceById('#{editor_id}').setContent('#{html}');")
 end
+
+When /^I reload the page$/ do
+  page.evaluate_script 'window.location.reload()'
+end

--- a/features/teacher_manages_class.feature
+++ b/features/teacher_manages_class.feature
@@ -46,15 +46,18 @@ Feature: Teacher manages a class
     And "Mathematics" should be the first class within left panel for class navigation
 
 
-  # NP: Not sure why this test broke PP-Navigation 2018-07-09
   @javascript
-  @pending
   Scenario: Teacher deactivates classes
     When I uncheck "Biology"
     And the Manage class list state starts saving
     And the modal for saving manage classes dissappears
+    # this requires a reload to see the changes in the menu
+    # the reloads should be removed from this test if this is fixed
+    Then I should see "Biology" within left panel for class navigation
+    And I reload the page
     Then I should not see "Biology" within left panel for class navigation
     When I uncheck "Geography"
+    And I reload the page
     And I should not see "Geography" within left panel for class navigation
 
 

--- a/spec/helpers/navigation_helper_spec.rb
+++ b/spec/helpers/navigation_helper_spec.rb
@@ -16,9 +16,13 @@ describe NavigationHelper, type: :helper  do
   end
   let(:itsi_project) { double(links: itsi_links)}
   let(:fake_clazzes) { FactoryGirl.create_list(:portal_clazz, 3)}
-  let(:fake_teacher_clazzes) { fake_clazzes.map { |c| double(clazz: c)}}
-  let(:fake_student) { FactoryGirl.create(:full_portal_student) }
-  let(:fake_teacher) { FactoryGirl.create(:portal_teacher) }
+  let(:fake_inactive_clazz) { FactoryGirl.create(:portal_clazz)}
+  let(:fake_student) { FactoryGirl.create(:full_portal_student, clazzes: fake_clazzes) }
+  let(:fake_teacher) {
+    teacher = FactoryGirl.create(:portal_teacher, clazzes: fake_clazzes)
+    teacher.teacher_clazzes.create(clazz: fake_inactive_clazz, active: false)
+    teacher
+  }
   let(:fake_visitor) { fake_student.user }
   let(:params)       { {greeting: "bonjour"} }
   let(:projects)     { [itsi_project] }
@@ -27,8 +31,19 @@ describe NavigationHelper, type: :helper  do
     allow(helper).to receive(:current_user).and_return(fake_visitor)
     allow(fake_visitor).to receive(:name).and_return(name)
     allow(fake_visitor).to receive(:projects).and_return(projects)
-    allow(fake_teacher).to receive(:teacher_clazzes).and_return(fake_teacher_clazzes)
-    allow(fake_student).to receive(:clazzes).and_return(fake_clazzes)
+  end
+  describe "fakes are setup" do
+    describe "fake_teacher" do
+      it "should have 4 clazzes" do
+        expect(fake_teacher.clazzes.count).to eq(4)
+      end
+      it "should have 4 teacher_clazzes" do
+        expect(fake_teacher.teacher_clazzes.count).to eq(4)
+      end
+      it "should have 3 active teacher_clazzes" do
+        expect(fake_teacher.teacher_clazzes.where(active: true).count).to eq(3)
+      end
+    end
   end
   describe "get_nav_content" do
     describe "schema validation" do


### PR DESCRIPTION
Previously, when a teacher marked a class in active, it would immediately update the menu
It now requires requires a refresh.

One line of real code change to 31 lines of test changes. 😄 

@tjchambers and @benjaminwood I added a couple more methods (`call` and `to_s`) to skip from the prototype deprecation warnings. These seemed to just provide duplicate warnings on top of the real method calls.

[#158944733]