### PR TITLE
temporary fix to support debian jessie

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,16 +1,21 @@
 FROM concordconsortium/docker-rails-base-private:ruby-2.2.6-rails-3.2.22.9
 
+# Debian 8 (jessie) is no longer supported
+RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie main" >> /etc/apt/sources.list.d/jessie.list
+RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main" >> /etc/apt/sources.list.d/jessie.list
+RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie.* main/d' /etc/apt/sources.list
+RUN apt-get -o Acquire::Check-Valid-Until=false update
+
 #
 # Install some basic dev tools
 #
-RUN apt-get update && apt-get install -y vim
+RUN apt-get install -y vim
 #
 #Install Google Chrome for Selenium
 #
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list \
-  && apt-get update \
-  && apt-get install -y google-chrome-stable
+  && apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y google-chrome-stable
 #
 # Install wait-for-it to support docker-volume-sync
 WORKDIR /usr/local/bin


### PR DESCRIPTION
the repositories of debian jessies packages was moved to archive, and the
repositories are not supported so all apt updates need to be told skip the Check-Valid-Until