### PR TITLE
Add class ID to API report output

### DIFF
--- a/app/models/api/v1/report.rb
+++ b/app/models/api/v1/report.rb
@@ -58,6 +58,7 @@ class API::V1::Report
     section = clazz.section && clazz.section.length > 0 ? clazz.section : nil
     section = section ? " (#{section})" : ""
     {
+      id: clazz.id,
       name: clazz.name + section,
       students: @students
                     .sort_by { |s| "#{s.last_name} #{s.first_name}".downcase }


### PR DESCRIPTION
This is a companion to this portal-reports PR: https://github.com/concord-consortium/portal-report/pull/90

We want to use the class ID instead of the class name when recording events with Google Analytics. (Class name's could potentially contain personally identifiable information.)