### PR TITLE
fix broken image library

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,12 @@ source "http://rubygems.org"
   gem "delayed_job_web"
   gem 'daemons',              "~> 1.1.8"
   gem 'rush',                 :git => 'git://github.com/concord-consortium/rush'
+  # this is the old version of aws and is needed by our old version of paperclip
+  # we cannot upgrade paperclip until we have rails up to version 4. This uses the AWS
+  # namespace.
+  gem 'aws-sdk-v1'
+  # this is the new version of the aws sdk. It uses the Aws namespace. It is currently used
+  # by a rake task to archive old portals
   gem "aws-sdk",              "~> 3"
   gem 'newrelic_rpm', '~> 4.4', '>= 4.4.0.336'
   gem "tinymce-rails",        "~>3.5.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -689,6 +689,9 @@ GEM
     aws-sdk-translate (1.2.0)
       aws-sdk-core (~> 3)
       aws-sigv4 (~> 1.0)
+    aws-sdk-v1 (1.67.0)
+      json (~> 1.4)
+      nokogiri (~> 1)
     aws-sdk-waf (1.5.0)
       aws-sdk-core (~> 3)
       aws-sigv4 (~> 1.0)
@@ -1245,6 +1248,7 @@ DEPENDENCIES
   arrayfields
   awesome_print
   aws-sdk (~> 3)
+  aws-sdk-v1
   axlsx (> 2.5)
   better_errors (~> 1.1.0)
   bullet

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -346,5 +346,30 @@ describe Image do
     end
   end
 
+  describe '#image.url' do
+    it 'is the missing image when not initialized' do
+      image = described_class.new
+      result = image.image.url
+      expect(result).to eq("/images/original/missing.png")
+    end
+  end
 
+  describe "when s3 is configured" do
+    # These tests are useful to confirm that the gems are configured correctly to work
+    # with paper clip. There paperclip requires aws-sdk version one
+    before(:each) do
+      Paperclip::Attachment.default_options[:storage] = :s3
+    end
+    after(:each) do
+      Paperclip::Attachment.default_options[:storage] = :filesystem
+    end
+
+    describe '#image.url' do
+      it 'is the missing image when not initialized' do
+        image = described_class.new
+        result = image.image.url
+        expect(result).to eq("/images/original/missing.png")
+      end
+    end
+  end
 end


### PR DESCRIPTION
paperclip requires version 1 of aws-sdk
the aws-sdk was upgraded to version 3 recently which broke paperclip
luckly the v1 aws-sdk and v3 aws-sdk can be installed at the same time

[#160494411]