### PR TITLE
Add userId to `Portal.currentUser`

### DIFF
--- a/app/views/dynamic_scripts/_current_user.html.haml
+++ b/app/views/dynamic_scripts/_current_user.html.haml
@@ -37,5 +37,8 @@
     },
     get homePath() {
       return "#{current_user_home_path}";
+    },
+    get userId() {
+      return "#{current_visitor.id}";
     }
   };


### PR DESCRIPTION
I searched and searched and could not find a way to fetch the userId from `window.Portal` this PR adds that.

[#161966948] figure out if javascript on the collection page can access the user.id of the current user

https://www.pivotaltracker.com/story/show/161966948