### PR TITLE
FactoryGirl usage cleanup

### DIFF
--- a/factories/admin_settings.rb
+++ b/factories/admin_settings.rb
@@ -1,5 +1,5 @@
 Factory.define :admin_settings, :class => Admin::Settings do |f|
-  f.user  { |p| Factory.next(:admin_user) }
+  f.user  { |p| FactoryGirl.generate(:admin_user) }
   f.active true
   f.help_type "no help"
 end

--- a/factories/interactive.rb
+++ b/factories/interactive.rb
@@ -3,5 +3,5 @@ Factory.sequence :interactive_name do |n|
 end
 
 Factory.define :interactive do |f|
-  f.name {Factory.next(:interactive_name)}
+  f.name {FactoryGirl.generate(:interactive_name)}
 end

--- a/factories/investigations.rb
+++ b/factories/investigations.rb
@@ -3,9 +3,9 @@ Factory.sequence :investigation_name do |n|
 end
 
 Factory.define :investigation do |f|
-  f.name {Factory.next(:investigation_name)}
+  f.name {FactoryGirl.generate(:investigation_name)}
   f.description "fake investigation description"
-  f.user { Factory.next(:author_user) }
+  f.user { FactoryGirl.generate(:author_user) }
 end
 
 Factory.define :investigation_template, parent: :investigation do |f|

--- a/factories/portal_clazzes.rb
+++ b/factories/portal_clazzes.rb
@@ -7,9 +7,9 @@ Factory.sequence :class_name do |n|
 end
 
 Factory.define :portal_clazz, :class => Portal::Clazz do |f|
-  f.class_word {Factory.next(:class_word)}
+  f.class_word {FactoryGirl.generate(:class_word)}
   f.association :course, :factory => :portal_course
-  f.name {Factory.next(:class_name)}
+  f.name {FactoryGirl.generate(:class_name)}
   f.uuid { UUIDTools::UUID.timestamp_create.to_s }
 end
 

--- a/factories/portal_courses.rb
+++ b/factories/portal_courses.rb
@@ -5,7 +5,7 @@ end
 
 Factory.define :portal_course, :class => Portal::Course do |f|
   f.name  "first course"
-  f.course_number {Factory.next(:course_number)}
+  f.course_number {FactoryGirl.generate(:course_number)}
   f.uuid  UUIDTools::UUID.timestamp_create.to_s
   f.association :school, :factory => :portal_school
 end

--- a/factories/portal_nces06_districts.rb
+++ b/factories/portal_nces06_districts.rb
@@ -1,5 +1,5 @@
 Factory.sequence(:nces_district_name) { |n| "factory generated nces district ##{n}" }
 Factory.define :portal_nces06_district, :class => Portal::Nces06District do |f|
-  f.NAME {Factory.next :nces_district_name}
+  f.NAME {FactoryGirl.generate :nces_district_name}
 end
 

--- a/factories/portal_nces06_schools.rb
+++ b/factories/portal_nces06_schools.rb
@@ -13,7 +13,7 @@ Factory.define :portal_nces06_school, :class => Portal::Nces06School do |f|
   f.MEMBER   607
   f.FTE      49.0
   f.TOTFRL   265
-  f.SCHNAM {Factory.next :nces_school_name}
+  f.SCHNAM {FactoryGirl.generate :nces_school_name}
   f.association :nces_district, :factory => :portal_nces06_district
 end
 

--- a/factories/roles.rb
+++ b/factories/roles.rb
@@ -9,7 +9,7 @@
   Factory.sequence "#{role_name}_role".to_sym do |n| 
     role = Role.find_by_title(role_name)
     unless role
-      role = Factory.create(:role, :title => role_name, :position => index)
+      role = FactoryGirl.create(:role, :title => role_name, :position => index)
     end
     role
   end

--- a/factories/roles.rb
+++ b/factories/roles.rb
@@ -1,9 +1,9 @@
 
 #
 # Dynamically generate our Role Singleton Factories for named roles:
-# Factory.next :admin_role
-# Factory.next :member_role
-# Factory.next :guest_role
+# FactoryGirl.generate :admin_role
+# FactoryGirl.generate :member_role
+# FactoryGirl.generate :guest_role
 #
 %w| guest member admin researcher manager author|.each_with_index do |role_name,index|  
   Factory.sequence "#{role_name}_role".to_sym do |n| 

--- a/factories/site_notices.rb
+++ b/factories/site_notices.rb
@@ -1,6 +1,6 @@
 Factory.define :site_notice, class: Admin::SiteNotice  do |f|
   f.notice_html 'non white space characters'
-  f.creator { Factory.next(:admin_user) }
+  f.creator { FactoryGirl.generate(:admin_user) }
 end
 
 Factory.define :site_notice_role, class: Admin::SiteNoticeRole do |f|

--- a/factories/standard_statements.rb
+++ b/factories/standard_statements.rb
@@ -3,6 +3,6 @@ Factory.sequence(:standard_statement_uri) do |n|
 end
 
 Factory.define :standard_statement, :class => StandardStatement do |f|
-  f.uri { Factory.next(:standard_statement_uri) }
+  f.uri { FactoryGirl.generate(:standard_statement_uri) }
   f.material_type "external_activity"
 end

--- a/factories/users.rb
+++ b/factories/users.rb
@@ -14,7 +14,7 @@ end
 ## Factory for user
 ##
 Factory.define :user do |f|
-  f.login    { Factory.next(:login) }
+  f.login    { FactoryGirl.generate(:login) }
   f.first_name  'joe'
   f.last_name  'user' 
   f.email  { |u| "#{u.login}@concord.org"}
@@ -22,7 +22,7 @@ Factory.define :user do |f|
   f.password_confirmation  {|u| u.password}
   f.skip_notifications true
   f.require_password_reset false
-  f.roles  { [ Factory.next(:member_role)] }
+  f.roles  { [ FactoryGirl.generate(:member_role)] }
 end
 
 Factory.define :confirmed_user, :parent => :user do |f|
@@ -41,7 +41,7 @@ Factory.sequence :admin_user do |n|
       # :password =>'password',  # all passwords are 'password' (defined in user factory)
       :first_name => 'admin',
       :site_admin => 1,
-      :roles => [Factory.next(:member_role),Factory.next(:admin_role)]
+      :roles => [FactoryGirl.generate(:member_role),FactoryGirl.generate(:admin_role)]
     })
     admin.save!
     admin.confirm!
@@ -62,7 +62,7 @@ Factory.sequence :researcher_user do |n|
       # :password =>'password',  # all passwords are 'password' (defined in user factory)
       :first_name => 'researcher',
       :site_admin => 0,
-      :roles => [Factory.next(:member_role),Factory.next(:researcher_role)]
+      :roles => [FactoryGirl.generate(:member_role),FactoryGirl.generate(:researcher_role)]
     })
     researcher.save!
     researcher.confirm!
@@ -83,7 +83,7 @@ Factory.sequence :manager_user do |n|
       # :password =>'password',  # all passwords are 'password' (defined in user factory)
       :first_name => 'manager',
       :site_admin => 1,
-      :roles => [Factory.next(:member_role),Factory.next(:manager_role)]
+      :roles => [FactoryGirl.generate(:member_role),FactoryGirl.generate(:manager_role)]
     })
     manager.save!
     manager.confirm!
@@ -103,7 +103,7 @@ Factory.sequence :author_user do |n|
       # :password =>'password',  # all passwords are 'password' (defined in user factory)
       :first_name => 'author',
       :site_admin => 0,
-      :roles => [Factory.next(:member_role),Factory.next(:author_role)]
+      :roles => [FactoryGirl.generate(:member_role),FactoryGirl.generate(:author_role)]
     })
     author.save!
     author.confirm!
@@ -123,7 +123,7 @@ Factory.sequence :anonymous_user do |n|
       {
         :login => 'anonymous',
         :first_name => 'anonymous',
-        :roles => [Factory.next(:guest_role)]
+        :roles => [FactoryGirl.generate(:guest_role)]
       })
       anon.save!
       anon.confirm!
@@ -139,4 +139,4 @@ Factory.sequence :anonymous_user do |n|
   end
 end
 
-Factory.next(:anonymous_user)
+FactoryGirl.generate(:anonymous_user)

--- a/factories/zz_default_data.rb
+++ b/factories/zz_default_data.rb
@@ -12,8 +12,8 @@
 # (Left here for legacy documentation??)
 #
 # puts "Loading default data set... "
-# anon =  Factory.next :anonymous_user
-# admin = Factory.next :admin_user 
+# anon =  FactoryGirl.generate :anonymous_user
+# admin = FactoryGirl.generate :admin_user
 # device_config = Factory.create(:device_config)
 # Admin::Settings.create_or_update_default_settings_from_settings_yml
 # puts "done."

--- a/factories/zz_default_data.rb
+++ b/factories/zz_default_data.rb
@@ -14,6 +14,6 @@
 # puts "Loading default data set... "
 # anon =  FactoryGirl.generate :anonymous_user
 # admin = FactoryGirl.generate :admin_user
-# device_config = Factory.create(:device_config)
+# device_config = FactoryGirl.create(:device_config)
 # Admin::Settings.create_or_update_default_settings_from_settings_yml
 # puts "done."

--- a/features/step_definitions/activity_runtime_api_steps.rb
+++ b/features/step_definitions/activity_runtime_api_steps.rb
@@ -1,5 +1,5 @@
 Given /^the following external REST activity:$/ do |table|
-  @external_activity = Factory.create(:external_activity, table.rows_hash)
+  @external_activity = FactoryGirl.create(:external_activity, table.rows_hash)
 
   # also create the mirrored activity template
   activity = Activity.create(:name => "#{@external_activity.name} Template")
@@ -28,7 +28,7 @@ Given /^the following external REST activity:$/ do |table|
   page.save
 
   clazz = Portal::Clazz.find_by_name("My Class")
-  offering = Factory.create(:portal_offering, :runnable => @external_activity, :clazz => clazz)
+  offering = FactoryGirl.create(:portal_offering, :runnable => @external_activity, :clazz => clazz)
   @learner = offering.find_or_create_learner(User.find_by_login('student').portal_student)
 end
 

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -28,7 +28,7 @@ When /^an admin sets the jnlp CDN hostname to "([^"]*)"$/ do |cdn_hostname|
 end
 
 Then /^the installer jnlp should have the CDN hostname "([^"]*)" in the right places$/ do |hostname|
-  inv = Factory.create(:investigation)
+  inv = FactoryGirl.create(:investigation)
   # switch the driver to rack_test so we can inspect the content
   original_driver = Capybara.current_driver
   Capybara.current_driver = :rack_test

--- a/features/step_definitions/assignment_steps.rb
+++ b/features/step_definitions/assignment_steps.rb
@@ -16,7 +16,7 @@ def polymorphic_assign(assignable_type, assignable_name, clazz_name)
   assignable = typeName.classify.constantize.find_by_name(assignable_name)
   material = makeMaterial(assignable)
   expect(material).not_to be_nil
-  Factory.create(:portal_offering, {
+  FactoryGirl.create(:portal_offering, {
     :runnable => material,
     :clazz => clazz
   })

--- a/features/step_definitions/default_settings_and_jnlps_steps.rb
+++ b/features/step_definitions/default_settings_and_jnlps_steps.rb
@@ -1,5 +1,5 @@
 Given /^the most basic default settings$/ do
-  Factory.create(:admin_settings)
+  FactoryGirl.create(:admin_settings)
 end
 
 Given /^the database has been seeded$/ do

--- a/features/step_definitions/global_steps.rb
+++ b/features/step_definitions/global_steps.rb
@@ -134,7 +134,7 @@ Given /^there are (\d+) (.+)$/ do |number, model_name|
 
   the_class.destroy_all
   number.to_i.times do |i|
-    Factory.create(model_name.to_sym)
+    FactoryGirl.create(model_name.to_sym)
   end
 end
 

--- a/features/step_definitions/investigations_steps.rb
+++ b/features/step_definitions/investigations_steps.rb
@@ -1,14 +1,14 @@
 Given /^the following empty investigations exist:$/ do |table|
   table.hashes.each do |hash|
     user = User.find_by_login hash['user']
-    Factory.create(:investigation, hash.merge('user' => user))
+    FactoryGirl.create(:investigation, hash.merge('user' => user))
   end
 end
 
 Given /^the following linked investigations exist:$/ do |table|
   table.hashes.each do |hash|
     user = User.find_by_login hash['user']
-    inv = Factory.create(:investigation, hash.merge('user' => user))
+    inv = FactoryGirl.create(:investigation, hash.merge('user' => user))
       inv.activities << (Factory :activity, { :user => user })
       inv.activities[0].sections << (Factory :section, {:user => user})
       inv.activities[0].sections[0].pages << (Factory :page, {:user => user})
@@ -91,7 +91,7 @@ Given /^the following classes exist:$/ do |table|
     end
     hash.merge!('teacher' => teacher)
     
-    Factory.create(:portal_clazz, hash)
+    FactoryGirl.create(:portal_clazz, hash)
   end
 end
 
@@ -175,7 +175,7 @@ When /^a student has performed work on the investigation "([^"]*)" for the class
     :runnable_id => investigation.id,
     :clazz_id => clazz.id
   })
-  Factory.create(:full_portal_learner, :offering => offering)
+  FactoryGirl.create(:full_portal_learner, :offering => offering)
 end
 
 When /^I open the accordion for the offering for investigation "([^"]*)" for the class "([^"]*)"$/ do |investigation_name, class_name|

--- a/features/step_definitions/materials_bin_steps.rb
+++ b/features/step_definitions/materials_bin_steps.rb
@@ -1,7 +1,7 @@
 Given /^the project "([^"]+)" has slug "([^"]+)" and ITSI bin$/ do |name, slug, page_cont|
   # Replace material collection names with IDs.
   page_cont.gsub!(/Collection \d/) { |name| MaterialsCollection.find_by_name(name).id }
-  Factory.create(:project, name: name, landing_page_slug: slug, landing_page_content: page_cont)
+  FactoryGirl.create(:project, name: name, landing_page_slug: slug, landing_page_content: page_cont)
 end
 
 Then /^category "([^"]+)" should be visible$/ do |category_name|
@@ -45,6 +45,6 @@ Then /^I click category "([^"]+)"$/ do |category_name|
 end
 
 Given /^user "([^"]+)" authored unofficial material "([^"]+)"$/ do |user_name, act_name|
-  author = Factory.create(:confirmed_user, first_name: user_name, last_name: 'testuser')
-  Factory.create(:external_activity, name: act_name, is_official: false, user: author, publication_status: 'published')
+  author = FactoryGirl.create(:confirmed_user, first_name: user_name, last_name: 'testuser')
+  FactoryGirl.create(:external_activity, name: act_name, is_official: false, user: author, publication_status: 'published')
 end

--- a/features/step_definitions/project_links_steps.rb
+++ b/features/step_definitions/project_links_steps.rb
@@ -1,5 +1,5 @@
 Given /^the default project links exist using factories$/ do
-  project = Factory.create(:project, name: 'project 1', landing_page_slug: 'project-1')
+  project = FactoryGirl.create(:project, name: 'project 1', landing_page_slug: 'project-1')
   Factory(:admin_cohort, {
     :project_id => project.id,
     :name => 'project 1 cohort'

--- a/features/step_definitions/student_steps.rb
+++ b/features/step_definitions/student_steps.rb
@@ -30,7 +30,7 @@ Given /^the student "(.*)" belongs to class "(.*)"$/ do |student_name, class_nam
   student = User.find_by_login(student_name).portal_student
   clazz   = Portal::Clazz.find_by_name(class_name)
 
-  Factory.create :portal_student_clazz, :student => student,
+  FactoryGirl.create :portal_student_clazz, :student => student,
                                         :clazz   => clazz
 end
 

--- a/lib/mock_data/create_default_data.rb
+++ b/lib/mock_data/create_default_data.rb
@@ -123,7 +123,7 @@ module MockData
         update_count += 1
         print '+'
       else
-        portal_grade = Factory.create(:portal_grade, grade_info)
+        portal_grade = FactoryGirl.create(:portal_grade, grade_info)
 
         create_count += 1
         print '.'
@@ -692,7 +692,7 @@ module MockData
               default_portal_offering.uuid = offering_uuid
               default_portal_offering.save!
             else
-              default_portal_offering = Factory.create(:portal_offering, { :runnable => study_material,:clazz => clazz})
+              default_portal_offering = FactoryGirl.create(:portal_offering, { :runnable => study_material,:clazz => clazz})
               default_portal_offering.runnable_type = assignable[:type]
               default_portal_offering.uuid = offering_uuid
               default_portal_offering.save!
@@ -954,9 +954,9 @@ module MockData
     MaterialsCollection.destroy_all
     DEFAULT_DATA[:materials_collections].each do |key, mc|
       if (mc[:items_count] > 0)
-        Factory.create(:materials_collection_with_items, items_count: mc[:items_count], name: mc[:name], description: mc[:description])
+        FactoryGirl.create(:materials_collection_with_items, items_count: mc[:items_count], name: mc[:name], description: mc[:description])
       else
-        Factory.create(:materials_collection, name: mc[:name], description: mc[:description])
+        FactoryGirl.create(:materials_collection, name: mc[:name], description: mc[:description])
       end
     end
     puts "Generated Materials Collections"
@@ -981,7 +981,7 @@ module MockData
     Interactive.destroy_all
     Admin::Tag.destroy_all
     DEFAULT_DATA[:interactives].each do |key, interactive|
-      new_interactive = Factory.create(:interactive, name: interactive[:name], description: interactive[:description], url: interactive[:url], image_url: interactive[:image_url], publication_status: interactive[:publication_status])
+      new_interactive = FactoryGirl.create(:interactive, name: interactive[:name], description: interactive[:description], url: interactive[:url], image_url: interactive[:image_url], publication_status: interactive[:publication_status])
       user_login = interactive[:user]
       user = @default_users.find{|u| u.login == user_login}
       new_interactive.user_id = user.id

--- a/spec/controllers/admin/authoring_sites_controller_spec.rb
+++ b/spec/controllers/admin/authoring_sites_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Admin::AuthoringSitesController, type: :controller do
   let(:data) {Admin::AuthoringSite}
   let(:params_key) { :admin_authoring_site }
   let(:valid_attributes)  { { } }
-  let(:admin_user) {Factory.next(:admin_user)}
+  let(:admin_user) {FactoryGirl.generate(:admin_user)}
   let(:stubs) {{}}
   let(:mock_content) {
     mock_model data, stubs

--- a/spec/controllers/admin/client_spec.rb
+++ b/spec/controllers/admin/client_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe Admin::ClientsController do
-  let(:admin_user)   { Factory.next(:admin_user)     }
-  let(:simple_user)  { Factory.next(:confirmed_user) }
-  let(:manager_user) { Factory.next(:manager_user)   }
+  let(:admin_user)   { FactoryGirl.generate(:admin_user)     }
+  let(:simple_user)  { FactoryGirl.generate(:confirmed_user) }
+  let(:manager_user) { FactoryGirl.generate(:manager_user)   }
   let(:client_id)    { 1 }
 
   describe "anonymous' access" do

--- a/spec/controllers/admin/clients_controller_spec.rb
+++ b/spec/controllers/admin/clients_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Admin::ClientsController, type: :controller do
   let(:data) {Client}
   let(:params_key) { :client }
   let(:valid_attributes)  { { } }
-  let(:admin_user) {Factory.next(:admin_user)}
+  let(:admin_user) {FactoryGirl.generate(:admin_user)}
   let(:stubs) {{}}
   let(:mock_content) {
     mock_model data, stubs

--- a/spec/controllers/admin/commons_licenses_controller_spec.rb
+++ b/spec/controllers/admin/commons_licenses_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Admin::CommonsLicensesController, type: :controller do
   let(:data) {CommonsLicense}
   let(:params_key) { :commons_license }
   let(:valid_attributes)  { { name: 'name' } }
-  let(:admin_user) {Factory.next(:admin_user)}
+  let(:admin_user) {FactoryGirl.generate(:admin_user)}
   let(:stubs) {{}}
   let(:mock_content) {
     mock_model data, stubs

--- a/spec/controllers/admin/external_report_spec.rb
+++ b/spec/controllers/admin/external_report_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe Admin::ExternalReportsController do
-  let(:admin_user)   { Factory.next(:admin_user)     }
-  let(:simple_user)  { Factory.next(:confirmed_user) }
-  let(:manager_user) { Factory.next(:manager_user)   }
+  let(:admin_user)   { FactoryGirl.generate(:admin_user)     }
+  let(:simple_user)  { FactoryGirl.generate(:confirmed_user) }
+  let(:manager_user) { FactoryGirl.generate(:manager_user)   }
   let(:report_id)    { 1 }
 
   describe "anonymous' access" do

--- a/spec/controllers/admin/external_reports_controller_spec.rb
+++ b/spec/controllers/admin/external_reports_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Admin::ExternalReportsController, type: :controller do
   let(:data) {ExternalReport}
   let(:params_key) { :external_report }
   let(:valid_attributes)  { { } }
-  let(:admin_user) {Factory.next(:admin_user)}
+  let(:admin_user) {FactoryGirl.generate(:admin_user)}
   let(:stubs) {{}}
   let(:mock_content) {
     mock_model data, stubs

--- a/spec/controllers/admin/learner_details_controller_spec.rb
+++ b/spec/controllers/admin/learner_details_controller_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe Admin::LearnerDetailsController, type: :controller do
 
-  let(:admin_user)   { Factory.next(:admin_user)     }
+  let(:admin_user)   { FactoryGirl.generate(:admin_user)     }
   before (:each) do
     sign_in admin_user
   end

--- a/spec/controllers/admin/permission_forms_controller_spec.rb
+++ b/spec/controllers/admin/permission_forms_controller_spec.rb
@@ -19,7 +19,7 @@ describe Admin::PermissionFormsController do
   end
 
   # User variable is overwritten by some test cases.
-  let(:user) { Factory.next(:admin_user) }
+  let(:user) { FactoryGirl.generate(:admin_user) }
   before(:each) { sign_in user }
 
   describe "#index" do

--- a/spec/controllers/admin/permission_forms_controller_spec.rb
+++ b/spec/controllers/admin/permission_forms_controller_spec.rb
@@ -2,18 +2,18 @@ require 'spec_helper'
 
 describe Admin::PermissionFormsController do
   before(:each) do
-    @cohort1 = Factory.create(:admin_cohort)
-    @cohort2 = Factory.create(:admin_cohort)
-    @project1 = Factory.create(:project)
+    @cohort1 = FactoryGirl.create(:admin_cohort)
+    @cohort2 = FactoryGirl.create(:admin_cohort)
+    @project1 = FactoryGirl.create(:project)
     @project1.cohorts << @cohort1
-    @project2 = Factory.create(:project)
+    @project2 = FactoryGirl.create(:project)
     @project2.cohorts << @cohort2
-    @form1 = Factory.create(:permission_form, project: @project1)
-    @form2 = Factory.create(:permission_form, project: @project2)
-    @teacher1 = Factory.create(:portal_teacher, :user => Factory.create(:user, :login => "teacher1", :first_name => "Teacher", :last_name => "One"))
+    @form1 = FactoryGirl.create(:permission_form, project: @project1)
+    @form2 = FactoryGirl.create(:permission_form, project: @project2)
+    @teacher1 = FactoryGirl.create(:portal_teacher, :user => FactoryGirl.create(:user, :login => "teacher1", :first_name => "Teacher", :last_name => "One"))
     @teacher1.cohorts << @cohort1
     @teacher_view1 = Admin::PermissionFormsController::TeacherView.new(@teacher1)
-    @teacher2 = Factory.create(:portal_teacher, :user => Factory.create(:user, :login => "teacher2", :first_name => "Teacher", :last_name => "Two"))
+    @teacher2 = FactoryGirl.create(:portal_teacher, :user => FactoryGirl.create(:user, :login => "teacher2", :first_name => "Teacher", :last_name => "Two"))
     @teacher_view2 = Admin::PermissionFormsController::TeacherView.new(@teacher2)
     @teacher2.cohorts << @cohort2
   end
@@ -43,7 +43,7 @@ describe Admin::PermissionFormsController do
 
     describe "when user is a project admin" do
       let(:user) do
-        user = Factory.create(:confirmed_user)
+        user = FactoryGirl.create(:confirmed_user)
         user.add_role_for_project('admin', @project1)
         user
       end
@@ -58,7 +58,7 @@ describe Admin::PermissionFormsController do
 
     describe "when user is a project researcher" do
       let(:user) do
-        user = Factory.create(:confirmed_user)
+        user = FactoryGirl.create(:confirmed_user)
         user.add_role_for_project('researcher', @project2)
         user
       end

--- a/spec/controllers/admin/projects_controller_spec.rb
+++ b/spec/controllers/admin/projects_controller_spec.rb
@@ -19,7 +19,7 @@ require 'spec_helper'
 # that an instance is receiving a specific message.
 
 describe Admin::ProjectsController do
-  let(:project) { Factory.create(:project, landing_page_slug: 'foo-proj', landing_page_content: '<h1>Foo</h1>') }
+  let(:project) { FactoryGirl.create(:project, landing_page_slug: 'foo-proj', landing_page_content: '<h1>Foo</h1>') }
   let(:valid_attributes) { { name: "Some name" } }
 
   describe 'when user is an admin' do

--- a/spec/controllers/admin/settings_controller_spec.rb
+++ b/spec/controllers/admin/settings_controller_spec.rb
@@ -33,8 +33,8 @@ describe Admin::SettingsController do
     render_views
 
     it "only allows managers to edit the current settings and only shows them the information they can change" do
-      settings = Factory.create(:admin_settings, :active => true)
-      second_settings = Factory.create(:admin_settings)
+      settings = FactoryGirl.create(:admin_settings, :active => true)
+      second_settings = FactoryGirl.create(:admin_settings)
       allow(Admin::Settings).to receive(:default_settings).and_return(settings)
 
       login_manager
@@ -94,7 +94,7 @@ describe Admin::SettingsController do
     render_views
 
     it "renders the _form_for_managers partial" do
-      settings = Factory.create(:admin_settings)
+      settings = FactoryGirl.create(:admin_settings)
       expect(Admin::Settings).to receive(:find).with("37").and_return(settings)
 
       login_manager

--- a/spec/controllers/admin/site_notices_controller_spec.rb
+++ b/spec/controllers/admin/site_notices_controller_spec.rb
@@ -4,16 +4,16 @@ describe Admin::SiteNoticesController do
   before(:each) do
     @mock_school = Factory.create(:portal_school)
 
-    @admin_user = Factory.next(:admin_user)
+    @admin_user = FactoryGirl.generate(:admin_user)
     @teacher_user = Factory.create(:confirmed_user, :login => "teacher_user")
     @teacher_user.add_role('member')
     @teacher = Factory.create(:portal_teacher, :user => @teacher_user, :schools => [@mock_school])
-    @manager_user = Factory.next(:manager_user)
-    @researcher_user = Factory.next(:researcher_user)
-    @author_user = Factory.next(:author_user)
+    @manager_user = FactoryGirl.generate(:manager_user)
+    @researcher_user = FactoryGirl.generate(:researcher_user)
+    @author_user = FactoryGirl.generate(:author_user)
     @student_user = Factory.create(:confirmed_user, :login => "authorized_student")
     @portal_student = Factory.create(:portal_student, :user => @student_user)
-    @guest_user = Factory.next(:anonymous_user)
+    @guest_user = FactoryGirl.generate(:anonymous_user)
 
     @all_role_ids = Role.all.map {|r| r.id}
 

--- a/spec/controllers/admin/site_notices_controller_spec.rb
+++ b/spec/controllers/admin/site_notices_controller_spec.rb
@@ -2,17 +2,17 @@ require File.expand_path('../../../spec_helper', __FILE__)
 
 describe Admin::SiteNoticesController do
   before(:each) do
-    @mock_school = Factory.create(:portal_school)
+    @mock_school = FactoryGirl.create(:portal_school)
 
     @admin_user = FactoryGirl.generate(:admin_user)
-    @teacher_user = Factory.create(:confirmed_user, :login => "teacher_user")
+    @teacher_user = FactoryGirl.create(:confirmed_user, :login => "teacher_user")
     @teacher_user.add_role('member')
-    @teacher = Factory.create(:portal_teacher, :user => @teacher_user, :schools => [@mock_school])
+    @teacher = FactoryGirl.create(:portal_teacher, :user => @teacher_user, :schools => [@mock_school])
     @manager_user = FactoryGirl.generate(:manager_user)
     @researcher_user = FactoryGirl.generate(:researcher_user)
     @author_user = FactoryGirl.generate(:author_user)
-    @student_user = Factory.create(:confirmed_user, :login => "authorized_student")
-    @portal_student = Factory.create(:portal_student, :user => @student_user)
+    @student_user = FactoryGirl.create(:confirmed_user, :login => "authorized_student")
+    @portal_student = FactoryGirl.create(:portal_student, :user => @student_user)
     @guest_user = FactoryGirl.generate(:anonymous_user)
 
     @all_role_ids = Role.all.map {|r| r.id}
@@ -102,10 +102,10 @@ describe Admin::SiteNoticesController do
 
   describe "GET edit notice form" do
     before(:each) do
-      @notice = Factory.create(:site_notice, :created_by => @admin_user.id)
+      @notice = FactoryGirl.create(:site_notice, :created_by => @admin_user.id)
       roles = Role.all
       roles.each do |role|
-        Factory.create(:site_notice_role, :notice_id => @notice.id,:role_id => role.id)
+        FactoryGirl.create(:site_notice_role, :notice_id => @notice.id,:role_id => role.id)
       end
       @params = {
         :id => @notice.id
@@ -119,10 +119,10 @@ describe Admin::SiteNoticesController do
 
   describe "Update a notice after saving it" do
     before(:each) do
-      @notice = Factory.create(:site_notice, :created_by => @admin_user.id)
+      @notice = FactoryGirl.create(:site_notice, :created_by => @admin_user.id)
       roles = Role.all
       roles.each do |role|
-        Factory.create(:site_notice_role, :notice_id => @notice.id,:role_id => role.id)
+        FactoryGirl.create(:site_notice_role, :notice_id => @notice.id,:role_id => role.id)
       end
       @post_params = {
         :notice_html =>"updated text",
@@ -165,10 +165,10 @@ describe Admin::SiteNoticesController do
 
   describe "Delete a Notice" do
     before(:each) do
-      @notice = Factory.create(:site_notice, :created_by => @admin_user.id)
+      @notice = FactoryGirl.create(:site_notice, :created_by => @admin_user.id)
       roles = Role.all
       roles.each do |role|
-        Factory.create(:site_notice_role, :notice_id => @notice.id,:role_id => role.id)
+        FactoryGirl.create(:site_notice_role, :notice_id => @notice.id,:role_id => role.id)
       end
       @params= {
         :id => @notice.id
@@ -191,10 +191,10 @@ describe Admin::SiteNoticesController do
   describe "Dismiss a notice" do
     before(:each) do
       sign_in @teacher_user
-      @notice = Factory.create(:site_notice, :created_by => @admin_user.id)
+      @notice = FactoryGirl.create(:site_notice, :created_by => @admin_user.id)
       roles = Role.all
       roles.each do |role|
-        Factory.create(:site_notice_role, :notice_id => @notice.id,:role_id => role.id)
+        FactoryGirl.create(:site_notice_role, :notice_id => @notice.id,:role_id => role.id)
       end
       @params = {
         :id => @notice.id
@@ -211,10 +211,10 @@ describe Admin::SiteNoticesController do
   describe "toggle_notice_display" do
     before(:each) do
       sign_in @teacher_user
-      @notice = Factory.create(:site_notice, :created_by => @admin_user.id)
+      @notice = FactoryGirl.create(:site_notice, :created_by => @admin_user.id)
       roles = Role.all
       roles.each do |role|
-        Factory.create(:site_notice_role, :notice_id => @notice.id,:role_id => role.id)
+        FactoryGirl.create(:site_notice_role, :notice_id => @notice.id,:role_id => role.id)
       end
     end
     it"should store collapse time and expand and collapse status" do

--- a/spec/controllers/api/v1/classes_controller_spec.rb
+++ b/spec/controllers/api/v1/classes_controller_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
 describe API::V1::ClassesController do
-  let(:teacher)           { Factory.create(:portal_teacher) }
-  let(:clazz)             { Factory.create(:portal_clazz, name: 'test class', teachers: [teacher]) }
-  let(:runnable_a)          { Factory.create(:external_activity, name: 'Test Sequence') }
-  let(:offering_a)          { Factory.create(:portal_offering, {clazz: clazz, runnable: runnable_a}) }
-  let(:runnable_b)          { Factory.create(:external_activity, name: 'Archived Test Sequence', is_archived: true) }
-  let(:offering_b)          { Factory.create(:portal_offering, {clazz: clazz, runnable: runnable_b}) }
-  let(:runnable_c)          { Factory.create(:external_activity, name: 'Test Sequence 2') }
-  let(:offering_c)          { Factory.create(:portal_offering, {clazz: clazz, runnable: runnable_c}) }
+  let(:teacher)           { FactoryGirl.create(:portal_teacher) }
+  let(:clazz)             { FactoryGirl.create(:portal_clazz, name: 'test class', teachers: [teacher]) }
+  let(:runnable_a)          { FactoryGirl.create(:external_activity, name: 'Test Sequence') }
+  let(:offering_a)          { FactoryGirl.create(:portal_offering, {clazz: clazz, runnable: runnable_a}) }
+  let(:runnable_b)          { FactoryGirl.create(:external_activity, name: 'Archived Test Sequence', is_archived: true) }
+  let(:offering_b)          { FactoryGirl.create(:portal_offering, {clazz: clazz, runnable: runnable_b}) }
+  let(:runnable_c)          { FactoryGirl.create(:external_activity, name: 'Test Sequence 2') }
+  let(:offering_c)          { FactoryGirl.create(:portal_offering, {clazz: clazz, runnable: runnable_c}) }
 
   describe "GET #show" do
     before (:each) do

--- a/spec/controllers/api/v1/external_activities_controller_spec.rb
+++ b/spec/controllers/api/v1/external_activities_controller_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 describe API::V1::ExternalActivitiesController do
 
-  let(:admin_user)        { Factory.next(:admin_user)     }
+  let(:admin_user)        { FactoryGirl.generate(:admin_user)     }
   let(:simple_user)       { Factory.create(:confirmed_user) }
-  let(:manager_user)      { Factory.next(:manager_user)   }
-  let(:researcher_user)   { Factory.next(:researcher_user)   }
+  let(:manager_user)      { FactoryGirl.generate(:manager_user)   }
+  let(:researcher_user)   { FactoryGirl.generate(:researcher_user)   }
 
   describe "#create" do
     context "with a guest" do

--- a/spec/controllers/api/v1/external_activities_controller_spec.rb
+++ b/spec/controllers/api/v1/external_activities_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe API::V1::ExternalActivitiesController do
 
   let(:admin_user)        { FactoryGirl.generate(:admin_user)     }
-  let(:simple_user)       { Factory.create(:confirmed_user) }
+  let(:simple_user)       { FactoryGirl.create(:confirmed_user) }
   let(:manager_user)      { FactoryGirl.generate(:manager_user)   }
   let(:researcher_user)   { FactoryGirl.generate(:researcher_user)   }
 

--- a/spec/controllers/api/v1/jwt_controller_spec.rb
+++ b/spec/controllers/api/v1/jwt_controller_spec.rb
@@ -47,12 +47,12 @@ describe API::V1::JwtController, :type => :controller do
   let(:uid)             { Digest::MD5.hexdigest(url_for_user) }
   let(:learner_token)   { addTokenForLearner(user, client, learner, expires) }
   let(:teacher_token)   { addTokenForTeacher(user, client, class_teacher, expires) }
-  let(:runnable)        { Factory.create(:activity, runnable_opts)    }
+  let(:runnable)        { FactoryGirl.create(:activity, runnable_opts)    }
   let(:offering)        { Factory(:portal_offering, offering_opts)    }
   let(:clazz)           { Factory(:portal_clazz, teachers: [class_teacher], students:[student], logging: true, class_hash: "test") }
   let(:offering_opts)   { {clazz: clazz, runnable: runnable}  }
   let(:runnable_opts)   { {name: 'the activity'}              }
-  let(:class_teacher)   { Factory.create(:portal_teacher)     }
+  let(:class_teacher)   { FactoryGirl.create(:portal_teacher)     }
   let(:student)         { FactoryGirl.create(:full_portal_student) }
   let(:learner)         { Portal::Learner.where(offering_id: offering.id, student_id: student.id ).first_or_create }
   let(:domain_matchers) { "http://x.y.z" }   # don't know why this is required

--- a/spec/controllers/api/v1/materials_bin_controller_spec.rb
+++ b/spec/controllers/api/v1/materials_bin_controller_spec.rb
@@ -168,7 +168,7 @@ describe API::V1::MaterialsBinController do
 
     context 'when an admin is logged in' do
       before(:each) do
-        sign_in Factory.next(:admin_user)
+        sign_in FactoryGirl.generate(:admin_user)
       end
 
       let (:request_user) { user2 }

--- a/spec/controllers/api/v1/materials_bin_controller_spec.rb
+++ b/spec/controllers/api/v1/materials_bin_controller_spec.rb
@@ -6,7 +6,7 @@ describe API::V1::MaterialsBinController do
   let(:bar_cohort) { FactoryGirl.create(:admin_cohort, name: 'bar') }
 
   def sign_in_user_in_cohort(cohort)
-    teacher = Factory.create(:portal_teacher)
+    teacher = FactoryGirl.create(:portal_teacher)
     teacher.cohorts = [cohort]
     sign_in teacher.user
   end

--- a/spec/controllers/api/v1/offerings_controller_spec.rb
+++ b/spec/controllers/api/v1/offerings_controller_spec.rb
@@ -4,8 +4,8 @@ include ReportLearnerSpecHelper
 
 describe API::V1::OfferingsController do
 
-  let(:admin_user)        { Factory.next(:admin_user) }
-  let(:manager_user)      { Factory.next(:manager_user) }
+  let(:admin_user)        { FactoryGirl.generate(:admin_user) }
+  let(:manager_user)      { FactoryGirl.generate(:manager_user) }
   let(:teacher)           { Factory.create(:portal_teacher) }
   let(:open_response_1)   { Factory.create(:open_response) }
   let(:open_response_2)   { Factory.create(:open_response) }

--- a/spec/controllers/api/v1/offerings_controller_spec.rb
+++ b/spec/controllers/api/v1/offerings_controller_spec.rb
@@ -6,22 +6,22 @@ describe API::V1::OfferingsController do
 
   let(:admin_user)        { FactoryGirl.generate(:admin_user) }
   let(:manager_user)      { FactoryGirl.generate(:manager_user) }
-  let(:teacher)           { Factory.create(:portal_teacher) }
-  let(:open_response_1)   { Factory.create(:open_response) }
-  let(:open_response_2)   { Factory.create(:open_response) }
-  let(:open_response_3)   { Factory.create(:open_response) }
-  let(:open_response_4)   { Factory.create(:open_response) }
-  let(:activity_1)        { Factory.create(:activity, name: 'Activity 1') }
-  let(:activity_2)        { Factory.create(:activity, name: 'Activity 2') }
-  let(:runnable)          { Factory.create(:external_activity, name: 'Test Sequence') }
-  let(:clazz)             { Factory.create(:portal_clazz, name: 'test class', teachers: [teacher], students:[student_a, student_b]) }
-  let(:student_a)         { Factory.create(:full_portal_student) }
-  let(:student_b)         { Factory.create(:full_portal_student) }
-  let(:offering)          { Factory.create(:portal_offering, {clazz: clazz, runnable: runnable}) }
+  let(:teacher)           { FactoryGirl.create(:portal_teacher) }
+  let(:open_response_1)   { FactoryGirl.create(:open_response) }
+  let(:open_response_2)   { FactoryGirl.create(:open_response) }
+  let(:open_response_3)   { FactoryGirl.create(:open_response) }
+  let(:open_response_4)   { FactoryGirl.create(:open_response) }
+  let(:activity_1)        { FactoryGirl.create(:activity, name: 'Activity 1') }
+  let(:activity_2)        { FactoryGirl.create(:activity, name: 'Activity 2') }
+  let(:runnable)          { FactoryGirl.create(:external_activity, name: 'Test Sequence') }
+  let(:clazz)             { FactoryGirl.create(:portal_clazz, name: 'test class', teachers: [teacher], students:[student_a, student_b]) }
+  let(:student_a)         { FactoryGirl.create(:full_portal_student) }
+  let(:student_b)         { FactoryGirl.create(:full_portal_student) }
+  let(:offering)          { FactoryGirl.create(:portal_offering, {clazz: clazz, runnable: runnable}) }
 
   def setup_activity(activity, embeddables)
-    section = Factory.create(:section)
-    page = Factory.create(:page)
+    section = FactoryGirl.create(:section)
+    page = FactoryGirl.create(:page)
     embeddables.each { |e| page.add_embeddable(e) }
     section.pages << page
     activity.sections << section
@@ -29,7 +29,7 @@ describe API::V1::OfferingsController do
   end
 
   def setup_runnable(runnable, activities)
-    investigation = Factory.create(:investigation)
+    investigation = FactoryGirl.create(:investigation)
     activities.each { |a| investigation.activities << a }
     investigation.save
     runnable.template = investigation
@@ -87,7 +87,7 @@ describe API::V1::OfferingsController do
     describe "when user is a teacher" do
       describe "when the offering doesn't belong to the teachers class" do
         before(:each) do
-          other_teacher = Factory.create(:portal_teacher)
+          other_teacher = FactoryGirl.create(:portal_teacher)
           sign_in other_teacher.user
         end
         it "returns error 403" do
@@ -320,12 +320,12 @@ describe API::V1::OfferingsController do
     end
 
     describe "when there are multiple teachers, classes and offerings" do
-      let(:teacher_b)  { Factory.create(:portal_teacher) }
-      let(:clazz_b)    { Factory.create(:portal_clazz, teachers: [teacher_b]) }
-      let(:offering_b) { Factory.create(:portal_offering, {clazz: clazz_b, runnable: runnable}) }
+      let(:teacher_b)  { FactoryGirl.create(:portal_teacher) }
+      let(:clazz_b)    { FactoryGirl.create(:portal_clazz, teachers: [teacher_b]) }
+      let(:offering_b) { FactoryGirl.create(:portal_offering, {clazz: clazz_b, runnable: runnable}) }
 
-      let(:clazz_2)    { Factory.create(:portal_clazz, teachers: [teacher]) }
-      let(:offering_2) { Factory.create(:portal_offering, {clazz: clazz_2, runnable: runnable}) }
+      let(:clazz_2)    { FactoryGirl.create(:portal_clazz, teachers: [teacher]) }
+      let(:offering_2) { FactoryGirl.create(:portal_offering, {clazz: clazz_2, runnable: runnable}) }
 
       describe "and teacher is logged in" do
         before (:each) do
@@ -498,7 +498,7 @@ describe API::V1::OfferingsController do
 
     describe "when user is teacher, but does not own the offering" do
       before (:each) do
-        sign_in Factory.create(:portal_teacher).user
+        sign_in FactoryGirl.create(:portal_teacher).user
       end
       it "returns 403 error" do
         put :update, id: offering.id, active: false
@@ -527,8 +527,8 @@ describe API::V1::OfferingsController do
 
       describe "when there are multiple offerings" do
         let(:offering_1) { offering }
-        let(:offering_2) { Factory.create(:portal_offering, {clazz: clazz, runnable: runnable}) }
-        let(:offering_3) { Factory.create(:portal_offering, {clazz: clazz, runnable: runnable}) }
+        let(:offering_2) { FactoryGirl.create(:portal_offering, {clazz: clazz, runnable: runnable}) }
+        let(:offering_3) { FactoryGirl.create(:portal_offering, {clazz: clazz, runnable: runnable}) }
 
         it "should let user reorder them" do
           expect(clazz.offerings).to eq [ offering_1, offering_2, offering_3 ]
@@ -554,14 +554,14 @@ describe API::V1::OfferingsController do
 
   describe "GET #for_class [DEPRECIATED]" do
     describe "when there are multiple teachers, classes and offerings" do
-      let(:teacher_b)  { Factory.create(:portal_teacher) }
-      let(:clazz_b)    { Factory.create(:portal_clazz, teachers: [teacher_b]) }
-      let(:offering_b) { Factory.create(:portal_offering, {clazz: clazz_b, runnable: runnable}) }
+      let(:teacher_b)  { FactoryGirl.create(:portal_teacher) }
+      let(:clazz_b)    { FactoryGirl.create(:portal_clazz, teachers: [teacher_b]) }
+      let(:offering_b) { FactoryGirl.create(:portal_offering, {clazz: clazz_b, runnable: runnable}) }
 
-      let(:offering_2) { Factory.create(:portal_offering, {clazz: clazz, runnable: runnable}) }
+      let(:offering_2) { FactoryGirl.create(:portal_offering, {clazz: clazz, runnable: runnable}) }
 
-      let(:clazz_2)    { Factory.create(:portal_clazz, teachers: [teacher]) }
-      let(:offering_3) { Factory.create(:portal_offering, {clazz: clazz_2, runnable: runnable}) }
+      let(:clazz_2)    { FactoryGirl.create(:portal_clazz, teachers: [teacher]) }
+      let(:offering_3) { FactoryGirl.create(:portal_offering, {clazz: clazz_2, runnable: runnable}) }
 
       before (:each) do
         sign_in teacher.user
@@ -598,12 +598,12 @@ describe API::V1::OfferingsController do
 
   describe "GET #for_teacher [DEPRECIATED]" do
     describe "when there are multiple teachers, classes and offerings" do
-      let(:teacher_b)  { Factory.create(:portal_teacher) }
-      let(:clazz_b)    { Factory.create(:portal_clazz, teachers: [teacher_b]) }
-      let(:offering_b) { Factory.create(:portal_offering, {clazz: clazz_b, runnable: runnable}) }
+      let(:teacher_b)  { FactoryGirl.create(:portal_teacher) }
+      let(:clazz_b)    { FactoryGirl.create(:portal_clazz, teachers: [teacher_b]) }
+      let(:offering_b) { FactoryGirl.create(:portal_offering, {clazz: clazz_b, runnable: runnable}) }
 
-      let(:clazz_2)    { Factory.create(:portal_clazz, teachers: [teacher]) }
-      let(:offering_2) { Factory.create(:portal_offering, {clazz: clazz_2, runnable: runnable}) }
+      let(:clazz_2)    { FactoryGirl.create(:portal_clazz, teachers: [teacher]) }
+      let(:offering_2) { FactoryGirl.create(:portal_offering, {clazz: clazz_2, runnable: runnable}) }
 
       before (:each) do
         sign_in teacher.user

--- a/spec/controllers/api/v1/passwords_controller_spec.rb
+++ b/spec/controllers/api/v1/passwords_controller_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe API::V1::PasswordsController do
 
-    let(:user1) { Factory.create(   :user,
+    let(:user1) { FactoryGirl.create(   :user,
                                     :login => 'testuser',
                                     :email => 'foo@foo.com' ) }
 
@@ -44,7 +44,7 @@ describe API::V1::PasswordsController do
         context "with SSO email" do
             it "returns failure" do
 
-                sso_user = Factory.create(:user,
+                sso_user = FactoryGirl.create(:user,
                                     :login => 'ssouser',
                                     :email => 'foo@gmail.com')
 

--- a/spec/controllers/api/v1/report_learners_es_controller_spec.rb
+++ b/spec/controllers/api/v1/report_learners_es_controller_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 describe API::V1::ReportLearnersEsController do
 
-  let(:admin_user)        { Factory.next(:admin_user)     }
+  let(:admin_user)        { FactoryGirl.generate(:admin_user)     }
   let(:simple_user)       { Factory.create(:confirmed_user, :login => "authorized_student") }
-  let(:manager_user)      { Factory.next(:manager_user)   }
+  let(:manager_user)      { FactoryGirl.generate(:manager_user)   }
 
   let(:search_body)       { {
                               "size" => 0,

--- a/spec/controllers/api/v1/report_learners_es_controller_spec.rb
+++ b/spec/controllers/api/v1/report_learners_es_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe API::V1::ReportLearnersEsController do
 
   let(:admin_user)        { FactoryGirl.generate(:admin_user)     }
-  let(:simple_user)       { Factory.create(:confirmed_user, :login => "authorized_student") }
+  let(:simple_user)       { FactoryGirl.create(:confirmed_user, :login => "authorized_student") }
   let(:manager_user)      { FactoryGirl.generate(:manager_user)   }
 
   let(:search_body)       { {
@@ -124,9 +124,9 @@ describe API::V1::ReportLearnersEsController do
   describe "project researcher access" do
 
     before (:each) do
-      @project1 = Factory.create(:project)
-      @form1 = Factory.create(:permission_form, project: @project1)
-      user = Factory.create(:confirmed_user)
+      @project1 = FactoryGirl.create(:project)
+      @form1 = FactoryGirl.create(:permission_form, project: @project1)
+      user = FactoryGirl.create(:confirmed_user)
       user.add_role_for_project('researcher', @project1)
       sign_in user
     end

--- a/spec/controllers/api/v1/reports_controller_spec.rb
+++ b/spec/controllers/api/v1/reports_controller_spec.rb
@@ -18,16 +18,16 @@ RSpec::Matchers.define :include_hash do |comp_hash|
 end
 
 describe API::V1::ReportsController do
-  let(:open_response)     { Factory.create(:open_response, show_in_featured_question_report: true, is_required: true)}
-  let(:section)           { Factory.create(:section) }
-  let(:page)              { Factory.create(:page) }
-  let(:activity)          { Factory.create(:activity, runnable_opts)          }
-  let(:runnable)          { Factory.create(:external_activity, runnable_opts) }
+  let(:open_response)     { FactoryGirl.create(:open_response, show_in_featured_question_report: true, is_required: true)}
+  let(:section)           { FactoryGirl.create(:section) }
+  let(:page)              { FactoryGirl.create(:page) }
+  let(:activity)          { FactoryGirl.create(:activity, runnable_opts)          }
+  let(:runnable)          { FactoryGirl.create(:external_activity, runnable_opts) }
   let(:offering)          { Factory(:portal_offering, offering_opts)    }
   let(:clazz)             { Factory(:portal_clazz, teachers: [class_teacher], students:[student_a,student_b]) }
   let(:offering_opts)     { {clazz: clazz, runnable: runnable}  }
   let(:runnable_opts)     { {name: 'the activity'}              }
-  let(:class_teacher)     { Factory.create(:portal_teacher)     }
+  let(:class_teacher)     { FactoryGirl.create(:portal_teacher)     }
   let(:learner_a)         { Portal::Learner.where(offering_id: offering.id, student_id: student_a.id).first_or_create}
   let(:learner_b)         { Portal::Learner.where(offering_id: offering.id, student_id: student_b.id).first_or_create}
   let(:student_a)         { FactoryGirl.create(:full_portal_student) }

--- a/spec/controllers/api/v1/search_controller_spec.rb
+++ b/spec/controllers/api/v1/search_controller_spec.rb
@@ -11,10 +11,10 @@ describe API::V1::SearchController do
 
   let(:teacher_user)    { Factory.create(:confirmed_user, :login => "teacher_user") }
   let(:teacher)         { Factory.create(:portal_teacher, :user => teacher_user, :schools => [mock_school]) }
-  let(:admin_user)      { Factory.next(:admin_user) }
-  let(:author_user)     { Factory.next(:author_user) }
-  let(:manager_user)    { Factory.next(:manager_user) }
-  let(:researcher_user) { Factory.next(:researcher_user) }
+  let(:admin_user)      { FactoryGirl.generate(:admin_user) }
+  let(:author_user)     { FactoryGirl.generate(:author_user) }
+  let(:manager_user)    { FactoryGirl.generate(:manager_user) }
+  let(:researcher_user) { FactoryGirl.generate(:researcher_user) }
 
   let(:student_user)    { Factory.create(:confirmed_user, :login => "authorized_student") }
   let(:student)         { Factory.create(:portal_student, :user_id => student_user.id) }

--- a/spec/controllers/api/v1/search_controller_spec.rb
+++ b/spec/controllers/api/v1/search_controller_spec.rb
@@ -5,39 +5,39 @@ describe API::V1::SearchController do
 
   def make(let); end
 
-  let(:admin_settings)   { Factory.create(:admin_settings, :include_external_activities => false) }
+  let(:admin_settings)   { FactoryGirl.create(:admin_settings, :include_external_activities => false) }
 
-  let(:mock_school)     { Factory.create(:portal_school) }
+  let(:mock_school)     { FactoryGirl.create(:portal_school) }
 
-  let(:teacher_user)    { Factory.create(:confirmed_user, :login => "teacher_user") }
-  let(:teacher)         { Factory.create(:portal_teacher, :user => teacher_user, :schools => [mock_school]) }
+  let(:teacher_user)    { FactoryGirl.create(:confirmed_user, :login => "teacher_user") }
+  let(:teacher)         { FactoryGirl.create(:portal_teacher, :user => teacher_user, :schools => [mock_school]) }
   let(:admin_user)      { FactoryGirl.generate(:admin_user) }
   let(:author_user)     { FactoryGirl.generate(:author_user) }
   let(:manager_user)    { FactoryGirl.generate(:manager_user) }
   let(:researcher_user) { FactoryGirl.generate(:researcher_user) }
 
-  let(:student_user)    { Factory.create(:confirmed_user, :login => "authorized_student") }
-  let(:student)         { Factory.create(:portal_student, :user_id => student_user.id) }
+  let(:student_user)    { FactoryGirl.create(:confirmed_user, :login => "authorized_student") }
+  let(:student)         { FactoryGirl.create(:portal_student, :user_id => student_user.id) }
 
-  let(:physics_investigation)     { Factory.create(:investigation, :name => 'physics_inv', :user => author_user, :publication_status => 'published') }
-  let(:chemistry_investigation)   { Factory.create(:investigation, :name => 'chemistry_inv', :user => author_user, :publication_status => 'published') }
-  let(:biology_investigation)     { Factory.create(:investigation, :name => 'mathematics_inv', :user => author_user, :publication_status => 'published') }
-  let(:mathematics_investigation) { Factory.create(:investigation, :name => 'biology_inv', :user => author_user, :publication_status => 'published') }
-  let(:lines)                     { Factory.create(:investigation, :name => 'lines_inv', :user => author_user, :publication_status => 'published') }
+  let(:physics_investigation)     { FactoryGirl.create(:investigation, :name => 'physics_inv', :user => author_user, :publication_status => 'published') }
+  let(:chemistry_investigation)   { FactoryGirl.create(:investigation, :name => 'chemistry_inv', :user => author_user, :publication_status => 'published') }
+  let(:biology_investigation)     { FactoryGirl.create(:investigation, :name => 'mathematics_inv', :user => author_user, :publication_status => 'published') }
+  let(:mathematics_investigation) { FactoryGirl.create(:investigation, :name => 'biology_inv', :user => author_user, :publication_status => 'published') }
+  let(:lines)                     { FactoryGirl.create(:investigation, :name => 'lines_inv', :user => author_user, :publication_status => 'published') }
 
-  let(:laws_of_motion_activity)  { Factory.create(:activity, :name => 'laws_of_motion_activity' ,:investigation_id => physics_investigation.id, :user => author_user) }
-  let(:fluid_mechanics_activity) { Factory.create(:activity, :name => 'fluid_mechanics_activity' , :investigation_id => physics_investigation.id, :user => author_user) }
-  let(:thermodynamics_activity)  { Factory.create(:activity, :name => 'thermodynamics_activity' , :investigation_id => physics_investigation.id, :user => author_user) }
-  let(:parallel_lines)           { Factory.create(:activity, :name => 'parallel_lines' , :investigation_id => lines.id, :user => author_user) }
+  let(:laws_of_motion_activity)  { FactoryGirl.create(:activity, :name => 'laws_of_motion_activity' ,:investigation_id => physics_investigation.id, :user => author_user) }
+  let(:fluid_mechanics_activity) { FactoryGirl.create(:activity, :name => 'fluid_mechanics_activity' , :investigation_id => physics_investigation.id, :user => author_user) }
+  let(:thermodynamics_activity)  { FactoryGirl.create(:activity, :name => 'thermodynamics_activity' , :investigation_id => physics_investigation.id, :user => author_user) }
+  let(:parallel_lines)           { FactoryGirl.create(:activity, :name => 'parallel_lines' , :investigation_id => lines.id, :user => author_user) }
 
-  let(:external_activity1)   { Factory.create(:external_activity, 
+  let(:external_activity1)   { FactoryGirl.create(:external_activity, 
                                         :name => 'external_1', 
                                         :url => "http://concord.org", 
                                         :publication_status => 'published', 
                                         :is_official => true,
                                         :material_type => 'Activity' ) }
 
-  let(:external_activity2)   { Factory.create(:external_activity, 
+  let(:external_activity2)   { FactoryGirl.create(:external_activity, 
                                         :name => 'a_study_in_lines_and_curves', 
                                         :url => "http://github.com", 
                                         :publication_status => 
@@ -46,7 +46,7 @@ describe API::V1::SearchController do
                                         :material_type => 'Activity' ) }
 
 
-  let(:external_activity3)   { Factory.create(:external_activity,
+  let(:external_activity3)   { FactoryGirl.create(:external_activity,
                                         :name => 'a_study_in_lines_and_curves',
                                         :url => "http://github.com",
                                         :publication_status =>
@@ -55,7 +55,7 @@ describe API::V1::SearchController do
                                         :material_type => 'Investigation' ) }
 
 
-  let(:contributed_activity) { Factory.create(:external_activity,
+  let(:contributed_activity) { FactoryGirl.create(:external_activity,
                                         :name => "Copy of external_1",
                                         :url => "http://concord.org",
                                         :publication_status => 'published',

--- a/spec/controllers/browse/activities_controller_spec.rb
+++ b/spec/controllers/browse/activities_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Browse::ActivitiesController, type: :controller do
   # TODO: auto-generated
   describe '#show' do
     xit 'GET show' do
-      get :show, id: Factory.create(:activity).to_param
+      get :show, id: FactoryGirl.create(:activity).to_param
 
       expect(response).to have_http_status(:ok)
     end

--- a/spec/controllers/browse/external_activities_controller_spec.rb
+++ b/spec/controllers/browse/external_activities_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Browse::ExternalActivitiesController do
     before(:each) do
         @author_user = FactoryGirl.generate(:author_user)
-        @external_activity = Factory.create(:external_activity, :name => 'activity', :url => 'external.activity.org/1', :user => @author_user, :publication_status => 'published')
+        @external_activity = FactoryGirl.create(:external_activity, :name => 'activity', :url => 'external.activity.org/1', :user => @author_user, :publication_status => 'published')
     end
 
     describe "GET show" do

--- a/spec/controllers/browse/external_activities_controller_spec.rb
+++ b/spec/controllers/browse/external_activities_controller_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Browse::ExternalActivitiesController do
     before(:each) do
-        @author_user = Factory.next(:author_user)
+        @author_user = FactoryGirl.generate(:author_user)
         @external_activity = Factory.create(:external_activity, :name => 'activity', :url => 'external.activity.org/1', :user => @author_user, :publication_status => 'published')
     end
 

--- a/spec/controllers/browse/investigations_controller_spec.rb
+++ b/spec/controllers/browse/investigations_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Browse::InvestigationsController, type: :controller do
   # TODO: auto-generated
   describe '#show' do
     xit 'GET show' do
-      get :show, id: Factory.create(:investigation).to_param
+      get :show, id: FactoryGirl.create(:investigation).to_param
 
       expect(response).to have_http_status(:ok)
     end

--- a/spec/controllers/dataservice/bucket_contents_metal_controller_spec.rb
+++ b/spec/controllers/dataservice/bucket_contents_metal_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Dataservice::BucketContentsMetalController, type: :controller do
   # TODO: auto-generated
   describe '#create_by_learner' do
     xit 'GET create_by_learner' do
-      get :create_by_learner, id: Factory.create(:full_portal_learner).to_param
+      get :create_by_learner, id: FactoryGirl.create(:full_portal_learner).to_param
 
       expect(response).to have_http_status(:not_found)
     end

--- a/spec/controllers/dataservice/console_contents_metal_controller_spec.rb
+++ b/spec/controllers/dataservice/console_contents_metal_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Dataservice::ConsoleContentsMetalController, type: :controller do
   # TODO: auto-generated
   describe '#create' do
     xit 'POST create' do
-      post :create, id: Factory.create(:console_logger).to_param
+      post :create, id: FactoryGirl.create(:console_logger).to_param
 
       expect(response).to have_http_status(:ok)
     end

--- a/spec/controllers/dataservice/periodic_bundle_loggers_controller_spec.rb
+++ b/spec/controllers/dataservice/periodic_bundle_loggers_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Dataservice::PeriodicBundleLoggersController, type: :controller d
   # TODO: auto-generated
   describe '#show' do
     xit 'GET show' do
-      get :show, id: Factory.create(:periodic_bundle_logger).to_param
+      get :show, id: FactoryGirl.create(:periodic_bundle_logger).to_param
 
       expect(response).to have_http_status(:ok)
     end

--- a/spec/controllers/dataservice/periodic_bundle_loggers_metal_controller_spec.rb
+++ b/spec/controllers/dataservice/periodic_bundle_loggers_metal_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Dataservice::PeriodicBundleLoggersMetalController, type: :control
   # TODO: auto-generated
   describe '#session_end_notification' do
     xit 'GET session_end_notification' do
-      get :session_end_notification, id: Factory.create(:periodic_bundle_logger).to_param
+      get :session_end_notification, id: FactoryGirl.create(:periodic_bundle_logger).to_param
 
       expect(response).to have_http_status(:ok)
     end

--- a/spec/controllers/embeddable/multiple_choices_controller_spec.rb
+++ b/spec/controllers/embeddable/multiple_choices_controller_spec.rb
@@ -22,7 +22,7 @@ describe Embeddable::MultipleChoicesController do
   # TODO: auto-generated
   describe '#add_choice' do
     it 'GET add_choice' do
-      get :add_choice, id: Factory.create(:multiple_choice).to_param
+      get :add_choice, id: FactoryGirl.create(:multiple_choice).to_param
 
       expect(response).to have_http_status(:not_acceptable)
     end

--- a/spec/controllers/external_activities_controller_spec.rb
+++ b/spec/controllers/external_activities_controller_spec.rb
@@ -80,17 +80,17 @@ describe ExternalActivitiesController do
     }
   end
 
-  let (:existing) { Factory.create(:external_activity, {
+  let (:existing) { FactoryGirl.create(:external_activity, {
       :name        => name,
       :long_description => description,
       :url         => url,
       :publication_status => 'published',
-      :template    => Factory.create(:activity, {
-        :investigation => Factory.create(:investigation)
+      :template    => FactoryGirl.create(:activity, {
+        :investigation => FactoryGirl.create(:investigation)
       })
     })}
 
-  let (:another) { Factory.create(:external_activity, {
+  let (:another) { FactoryGirl.create(:external_activity, {
       :name        => "#{name} again",
       :long_description => "#{description} again",
       :url         => url,
@@ -173,11 +173,11 @@ describe ExternalActivitiesController do
 
     context "when version 2 of the API is requested" do
 
-      let (:existing_sequence) { Factory.create(:external_activity, {
+      let (:existing_sequence) { FactoryGirl.create(:external_activity, {
           :name => sequence_name,
           :long_description => sequence_desc,
           :url => sequence_url,
-          :template => Factory.create(:investigation)
+          :template => FactoryGirl.create(:investigation)
         }) }
 
       describe "when there is no existing external_activity" do
@@ -292,7 +292,7 @@ describe ExternalActivitiesController do
   # TODO: auto-generated
   describe '#show' do
     it 'GET show' do
-      get :show, id: Factory.create(:external_activity).to_param
+      get :show, id: FactoryGirl.create(:external_activity).to_param
 
       expect(response).to have_http_status(:redirect)
     end
@@ -301,7 +301,7 @@ describe ExternalActivitiesController do
   # TODO: auto-generated
   describe '#edit' do
     it 'GET edit' do
-      get :edit, id: Factory.create(:external_activity).to_param
+      get :edit, id: FactoryGirl.create(:external_activity).to_param
 
       expect(response).to have_http_status(:ok)
     end
@@ -328,7 +328,7 @@ describe ExternalActivitiesController do
   # TODO: auto-generated
   describe '#destroy' do
     it 'DELETE destroy' do
-      delete :destroy, id: Factory.create(:external_activity).to_param
+      delete :destroy, id: FactoryGirl.create(:external_activity).to_param
 
       expect(response).to have_http_status(:redirect)
     end

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -4,7 +4,7 @@ describe HelpController, type: :controller do
   
   before(:each) do
       @admin_user = FactoryGirl.generate(:admin_user)
-      @test_settings = Factory.create(:admin_settings, :user => @admin_user, :id=> 1)
+      @test_settings = FactoryGirl.create(:admin_settings, :user => @admin_user, :id=> 1)
       login_admin
       allow(Admin::Settings).to receive(:default_settings).and_return(@test_settings)
   end

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe HelpController, type: :controller do
   
   before(:each) do
-      @admin_user = Factory.next(:admin_user)
+      @admin_user = FactoryGirl.generate(:admin_user)
       @test_settings = Factory.create(:admin_settings, :user => @admin_user, :id=> 1)
       login_admin
       allow(Admin::Settings).to receive(:default_settings).and_return(@test_settings)

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -60,7 +60,7 @@ describe HomeController do
 
   describe "Post preview_home_page" do
     it "should set variables to preview home page" do
-      anonymous_user = Factory.next(:anonymous_user)
+      anonymous_user = FactoryGirl.generate(:anonymous_user)
       @post_params = {
         :home_page_preview_content =>"<b>Home page content.</b>",
       }

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -2,15 +2,15 @@ require File.expand_path('../../spec_helper', __FILE__)
 describe HomeController do
   render_views
 
-  let(:activity) { Factory.create(      :external_activity,
+  let(:activity) { FactoryGirl.create(      :external_activity,
                                         :name => "test activity",
                                         :publication_status => "published") }
 
-  let(:sequence) { Factory.create(      :external_activity,
+  let(:sequence) { FactoryGirl.create(      :external_activity,
                                         :name => "test sequence",
                                         :publication_status => "published") }
 
-  let(:interactive) { Factory.create(   :interactive,
+  let(:interactive) { FactoryGirl.create(   :interactive,
                                         :name => "test interactive",
                                         :publication_status => "published",
                                         :external_activity_id => activity.id ) }

--- a/spec/controllers/interactives_controller_spec.rb
+++ b/spec/controllers/interactives_controller_spec.rb
@@ -15,7 +15,7 @@ describe InteractivesController do
   let(:publication_status)  { "published" }
 
   let(:test_interactive) {
-    test_interactive = Factory.create(:interactive,
+    test_interactive = FactoryGirl.create(:interactive,
       :name => name,
       :description => description,
       :url => url,

--- a/spec/controllers/materials_collections_controller_spec.rb
+++ b/spec/controllers/materials_collections_controller_spec.rb
@@ -20,7 +20,7 @@ require 'spec_helper'
 
 describe MaterialsCollectionsController do
   before(:each) do
-    @admin_user = Factory.next(:admin_user)
+    @admin_user = FactoryGirl.generate(:admin_user)
     allow(controller).to receive(:current_visitor).and_return(@admin_user)
 
     login_admin

--- a/spec/controllers/materials_collections_controller_spec.rb
+++ b/spec/controllers/materials_collections_controller_spec.rb
@@ -26,7 +26,7 @@ describe MaterialsCollectionsController do
     login_admin
   end
 
-  let(:materials_collection) { Factory.create(:materials_collection) }
+  let(:materials_collection) { FactoryGirl.create(:materials_collection) }
   let(:valid_attributes)     { { name: "Some name", description: "Some description" } }
 
   describe "GET index" do
@@ -152,7 +152,7 @@ describe MaterialsCollectionsController do
 
   describe "POST sort_materials" do
     it 'sorts materials appropriately' do
-      collection =  Factory.create(:materials_collection_with_items)
+      collection =  FactoryGirl.create(:materials_collection_with_items)
       current_order = collection.materials_collection_items.map {|i| i.id }.dup
       shuffled_order = current_order.shuffle
       post :sort_materials, { :id => collection.id, "materials_materials_collection_#{collection.id}" => shuffled_order }

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -9,7 +9,7 @@ describe PasswordsController do
 
   describe "Reset password by login" do
     before(:each) do
-      @forgetful_user = Factory.create(:user, :login => "forgetful_jones", :password => "password", :password_confirmation => "password", :email => "valid@test.com")
+      @forgetful_user = FactoryGirl.create(:user, :login => "forgetful_jones", :password => "password", :password_confirmation => "password", :email => "valid@test.com")
 
       @params = { :login => @forgetful_user.login }
 
@@ -30,7 +30,7 @@ describe PasswordsController do
     end
 
     it "will fail gracefully for students without security questions" do
-      @forgetful_user.portal_student = Factory.create(:portal_student)
+      @forgetful_user.portal_student = FactoryGirl.create(:portal_student)
 
       post :create_by_login, @params
 
@@ -51,7 +51,7 @@ describe PasswordsController do
     end
 
     it "will ask security questions for students" do
-      @forgetful_user.portal_student = Factory.create(:portal_student)
+      @forgetful_user.portal_student = FactoryGirl.create(:portal_student)
       Array.new(3) { |i| SecurityQuestion.create({ :question => "test #{i}", :answer => "test" }) }.each { |q| @forgetful_user.security_questions << q }
 
       expect(PasswordMailer).not_to receive(:forgot_password)
@@ -117,7 +117,7 @@ describe PasswordsController do
 
   describe "Reset password by email address" do
     before(:each) do
-      @forgetful_user = Factory.create(:user, :email => "test@test.com")
+      @forgetful_user = FactoryGirl.create(:user, :email => "test@test.com")
 
       @params = {
         :password => {

--- a/spec/controllers/portal/clazzes_controller_spec.rb
+++ b/spec/controllers/portal/clazzes_controller_spec.rb
@@ -28,8 +28,8 @@ describe Portal::ClazzesController do
     @mock_school = Factory.create(:portal_school)
 
     # set up our user types
-    @normal_user = Factory.next(:anonymous_user)
-    @admin_user = Factory.next(:admin_user)
+    @normal_user = FactoryGirl.generate(:anonymous_user)
+    @admin_user = FactoryGirl.generate(:admin_user)
     @authorized_student =         Factory.create(:portal_student, :user => Factory.create(:confirmed_user, :login => "authorized_student"))
     @authorized_teacher =         Factory.create(:portal_teacher, :user => Factory.create(:confirmed_user, :login => "authorized_teacher"), :schools => [@mock_school])
     @another_authorized_teacher = Factory.create(:portal_teacher, :user => Factory.create(:confirmed_user, :login => "another_authorized_teacher"), :schools => [@mock_school])

--- a/spec/controllers/portal/clazzes_controller_spec.rb
+++ b/spec/controllers/portal/clazzes_controller_spec.rb
@@ -14,7 +14,7 @@ describe Portal::ClazzesController do
   render_views
 
   def mock_clazz(stubs={})
-    mock_clazz = Factory.create(:portal_clazz, stubs) #mock_model(Portal::Clazz)
+    mock_clazz = FactoryGirl.create(:portal_clazz, stubs) #mock_model(Portal::Clazz)
     #mock_clazz.stub!(stubs) unless stubs.empty?
 
     mock_clazz
@@ -25,24 +25,24 @@ describe Portal::ClazzesController do
   end
 
   before(:each) do
-    @mock_school = Factory.create(:portal_school)
+    @mock_school = FactoryGirl.create(:portal_school)
 
     # set up our user types
     @normal_user = FactoryGirl.generate(:anonymous_user)
     @admin_user = FactoryGirl.generate(:admin_user)
-    @authorized_student =         Factory.create(:portal_student, :user => Factory.create(:confirmed_user, :login => "authorized_student"))
-    @authorized_teacher =         Factory.create(:portal_teacher, :user => Factory.create(:confirmed_user, :login => "authorized_teacher"), :schools => [@mock_school])
-    @another_authorized_teacher = Factory.create(:portal_teacher, :user => Factory.create(:confirmed_user, :login => "another_authorized_teacher"), :schools => [@mock_school])
-    @unauthorized_teacher =       Factory.create(:portal_teacher, :user => Factory.create(:confirmed_user, :login => "unauthorized_teacher"), :schools => [@mock_school])
+    @authorized_student =         FactoryGirl.create(:portal_student, :user => FactoryGirl.create(:confirmed_user, :login => "authorized_student"))
+    @authorized_teacher =         FactoryGirl.create(:portal_teacher, :user => FactoryGirl.create(:confirmed_user, :login => "authorized_teacher"), :schools => [@mock_school])
+    @another_authorized_teacher = FactoryGirl.create(:portal_teacher, :user => FactoryGirl.create(:confirmed_user, :login => "another_authorized_teacher"), :schools => [@mock_school])
+    @unauthorized_teacher =       FactoryGirl.create(:portal_teacher, :user => FactoryGirl.create(:confirmed_user, :login => "unauthorized_teacher"), :schools => [@mock_school])
     # another teacher, to act as an arbitrary third party
-    @random_teacher =             Factory.create(:portal_teacher, :user => Factory.create(:confirmed_user, :login => "random_teacher"), :schools => [@mock_school])
+    @random_teacher =             FactoryGirl.create(:portal_teacher, :user => FactoryGirl.create(:confirmed_user, :login => "random_teacher"), :schools => [@mock_school])
 
     @authorized_teacher_user = @authorized_teacher.user
     @unauthorized_teacher_user = @unauthorized_teacher.user
 
 
     @mock_clazz_name = "Random Test Class"
-    @mock_course = Factory.create(:portal_course, :name => @mock_clazz_name, :school => @mock_school)
+    @mock_course = FactoryGirl.create(:portal_course, :name => @mock_clazz_name, :school => @mock_school)
     @mock_clazz = mock_clazz({ :name => @mock_clazz_name, :teachers => [@authorized_teacher, @another_authorized_teacher], :course => @mock_course })
 
     allow(@controller).to receive(:before_render) {
@@ -311,7 +311,7 @@ describe Portal::ClazzesController do
     #   login_as :authorized_teacher_user
     #
     #   1.upto 10 do |i|
-    #     teacher = Factory.create(:portal_teacher, :user => Factory.create(:user, :login => "teacher#{i}"))
+    #     teacher = FactoryGirl.create(:portal_teacher, :user => FactoryGirl.create(:user, :login => "teacher#{i}"))
     #     @logged_in_user.portal_teacher.school.portal_teachers << teacher
     #   end
     #
@@ -369,7 +369,7 @@ describe Portal::ClazzesController do
     end
 
     it "should attach this class to the appropriate course in the specified school, if one exists" do
-      course = Factory.create(:portal_course, :name => @post_params[:portal_clazz][:name], :school => @mock_school)
+      course = FactoryGirl.create(:portal_course, :name => @post_params[:portal_clazz][:name], :school => @mock_school)
       assert course
       expect(course.clazzes.size).to eq(0)
 
@@ -402,7 +402,7 @@ describe Portal::ClazzesController do
     end
 
     it "should create exactly one teacher object for the current user if the current user does not already have one" do
-      @random_user = Factory.create(:confirmed_user, :login => "random_user")
+      @random_user = FactoryGirl.create(:confirmed_user, :login => "random_user")
       sign_in @random_user
 
       expect(@random_user.portal_teacher).to be_nil
@@ -521,7 +521,7 @@ describe Portal::ClazzesController do
   describe "POST add_offering" do
     it "should run without error" do
       login_admin
-      external_activity = Factory.create(:external_activity)
+      external_activity = FactoryGirl.create(:external_activity)
       post_params = runnable_params(external_activity, @mock_clazz)
       post :add_offering, post_params
     end
@@ -530,7 +530,7 @@ describe Portal::ClazzesController do
 
   describe "Post edit class information" do
     before(:each) do
-      external_activity = Factory.create(:external_activity)
+      external_activity = FactoryGirl.create(:external_activity)
       post_params = runnable_params(external_activity, @mock_clazz)
       post :add_offering, post_params
       offers = Array.new
@@ -758,10 +758,10 @@ describe Portal::ClazzesController do
 
   describe "Post teacher sorts class offerings on class summary page" do
     before(:each) do
-      @physics_offering = Factory.create(:portal_offering)
-      @chemistry_offering = Factory.create(:portal_offering)
-      @biology_offering = Factory.create(:portal_offering)
-      @mathematics_offering = Factory.create(:portal_offering)
+      @physics_offering = FactoryGirl.create(:portal_offering)
+      @chemistry_offering = FactoryGirl.create(:portal_offering)
+      @biology_offering = FactoryGirl.create(:portal_offering)
+      @mathematics_offering = FactoryGirl.create(:portal_offering)
       @params = {
         :clazz_offerings => [@physics_offering.id, @chemistry_offering.id, @biology_offering.id , @mathematics_offering.id]
       }

--- a/spec/controllers/portal/courses_controller_spec.rb
+++ b/spec/controllers/portal/courses_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Portal::CoursesController, type: :controller do
   # TODO: auto-generated
   describe '#show' do
     xit 'GET show' do
-      get :show, id: Factory.create(:course).to_param
+      get :show, id: FactoryGirl.create(:course).to_param
 
       expect(response).to have_http_status(:ok)
     end
@@ -25,7 +25,7 @@ RSpec.describe Portal::CoursesController, type: :controller do
   # TODO: auto-generated
   describe '#edit' do
     xit 'GET edit' do
-      get :edit, id: Factory.create(:course).to_param
+      get :edit, id: FactoryGirl.create(:course).to_param
 
       expect(response).to have_http_status(:ok)
     end
@@ -52,7 +52,7 @@ RSpec.describe Portal::CoursesController, type: :controller do
   # TODO: auto-generated
   describe '#destroy' do
     xit 'DELETE destroy' do
-      delete :destroy, id: Factory.create(:course).to_param
+      delete :destroy, id: FactoryGirl.create(:course).to_param
 
       expect(response).to have_http_status(:ok)
     end

--- a/spec/controllers/portal/learners_controller_spec.rb
+++ b/spec/controllers/portal/learners_controller_spec.rb
@@ -3,18 +3,18 @@ require File.expand_path('../../../spec_helper', __FILE__)
 describe Portal::LearnersController do
 
   describe "GET report" do
-    let(:physics_investigation) { Factory.create(
+    let(:physics_investigation) { FactoryGirl.create(
         :investigation,
         :name => 'physics_inv',
         :publication_status => 'published') }
 
-    let(:offering) { Factory.create(
+    let(:offering) { FactoryGirl.create(
         :portal_offering,
         runnable_id: physics_investigation.id,
         runnable_type: 'Activity',
         clazz: clazz)}
 
-    let(:clazz)       { Factory.create :portal_clazz, teachers: [teacher] }
+    let(:clazz)       { FactoryGirl.create :portal_clazz, teachers: [teacher] }
     let(:student_id)  { 7 }
     let(:learner_stubs) {{
         student_id: student_id,
@@ -23,8 +23,8 @@ describe Portal::LearnersController do
     }}
     let(:learner)     { mock_model(Portal::Learner, learner_stubs)}
     let(:post_params) { {id: learner.id }      }
-    let(:teacher)     { Factory.create :teacher }
-    let(:teacher_b)   { Factory.create :teacher }
+    let(:teacher)     { FactoryGirl.create :teacher }
+    let(:teacher_b)   { FactoryGirl.create :teacher }
 
     before(:each) do
       sign_in user

--- a/spec/controllers/portal/offerings_controller_spec.rb
+++ b/spec/controllers/portal/offerings_controller_spec.rb
@@ -4,7 +4,7 @@ describe Portal::OfferingsController do
   describe "Show Jnlp Offering" do
     it "renders a jnlp for an admin" do
       offering = Factory(:portal_offering)
-      admin = Factory.next :admin_user
+      admin = FactoryGirl.generate :admin_user
       sign_in admin
       get :show, :id => offering.id, :format => :jnlp
       expect(response).to render_template('shared/_installer')
@@ -74,11 +74,11 @@ describe Portal::OfferingsController do
     before(:each) do
       @mock_school = Factory.create(:portal_school)
 
-      @admin_user = Factory.next(:admin_user)
-      @manager_user = Factory.next(:manager_user)
-      @researcher_user = Factory.next(:researcher_user)
-      @author_user = Factory.next(:author_user)
-      @guest_user = Factory.next(:anonymous_user)
+      @admin_user = FactoryGirl.generate(:admin_user)
+      @manager_user = FactoryGirl.generate(:manager_user)
+      @researcher_user = FactoryGirl.generate(:researcher_user)
+      @author_user = FactoryGirl.generate(:author_user)
+      @guest_user = FactoryGirl.generate(:anonymous_user)
       @student_user = Factory.create(:confirmed_user, :login => "authorized_student")
       @portal_student = Factory.create(:portal_student, :user => @student_user)
       @authorized_teacher = Factory.create(:portal_teacher, :user => Factory.create(:confirmed_user, :login => "authorized_teacher"), :schools => [@mock_school])
@@ -149,7 +149,7 @@ describe Portal::OfferingsController do
 
     let(:clazz)       { Factory.create :portal_clazz, teachers: [teacher] }
     let(:post_params) { {id: offering.id }      }
-    let(:eacher_user) { Factory.next()          }
+    let(:eacher_user) { FactoryGirl.generate()          }
     let(:teacher)     { Factory.create :teacher }
     let(:teacher_b)   { Factory.create :teacher }
 

--- a/spec/controllers/portal/offerings_controller_spec.rb
+++ b/spec/controllers/portal/offerings_controller_spec.rb
@@ -72,16 +72,16 @@ describe Portal::OfferingsController do
 
   describe "POST offering_collapsed_status" do
     before(:each) do
-      @mock_school = Factory.create(:portal_school)
+      @mock_school = FactoryGirl.create(:portal_school)
 
       @admin_user = FactoryGirl.generate(:admin_user)
       @manager_user = FactoryGirl.generate(:manager_user)
       @researcher_user = FactoryGirl.generate(:researcher_user)
       @author_user = FactoryGirl.generate(:author_user)
       @guest_user = FactoryGirl.generate(:anonymous_user)
-      @student_user = Factory.create(:confirmed_user, :login => "authorized_student")
-      @portal_student = Factory.create(:portal_student, :user => @student_user)
-      @authorized_teacher = Factory.create(:portal_teacher, :user => Factory.create(:confirmed_user, :login => "authorized_teacher"), :schools => [@mock_school])
+      @student_user = FactoryGirl.create(:confirmed_user, :login => "authorized_student")
+      @portal_student = FactoryGirl.create(:portal_student, :user => @student_user)
+      @authorized_teacher = FactoryGirl.create(:portal_teacher, :user => FactoryGirl.create(:confirmed_user, :login => "authorized_teacher"), :schools => [@mock_school])
       @authorized_teacher_user = @authorized_teacher.user
       @offering = mock_model(Portal::Offering, :runnable => @runnable, :clazz => @clazz)
       @params = {
@@ -136,22 +136,22 @@ describe Portal::OfferingsController do
   end
 
   describe "GET report" do
-    let(:physics_investigation) { Factory.create(
+    let(:physics_investigation) { FactoryGirl.create(
         :investigation,
         :name => 'physics_inv',
         :publication_status => 'published') }
 
-    let(:offering) { Factory.create(
+    let(:offering) { FactoryGirl.create(
         :portal_offering,
         runnable_id: physics_investigation,
         runnable_type: 'Activity',
         clazz: clazz)}
 
-    let(:clazz)       { Factory.create :portal_clazz, teachers: [teacher] }
+    let(:clazz)       { FactoryGirl.create :portal_clazz, teachers: [teacher] }
     let(:post_params) { {id: offering.id }      }
     let(:eacher_user) { FactoryGirl.generate()          }
-    let(:teacher)     { Factory.create :teacher }
-    let(:teacher_b)   { Factory.create :teacher }
+    let(:teacher)     { FactoryGirl.create :teacher }
+    let(:teacher_b)   { FactoryGirl.create :teacher }
 
     before(:each) do
       sign_in user

--- a/spec/controllers/portal/school_memberships_controller_spec.rb
+++ b/spec/controllers/portal/school_memberships_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Portal::SchoolMembershipsController, type: :controller do
   # TODO: auto-generated
   describe '#show' do
     xit 'GET show' do
-      get :show, id: Factory.create(:school_membership).to_param
+      get :show, id: FactoryGirl.create(:school_membership).to_param
 
       expect(response).to have_http_status(:ok)
     end
@@ -29,7 +29,7 @@ RSpec.describe Portal::SchoolMembershipsController, type: :controller do
   # TODO: auto-generated
   describe '#edit' do
     xit 'GET edit' do
-      get :edit, Factory.create(:school_membership).to_param
+      get :edit, FactoryGirl.create(:school_membership).to_param
 
       expect(response).to have_http_status(:ok)
     end
@@ -56,7 +56,7 @@ RSpec.describe Portal::SchoolMembershipsController, type: :controller do
   # TODO: auto-generated
   describe '#destroy' do
     xit 'DELETE destroy' do
-      delete :destroy, Factory.create(:school_membership).to_param
+      delete :destroy, FactoryGirl.create(:school_membership).to_param
 
       expect(response).to have_http_status(:ok)
     end

--- a/spec/controllers/portal/student_clazzes_controller_spec.rb
+++ b/spec/controllers/portal/student_clazzes_controller_spec.rb
@@ -4,7 +4,7 @@ describe Portal::StudentClazzesController do
   render_views
     
   def mock_clazz(stubs={})
-    mock_clazz = Factory.create(:portal_clazz, stubs) #mock_model(Portal::Clazz)
+    mock_clazz = FactoryGirl.create(:portal_clazz, stubs) #mock_model(Portal::Clazz)
     #mock_clazz.stub!(stubs) unless stubs.empty?
 
     mock_clazz
@@ -12,12 +12,12 @@ describe Portal::StudentClazzesController do
   
   describe "Delete remove a student" do
     before(:each) do
-      @mock_school = Factory.create(:portal_school)
-      @authorized_teacher = Factory.create(:portal_teacher, :user => Factory.create(:confirmed_user, :login => "authorized_teacher"), :schools => [@mock_school])
-      @authorized_student = Factory.create(:portal_student, :user =>Factory.create(:confirmed_user, :login => "authorized_student"))
+      @mock_school = FactoryGirl.create(:portal_school)
+      @authorized_teacher = FactoryGirl.create(:portal_teacher, :user => FactoryGirl.create(:confirmed_user, :login => "authorized_teacher"), :schools => [@mock_school])
+      @authorized_student = FactoryGirl.create(:portal_student, :user =>FactoryGirl.create(:confirmed_user, :login => "authorized_student"))
       
       @mock_clazz_name = "Random Test Class"
-      @mock_course = Factory.create(:portal_course, :name => @mock_clazz_name, :school => @mock_school)
+      @mock_course = FactoryGirl.create(:portal_course, :name => @mock_clazz_name, :school => @mock_school)
       @mock_clazz = mock_clazz({ :name => @mock_clazz_name, :teachers => [@authorized_teacher], :course => @mock_course })
       
       @authorized_student.add_clazz(@mock_clazz)

--- a/spec/controllers/portal/students_controller_spec.rb
+++ b/spec/controllers/portal/students_controller_spec.rb
@@ -39,7 +39,7 @@ describe Portal::StudentsController do
       }
 
       @grade_level = Portal::GradeLevel.create({ :name => "9" }) # default grade level
-      @clazz = Factory.create(:portal_clazz, :class_word => @params_for_creation[:clazz][:class_word])
+      @clazz = FactoryGirl.create(:portal_clazz, :class_word => @params_for_creation[:clazz][:class_word])
     end
 
     def stub_user_with_params(user_attributes = nil)
@@ -196,7 +196,7 @@ describe Portal::StudentsController do
   # TODO: auto-generated
   describe '#status' do
     it 'GET status' do
-      get :status, id: Factory.create(:portal_student).to_param
+      get :status, id: FactoryGirl.create(:portal_student).to_param
 
       expect(response).to have_http_status(406)
     end
@@ -214,7 +214,7 @@ describe Portal::StudentsController do
   # TODO: auto-generated
   describe '#edit' do
     xit 'GET edit' do
-      get :edit, id: Factory.create(:portal_student).to_param
+      get :edit, id: FactoryGirl.create(:portal_student).to_param
 
       expect(response).to have_http_status(:ok)
     end
@@ -223,7 +223,7 @@ describe Portal::StudentsController do
   # TODO: auto-generated
   describe '#update' do
     xit 'PATCH update' do
-      put :update, id: Factory.create(:portal_student).to_param
+      put :update, id: FactoryGirl.create(:portal_student).to_param
 
       expect(response).to have_http_status(:ok)
     end
@@ -232,7 +232,7 @@ describe Portal::StudentsController do
   # TODO: auto-generated
   describe '#destroy' do
     it 'DELETE destroy' do
-      delete :destroy,id: Factory.create(:portal_student).to_param
+      delete :destroy,id: FactoryGirl.create(:portal_student).to_param
 
       expect(response).to have_http_status(:redirect)
     end
@@ -241,7 +241,7 @@ describe Portal::StudentsController do
   # TODO: auto-generated
   describe '#ask_consent' do
     xit 'GET ask_consent' do
-      get :ask_consent, id: Factory.create(:portal_student).to_param
+      get :ask_consent, id: FactoryGirl.create(:portal_student).to_param
 
       expect(response).to have_http_status(:ok)
     end
@@ -250,7 +250,7 @@ describe Portal::StudentsController do
   # TODO: auto-generated
   describe '#update_consent' do
     xit 'GET update_consent' do
-      get :update_consent, id: Factory.create(:portal_student).to_param
+      get :update_consent, id: FactoryGirl.create(:portal_student).to_param
 
       expect(response).to have_http_status(:ok)
     end

--- a/spec/controllers/portal/subjects_controller_spec.rb
+++ b/spec/controllers/portal/subjects_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Portal::SubjectsController, type: :controller do
   # TODO: auto-generated
   describe '#show' do
     it 'GET show' do
-      get :show, id: Factory.create(:portal_subject).to_param
+      get :show, id: FactoryGirl.create(:portal_subject).to_param
 
       expect(response).to have_http_status(:ok)
     end
@@ -34,7 +34,7 @@ RSpec.describe Portal::SubjectsController, type: :controller do
   # TODO: auto-generated
   describe '#edit' do
     it 'GET edit' do
-      get :edit, id: Factory.create(:portal_subject).to_param
+      get :edit, id: FactoryGirl.create(:portal_subject).to_param
 
       expect(response).to have_http_status(:ok)
     end
@@ -61,7 +61,7 @@ RSpec.describe Portal::SubjectsController, type: :controller do
   # TODO: auto-generated
   describe '#destroy' do
     it 'DELETE destroy' do
-      delete :destroy, id: Factory.create(:portal_subject).to_param
+      delete :destroy, id: FactoryGirl.create(:portal_subject).to_param
 
       expect(response).to have_http_status(:redirect)
     end

--- a/spec/controllers/portal/teachers_controller_spec.rb
+++ b/spec/controllers/portal/teachers_controller_spec.rb
@@ -3,10 +3,10 @@ require File.expand_path('../../../spec_helper', __FILE__)
 describe Portal::TeachersController do
   describe "POST create" do
     it "should complain if the login is the same except for case" do
-      school   = Factory.create(:portal_school)
+      school   = FactoryGirl.create(:portal_school)
       selector = double(:portal_selector, :school => school, :valid? => true)
       allow(Portal::SchoolSelector).to receive(:new).and_return(selector) 
-      Factory.create(:user, :login => "tteacher")
+      FactoryGirl.create(:user, :login => "tteacher")
 
       params = {
         :user => {
@@ -34,7 +34,7 @@ describe Portal::TeachersController do
     end
 
     before(:each) do
-      @school   = Factory.create(:portal_school)
+      @school   = FactoryGirl.create(:portal_school)
       @selector = Portal::SchoolSelector.new({
         :country => Portal::SchoolSelector::USA,
         :state   => 'MA'})
@@ -112,7 +112,7 @@ describe Portal::TeachersController do
   # TODO: auto-generated
   describe '#show' do
     it 'GET show' do
-      get :show, id: Factory.create(:portal_teacher).to_param
+      get :show, id: FactoryGirl.create(:portal_teacher).to_param
 
       expect(response).to have_http_status(:redirect)
     end
@@ -121,7 +121,7 @@ describe Portal::TeachersController do
   # TODO: auto-generated
   describe '#edit' do
     it 'GET edit' do
-      get :edit, id: Factory.create(:portal_teacher).to_param
+      get :edit, id: FactoryGirl.create(:portal_teacher).to_param
 
       expect(response).to have_http_status(:redirect)
     end
@@ -130,7 +130,7 @@ describe Portal::TeachersController do
   # TODO: auto-generated
   describe '#update' do
     it 'PATCH update' do
-      put :update, id: Factory.create(:portal_teacher).to_param
+      put :update, id: FactoryGirl.create(:portal_teacher).to_param
 
       expect(response).to have_http_status(:redirect)
     end
@@ -139,7 +139,7 @@ describe Portal::TeachersController do
   # TODO: auto-generated
   describe '#destroy' do
     it 'DELETE destroy' do
-      delete :destroy, id: Factory.create(:portal_teacher).to_param
+      delete :destroy, id: FactoryGirl.create(:portal_teacher).to_param
 
       expect(response).to have_http_status(:redirect)
     end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -5,35 +5,35 @@ describe SearchController do
 
   def make(let); end
 
-  let(:admin_settings)   { Factory.create(:admin_settings, :include_external_activities => false) }
+  let(:admin_settings)   { FactoryGirl.create(:admin_settings, :include_external_activities => false) }
 
-  let(:mock_school)     { Factory.create(:portal_school) }
+  let(:mock_school)     { FactoryGirl.create(:portal_school) }
 
-  let(:teacher_user)    { Factory.create(:confirmed_user, :login => "teacher_user") }
-  let(:teacher)         { Factory.create(:portal_teacher, :user => teacher_user, :schools => [mock_school]) }
+  let(:teacher_user)    { FactoryGirl.create(:confirmed_user, :login => "teacher_user") }
+  let(:teacher)         { FactoryGirl.create(:portal_teacher, :user => teacher_user, :schools => [mock_school]) }
   let(:admin_user)      { FactoryGirl.generate(:admin_user) }
   let(:author_user)     { FactoryGirl.generate(:author_user) }
   let(:manager_user)    { FactoryGirl.generate(:manager_user) }
   let(:researcher_user) { FactoryGirl.generate(:researcher_user) }
 
-  let(:student_user)    { Factory.create(:confirmed_user, :login => "authorized_student") }
-  let(:student)         { Factory.create(:portal_student, :user_id => student_user.id) }
+  let(:student_user)    { FactoryGirl.create(:confirmed_user, :login => "authorized_student") }
+  let(:student)         { FactoryGirl.create(:portal_student, :user_id => student_user.id) }
 
-  let(:physics_investigation)     { Factory.create(:investigation, :name => 'physics_inv', :user => author_user, :publication_status => 'published') }
-  let(:chemistry_investigation)   { Factory.create(:investigation, :name => 'chemistry_inv', :user => author_user, :publication_status => 'published') }
-  let(:biology_investigation)     { Factory.create(:investigation, :name => 'mathematics_inv', :user => author_user, :publication_status => 'published') }
-  let(:mathematics_investigation) { Factory.create(:investigation, :name => 'biology_inv', :user => author_user, :publication_status => 'published') }
-  let(:lines)                     { Factory.create(:investigation, :name => 'lines_inv', :user => author_user, :publication_status => 'published') }
+  let(:physics_investigation)     { FactoryGirl.create(:investigation, :name => 'physics_inv', :user => author_user, :publication_status => 'published') }
+  let(:chemistry_investigation)   { FactoryGirl.create(:investigation, :name => 'chemistry_inv', :user => author_user, :publication_status => 'published') }
+  let(:biology_investigation)     { FactoryGirl.create(:investigation, :name => 'mathematics_inv', :user => author_user, :publication_status => 'published') }
+  let(:mathematics_investigation) { FactoryGirl.create(:investigation, :name => 'biology_inv', :user => author_user, :publication_status => 'published') }
+  let(:lines)                     { FactoryGirl.create(:investigation, :name => 'lines_inv', :user => author_user, :publication_status => 'published') }
 
-  let(:laws_of_motion_activity)  { Factory.create(:activity, :name => 'laws_of_motion_activity' ,:investigation_id => physics_investigation.id, :user => author_user) }
-  let(:fluid_mechanics_activity) { Factory.create(:activity, :name => 'fluid_mechanics_activity' , :investigation_id => physics_investigation.id, :user => author_user) }
-  let(:thermodynamics_activity)  { Factory.create(:activity, :name => 'thermodynamics_activity' , :investigation_id => physics_investigation.id, :user => author_user) }
-  let(:parallel_lines)           { Factory.create(:activity, :name => 'parallel_lines' , :investigation_id => lines.id, :user => author_user) }
+  let(:laws_of_motion_activity)  { FactoryGirl.create(:activity, :name => 'laws_of_motion_activity' ,:investigation_id => physics_investigation.id, :user => author_user) }
+  let(:fluid_mechanics_activity) { FactoryGirl.create(:activity, :name => 'fluid_mechanics_activity' , :investigation_id => physics_investigation.id, :user => author_user) }
+  let(:thermodynamics_activity)  { FactoryGirl.create(:activity, :name => 'thermodynamics_activity' , :investigation_id => physics_investigation.id, :user => author_user) }
+  let(:parallel_lines)           { FactoryGirl.create(:activity, :name => 'parallel_lines' , :investigation_id => lines.id, :user => author_user) }
 
-  let(:external_activity1)   { Factory.create(:external_activity, :name => 'external_1', :url => "http://concord.org", :publication_status => 'published', :is_official => true) }
-  let(:external_activity2)   { Factory.create(:external_activity, :name => 'a_study_in_lines_and_curves', :url => "http://github.com", :publication_status => 'published', :is_official => true) }
+  let(:external_activity1)   { FactoryGirl.create(:external_activity, :name => 'external_1', :url => "http://concord.org", :publication_status => 'published', :is_official => true) }
+  let(:external_activity2)   { FactoryGirl.create(:external_activity, :name => 'a_study_in_lines_and_curves', :url => "http://github.com", :publication_status => 'published', :is_official => true) }
 
-  let(:contributed_activity) { Factory.create(:external_activity, :name => "Copy of external_1", :url => "http://concord.org", :publication_status => 'published', :is_official => false) }
+  let(:contributed_activity) { FactoryGirl.create(:external_activity, :name => "Copy of external_1", :url => "http://concord.org", :publication_status => 'published', :is_official => false) }
 
   let(:all_investigations)    { [physics_investigation, chemistry_investigation, biology_investigation, mathematics_investigation, lines]}
   let(:official_activities)   { [laws_of_motion_activity, fluid_mechanics_activity, thermodynamics_activity, parallel_lines, external_activity1, external_activity2]}
@@ -84,19 +84,19 @@ describe SearchController do
 
   describe "Post get_current_material_unassigned_clazzes" do
 
-    let(:physics_clazz)     { Factory.create(:portal_clazz, :name => 'Physics Clazz', :course => @mock_course,:teachers => [teacher]) }
-    let(:chemistry_clazz)   { Factory.create(:portal_clazz, :name => 'Chemistry Clazz', :course => @mock_course,:teachers => [teacher]) }
-    let(:mathematics_clazz) { Factory.create(:portal_clazz, :name => 'Mathematics Clazz', :course => @mock_course,:teachers => [teacher]) }
+    let(:physics_clazz)     { FactoryGirl.create(:portal_clazz, :name => 'Physics Clazz', :course => @mock_course,:teachers => [teacher]) }
+    let(:chemistry_clazz)   { FactoryGirl.create(:portal_clazz, :name => 'Chemistry Clazz', :course => @mock_course,:teachers => [teacher]) }
+    let(:mathematics_clazz) { FactoryGirl.create(:portal_clazz, :name => 'Mathematics Clazz', :course => @mock_course,:teachers => [teacher]) }
 
     let(:investigations_for_all_clazz) do
-      inv = Factory.create(:investigation, :name => 'investigations_for_all_clazz', :user => author_user, :publication_status => 'published')
+      inv = FactoryGirl.create(:investigation, :name => 'investigations_for_all_clazz', :user => author_user, :publication_status => 'published')
       #assign investigations_for_all_clazz to physics class
       Portal::Offering.where(clazz_id: physics_clazz.id, runnable_type: 'Investigation',runnable_id: inv.id).first_or_create
       inv
     end
 
     let(:activity_for_all_clazz) do
-      act = Factory.create(:activity, :name => 'activity_for_all_clazz' ,:investigation_id => physics_investigation.id, :user => author_user)
+      act = FactoryGirl.create(:activity, :name => 'activity_for_all_clazz' ,:investigation_id => physics_investigation.id, :user => author_user)
       #assign activity_for_all_clazz to physics class
       Portal::Offering.where(clazz_id: physics_clazz.id, runnable_type: 'Activity', runnable_id: act.id).first_or_create
       act
@@ -133,7 +133,7 @@ describe SearchController do
     end
 
     it "should get all the classes to which the activity is not assigned. Material to be assigned is a multiple activity" do
-      another_activity_for_all_clazz = Factory.create(:activity, :name => 'another_activity_for_all_clazz' ,:investigation_id => physics_investigation.id, :user => author_user)
+      another_activity_for_all_clazz = FactoryGirl.create(:activity, :name => 'another_activity_for_all_clazz' ,:investigation_id => physics_investigation.id, :user => author_user)
       post_params = {
         :material_type => 'Activity',
         :material_id => "#{activity_for_all_clazz.id},#{another_activity_for_all_clazz.id}"
@@ -147,11 +147,11 @@ describe SearchController do
   end
   describe "POST add_material_to_clazzes" do
 
-    let(:clazz)         { Factory.create(:portal_clazz,:course => @mock_course,:teachers => [teacher]) }
-    let(:another_clazz) { Factory.create(:portal_clazz,:course => @mock_course,:teachers => [teacher]) }
+    let(:clazz)         { FactoryGirl.create(:portal_clazz,:course => @mock_course,:teachers => [teacher]) }
+    let(:another_clazz) { FactoryGirl.create(:portal_clazz,:course => @mock_course,:teachers => [teacher]) }
 
-    let(:already_assigned_offering) { Factory.create(:portal_offering, :clazz_id=> clazz.id, :runnable_id=> chemistry_investigation.id, :runnable_type => 'Investigation'.classify) }
-    let(:another_assigned_offering) { Factory.create(:portal_offering, :clazz_id=> clazz.id, :runnable_id=> laws_of_motion_activity.id, :runnable_type => 'Investigation'.classify) }
+    let(:already_assigned_offering) { FactoryGirl.create(:portal_offering, :clazz_id=> clazz.id, :runnable_id=> chemistry_investigation.id, :runnable_type => 'Investigation'.classify) }
+    let(:another_assigned_offering) { FactoryGirl.create(:portal_offering, :clazz_id=> clazz.id, :runnable_id=> laws_of_motion_activity.id, :runnable_type => 'Investigation'.classify) }
 
     it "should assign only unassigned investigations to the classes" do
       already_assigned_offering

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -11,10 +11,10 @@ describe SearchController do
 
   let(:teacher_user)    { Factory.create(:confirmed_user, :login => "teacher_user") }
   let(:teacher)         { Factory.create(:portal_teacher, :user => teacher_user, :schools => [mock_school]) }
-  let(:admin_user)      { Factory.next(:admin_user) }
-  let(:author_user)     { Factory.next(:author_user) }
-  let(:manager_user)    { Factory.next(:manager_user) }
-  let(:researcher_user) { Factory.next(:researcher_user) }
+  let(:admin_user)      { FactoryGirl.generate(:admin_user) }
+  let(:author_user)     { FactoryGirl.generate(:author_user) }
+  let(:manager_user)    { FactoryGirl.generate(:manager_user) }
+  let(:researcher_user) { FactoryGirl.generate(:researcher_user) }
 
   let(:student_user)    { Factory.create(:confirmed_user, :login => "authorized_student") }
   let(:student)         { Factory.create(:portal_student, :user_id => student_user.id) }

--- a/spec/controllers/security_questions_controller_spec.rb
+++ b/spec/controllers/security_questions_controller_spec.rb
@@ -4,7 +4,7 @@ describe SecurityQuestionsController do
   render_views
 
   before(:each) do
-    @student = Factory.create(:portal_student, :user => Factory.create(:confirmed_user))
+    @student = FactoryGirl.create(:portal_student, :user => FactoryGirl.create(:confirmed_user))
     sign_in @student.user
     @test_settings = double("settings",:name=> "Test Settings")
     expect(@test_settings).to receive(:use_student_security_questions).and_return(true)

--- a/spec/features/admin_configures_help_page_spec.rb
+++ b/spec/features/admin_configures_help_page_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.feature 'Admin configures help page' do
   before do
-    Factory.create(:admin_settings)
+    FactoryGirl.create(:admin_settings)
     login_as('admin')
     visit admin_settings_path
     first(:link, 'edit settings').click

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -287,7 +287,7 @@ describe ApplicationHelper, type: :helper do
   # TODO: auto-generated
   describe '#learner_report_link_for' do
     xit 'works' do
-      result = helper.learner_report_link_for(Factory.create(:full_portal_learner), 'action', 'link_text', 'title')
+      result = helper.learner_report_link_for(FactoryGirl.create(:full_portal_learner), 'action', 'link_text', 'title')
 
       expect(result).not_to be_nil
     end
@@ -305,7 +305,7 @@ describe ApplicationHelper, type: :helper do
   # TODO: auto-generated
   describe '#alternate_report_link_for' do
     it 'works' do
-      result = helper.alternate_report_link_for(Factory.create(:portal_offering))
+      result = helper.alternate_report_link_for(FactoryGirl.create(:portal_offering))
 
       expect(result).to be_nil
     end
@@ -395,7 +395,7 @@ describe ApplicationHelper, type: :helper do
   # TODO: auto-generated
   describe '#sessions_learner_stat' do
     xit 'works' do
-      result = helper.sessions_learner_stat(Factory.create(:portal_learner))
+      result = helper.sessions_learner_stat(FactoryGirl.create(:portal_learner))
 
       expect(result).not_to be_nil
     end
@@ -404,7 +404,7 @@ describe ApplicationHelper, type: :helper do
   # TODO: auto-generated
   describe '#learner_specific_stats' do
     xit 'works' do
-      result = helper.learner_specific_stats(Factory.create(:portal_learner))
+      result = helper.learner_specific_stats(FactoryGirl.create(:portal_learner))
 
       expect(result).not_to be_nil
     end
@@ -413,7 +413,7 @@ describe ApplicationHelper, type: :helper do
   # TODO: auto-generated
   describe '#report_details_for_learner' do
     xit 'works' do
-      result = helper.report_details_for_learner(Factory.create(:portal_learner))
+      result = helper.report_details_for_learner(FactoryGirl.create(:portal_learner))
 
       expect(result).not_to be_nil
     end
@@ -422,7 +422,7 @@ describe ApplicationHelper, type: :helper do
   # TODO: auto-generated
   describe '#report_correct_count_for_learner' do
     xit 'works' do
-      result = helper.report_correct_count_for_learner(Factory.create(:portal_learner))
+      result = helper.report_correct_count_for_learner(FactoryGirl.create(:portal_learner))
 
       expect(result).not_to be_nil
     end
@@ -449,7 +449,7 @@ describe ApplicationHelper, type: :helper do
   # TODO: auto-generated
   describe '#menu_for_learner' do
     xit 'works' do
-      result = helper.menu_for_learner(Factory.create(:portal_learner), {})
+      result = helper.menu_for_learner(FactoryGirl.create(:portal_learner), {})
 
       expect(result).not_to be_nil
     end

--- a/spec/helpers/jnlp_helper_spec.rb
+++ b/spec/helpers/jnlp_helper_spec.rb
@@ -55,7 +55,7 @@ describe JnlpHelper, type: :helper  do
   # TODO: auto-generated
   describe '#jnlp_splash_url' do
     xit 'works' do
-      result = helper.jnlp_splash_url(Factory.create(:portal_learner))
+      result = helper.jnlp_splash_url(FactoryGirl.create(:portal_learner))
 
       expect(result).not_to be_nil
     end
@@ -91,7 +91,7 @@ describe JnlpHelper, type: :helper  do
   # TODO: auto-generated
   describe '#jnlp_information' do
     xit 'works' do
-      result = helper.jnlp_information('<root/>', Factory.create(:full_portal_learner))
+      result = helper.jnlp_information('<root/>', FactoryGirl.create(:full_portal_learner))
 
       expect(result).not_to be_nil
     end

--- a/spec/helpers/portal/clazzes_helper_spec.rb
+++ b/spec/helpers/portal/clazzes_helper_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Portal::ClazzesHelper, type: :helper do
   # TODO: auto-generated
   describe '#render_portal_clazz_partial' do
     xit 'works' do
-      result = helper.render_portal_clazz_partial('name', Factory.create(:portal_clazz))
+      result = helper.render_portal_clazz_partial('name', FactoryGirl.create(:portal_clazz))
 
       expect(result).not_to be_nil
     end

--- a/spec/helpers/portal/student_clazzes_helper_spec.rb
+++ b/spec/helpers/portal/student_clazzes_helper_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Portal::StudentClazzesHelper, type: :helper do
   # TODO: auto-generated
   describe '#student_add_dropdown' do
     xit 'works' do
-      result = helper.student_add_dropdown(Factory.create(:portal_student))
+      result = helper.student_add_dropdown(FactoryGirl.create(:portal_student))
 
       expect(result).not_to be_nil
     end

--- a/spec/helpers/portal/teachers_helper_spec.rb
+++ b/spec/helpers/portal/teachers_helper_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Portal::TeachersHelper, type: :helper do
   # TODO: auto-generated
   describe '#teacher_add_dropdown' do
     xit 'works' do
-      result = helper.teacher_add_dropdown(Factory.create(:portal_teacher))
+      result = helper.teacher_add_dropdown(FactoryGirl.create(:portal_teacher))
 
       expect(result).not_to be_nil
     end

--- a/spec/helpers/runnables_helper_spec.rb
+++ b/spec/helpers/runnables_helper_spec.rb
@@ -180,7 +180,7 @@ describe RunnablesHelper, type: :helper  do
   # TODO: auto-generated
   describe '#student_run_button_css' do
     it 'works' do
-      result = helper.student_run_button_css(Factory.create(:portal_offering), [])
+      result = helper.student_run_button_css(FactoryGirl.create(:portal_offering), [])
 
       expect(result).not_to be_nil
     end
@@ -252,7 +252,7 @@ describe RunnablesHelper, type: :helper  do
   # TODO: auto-generated
   describe '#preview_button_for' do
     xit 'works' do
-      result = helper.preview_button_for(Factory.create(:portal_offering), {}, img, run_as)
+      result = helper.preview_button_for(FactoryGirl.create(:portal_offering), {}, img, run_as)
 
       expect(result).not_to be_nil
     end
@@ -261,7 +261,7 @@ describe RunnablesHelper, type: :helper  do
   # TODO: auto-generated
   describe '#teacher_preview_button_for' do
     xit 'works' do
-      result = helper.teacher_preview_button_for(Factory.create(:portal_offering))
+      result = helper.teacher_preview_button_for(FactoryGirl.create(:portal_offering))
 
       expect(result).not_to be_nil
     end
@@ -270,7 +270,7 @@ describe RunnablesHelper, type: :helper  do
   # TODO: auto-generated
   describe '#preview_link_for' do
     xit 'works' do
-      result = helper.preview_link_for(Factory.create(:portal_offering))
+      result = helper.preview_link_for(FactoryGirl.create(:portal_offering))
 
       expect(result).not_to be_nil
     end
@@ -279,7 +279,7 @@ describe RunnablesHelper, type: :helper  do
   # TODO: auto-generated
   describe '#offering_link_for' do
     xit 'works' do
-      result = helper.offering_link_for(Factory.create(:portal_offering))
+      result = helper.offering_link_for(FactoryGirl.create(:portal_offering))
 
       expect(result).not_to be_nil
     end

--- a/spec/integration/dataservice/dataservice_buckets_spec.rb
+++ b/spec/integration/dataservice/dataservice_buckets_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe "Dataservice Buckets" do
   before :each do
     # set up a learner
-    student = Factory.create(:portal_student)
-    offering = Factory.create(:portal_offering)
-    @learner = Factory.create(:portal_learner, :student => student, :offering => offering)
+    student = FactoryGirl.create(:portal_student)
+    offering = FactoryGirl.create(:portal_offering)
+    @learner = FactoryGirl.create(:portal_learner, :student => student, :offering => offering)
   end
 
   it 'should deliver empty bucket data when no bucket contents exist' do

--- a/spec/integration/sign_in_redirect_spec.rb
+++ b/spec/integration/sign_in_redirect_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe "when user signs in and 'after_sign_in_path' parameter is provided" do
-  let(:user) { Factory.create(:confirmed_user) }
+  let(:user) { FactoryGirl.create(:confirmed_user) }
   let(:custom_url) { "/some-foo-bar-path" }
 
   it "user is redirected back to this page with extra param" do
@@ -10,7 +10,7 @@ describe "when user signs in and 'after_sign_in_path' parameter is provided" do
   end
 
   describe "and user is student" do
-    let(:user) { Factory.create(:full_portal_student).user }
+    let(:user) { FactoryGirl.create(:full_portal_student).user }
 
     it "user is sent to my classes" do
       post "/users/sign_in", user: {login: user.login, password: user.password}, after_sign_in_path: custom_url

--- a/spec/libs/activity_runtime_api_spec.rb
+++ b/spec/libs/activity_runtime_api_spec.rb
@@ -195,35 +195,35 @@ describe ActivityRuntimeAPI do
   end
 
   let(:investigation) do
-    Factory.create(:investigation,
+    FactoryGirl.create(:investigation,
                    :user => user
     )
   end
 
-  let(:multiple_choice) { Factory.create(:multiple_choice) }
-  let(:open_response)   { Factory.create(:open_response)   }
-  let(:image_question)  { Factory.create(:image_question)  }
-  let(:iframe)          { Factory.create(:embeddable_iframe)  }
+  let(:multiple_choice) { FactoryGirl.create(:multiple_choice) }
+  let(:open_response)   { FactoryGirl.create(:open_response)   }
+  let(:image_question)  { FactoryGirl.create(:image_question)  }
+  let(:iframe)          { FactoryGirl.create(:embeddable_iframe)  }
 
   let(:page) do
-    Factory.create(:page,
+    FactoryGirl.create(:page,
       :page_elements => [
-        Factory.create(:page_element, :embeddable => multiple_choice),
-        Factory.create(:page_element, :embeddable => open_response),
-        Factory.create(:page_element, :embeddable => image_question),
-        Factory.create(:page_element, :embeddable => iframe)
+        FactoryGirl.create(:page_element, :embeddable => multiple_choice),
+        FactoryGirl.create(:page_element, :embeddable => open_response),
+        FactoryGirl.create(:page_element, :embeddable => image_question),
+        FactoryGirl.create(:page_element, :embeddable => iframe)
       ]
     )
   end
 
   let(:section)do
-    Factory.create(:section,
+    FactoryGirl.create(:section,
       :pages => [page]
     )
   end
 
   let(:template) do
-    Factory.create(:activity,
+    FactoryGirl.create(:activity,
       :investigation => investigation,
       :sections => [section]
     )
@@ -237,7 +237,7 @@ describe ActivityRuntimeAPI do
     }
   end
 
-  let(:sequence_template) { Factory.create(:investigation) }
+  let(:sequence_template) { FactoryGirl.create(:investigation) }
 
   let(:existing_sequence_stubs) do
     {
@@ -247,17 +247,17 @@ describe ActivityRuntimeAPI do
     }
   end
 
-  let(:existing){ Factory.create(:external_activity, exist_stubs) }
+  let(:existing){ FactoryGirl.create(:external_activity, exist_stubs) }
 
-  let(:existing_sequence) { Factory.create(:external_activity, existing_sequence_stubs) }
+  let(:existing_sequence) { FactoryGirl.create(:external_activity, existing_sequence_stubs) }
 
   let(:existing_locked_sequence) {
     locked_sequence_properties = existing_sequence_stubs
     locked_sequence_properties[:is_locked] = true
-    Factory.create(:external_activity, locked_sequence_properties)
+    FactoryGirl.create(:external_activity, locked_sequence_properties)
   }
 
-  let(:user)    { Factory.create(:user) }
+  let(:user)    { FactoryGirl.create(:user) }
 
 
   describe "publish_activity" do
@@ -334,7 +334,7 @@ describe ActivityRuntimeAPI do
 
       describe "updating an existing open response" do
         let(:open_response) do
-          Factory.create(:open_response,
+          FactoryGirl.create(:open_response,
             :prompt => "the original prompt",  # this will be replaced as the test runs.
             :is_required => false,             # this will be replaced as the test runs.
             :show_in_featured_question_report => false, # this will be replaced as the test runs.
@@ -353,7 +353,7 @@ describe ActivityRuntimeAPI do
 
       describe "updating an existing image question" do
         let(:image_question) do
-          Factory.create(:image_question,
+          FactoryGirl.create(:image_question,
             :drawing_prompt => '',
             :prompt => "the original prompt",  # this will be replaced as the test runs.
             :is_required => false,             # this will be replaced as the test runs.
@@ -373,7 +373,7 @@ describe ActivityRuntimeAPI do
 
       describe "updating an existing embeddable iframe" do
         let(:iframe) do
-          Factory.create(:embeddable_iframe,
+          FactoryGirl.create(:embeddable_iframe,
             :url => "http://original.url",  # this will be replaced as the test runs.
             :is_required => false,          # this will be replaced as the test runs.
             :show_in_featured_question_report => false, # this will be replaced as the test runs.
@@ -393,13 +393,13 @@ describe ActivityRuntimeAPI do
 
       describe "updating an existing multiple choice" do
         let(:choice) do
-          Factory.create(:multiple_choice_choice,
+          FactoryGirl.create(:multiple_choice_choice,
             :choice => "this was an original choice",
             :external_id => "232323"
           )
         end
         let(:other_choice) do
-          Factory.create(:multiple_choice_choice,
+          FactoryGirl.create(:multiple_choice_choice,
             :choice => "this choice should be deleted",
             :external_id => "something_not_in_the_hash"
           )
@@ -409,7 +409,7 @@ describe ActivityRuntimeAPI do
         end
 
         let(:multiple_choice) do
-          Factory.create(:multiple_choice,
+          FactoryGirl.create(:multiple_choice,
             :prompt => "the original prompt",
             :external_id => "456789",
             :is_required => false,

--- a/spec/libs/bearer_token/bearer_token_authenticatable_spec.rb
+++ b/spec/libs/bearer_token/bearer_token_authenticatable_spec.rb
@@ -46,12 +46,12 @@ describe BearerTokenAuthenticatable::BearerToken do
   let(:learner_headers) { {"Authorization" => "Bearer #{learner_token}"} }
   let(:teacher_headers) { {"Authorization" => "Bearer #{teacher_token}"} }
   let(:user)            { FactoryGirl.create(:user) }
-  let(:runnable)        { Factory.create(:activity, runnable_opts)    }
+  let(:runnable)        { FactoryGirl.create(:activity, runnable_opts)    }
   let(:offering)        { Factory(:portal_offering, offering_opts)    }
   let(:clazz)           { Factory(:portal_clazz, teachers: [class_teacher], students:[student]) }
   let(:offering_opts)   { {clazz: clazz, runnable: runnable}  }
   let(:runnable_opts)   { {name: 'the activity'}              }
-  let(:class_teacher)   { Factory.create(:portal_teacher)     }
+  let(:class_teacher)   { FactoryGirl.create(:portal_teacher)     }
   let(:student)         { FactoryGirl.create(:full_portal_student) }
   let(:learner)         { Portal::Learner.where(offering_id: offering.id, student_id: student.id).first_or_create }
   let(:params)          { {} }

--- a/spec/libs/changeable_spec.rb
+++ b/spec/libs/changeable_spec.rb
@@ -4,13 +4,13 @@ require 'spec_helper'
 
 RSpec.describe Changeable do
 
-  let(:object) { Factory.create(:activity) }
+  let(:object) { FactoryGirl.create(:activity) }
   
   # TODO: auto-generated
   describe '#changeable?' do
     it 'changeable?' do
       changeable = object
-      user = Factory.create(:user)
+      user = FactoryGirl.create(:user)
       result = changeable.changeable?(user)
 
       expect(result).not_to be_nil

--- a/spec/libs/materials/data_helpers_spec.rb
+++ b/spec/libs/materials/data_helpers_spec.rb
@@ -8,7 +8,7 @@ end
 
 describe DataHelpersTestController, type: :controller do
   let(:sensor_names) { ["Temperature", "Light"] }
-  let(:material_a) { Factory.create(:external_activity, sensor_list: sensor_names) }
+  let(:material_a) { FactoryGirl.create(:external_activity, sensor_list: sensor_names) }
   let(:materials)  { [material_a] }
 
   describe "#materials_data" do

--- a/spec/libs/noteable_spec.rb
+++ b/spec/libs/noteable_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe Noteable do
 
 
-  let(:noteable) { Factory.create(:activity) }
+  let(:noteable) { FactoryGirl.create(:activity) }
   # TODO: auto-generated
   describe '#teacher_note' do
     it 'teacher_note' do

--- a/spec/libs/user_deleter_spec.rb
+++ b/spec/libs/user_deleter_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe UserDeleter do
     it 'delete_student' do
       options = double('options')
       user_deleter = described_class.new(options)
-      user = Factory.create(:user)
+      user = FactoryGirl.create(:user)
       result = user_deleter.delete_student(user)
 
       expect(result).to be_nil
@@ -69,7 +69,7 @@ RSpec.describe UserDeleter do
     it 'delete_clazzes' do
       options = double('options')
       user_deleter = described_class.new(options)
-      user = Factory.create(:user)
+      user = FactoryGirl.create(:user)
       result = user_deleter.delete_clazzes(user)
 
       expect(result).to be_nil

--- a/spec/models/about_page_spec.rb
+++ b/spec/models/about_page_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe AboutPage, type: :model do
   # TODO: auto-generated
   describe '#content' do
     it 'content' do
-      user = Factory.create(:user)
+      user = FactoryGirl.create(:user)
       settings = double('settings')
       preview_content = double('preview_content')
       about_page = described_class.new(user, settings, preview_content)
@@ -22,7 +22,7 @@ RSpec.describe AboutPage, type: :model do
   # TODO: auto-generated
   describe '#view_options' do
     it 'view_options' do
-      user = Factory.create(:user)
+      user = FactoryGirl.create(:user)
       settings = double('settings')
       preview_content = double('preview_content')
       about_page = described_class.new(user, settings, preview_content)

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -41,22 +41,22 @@ describe Activity do
 
   describe "search_list (searching for activity)" do
     # Preserving these "let" blocks temporarily in case we need them to set up a structure to test elsewhere - pjm 2013/10/08
-    let (:bio) { Factory.create( :rigse_domain, { :name => "biology" } ) }
+    let (:bio) { FactoryGirl.create( :rigse_domain, { :name => "biology" } ) }
     let (:seven) { "7" }
     let (:eight) { "8" }
 
-    let (:bio_ks) { Factory.create( :rigse_knowledge_statement, { :domain => bio } ) }
-    let (:bio_at) { Factory.create( :rigse_assessment_target, { :knowledge_statement => bio_ks } ) }
+    let (:bio_ks) { FactoryGirl.create( :rigse_knowledge_statement, { :domain => bio } ) }
+    let (:bio_at) { FactoryGirl.create( :rigse_assessment_target, { :knowledge_statement => bio_ks } ) }
 
-    let (:physics) { Factory.create( :rigse_domain, { :name => "physics" } ) }
-    let (:physics_ks) { Factory.create( :rigse_knowledge_statement, { :domain => physics } ) }
-    let (:physics_at) { Factory.create( :rigse_assessment_target, { :knowledge_statement => physics_ks }) }
+    let (:physics) { FactoryGirl.create( :rigse_domain, { :name => "physics" } ) }
+    let (:physics_ks) { FactoryGirl.create( :rigse_knowledge_statement, { :domain => physics } ) }
+    let (:physics_at) { FactoryGirl.create( :rigse_assessment_target, { :knowledge_statement => physics_ks }) }
 
-    let (:physics_gse_grade7) { Factory.create( :rigse_grade_span_expectation, { :assessment_target => physics_at, :grade_span => seven } ) }
-    let (:physics_gse_grade8) { Factory.create( :rigse_grade_span_expectation, { :assessment_target => physics_at, :grade_span => eight } ) }
+    let (:physics_gse_grade7) { FactoryGirl.create( :rigse_grade_span_expectation, { :assessment_target => physics_at, :grade_span => seven } ) }
+    let (:physics_gse_grade8) { FactoryGirl.create( :rigse_grade_span_expectation, { :assessment_target => physics_at, :grade_span => eight } ) }
 
-    let (:bio_gse_grade7)     { Factory.create( :rigse_grade_span_expectation, { :assessment_target => bio_at, :grade_span => seven } ) }
-    let (:bio_gse_grade8)     { Factory.create( :rigse_grade_span_expectation, { :assessment_target => bio_at, :grade_span => eight } ) }
+    let (:bio_gse_grade7)     { FactoryGirl.create( :rigse_grade_span_expectation, { :assessment_target => bio_at, :grade_span => seven } ) }
+    let (:bio_gse_grade8)     { FactoryGirl.create( :rigse_grade_span_expectation, { :assessment_target => bio_at, :grade_span => eight } ) }
 
     let (:invs) do
       [
@@ -82,7 +82,7 @@ describe Activity do
     let (:published) do
       pub = []
       invs.each do |inv|
-        investigation = Factory.create(:investigation, inv)
+        investigation = FactoryGirl.create(:investigation, inv)
         investigation.name << " (published) "
         investigation.publish!
         investigation.save
@@ -94,20 +94,20 @@ describe Activity do
     let (:drafts) do
       dra = []
       published.each do |inv|
-        published_activity = Factory.create(:activity, :name => "activity for #{inv.name}" ,:investigation_id => inv.id)
-        draft = Factory.create(:investigation, :name => inv.name, :grade_span_expectation => inv.grade_span_expectation)
+        published_activity = FactoryGirl.create(:activity, :name => "activity for #{inv.name}" ,:investigation_id => inv.id)
+        draft = FactoryGirl.create(:investigation, :name => inv.name, :grade_span_expectation => inv.grade_span_expectation)
         draft.name << " (draft) "
         draft.save
         dra << draft.reload
-        drafts_activity = Factory.create(:activity, :name => "activity for #{draft.name}" ,:investigation_id => draft.id)
+        drafts_activity = FactoryGirl.create(:activity, :name => "activity for #{draft.name}" ,:investigation_id => draft.id)
       end
       dra
     end
 
-    let (:public_non_gse)          { Factory.create(:investigation, :name => "published non-gse investigation", :publication_status => 'Published') }
-    let (:public_non_gse_activity) { Factory.create(:activity, :name => "activity for #{public_non_gse.name}" ,:investigation_id => public_non_gse.id) }
-    let (:draft_non_gse)           { Factory.create(:investigation, :name => "draft non-gse investigation") } 
-    let (:draft_non_gse_activity)  { Factory.create(:activity, :name => "activity for #{draft_non_gse.name}" ,:investigation_id => draft_non_gse.id) }
+    let (:public_non_gse)          { FactoryGirl.create(:investigation, :name => "published non-gse investigation", :publication_status => 'Published') }
+    let (:public_non_gse_activity) { FactoryGirl.create(:activity, :name => "activity for #{public_non_gse.name}" ,:investigation_id => public_non_gse.id) }
+    let (:draft_non_gse)           { FactoryGirl.create(:investigation, :name => "draft non-gse investigation") } 
+    let (:draft_non_gse_activity)  { FactoryGirl.create(:activity, :name => "activity for #{draft_non_gse.name}" ,:investigation_id => draft_non_gse.id) }
   end
 
   describe "#is_template method" do
@@ -116,7 +116,7 @@ describe Activity do
     let(:investigation)        { nil }
     let(:external_activities)  { [] }
     subject do
-      s = Factory.create(:activity)
+      s = FactoryGirl.create(:activity)
       allow(s).to receive_messages(:investigation => investigation)
       allow(s).to receive_messages(:external_activities => external_activities)
       s.is_template
@@ -145,12 +145,12 @@ describe Activity do
 
   describe '#is_template scope' do
     before(:each) do
-      e1 = Factory.create(:external_activity)
-      e2 = Factory.create(:external_activity)
-      i = Factory.create(:investigation, external_activities: [e2])
-      @a1 = Factory.create(:activity)
-      @a2 = Factory.create(:activity, external_activities: [e1])
-      @a3 = Factory.create(:activity, investigation: i)
+      e1 = FactoryGirl.create(:external_activity)
+      e2 = FactoryGirl.create(:external_activity)
+      i = FactoryGirl.create(:investigation, external_activities: [e2])
+      @a1 = FactoryGirl.create(:activity)
+      @a2 = FactoryGirl.create(:activity, external_activities: [e1])
+      @a3 = FactoryGirl.create(:activity, investigation: i)
     end
 
     it 'should return activities which are not templates if provided argument is false' do
@@ -170,9 +170,9 @@ describe Activity do
       allow(activity_with_questions).to receive(:reportable_elements).and_return(elements)
     end
     let(:activity_with_questions) { activity }
-    let(:mc_question)         {Factory.create(:multiple_choice) }
-    let(:or_question)         {Factory.create(:open_response)   }
-    let(:another_or_question) {Factory.create(:open_response)   }
+    let(:mc_question)         {FactoryGirl.create(:multiple_choice) }
+    let(:or_question)         {FactoryGirl.create(:open_response)   }
+    let(:another_or_question) {FactoryGirl.create(:open_response)   }
     let(:elements) {[
       {:activity => activity_with_questions, :embeddable => mc_question},
       {:activity => activity_with_questions, :embeddable => or_question}
@@ -197,7 +197,7 @@ describe Activity do
   end
 
   describe "project support" do
-    let (:activity) { Factory.create(:external_activity) }
+    let (:activity) { FactoryGirl.create(:external_activity) }
     let (:project) { FactoryGirl.create(:project) }
 
     it "can be assigned to a project" do
@@ -347,7 +347,7 @@ describe Activity do
   describe '#question_number' do
     it 'question_number' do
       activity = described_class.new
-      embeddable = Factory.create(:open_response)
+      embeddable = FactoryGirl.create(:open_response)
       result = activity.question_number(embeddable)
 
       expect(result).not_to be_nil

--- a/spec/models/admin/project_spec.rb
+++ b/spec/models/admin/project_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Admin::Project, type: :model do
   describe '#changeable?' do
     it 'changeable?' do
       project = described_class.new
-      user = Factory.create(:user)
+      user = FactoryGirl.create(:user)
       result = project.changeable?(user)
 
       expect(result).not_to be_nil

--- a/spec/models/admin/site_notice_spec.rb
+++ b/spec/models/admin/site_notice_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Admin::SiteNotice do
   describe "Display notices for different users" do
     before(:each) do
-      @admin_user = Factory.next(:admin_user)
+      @admin_user = FactoryGirl.generate(:admin_user)
 
       role = Role.find_by_title('admin')
       @first_notice = Factory.create(:site_notice, :created_by => @admin_user.id)

--- a/spec/models/admin/site_notice_spec.rb
+++ b/spec/models/admin/site_notice_spec.rb
@@ -6,14 +6,14 @@ describe Admin::SiteNotice do
       @admin_user = FactoryGirl.generate(:admin_user)
 
       role = Role.find_by_title('admin')
-      @first_notice = Factory.create(:site_notice, :created_by => @admin_user.id)
-      Factory.create(:site_notice_role, :notice_id => @first_notice.id,:role_id => role.id)
+      @first_notice = FactoryGirl.create(:site_notice, :created_by => @admin_user.id)
+      FactoryGirl.create(:site_notice_role, :notice_id => @first_notice.id,:role_id => role.id)
 
-      @second_notice = Factory.create(:site_notice, :created_by => @admin_user.id)
-      Factory.create(:site_notice_role, :notice_id => @second_notice.id,:role_id => role.id)
+      @second_notice = FactoryGirl.create(:site_notice, :created_by => @admin_user.id)
+      FactoryGirl.create(:site_notice_role, :notice_id => @second_notice.id,:role_id => role.id)
 
-      @third_notice = Factory.create(:site_notice, :created_by => @admin_user.id)
-      Factory.create(:site_notice_role, :notice_id => @third_notice.id,:role_id => role.id)
+      @third_notice = FactoryGirl.create(:site_notice, :created_by => @admin_user.id)
+      FactoryGirl.create(:site_notice_role, :notice_id => @third_notice.id,:role_id => role.id)
 
     end
     it"should show no notice if there is no notice" do
@@ -34,7 +34,7 @@ describe Admin::SiteNotice do
       assert(notice_ids.include?(@third_notice.id))
     end
     it"should not show dismissed notices" do
-      Factory.create(:site_notice_user, :notice_id => @first_notice.id,:user_id => @admin_user.id, :notice_dismissed => true)
+      FactoryGirl.create(:site_notice_user, :notice_id => @first_notice.id,:user_id => @admin_user.id, :notice_dismissed => true)
       notices_hash = Admin::SiteNotice.get_notices_for_user(@admin_user)
       expect(notices_hash[:notice_display_type] ).to eq(Admin::SiteNotice.NOTICE_DISPLAY_TYPES[:new_notices])
 
@@ -45,7 +45,7 @@ describe Admin::SiteNotice do
       assert(notice_ids.include?(@third_notice.id))
     end
     it"should show collapsed notice container if there are no recent notices and user had collapsed the notice container" do
-      Factory.create(:notice_user_display_status,:user_id => @admin_user.id,:last_collapsed_at_time => DateTime.now + 1.day, :collapsed_status => true)
+      FactoryGirl.create(:notice_user_display_status,:user_id => @admin_user.id,:last_collapsed_at_time => DateTime.now + 1.day, :collapsed_status => true)
       notices_hash = Admin::SiteNotice.get_notices_for_user(@admin_user)
       expect(notices_hash[:notice_display_type] ).to eq(Admin::SiteNotice.NOTICE_DISPLAY_TYPES[:collapsed_notices])
 
@@ -70,7 +70,7 @@ describe Admin::SiteNotice do
   # TODO: auto-generated
   describe '.get_notices_for_user' do
     it 'get_notices_for_user' do
-      user = Factory.create(:user)
+      user = FactoryGirl.create(:user)
       result = described_class.get_notices_for_user(user)
 
       expect(result).not_to be_nil

--- a/spec/models/api/v1/report_spec.rb
+++ b/spec/models/api/v1/report_spec.rb
@@ -446,7 +446,7 @@ describe API::V1::Report do
     xit 'is_teacher?' do
       options = {}
       report = described_class.new(options)
-      user = Factory.create(:user)
+      user = FactoryGirl.create(:user)
       result = report.is_teacher?(user)
 
       expect(result).not_to be_nil
@@ -458,7 +458,7 @@ describe API::V1::Report do
     xit 'is_student?' do
       options = {}
       report = described_class.new(options)
-      user = Factory.create(:user)
+      user = FactoryGirl.create(:user)
       result = report.is_student?(user)
 
       expect(result).not_to be_nil
@@ -470,7 +470,7 @@ describe API::V1::Report do
     xit 'is_report_for_student?' do
       options = {}
       report = described_class.new(options)
-      user = Factory.create(:user)
+      user = FactoryGirl.create(:user)
       result = report.is_report_for_student?(user)
 
       expect(result).not_to be_nil
@@ -589,7 +589,7 @@ describe API::V1::Report do
     xit 'investigation_json' do
       options = {}
       report = described_class.new(options)
-      investigation = Factory.create(:investigation)
+      investigation = FactoryGirl.create(:investigation)
       answers = {}
       associations_to_load = double('associations_to_load')
       result = report.investigation_json(investigation, answers, associations_to_load)
@@ -657,7 +657,7 @@ describe API::V1::Report do
       options = {}
       report = described_class.new(options)
       question_number = double('question_number')
-      embeddable = Factory.create(:open_response)
+      embeddable = FactoryGirl.create(:open_response)
       answers = {}
       result = report.embeddable_json(question_number, embeddable, answers)
 
@@ -671,7 +671,7 @@ describe API::V1::Report do
       options = {}
       report = described_class.new(options)
       hash = double('hash')
-      embeddable = Factory.create(:open_response)
+      embeddable = FactoryGirl.create(:open_response)
       result = report.process_multiple_choice(hash, embeddable)
 
       expect(result).not_to be_nil
@@ -684,7 +684,7 @@ describe API::V1::Report do
       options = {}
       report = described_class.new(options)
       hash = double('hash')
-      embeddable = Factory.create(:open_response)
+      embeddable = FactoryGirl.create(:open_response)
       result = report.process_iframe(hash, embeddable)
 
       expect(result).not_to be_nil
@@ -738,7 +738,7 @@ describe API::V1::Report do
   # TODO: auto-generated
   describe '.embeddable_key' do
     xit 'embeddable_key' do
-      embeddable = Factory.create(:open_response)
+      embeddable = FactoryGirl.create(:open_response)
       result = described_class.embeddable_key(embeddable)
 
       expect(result).not_to be_nil
@@ -768,7 +768,7 @@ describe API::V1::Report do
   # TODO: auto-generated
   describe '.update_feedback_settings' do
     xit 'update_feedback_settings' do
-      offering = Factory.create(:portal_offering)
+      offering = FactoryGirl.create(:portal_offering)
       feedback_settings = double('feedback_settings')
       result = described_class.update_feedback_settings(offering, feedback_settings)
 

--- a/spec/models/api/v1/user_registration_spec.rb
+++ b/spec/models/api/v1/user_registration_spec.rb
@@ -21,7 +21,7 @@ describe API::V1::UserRegistration do
   describe '#set_user' do
     it 'set_user' do
       user_registration = described_class.new
-      user = Factory.create(:user)
+      user = FactoryGirl.create(:user)
       result = user_registration.set_user(user)
 
       expect(result).not_to be_nil

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -107,7 +107,7 @@ describe Client do
   describe '#updated_grant_for' do
     xit 'updated_grant_for' do
       client = described_class.new
-      user = Factory.create(:user)
+      user = FactoryGirl.create(:user)
       time_to_live = double('time_to_live')
       result = client.updated_grant_for(user, time_to_live)
 

--- a/spec/models/commons_license_spec.rb
+++ b/spec/models/commons_license_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 
 RSpec.describe CommonsLicense, type: :model do
 
-  let(:license) { Factory.create(:commons_license) }
+  let(:license) { FactoryGirl.create(:commons_license) }
 
 
   # TODO: auto-generated

--- a/spec/models/dataservice/process_external_activity_data_job_spec.rb
+++ b/spec/models/dataservice/process_external_activity_data_job_spec.rb
@@ -105,7 +105,7 @@ describe Dataservice::ProcessExternalActivityDataJob do
       _content = double('_content')
       process_external_activity_data_job = described_class.new(_learner_id, _content)
       data = {}
-      embeddable = Factory.create(:open_response)
+      embeddable = FactoryGirl.create(:open_response)
       result = process_external_activity_data_job.internal_process_open_response(data, embeddable)
 
       expect(result).not_to be_nil
@@ -119,7 +119,7 @@ describe Dataservice::ProcessExternalActivityDataJob do
       _content = double('_content')
       process_external_activity_data_job = described_class.new(_learner_id, _content)
       data = {}
-      embeddable = Factory.create(:open_response)
+      embeddable = FactoryGirl.create(:open_response)
       result = process_external_activity_data_job.internal_process_multiple_choice(data, embeddable)
 
       expect(result).not_to be_nil
@@ -133,7 +133,7 @@ describe Dataservice::ProcessExternalActivityDataJob do
       _content = double('_content')
       process_external_activity_data_job = described_class.new(_learner_id, _content)
       data = double('data')
-      embeddable = Factory.create(:open_response)
+      embeddable = FactoryGirl.create(:open_response)
       result = process_external_activity_data_job.internal_process_image_question(data, embeddable)
 
       expect(result).not_to be_nil
@@ -147,7 +147,7 @@ describe Dataservice::ProcessExternalActivityDataJob do
       _content = double('_content')
       process_external_activity_data_job = described_class.new(_learner_id, _content)
       data = {}
-      embeddable = Factory.create(:open_response)
+      embeddable = FactoryGirl.create(:open_response)
       result = process_external_activity_data_job.internal_process_external_link(data, embeddable)
 
       expect(result).not_to be_nil
@@ -161,7 +161,7 @@ describe Dataservice::ProcessExternalActivityDataJob do
       _content = double('_content')
       process_external_activity_data_job = described_class.new(_learner_id, _content)
       data = double('data')
-      embeddable = Factory.create(:open_response)
+      embeddable = FactoryGirl.create(:open_response)
       result = process_external_activity_data_job.internal_process_interactive(data, embeddable)
 
       expect(result).not_to be_nil

--- a/spec/models/default_report_service_spec.rb
+++ b/spec/models/default_report_service_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe DefaultReportService do
     it 'url_for' do
       default_report_service = described_class.new
       api_offering_url = double('api_offering_url')
-      user = Factory.create(:user)
+      user = FactoryGirl.create(:user)
       result = default_report_service.url_for(api_offering_url, user)
 
       expect(result).not_to be_nil

--- a/spec/models/embeddable/multiple_choice_spec.rb
+++ b/spec/models/embeddable/multiple_choice_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Embeddable::MultipleChoice, type: :model do
   describe '#by_offering' do
     xit 'by_offering' do
       multiple_choice = described_class.new
-      offering = Factory.create(:portal_offering)
+      offering = FactoryGirl.create(:portal_offering)
       result = multiple_choice.by_offering(offering)
 
       expect(result).not_to be_nil

--- a/spec/models/embeddable/open_response_spec.rb
+++ b/spec/models/embeddable/open_response_spec.rb
@@ -36,7 +36,7 @@ describe Embeddable::OpenResponse do
   describe '#by_offering' do
     xit 'by_offering' do
       open_response = described_class.new
-      offering = Factory.create(:portal_offering)
+      offering = FactoryGirl.create(:portal_offering)
       result = open_response.by_offering(offering)
 
       expect(result).not_to be_nil

--- a/spec/models/external_activity_spec.rb
+++ b/spec/models/external_activity_spec.rb
@@ -297,7 +297,7 @@ describe ExternalActivity do
   # TODO: auto-generated
   describe '.by_user' do # scope test
     it 'supports named scope by_user' do
-      expect(described_class.limit(3).by_user(Factory.create(:user))).to all(be_a(described_class))
+      expect(described_class.limit(3).by_user(FactoryGirl.create(:user))).to all(be_a(described_class))
     end
   end
   # TODO: auto-generated

--- a/spec/models/external_report_spec.rb
+++ b/spec/models/external_report_spec.rb
@@ -1,13 +1,13 @@
 require File.expand_path('../../spec_helper', __FILE__)
 
 describe ExternalReport do
-  let(:runnable)        { Factory.create(:external_activity) }
+  let(:runnable)        { FactoryGirl.create(:external_activity) }
   let(:args)            { {runnable: runnable} }
-  let(:offering)        { Factory.create(:portal_offering, args) }
-  let(:external_report) { Factory.create(:external_report,
+  let(:offering)        { FactoryGirl.create(:portal_offering, args) }
+  let(:external_report) { FactoryGirl.create(:external_report,
     url: 'https://example.com?cool=true'
     )}
-  let(:portal_teacher)  { Factory.create(:portal_teacher)}
+  let(:portal_teacher)  { FactoryGirl.create(:portal_teacher)}
 
   describe "#url_for_offering" do
     subject { external_report.url_for_offering(offering, portal_teacher.user, 'https', 'perfect.host.com') }
@@ -74,7 +74,7 @@ describe ExternalReport do
   # TODO: auto-generated
   describe '#url_for_offering' do
     xit 'url_for_offering' do
-      user = Factory.create(:user)
+      user = FactoryGirl.create(:user)
       protocol = double('protocol')
       host = double('host')
       result = external_report.url_for_offering(offering, user, protocol, host)
@@ -87,7 +87,7 @@ describe ExternalReport do
   describe '#url_for_class' do
     xit 'url_for_class' do
       class_id = double('class_id')
-      user = Factory.create(:user)
+      user = FactoryGirl.create(:user)
       protocol = double('protocol')
       host = double('host')
       result = external_report.url_for_class(class_id, user, protocol, host)

--- a/spec/models/home_page_spec.rb
+++ b/spec/models/home_page_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe HomePage do
-  let(:user) { Factory.create(:user) }
+  let(:user) { FactoryGirl.create(:user) }
 
   # TODO: auto-generated
   describe '#redirect' do

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -191,7 +191,7 @@ describe Image do
   # TODO: auto-generated
   describe '.by_user' do # scope test
     it 'supports named scope by_user' do
-      expect(described_class.limit(3).by_user(Factory.create(:user))).to all(be_a(described_class))
+      expect(described_class.limit(3).by_user(FactoryGirl.create(:user))).to all(be_a(described_class))
     end
   end
   # TODO: auto-generated
@@ -240,7 +240,7 @@ describe Image do
   # TODO: auto-generated
   describe '.can_be_created_by?' do
     xit 'can_be_created_by?' do
-      user = Factory.create(:user)
+      user = FactoryGirl.create(:user)
       result = described_class.can_be_created_by?(user)
 
       expect(result).not_to be_nil

--- a/spec/models/import/import_spec.rb
+++ b/spec/models/import/import_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Import::Import, type: :model do
   describe '#send_mail' do
     xit 'send_mail' do
       import = described_class.new
-      user = Factory.create(:user)
+      user = FactoryGirl.create(:user)
       result = import.send_mail(user)
 
       expect(result).not_to be_nil

--- a/spec/models/investigation_spec.rb
+++ b/spec/models/investigation_spec.rb
@@ -167,9 +167,9 @@ describe Investigation do
         :name => "test investigation",
         :description => "new decription"
       } }
-    let (:investigation) { Factory.create(:investigation, inv_attributes) }
-    let (:activity_one)  { Factory.create(:activity) }
-    let (:activity_two)  { Factory.create(:activity) }
+    let (:investigation) { FactoryGirl.create(:investigation, inv_attributes) }
+    let (:activity_one)  { FactoryGirl.create(:activity) }
+    let (:activity_two)  { FactoryGirl.create(:activity) }
 
     # We might want to have one activity in the future. 
     it "should have no activities initially" do
@@ -329,7 +329,7 @@ describe Investigation do
     let(:activity)             { double(:external_activities => activity_externals) }
     let(:activities)           { [activity] }
     subject do
-      s = Factory.create(:investigation)
+      s = FactoryGirl.create(:investigation)
       allow(s).to receive_messages(:external_activities => external_activities)
       allow(s).to receive_messages(:activities => activities)
       s.is_template
@@ -352,12 +352,12 @@ describe Investigation do
 
   describe '#is_template scope' do
     before(:each) do
-      e1 = Factory.create(:external_activity)
-      e2 = Factory.create(:external_activity)
-      a = Factory.create(:activity, external_activities: [e2])
-      @i1 = Factory.create(:investigation)
-      @i2 = Factory.create(:investigation, external_activities: [e1])
-      @i3 = Factory.create(:investigation, activities: [a])
+      e1 = FactoryGirl.create(:external_activity)
+      e2 = FactoryGirl.create(:external_activity)
+      a = FactoryGirl.create(:activity, external_activities: [e2])
+      @i1 = FactoryGirl.create(:investigation)
+      @i2 = FactoryGirl.create(:investigation, external_activities: [e1])
+      @i3 = FactoryGirl.create(:investigation, activities: [a])
     end
 
     it 'should return investigations which are not templates if provided argument is false' do
@@ -373,7 +373,7 @@ describe Investigation do
   end
 
   describe "project support" do
-    let (:investigation) { Factory.create(:investigation) }
+    let (:investigation) { FactoryGirl.create(:investigation) }
     let (:project) { FactoryGirl.create(:project) }
 
     it "can be assigned to a project" do

--- a/spec/models/page_element_spec.rb
+++ b/spec/models/page_element_spec.rb
@@ -57,7 +57,7 @@ describe PageElement do
   # TODO: auto-generated
   describe '.by_investigation' do
     it 'by_investigation' do
-      investigation = Factory.create(:investigation)
+      investigation = FactoryGirl.create(:investigation)
       result = described_class.by_investigation(investigation)
 
       expect(result).not_to be_nil

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -151,7 +151,7 @@ describe Page do
   describe '#add_embeddable' do
     it 'add_embeddable' do
       page = described_class.new
-      embeddable = Factory.create(:open_response)
+      embeddable = FactoryGirl.create(:open_response)
       position = 1
       result = page.add_embeddable(embeddable, position)
 

--- a/spec/models/password_mailer_spec.rb
+++ b/spec/models/password_mailer_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe PasswordMailer, type: :mailer do
   describe '#reset_password' do
     it 'reset_password' do
       password_mailer = described_class
-      user = Factory.create(:user)
+      user = FactoryGirl.create(:user)
       result = password_mailer.reset_password(user)
 
       expect(result).not_to be_nil

--- a/spec/models/portal/bookmark_spec.rb
+++ b/spec/models/portal/bookmark_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 
 RSpec.describe Portal::Bookmark, type: :model do
 
-  let(:user) { Factory.create(:user) }
+  let(:user) { FactoryGirl.create(:user) }
 
   # TODO: auto-generated
   describe '.available_types' do

--- a/spec/models/portal/clazz_spec.rb
+++ b/spec/models/portal/clazz_spec.rb
@@ -4,8 +4,8 @@ describe Portal::Clazz do
   describe "asking if a user is allowed to remove a teacher from a clazz instance" do
     before(:each) do
       @existing_clazz = Factory(:portal_clazz)
-      @teacher1 = Factory.create(:portal_teacher, :user => Factory.create(:user, :login => "teacher1"))
-      @teacher2 = Factory.create(:portal_teacher, :user => Factory.create(:user, :login => "teacher2"))
+      @teacher1 = FactoryGirl.create(:portal_teacher, :user => FactoryGirl.create(:user, :login => "teacher1"))
+      @teacher2 = FactoryGirl.create(:portal_teacher, :user => FactoryGirl.create(:user, :login => "teacher2"))
     end
 
     it "under normal circumstances should say there is no reason admins cannot remove teachers" do
@@ -43,27 +43,27 @@ describe Portal::Clazz do
     end
 
     it "is true for class teacher" do
-      @teacher = Factory.create(:portal_teacher)
+      @teacher = FactoryGirl.create(:portal_teacher)
       @existing_clazz.teachers = [@teacher]
       expect(@existing_clazz.changeable?(@teacher.user)).to be_truthy
     end
 
     it "is true for second class teacher" do
-      @teacher1 = Factory.create(:portal_teacher)
-      @teacher2 = Factory.create(:portal_teacher)
+      @teacher1 = FactoryGirl.create(:portal_teacher)
+      @teacher2 = FactoryGirl.create(:portal_teacher)
       @existing_clazz.teachers = [@teacher1, @teacher2]
       expect(@existing_clazz.changeable?(@teacher2.user)).to be_truthy
     end
 
     it "is false for non class teacher" do
-      @teacher = Factory.create(:portal_teacher)
+      @teacher = FactoryGirl.create(:portal_teacher)
       expect(@existing_clazz.changeable?(@teacher.user)).to be_falsey
     end
   end
 
   describe "creating a new class" do
     before(:each) do
-      @teacher = Factory.create(:portal_teacher, :user => Factory.create(:user, :login => "test_teacher"))
+      @teacher = FactoryGirl.create(:portal_teacher, :user => FactoryGirl.create(:user, :login => "test_teacher"))
     end
 
     it "should require a school" do

--- a/spec/models/portal/clazz_spec.rb
+++ b/spec/models/portal/clazz_spec.rb
@@ -9,7 +9,7 @@ describe Portal::Clazz do
     end
 
     it "under normal circumstances should say there is no reason admins cannot remove teachers" do
-      admin_user = Factory.next(:admin_user)
+      admin_user = FactoryGirl.generate(:admin_user)
       @existing_clazz.teachers = [@teacher1, @teacher2]
       expect(@existing_clazz.reason_user_cannot_remove_teacher_from_class(admin_user, @teacher1)).to eq(nil)
     end
@@ -20,13 +20,13 @@ describe Portal::Clazz do
     end
 
     it "should say it is illegal for an unauthorized user to remove a teacher" do
-      random_user = Factory.next(:anonymous_user)
+      random_user = FactoryGirl.generate(:anonymous_user)
       @existing_clazz.teachers = [@teacher1, @teacher2]
       expect(@existing_clazz.reason_user_cannot_remove_teacher_from_class(random_user, @teacher1)).to eq(Portal::Clazz::ERROR_UNAUTHORIZED)
     end
 
     it "should say it is illegal for a user to remove the last teacher" do
-      admin_user = Factory.next(:admin_user)
+      admin_user = FactoryGirl.generate(:admin_user)
       @existing_clazz.teachers = [@teacher1]
       expect(@existing_clazz.reason_user_cannot_remove_teacher_from_class(admin_user, @teacher1)).to eq(Portal::Clazz::ERROR_REMOVE_TEACHER_LAST_TEACHER)
     end
@@ -38,7 +38,7 @@ describe Portal::Clazz do
     end
 
     it "is true for admins" do
-      admin_user = Factory.next(:admin_user)
+      admin_user = FactoryGirl.generate(:admin_user)
       expect(@existing_clazz.changeable?(admin_user)).to be_truthy
     end
 

--- a/spec/models/portal/learner_activity_feedback_spec.rb
+++ b/spec/models/portal/learner_activity_feedback_spec.rb
@@ -3,15 +3,15 @@ require File.expand_path('../../../spec_helper', __FILE__)
 testClazz = Portal::LearnerActivityFeedback
 
 describe Portal::LearnerActivityFeedback do
-  let(:activity)            { Factory.create(:activity)}
+  let(:activity)            { FactoryGirl.create(:activity)}
   let(:activities)          { [ activity ] }
-  let(:runnable)            { Factory.create(:investigation, {activities: activities}) }
+  let(:runnable)            { FactoryGirl.create(:investigation, {activities: activities}) }
   let(:args)                { {runnable: runnable} }
-  let(:offering)            { Factory.create(:portal_offering, args) }
+  let(:offering)            { FactoryGirl.create(:portal_offering, args) }
   let(:off_feedback_params) { {activity:activity, portal_offering: offering } }
   let(:activity_feedback)   { Portal::OfferingActivityFeedback.create(off_feedback_params) }
 
-  let(:learner) { Factory.create(:full_portal_learner, {offering:offering}) }
+  let(:learner) { FactoryGirl.create(:full_portal_learner, {offering:offering}) }
 
   let(:feedback_params)  { {portal_learner: learner, activity_feedback: activity_feedback} }
   let(:learner_feedback) { Portal::LearnerActivityFeedback.create(feedback_params)         }

--- a/spec/models/portal/offering_activity_feedback_spec.rb
+++ b/spec/models/portal/offering_activity_feedback_spec.rb
@@ -3,16 +3,16 @@ require File.expand_path('../../../spec_helper', __FILE__)
 testClazz = Portal::OfferingActivityFeedback
 
 describe Portal::OfferingActivityFeedback do
-  let(:activity)         { Factory.create(:activity)}
-  let(:offering)         { Factory.create(:portal_offering, args) }
-  let(:runnable)         { Factory.create(:investigation, {activities: activities}) }
+  let(:activity)         { FactoryGirl.create(:activity)}
+  let(:offering)         { FactoryGirl.create(:portal_offering, args) }
+  let(:runnable)         { FactoryGirl.create(:investigation, {activities: activities}) }
   let(:args)             { {runnable: runnable} }
   let(:feedback_params)  { {activity: activity, portal_offering: offering} }
   let(:activity_feedback){ Portal::OfferingActivityFeedback.create(feedback_params) }
 
   describe "Creation" do
     let(:activities)       { [activity] }
-    let(:runnable)         { Factory.create(:investigation, {activities: activities}) }
+    let(:runnable)         { FactoryGirl.create(:investigation, {activities: activities}) }
     let(:args)             { {runnable: runnable} }
 
     it "should have an activity" do

--- a/spec/models/portal/offering_spec.rb
+++ b/spec/models/portal/offering_spec.rb
@@ -3,9 +3,9 @@ require File.expand_path('../../../spec_helper', __FILE__)
 describe Portal::Offering do
   
   describe "after being created" do
-    let(:runnable) { Factory.create(:external_activity) }
+    let(:runnable) { FactoryGirl.create(:external_activity) }
     let(:args)     { {runnable: runnable} }
-    let(:offering) { Factory.create(:portal_offering, args) }
+    let(:offering) { FactoryGirl.create(:portal_offering, args) }
 
     it "should be active by default" do
      expect(offering.active).to be_truthy

--- a/spec/models/portal/padlet_bookmark_spec.rb
+++ b/spec/models/portal/padlet_bookmark_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Portal::PadletBookmark, type: :model do
   # TODO: auto-generated
   describe '.create_for_user' do
     xit 'create_for_user' do
-      user = Factory.create(:user)
+      user = FactoryGirl.create(:user)
       clazz = double('clazz')
       result = described_class.create_for_user(user, clazz)
 
@@ -21,7 +21,7 @@ RSpec.describe Portal::PadletBookmark, type: :model do
   # TODO: auto-generated
   describe '.user_can_make?' do
     it 'user_can_make?' do
-      user = Factory.create(:user)
+      user = FactoryGirl.create(:user)
       result = described_class.user_can_make?(user)
 
       expect(result).not_to be_nil

--- a/spec/models/portal/school_spec.rb
+++ b/spec/models/portal/school_spec.rb
@@ -50,7 +50,7 @@ describe Portal::School do
     it "should be writable" do
       school = Factory(:portal_school)
       expect(school.members).to be_empty
-      teacher = Factory.create(:portal_teacher, :user => Factory.create(:user, :login => "authorized_teacher"))
+      teacher = FactoryGirl.create(:portal_teacher, :user => FactoryGirl.create(:user, :login => "authorized_teacher"))
 
       school.portal_teachers << teacher
 
@@ -64,10 +64,10 @@ describe Portal::School do
     it "should only return teachers" do
       school = Factory(:portal_school)
       expect(school.members).to be_empty
-      teacher = Factory.create(:portal_teacher, :user => Factory.create(:user, :login => "authorized_teacher"), :schools => [school])
+      teacher = FactoryGirl.create(:portal_teacher, :user => FactoryGirl.create(:user, :login => "authorized_teacher"), :schools => [school])
 
       # we actually don't add students to schools anymore but in case we start doing it again
-      student = Factory.create(:portal_student)
+      student = FactoryGirl.create(:portal_student)
       Portal::SchoolMembership.create(:school => school, :member => student)
 
       school.reload

--- a/spec/models/portal/student_spec.rb
+++ b/spec/models/portal/student_spec.rb
@@ -33,7 +33,7 @@ describe Portal::Student do
     
     first_name = "Nametest"
     last_name  = "Testuser"
-    @student.user = Factory.create(:user, {
+    @student.user = FactoryGirl.create(:user, {
       :first_name => first_name,
       :last_name => last_name,
       :login => Portal::Student.generate_user_login(first_name, last_name),

--- a/spec/models/portal/teacher_spec.rb
+++ b/spec/models/portal/teacher_spec.rb
@@ -63,7 +63,7 @@ describe Portal::Teacher do
     describe "when the portal allows teachers to author" do
       it "should add the authoring role to teachers when they are created" do
         allow(Admin::Settings).to receive_messages(:teachers_can_author? => true)
-        teacher = Factory.create(:portal_teacher)
+        teacher = FactoryGirl.create(:portal_teacher)
         teacher.possibly_add_authoring_role
         expect(teacher.user).to have_role('author')
       end
@@ -72,7 +72,7 @@ describe Portal::Teacher do
     describe "when the portal doesn't allow the teacher to author" do
       it "should not add the authoring role to teachers when they are created" do
         allow(Admin::Settings).to receive_messages(:teachers_can_author? => false)
-        teacher = Factory.create(:portal_teacher)
+        teacher = FactoryGirl.create(:portal_teacher)
         teacher.possibly_add_authoring_role
         expect(teacher.user).not_to have_role('author')
       end
@@ -80,7 +80,7 @@ describe Portal::Teacher do
   end
 
   describe '[default cohort support]' do
-    let(:settings) { Factory.create(:admin_settings) }
+    let(:settings) { FactoryGirl.create(:admin_settings) }
     let(:teacher) { Factory(:portal_teacher) }
     before(:each) do
       allow(Admin::Settings).to receive(:default_settings).and_return(settings)
@@ -93,8 +93,8 @@ describe Portal::Teacher do
     end
 
     describe 'when default cohort is specified in portal settings' do
-      let(:cohort) { Factory.create(:admin_cohort) }
-      let(:settings) { Factory.create(:admin_settings, default_cohort: cohort) }
+      let(:cohort) { FactoryGirl.create(:admin_cohort) }
+      let(:settings) { FactoryGirl.create(:admin_settings, default_cohort: cohort) }
 
       it 'is added to the default cohort' do
         expect(teacher.cohorts.length).to eql(1)

--- a/spec/models/report/learner/selector_spec.rb
+++ b/spec/models/report/learner/selector_spec.rb
@@ -9,7 +9,7 @@ describe Report::Learner::Selector do
     learner.student.permission_forms << students_p_forms
   }
 
-  let(:current_user)        { Factory.next(:admin_user) }
+  let(:current_user)        { FactoryGirl.generate(:admin_user) }
   let(:project_a)           { FactoryGirl.create(:admin_project, name: "project-a") }
   let(:permission_params_a) { { name: "a", project: project_a } }
   let(:permission_form_a)   { FactoryGirl.create(:permission_form, permission_params_a) }

--- a/spec/models/report/offering/activity_spec.rb
+++ b/spec/models/report/offering/activity_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Report::Offering::Activity, type: :model do
   describe '#respondables' do
     it 'respondables' do
       investigation_report = double('investigation_report')
-      offering = Factory.create(:portal_offering)
+      offering = FactoryGirl.create(:portal_offering)
       activity = Activity.new
       activity = described_class.new(investigation_report, offering, activity)
       klazz = double('klazz')

--- a/spec/models/report/offering/investigation_spec.rb
+++ b/spec/models/report/offering/investigation_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Report::Offering::Investigation, type: :model do
   # TODO: auto-generated
   describe '#respondables' do
     it 'respondables' do
-      offering = Factory.create(:portal_offering)
+      offering = FactoryGirl.create(:portal_offering)
       investigation = described_class.new(offering)
       klazz = double('klazz')
       result = investigation.respondables(klazz)

--- a/spec/models/report/offering/page_spec.rb
+++ b/spec/models/report/offering/page_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Report::Offering::Page, type: :model do
   describe '#respondables' do
     xit 'respondables' do
       section_report = []
-      offering = Factory.create(:portal_offering)
+      offering = FactoryGirl.create(:portal_offering)
       page = Page.new
       page = described_class.new(section_report, offering, page)
       klazz = ('klazz')

--- a/spec/models/report/offering/section_spec.rb
+++ b/spec/models/report/offering/section_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Report::Offering::Section, type: :model do
   describe '#respondables' do
     it 'respondables' do
       activity_report = double('activity_report')
-      offering = Factory.create(:portal_offering)
+      offering = FactoryGirl.create(:portal_offering)
       section = Section.new
       section = described_class.new(activity_report, offering, section)
       klazz = ('klazz')

--- a/spec/models/report/offering_status_spec.rb
+++ b/spec/models/report/offering_status_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 
 RSpec.describe Report::OfferingStatus do
   
-  let(:offering) { Factory.create(:portal_offering) }
-  let(:requester) { Factory.create(:user) }
+  let(:offering) { FactoryGirl.create(:portal_offering) }
+  let(:requester) { FactoryGirl.create(:user) }
   let(:offering_status) { described_class.new(offering, requester) }
   let(:student) { Portal::Student.new }
 

--- a/spec/models/report/util_learner_spec.rb
+++ b/spec/models/report/util_learner_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 
 RSpec.describe Report::UtilLearner do
 
-  let(:learner) { Factory.create(:full_portal_learner) }
-  let(:activity) { Factory.create(:activity) }
+  let(:learner) { FactoryGirl.create(:full_portal_learner) }
+  let(:activity) { FactoryGirl.create(:activity) }
 
   # TODO: auto-generated
   describe '#complete_number' do

--- a/spec/models/report/util_spec.rb
+++ b/spec/models/report/util_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe Report::Util do
 
-  let(:offering) { Factory.create(:portal_offering) }
+  let(:offering) { FactoryGirl.create(:portal_offering) }
   let(:learner) { Portal::Learner.new }
 
   # TODO: auto-generated
@@ -57,7 +57,7 @@ RSpec.describe Report::Util do
     xit 'saveable' do
       offering_or_learner = double('offering_or_learner')
       util = described_class.new(offering_or_learner)
-      embeddable = Factory.create(:open_response)
+      embeddable = FactoryGirl.create(:open_response)
       result = util.saveable(learner, embeddable)
 
       expect(result).not_to be_nil

--- a/spec/models/saveable/saveable_spec.rb
+++ b/spec/models/saveable/saveable_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe Saveable, type: :model do
 
-  let(:object) { Factory.create(:multiple_choice)}
+  let(:object) { FactoryGirl.create(:multiple_choice)}
   
   # TODO: auto-generated
   describe '#submitted?' do

--- a/spec/models/search/search_material_spec.rb
+++ b/spec/models/search/search_material_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Search::SearchMaterial do
   # TODO: auto-generated
   describe '#populateMaterialData' do
     xit 'populateMaterialData' do
-      user = Factory.create(:user)
+      user = FactoryGirl.create(:user)
       search_material = described_class.new(material, user)
       result = search_material.populateMaterialData
 
@@ -21,7 +21,7 @@ RSpec.describe Search::SearchMaterial do
   # TODO: auto-generated
   describe '#get_page_title_and_meta_tags' do
     xit 'get_page_title_and_meta_tags' do
-      user = Factory.create(:user)
+      user = FactoryGirl.create(:user)
       search_material = described_class.new(material, user)
       result = search_material.get_page_title_and_meta_tags
 

--- a/spec/models/security_question_spec.rb
+++ b/spec/models/security_question_spec.rb
@@ -22,7 +22,7 @@ describe SecurityQuestion do
         }
       }
       
-      @user = Factory.create(:user)
+      @user = FactoryGirl.create(:user)
     end
     
     it "makes a new set of questions according to provided information" do
@@ -130,7 +130,7 @@ describe SecurityQuestion do
   describe '.make_questions_from_hash_and_user' do
     it 'make_questions_from_hash_and_user' do
       hash = {}
-      user = Factory.create(:user)
+      user = FactoryGirl.create(:user)
       result = described_class.make_questions_from_hash_and_user(hash, user)
 
       expect(result).not_to be_nil

--- a/spec/models/user_mailer_spec.rb
+++ b/spec/models/user_mailer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe UserMailer, type: :mailer do
   describe '#signup_notification' do
     it 'signup_notification' do
       user_mailer = described_class
-      user = Factory.create(:user)
+      user = FactoryGirl.create(:user)
       result = user_mailer.signup_notification(user)
 
       expect(result).not_to be_nil
@@ -33,7 +33,7 @@ RSpec.describe UserMailer, type: :mailer do
   describe '#activation' do
     it 'activation' do
       user_mailer = described_class
-      user = Factory.create(:user)
+      user = FactoryGirl.create(:user)
       result = user_mailer.activation(user)
 
       expect(result).not_to be_nil

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -867,7 +867,7 @@ protected
   describe '#is_project_admin?' do
     it 'is_project_admin?' do
       user = described_class.new
-      project = Factory.create(:project)
+      project = FactoryGirl.create(:project)
       result = user.is_project_admin?(project)
 
       expect(result).not_to be_nil
@@ -878,7 +878,7 @@ protected
   describe '#is_project_researcher?' do
     it 'is_project_researcher?' do
       user = described_class.new
-      project = Factory.create(:project)
+      project = FactoryGirl.create(:project)
       result = user.is_project_researcher?(project)
 
       expect(result).not_to be_nil
@@ -889,7 +889,7 @@ protected
   describe '#is_project_cohort_member?' do
     it 'is_project_cohort_member?' do
       user = described_class.new
-      project = Factory.create(:project)
+      project = FactoryGirl.create(:project)
       result = user.is_project_cohort_member?(project)
 
       expect(result).not_to be_nil
@@ -900,7 +900,7 @@ protected
   describe '#is_project_member?' do
     it 'is_project_member?' do
       user = described_class.new
-      project = Factory.create(:project)
+      project = FactoryGirl.create(:project)
       result = user.is_project_member?(project)
 
       expect(result).not_to be_nil
@@ -912,7 +912,7 @@ protected
     xit 'add_role_for_project' do
       user = described_class.new
       role = double('role')
-      project = Factory.create(:project)
+      project = FactoryGirl.create(:project)
       result = user.add_role_for_project(role, project)
 
       expect(result).not_to be_nil
@@ -924,7 +924,7 @@ protected
     it 'remove_role_for_project' do
       user = described_class.new
       role = double('role')
-      project = Factory.create(:project)
+      project = FactoryGirl.create(:project)
       result = user.remove_role_for_project(role, project)
 
       expect(result).to be_nil
@@ -1030,7 +1030,7 @@ protected
   # TODO: auto-generated
   describe '#set_passive_users_as_pending' do
     it 'set_passive_users_as_pending' do
-      user = Factory.create(:user)
+      user = FactoryGirl.create(:user)
       result = user.set_passive_users_as_pending
 
       expect(result).not_to be_nil

--- a/spec/policies/api/v1/answer_policy_spec.rb
+++ b/spec/policies/api/v1/answer_policy_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe API::V1::AnswerPolicy do
-  let(:context) { OpenStruct.new(user: Factory.create(:user), request: nil, params: [])}
+  let(:context) { OpenStruct.new(user: FactoryGirl.create(:user), request: nil, params: [])}
 
   # TODO: auto-generated
   describe '#student_answers?' do

--- a/spec/policies/api/v1/collaboration_policy_spec.rb
+++ b/spec/policies/api/v1/collaboration_policy_spec.rb
@@ -4,11 +4,11 @@ require 'spec_helper'
 
 RSpec.describe API::V1::CollaborationPolicy do
 
-  let(:context) { OpenStruct.new(user: Factory.create(:user), request: nil, params: [])}
+  let(:context) { OpenStruct.new(user: FactoryGirl.create(:user), request: nil, params: [])}
   # TODO: auto-generated
   describe '#create?' do
     it 'create?' do
-      api_v1_collaboration = OpenStruct.new(user: Factory.create(:user), request: nil, params: [])
+      api_v1_collaboration = OpenStruct.new(user: FactoryGirl.create(:user), request: nil, params: [])
       collaboration_policy = described_class.new(context, api_v1_collaboration)
       result = collaboration_policy.create?
 
@@ -19,7 +19,7 @@ RSpec.describe API::V1::CollaborationPolicy do
   # TODO: auto-generated
   describe '#available_collaborators?' do
     it 'available_collaborators?' do
-      api_v1_collaboration = OpenStruct.new(user: Factory.create(:user), request: nil, params: [])
+      api_v1_collaboration = OpenStruct.new(user: FactoryGirl.create(:user), request: nil, params: [])
       collaboration_policy = described_class.new(context, api_v1_collaboration)
       result = collaboration_policy.available_collaborators?
 
@@ -30,7 +30,7 @@ RSpec.describe API::V1::CollaborationPolicy do
   # TODO: auto-generated
   describe '#collaborators_data?' do
     xit 'collaborators_data?' do
-      api_v1_collaboration = OpenStruct.new(user: Factory.create(:user), request: nil, params: [])
+      api_v1_collaboration = OpenStruct.new(user: FactoryGirl.create(:user), request: nil, params: [])
       collaboration_policy = described_class.new(context, api_v1_collaboration)
       result = collaboration_policy.collaborators_data?
 

--- a/spec/policies/commons_license_policy_spec.rb
+++ b/spec/policies/commons_license_policy_spec.rb
@@ -28,7 +28,7 @@ describe CommonsLicensePolicy do
   end
 
   context "for an admin" do
-    let(:active_user) { Factory.next(:admin_user)   }
+    let(:active_user) { FactoryGirl.generate(:admin_user)   }
 
     it { is_expected.to permit(:index)   }
     it { is_expected.to permit(:show)    }

--- a/spec/policies/dataservice/process_external_activity_data_job_policy_spec.rb
+++ b/spec/policies/dataservice/process_external_activity_data_job_policy_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe Dataservice::ProcessExternalActivityDataJobPolicy do
 
-  let(:context) { OpenStruct.new(request: [], params: {id_or_key: ''}, user: Factory.create(:user) )}
+  let(:context) { OpenStruct.new(request: [], params: {id_or_key: ''}, user: FactoryGirl.create(:user) )}
 
   # TODO: auto-generated
   describe '#create?' do

--- a/spec/policies/external_activity_policy_spec.rb
+++ b/spec/policies/external_activity_policy_spec.rb
@@ -59,7 +59,7 @@ describe ExternalActivityPolicy do
   end
 
   context "for an admin" do
-    let(:active_user) { Factory.next(:admin_user)   }
+    let(:active_user) { FactoryGirl.generate(:admin_user)   }
 
     it { is_expected.to permit(:preview_index)            }
     it { is_expected.to permit(:copy)                     }

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -43,7 +43,7 @@ describe UserPolicy do
   end
 
   context "for an admin" do
-    let(:active_user) { Factory.next(:admin_user)   }
+    let(:active_user) { FactoryGirl.generate(:admin_user)   }
     it { is_expected.to permit(:limited_edit)               }
     it { is_expected.to permit(:limited_update)             }
     it { is_expected.to permit(:index)                      }

--- a/spec/services/reports/account_spec.rb
+++ b/spec/services/reports/account_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Reports::Account do
     xit 'process_portal_user' do
       opts = {}
       account = described_class.new(opts)
-      user = Factory.create(:user)
+      user = FactoryGirl.create(:user)
       portal_user = double('portal_user')
       user_type = double('user_type')
       sheet = double('sheet')

--- a/spec/services/reports/detail_spec.rb
+++ b/spec/services/reports/detail_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Reports::Detail do
     it 'default_answer_for' do
       opts = {}
       detail = described_class.new(opts)
-      embeddable = Factory.create(:open_response)
+      embeddable = FactoryGirl.create(:open_response)
       result = detail.default_answer_for(embeddable)
 
       expect(result).not_to be_nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,5 +43,5 @@ def factory_stubbed
 end
 
 def factory_create
-  Factory.create(subject_class_factory)
+  FactoryGirl.create(subject_class_factory)
 end

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -38,7 +38,7 @@ suppress_warnings {
 # Factory Generators
 #
 def generate_default_settings_and_jnlps_with_factories
-  @admin_settings = Factory.create(:admin_settings)
+  @admin_settings = FactoryGirl.create(:admin_settings)
   generate_default_school_resources_with_factories
 end
 

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -96,25 +96,25 @@ def generate_portal_resources_with_mocks
 end
 
 def login_admin
-  logged_in_user = Factory.next :admin_user
+  logged_in_user = FactoryGirl.generate :admin_user
   sign_in logged_in_user
   logged_in_user
 end
 
 def login_manager
-  logged_in_user = Factory.next :manager_user
+  logged_in_user = FactoryGirl.generate :manager_user
   sign_in logged_in_user
   logged_in_user
 end
 
 def login_researcher
-  logged_in_user = Factory.next :researcher_user
+  logged_in_user = FactoryGirl.generate :researcher_user
   sign_in logged_in_user
   logged_in_user
 end
 
 def login_author
-  logged_in_user = Factory.next :author_user
+  logged_in_user = FactoryGirl.generate :author_user
   sign_in logged_in_user
   logged_in_user
 end

--- a/spec/support/embeddable_controller_helper.rb
+++ b/spec/support/embeddable_controller_helper.rb
@@ -10,7 +10,7 @@ shared_examples_for 'an embeddable controller' do
     if self.respond_to?(method_name)
       return self.send(method_name)
     else
-      return Factory.create(model_name)
+      return FactoryGirl.create(model_name)
     end
   end
 

--- a/spec/support/projects_listing_shared_examples.rb
+++ b/spec/support/projects_listing_shared_examples.rb
@@ -6,8 +6,8 @@ shared_examples 'projects listing' do
 
   context 'when user is an admin' do
     before(:each) do
-      allow(view).to receive(:current_visitor).and_return(Factory.next(:admin_user))
-      allow(view).to receive(:current_user).and_return(Factory.next(:admin_user))
+      allow(view).to receive(:current_visitor).and_return(FactoryGirl.generate(:admin_user))
+      allow(view).to receive(:current_user).and_return(FactoryGirl.generate(:admin_user))
     end
     it 'should be visible' do
       render
@@ -17,8 +17,8 @@ shared_examples 'projects listing' do
 
   context 'when user is an author' do
     before(:each) do
-      allow(view).to receive(:current_visitor).and_return(Factory.next(:author_user))
-      allow(view).to receive(:current_user).and_return(Factory.next(:author_user))
+      allow(view).to receive(:current_visitor).and_return(FactoryGirl.generate(:author_user))
+      allow(view).to receive(:current_user).and_return(FactoryGirl.generate(:author_user))
     end
     it 'should not be visible' do
       render

--- a/spec/support/saveable_helper.rb
+++ b/spec/support/saveable_helper.rb
@@ -1,7 +1,7 @@
 shared_examples_for 'a saveable' do
 
   let(:model_name) { described_class.name.underscore_module }
-  let(:saveable)   { Factory.create model_name }
+  let(:saveable)   { FactoryGirl.create model_name }
 
   
   describe "belong to an embeddable and" do

--- a/spec/views/admin/settings/edit.html.haml_spec.rb
+++ b/spec/views/admin/settings/edit.html.haml_spec.rb
@@ -7,7 +7,7 @@ describe "/admin/settings/edit.html.haml" do
     @pub_interval = 30000;
     @settings = Admin::Settings.new(:pub_interval => @pub_interval)
     assign(:admin_settings,@settings)
-    allow(view).to receive(:current_visitor).and_return(Factory.next(:admin_user))
+    allow(view).to receive(:current_visitor).and_return(FactoryGirl.generate(:admin_user))
     render
   end
 

--- a/spec/views/admin/settings/show.html.haml_spec.rb
+++ b/spec/views/admin/settings/show.html.haml_spec.rb
@@ -7,7 +7,7 @@ describe "/admin/settings/show.html.haml" do
     @pub_interval = 30000;
     @settings = Admin::Settings.new(:pub_interval => @pub_interval)
     assign(:admin_settings,@settings)
-    allow(view).to receive(:current_visitor).and_return(Factory.next(:admin_user))
+    allow(view).to receive(:current_visitor).and_return(FactoryGirl.generate(:admin_user))
     render
   end
 

--- a/spec/views/browse/external_activities/show.html.haml_spec.rb
+++ b/spec/views/browse/external_activities/show.html.haml_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe "browse/external_activities/show" do
-  let (:user) { Factory.create(:user) }
-  let (:ext_act) { Factory.create(:external_activity, :url => 'http://activities.com', :long_description => '<p>desc foo bar</p><script>alert("evil!");</script>', :user => user) }
+  let (:user) { FactoryGirl.create(:user) }
+  let (:ext_act) { FactoryGirl.create(:external_activity, :url => 'http://activities.com', :long_description => '<p>desc foo bar</p><script>alert("evil!");</script>', :user => user) }
   let (:search_material) { Search::SearchMaterial.new(ext_act, user) }
 
   before(:each) do

--- a/spec/views/external_activities/edit.html.haml_spec.rb
+++ b/spec/views/external_activities/edit.html.haml_spec.rb
@@ -5,7 +5,7 @@ describe "/external_activities/edit.html.haml" do
 
   before(:each) do
     assigns[:external_activity] = @external_activity = ext_act
-    allow(view).to receive(:current_user).and_return(Factory.next(:admin_user))
+    allow(view).to receive(:current_user).and_return(FactoryGirl.generate(:admin_user))
   end
 
   it 'should have an is_official check box to designate official activities' do
@@ -14,14 +14,14 @@ describe "/external_activities/edit.html.haml" do
   end
 
   it 'should not show the is_official check box to users without permissions' do
-    allow(view).to receive(:current_user).and_return(Factory.next(:author_user))
+    allow(view).to receive(:current_user).and_return(FactoryGirl.generate(:author_user))
     render
     assert_select "input[id=?]", 'external_activity_is_official', false
   end
 
   it 'should show the offical checkbox to project admins of the project material' do
     common_projects = [mock_model(Admin::Project, cohorts: [])]
-    auth_user = Factory.next(:author_user)
+    auth_user = FactoryGirl.generate(:author_user)
     allow(auth_user).to receive_messages(admin_for_projects: common_projects)
     allow(ext_act).to receive_messages(projects: common_projects)
     allow(view).to receive(:current_user).and_return(auth_user)

--- a/spec/views/external_activities/edit.html.haml_spec.rb
+++ b/spec/views/external_activities/edit.html.haml_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe "/external_activities/edit.html.haml" do
-  let(:ext_act) { Factory.create(:external_activity, :url => 'http://activities.com') }
+  let(:ext_act) { FactoryGirl.create(:external_activity, :url => 'http://activities.com') }
 
   before(:each) do
     assigns[:external_activity] = @external_activity = ext_act

--- a/spec/views/materials_collections/edit.html.haml_spec.rb
+++ b/spec/views/materials_collections/edit.html.haml_spec.rb
@@ -8,7 +8,7 @@ describe "materials_collections/edit" do
       :project_id => 1
     ))
 
-    @admin_user = Factory.next(:admin_user)
+    @admin_user = FactoryGirl.generate(:admin_user)
     allow(controller).to receive(:current_user).and_return(@admin_user)
   end
 

--- a/spec/views/materials_collections/index.html.haml_spec.rb
+++ b/spec/views/materials_collections/index.html.haml_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe "materials_collections/index" do
   before(:each) do
 
-    collection1 = Factory.create(:materials_collection)
-    collection2 = Factory.create(:materials_collection_with_items)
+    collection1 = FactoryGirl.create(:materials_collection)
+    collection2 = FactoryGirl.create(:materials_collection_with_items)
 
     assign(:materials_collections, MaterialsCollection.search(nil, nil, nil))
 

--- a/spec/views/materials_collections/index.html.haml_spec.rb
+++ b/spec/views/materials_collections/index.html.haml_spec.rb
@@ -8,7 +8,7 @@ describe "materials_collections/index" do
 
     assign(:materials_collections, MaterialsCollection.search(nil, nil, nil))
 
-    @admin_user = Factory.next(:admin_user)
+    @admin_user = FactoryGirl.generate(:admin_user)
     allow(controller).to receive(:current_user).and_return(@admin_user)
   end
 

--- a/spec/views/materials_collections/new.html.haml_spec.rb
+++ b/spec/views/materials_collections/new.html.haml_spec.rb
@@ -8,7 +8,7 @@ describe "materials_collections/new" do
       :project_id => 1
     ).as_new_record)
 
-    @admin_user = Factory.next(:admin_user)
+    @admin_user = FactoryGirl.generate(:admin_user)
     allow(controller).to receive(:current_user).and_return(@admin_user)
   end
 

--- a/spec/views/materials_collections/show.html.haml_spec.rb
+++ b/spec/views/materials_collections/show.html.haml_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe "materials_collections/show" do
   before(:each) do
 
-    @admin_user = Factory.next(:admin_user)
+    @admin_user = FactoryGirl.generate(:admin_user)
     allow(controller).to receive(:current_user).and_return(@admin_user)
   end
 


### PR DESCRIPTION
Convert vintage Factory method calls to current syntax. 

- Factory.next -> FactoryGirl.generate
- Factory.create -> FactoryGirl.create

That's it for now - will finish other work and then open additional PR(s).