### PR TITLE
Admin move student

### DIFF
--- a/app/controllers/portal/students_controller.rb
+++ b/app/controllers/portal/students_controller.rb
@@ -419,8 +419,8 @@ class Portal::StudentsController < ApplicationController
     if @portal_clazz.nil?
       render :update do |page|
         page.remove "invalid_word"
-        page.insert_html :top, "word_form", "<p id='invalid_word' style='display:none;'>Please enter a valid class word and try again.</p>"
-        page.visual_effect :BlindDown, "invalid_word", :duration => 1
+        page.insert_html :top, "word_form", "<p id='invalid_word' style='background: #f5f5f5; display:none; padding: 10px;'>Please enter a valid class word and try again.</p>"
+        page.visual_effect :BlindDown, "invalid_word", :duration => 0.25
       end
       return
     end
@@ -446,8 +446,8 @@ class Portal::StudentsController < ApplicationController
     if @current_class.nil? || @new_class.nil?
       render :update do |page|
         page.replace "invalid_class", "<p id='invalid_class'></p>"
-        page.replace "invalid_word", "<p id='invalid_word' style='display:none;'>One or more of the class words you entered is invalid. Please try again.</p>"
-        page.visual_effect :BlindDown, "invalid_word", :duration => 1
+        page.replace "invalid_word", "<p id='invalid_word' style='background: #f5f5f5; display:none; padding: 10px;'>One or more of the class words you entered is invalid. Please try again.</p>"
+        page.visual_effect :BlindDown, "invalid_word", :duration => 0.25
       end
       return
     end
@@ -474,15 +474,15 @@ class Portal::StudentsController < ApplicationController
     if @already_in_class
       render :update do |page|
         page.replace "invalid_word", "<p id='invalid_word'></p>"
-        page.replace "invalid_class", "<p id='invalid_class' style='display:none;'>The student is already in the class you are trying to move them to. Please check the class words you are using and try again.</p>"
-        page.visual_effect :BlindDown, "invalid_class", :duration => 1
+        page.replace "invalid_class", "<p id='invalid_class' style='background: #f5f5f5; display:none; padding: 10px;'>The student is already in the class you are trying to move them to. Please check the class words you are using and try again.</p>"
+        page.visual_effect :BlindDown, "invalid_class", :duration => 0.25
       end
       return
     elsif @not_in_current_class
       render :update do |page|
         page.replace "invalid_word", "<p id='invalid_word'></p>"
-        page.replace "invalid_class", "<p id='invalid_class' style='display:none;'>The student is not in the class you are trying to move them from. Please check the class words you are using and try again.</p>"
-        page.visual_effect :BlindDown, "invalid_class", :duration => 1
+        page.replace "invalid_class", "<p id='invalid_class' style='background: #f5f5f5; display:none; padding: 10px;'>The student is not in the class you are trying to move them from. Please check the class words you are using and try again.</p>"
+        page.visual_effect :BlindDown, "invalid_class", :duration => 0.25
       end
       return
     else
@@ -514,7 +514,7 @@ class Portal::StudentsController < ApplicationController
                       :clazz      => @new_class,
                       :portal_student => @portal_student,
                       :potentially_orphaned_assignments => @potentially_orphaned_assignments}
-        page.visual_effect :BlindDown, "move_confirmation", :duration => 1
+        page.visual_effect :BlindDown, "move_confirmation", :duration => 0.25
       end
     end
   end

--- a/app/controllers/portal/students_controller.rb
+++ b/app/controllers/portal/students_controller.rb
@@ -292,6 +292,7 @@ class Portal::StudentsController < ApplicationController
         if sa[:offering_name] == nca[:name]
           @learner_to_update = Portal::Learner.find(sa[:learner_id])
           @learner_to_update.update_attribute('offering_id', nca[:id])
+          @learner_to_update.report_learner.update_fields
         end
       end
     end

--- a/app/controllers/portal/students_controller.rb
+++ b/app/controllers/portal/students_controller.rb
@@ -436,13 +436,11 @@ class Portal::StudentsController < ApplicationController
   end
 
   def move_confirm
-    # find current and new classes
     @current_class_word = params[:clazz][:current_class_word]
     @new_class_word = params[:clazz][:new_class_word]
     @current_class = Portal::Clazz.find_by_class_word(@current_class_word)
     @new_class = Portal::Clazz.find_by_class_word(@new_class_word)
 
-    # notify if no classes exist with the specified class passwords
     if @current_class.nil? || @new_class.nil?
       render :update do |page|
         page.replace "invalid_class", "<p id='invalid_class'></p>"
@@ -452,33 +450,16 @@ class Portal::StudentsController < ApplicationController
       return
     end
 
-    # get student
     @portal_student = Portal::Student.find(params[:id])
 
-    # make sure student isn't already in the new class specified
-    @already_in_class = false
-    @portal_student.clazzes.each do |ec|
-      if ec.class_word == @new_class_word
-        @already_in_class = true
-      end
-    end
-
-    # make sure student is in the current class specified
-    @not_in_current_class = true
-    @portal_student.clazzes.each do |ec|
-      if ec.class_word == @current_class_word
-        @not_in_current_class = false
-      end
-    end
-
-    if @already_in_class
+    if @portal_student.has_clazz?(@new_class)
       render :update do |page|
         page.replace "invalid_word", "<p id='invalid_word'></p>"
         page.replace "invalid_class", "<p id='invalid_class' style='background: #f5f5f5; display:none; padding: 10px;'>The student is already in the class you are trying to move them to. Please check the class words you are using and try again.</p>"
         page.visual_effect :BlindDown, "invalid_class", :duration => 0.25
       end
       return
-    elsif @not_in_current_class
+    elsif !@portal_student.has_clazz?(@current_class)
       render :update do |page|
         page.replace "invalid_word", "<p id='invalid_word'></p>"
         page.replace "invalid_class", "<p id='invalid_class' style='background: #f5f5f5; display:none; padding: 10px;'>The student is not in the class you are trying to move them from. Please check the class words you are using and try again.</p>"

--- a/app/controllers/portal/students_controller.rb
+++ b/app/controllers/portal/students_controller.rb
@@ -272,33 +272,32 @@ class Portal::StudentsController < ApplicationController
   end
 
   def move
-    # get student
     @portal_student = Portal::Student.find(params[:id])
-    # find current and new classes
+
     @current_class_word = params[:clazz][:current_class_word]
     @current_class = Portal::Clazz.find_by_class_word(@current_class_word)
     @new_class_word = params[:clazz][:new_class_word]
     @new_class = Portal::Clazz.find_by_class_word(@new_class_word)
-    # remove student from current class and add to new
+
     @portal_student.remove_clazz(@current_class)
     @portal_student.add_clazz(@new_class)
+
     # get list of new class's offerings
     @new_class_assignments = @new_class.offerings.map { |o| {name: o.name, id: o.id } }
     # get student's learners, and offerings (id and names)
     @students_assignments = @portal_student.learners.map { |l| {learner_id: l.id, offering_id: l.offering_id, offering_name: l.offering.name}}
     # find matching learners and update offering_id values to match those in new class (what happens to any work on assignments that aren't assigned to new class?)
-    @students_assignments.each { |sa|
-      @new_class_assignments.each { |nca|
+    @students_assignments.each do |sa|
+      @new_class_assignments.each do |nca|
         if sa[:offering_name] == nca[:name]
           @learner_to_update = Portal::Learner.find(sa[:learner_id])
           @learner_to_update.update_attribute('offering_id', nca[:id])
         end
-      }
-    }
+      end
+    end
 
     flash[:notice] = 'Successfully moved student to new class.'
     redirect_to(@portal_student)
-
   end
 
   # DELETE /portal_students/1

--- a/app/models/portal/student.rb
+++ b/app/models/portal/student.rb
@@ -48,7 +48,7 @@ class Portal::Student < ActiveRecord::Base
 
   def self.generate_user_login(first_name, last_name)
 
-    suggested_login =   "#{first_name.downcase.gsub(/[^\p{L}\d]/,'')[0..0]}" + 
+    suggested_login =   "#{first_name.downcase.gsub(/[^\p{L}\d]/,'')[0..0]}" +
                         "#{last_name.downcase.gsub(/[^\p{L}\d]/,'')}"
 
 
@@ -157,6 +157,10 @@ class Portal::Student < ActiveRecord::Base
     unless self.has_clazz?(clazz)
       self.clazzes << clazz
     end
+  end
+
+  def remove_clazz(clazz)
+    self.clazzes.delete clazz
   end
 
 end

--- a/app/views/portal/students/_move.html.haml
+++ b/app/views/portal/students/_move.html.haml
@@ -1,0 +1,17 @@
+= remote_form_for(portal_student, :as => :portal_student, :url => { :controller => 'portal/students', :action => "move_confirm/#{@portal_student.id}" }, :html => {:id => "move_form"}) do |f|
+  %p#invalid_word
+  = field_set_tag 'Class Word' do
+    %ul
+      %li
+        = label_tag :clazz, 'Current Class Word: '
+        %p= "Not case sensitive"
+        = text_field :clazz, :current_class_word, {:live => false}
+      %li
+        = label_tag :clazz, 'New Class Word: '
+        %p= "Not case sensitive"
+        = text_field :clazz, :new_class_word, {:live => false}
+      %li
+        = f.submit 'Submit'
+    %p
+      %strong IMPORTANT:
+      Any work done by the student for assignments in their current class that are not assigned to the new class will be lost.

--- a/app/views/portal/students/_move.html.haml
+++ b/app/views/portal/students/_move.html.haml
@@ -1,6 +1,5 @@
 = remote_form_for(portal_student, :as => :portal_student, :url => { :controller => 'portal/students', :action => "move_confirm/#{@portal_student.id}" }, :html => {:id => "move_form"}) do |f|
-  %p#invalid_word
-  %p#invalid_class
+  %p#invalid
   = field_set_tag 'Class Word' do
     %ul
       %li

--- a/app/views/portal/students/_move.html.haml
+++ b/app/views/portal/students/_move.html.haml
@@ -1,5 +1,6 @@
 = remote_form_for(portal_student, :as => :portal_student, :url => { :controller => 'portal/students', :action => "move_confirm/#{@portal_student.id}" }, :html => {:id => "move_form"}) do |f|
   %p#invalid_word
+  %p#invalid_class
   = field_set_tag 'Class Word' do
     %ul
       %li

--- a/app/views/portal/students/_move2_confirmation.html.haml
+++ b/app/views/portal/students/_move2_confirmation.html.haml
@@ -1,3 +1,0 @@
-#move2_confirmation{:style=>"display: none;"}
-  %p
-    The student has been moved to the new class.

--- a/app/views/portal/students/_move2_confirmation.html.haml
+++ b/app/views/portal/students/_move2_confirmation.html.haml
@@ -1,0 +1,3 @@
+#move2_confirmation{:style=>"display: none;"}
+  %p
+    The student has been moved to the new class.

--- a/app/views/portal/students/_move_confirmation.html.haml
+++ b/app/views/portal/students/_move_confirmation.html.haml
@@ -1,4 +1,4 @@
-#move_confirmation{:style=>"display: none;"}
+#move_confirmation{:style=>"background: #f5f5f5; display: none; padding: 10px;"}
   %p
     Are you sure you want to move #{portal_student.name} from #{current_clazz.teacher.user.first_name} #{current_clazz.teacher.user.last_name}'s #{current_clazz.name} to #{clazz.teacher.user.first_name} #{clazz.teacher.user.last_name}'s #{clazz.name}?
 

--- a/app/views/portal/students/_move_confirmation.html.haml
+++ b/app/views/portal/students/_move_confirmation.html.haml
@@ -16,7 +16,7 @@
             #{poa}
   %p
     Click 'Confirm' to complete the process.
-  = form_for(portal_student, :as => :portal_student, :url => '4/move', :html => {:id => "move_form"}) do |f|
+  = form_for(portal_student, :as => :portal_student, :url => "#{portal_student.id}/move", :html => {:id => "move_form"}) do |f|
     = hidden_field_tag "clazz[current_class_word]", current_class_word
     = hidden_field_tag "clazz[new_class_word]", new_class_word
     = f.submit "Confirm"

--- a/app/views/portal/students/_move_confirmation.html.haml
+++ b/app/views/portal/students/_move_confirmation.html.haml
@@ -1,6 +1,7 @@
 #move_confirmation{:style=>"background: #f5f5f5; display: none; padding: 10px;"}
-  %p
-    Are you sure you want to move #{portal_student.name} from #{current_clazz.teacher.user.first_name} #{current_clazz.teacher.user.last_name}'s #{current_clazz.name} to #{clazz.teacher.user.first_name} #{clazz.teacher.user.last_name}'s #{clazz.name}?
+  - if !current_clazz.nil? && !clazz.nil?
+    %p
+      Are you sure you want to move #{portal_student.name} from #{current_clazz.teacher.user.first_name} #{current_clazz.teacher.user.last_name}'s #{current_clazz.name} to #{clazz.teacher.user.first_name} #{clazz.teacher.user.last_name}'s #{clazz.name}?
 
   - if !potentially_orphaned_assignments.empty?
     %div{:class => 'warning', :style => 'background: #fc0; margin-bottom: 10px; padding: 10px;'}

--- a/app/views/portal/students/_move_confirmation.html.haml
+++ b/app/views/portal/students/_move_confirmation.html.haml
@@ -1,0 +1,18 @@
+#move_confirmation{:style=>"display: none;"}
+  %p
+    The teacher of the new class is #{clazz.teacher.user.first_name} #{clazz.teacher.user.last_name}. Is this the class you want to move this student to?
+  - if !potentially_orphaned_assignments.empty?
+    %p
+      %strong
+        WARNING:
+      The following assignments have been completed by the student in their current class, but there are no corresponding assignments in the new class. Moving the student will result in this work being lost.
+    %ul
+      - potentially_orphaned_assignments.each do |poa|
+        %li
+          #{poa}
+  %p
+    Click 'Submit' to complete the process of moving this student to this class.
+  = form_for(portal_student, :as => :portal_student, :url => '4/move', :html => {:id => "move_form"}) do |f|
+    = hidden_field_tag "clazz[current_class_word]", current_class_word
+    = hidden_field_tag "clazz[new_class_word]", new_class_word
+    = f.submit "Submit"

--- a/app/views/portal/students/_move_confirmation.html.haml
+++ b/app/views/portal/students/_move_confirmation.html.haml
@@ -1,18 +1,21 @@
 #move_confirmation{:style=>"display: none;"}
   %p
-    The teacher of the new class is #{clazz.teacher.user.first_name} #{clazz.teacher.user.last_name}. Is this the class you want to move this student to?
+    Are you sure you want to move #{portal_student.name} from #{current_clazz.teacher.user.first_name} #{current_clazz.teacher.user.last_name}'s #{current_clazz.name} to #{clazz.teacher.user.first_name} #{clazz.teacher.user.last_name}'s #{clazz.name}?
+
   - if !potentially_orphaned_assignments.empty?
-    %p
-      %strong
-        WARNING:
-      The following assignments have been completed by the student in their current class, but there are no corresponding assignments in the new class. Moving the student will result in this work being lost.
-    %ul
-      - potentially_orphaned_assignments.each do |poa|
-        %li
-          #{poa}
+    %div{:class => 'warning', :style => 'background: #fc0; margin-bottom: 10px; padding: 10px;'}
+      %p
+        %strong
+          WARNING
+        %br
+        The following assignments have been completed by #{portal_student.name} in #{current_clazz.name}, but there are no corresponding assignments in #{clazz.name}. Moving #{portal_student.name} will result in this work being orphaned and inaccessible to both teacher and student.
+      %ul
+        - potentially_orphaned_assignments.each do |poa|
+          %li
+            #{poa}
   %p
-    Click 'Submit' to complete the process of moving this student to this class.
+    Click 'Confirm' to complete the process.
   = form_for(portal_student, :as => :portal_student, :url => '4/move', :html => {:id => "move_form"}) do |f|
     = hidden_field_tag "clazz[current_class_word]", current_class_word
     = hidden_field_tag "clazz[new_class_word]", new_class_word
-    = f.submit "Submit"
+    = f.submit "Confirm"

--- a/app/views/portal/students/_show.html.haml
+++ b/app/views/portal/students/_show.html.haml
@@ -11,7 +11,9 @@
   :javascript
     poll_to_update_student_data_percentages(#{ poll_options.to_json })
 
+  %h3 Move this student to a new class
+  = render :partial => 'portal/students/move', :locals => { :portal_student => portal_student }
+
   %p
     %h3 Enter a new class word to join another class:
     = render :partial => 'portal/students/register', :locals => { :portal_student => portal_student }
-

--- a/app/views/portal/students/_show.html.haml
+++ b/app/views/portal/students/_show.html.haml
@@ -11,8 +11,9 @@
   :javascript
     poll_to_update_student_data_percentages(#{ poll_options.to_json })
 
-  %h3 Move this student to a new class
-  = render :partial => 'portal/students/move', :locals => { :portal_student => portal_student }
+  - if current_visitor.has_role?('admin')
+    %h3 Move this student to a new class
+    = render :partial => 'portal/students/move', :locals => { :portal_student => portal_student }
 
   %p
     %h3 Enter a new class word to join another class:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,11 +143,21 @@ RailsPortal::Application.routes.draw do
           get :register
           post :register
           post :confirm
+          get :move_confirm
+          post :move_confirm
+          get :move
+          post :move
+          put :move
         end
         member do
           get :ask_consent
           put :update_consent
           get :status
+          get :move_confirm
+          post :move_confirm
+          get :move
+          post :move
+          put :move
         end
       end
 

--- a/spec/controllers/portal/students_controller_spec.rb
+++ b/spec/controllers/portal/students_controller_spec.rb
@@ -199,6 +199,8 @@ describe Portal::StudentsController do
         :current_class_word => "currentclassword",
         :new_class_word => "newclassword"
       }
+      student.add_clazz(clazz_1)
+      student.remove_clazz(clazz_2)
     end
 
     let(:student) { FactoryBot.create(:full_portal_student) }
@@ -206,8 +208,6 @@ describe Portal::StudentsController do
     let(:clazz_2) { FactoryBot.create(:portal_clazz, :class_word => @clazz_params[:new_class_word]) }
 
     it 'should flash success notice' do
-      student.add_clazz(clazz_1)
-      student.remove_clazz(clazz_2)
       post :move, id: student.id, clazz: @clazz_params
       expect(flash[:notice]).to match(/Successfully moved student to new class./)
     end

--- a/spec/controllers/portal/students_controller_spec.rb
+++ b/spec/controllers/portal/students_controller_spec.rb
@@ -193,6 +193,26 @@ describe Portal::StudentsController do
     end
   end
 
+  describe "POST move" do
+    before(:each) do
+      @clazz_params = {
+        :current_class_word => "currentclassword",
+        :new_class_word => "newclassword"
+      }
+    end
+
+    let(:student) { FactoryBot.create(:full_portal_student) }
+    let(:clazz_1) { FactoryBot.create(:portal_clazz, :class_word => @clazz_params[:current_class_word]) }
+    let(:clazz_2) { FactoryBot.create(:portal_clazz, :class_word => @clazz_params[:new_class_word]) }
+
+    it 'should flash success notice' do
+      student.add_clazz(clazz_1)
+      student.remove_clazz(clazz_2)
+      post :move, id: student.id, clazz: @clazz_params
+      expect(flash[:notice]).to match(/Successfully moved student to new class./)
+    end
+  end
+
   # TODO: auto-generated
   describe '#status' do
     it 'GET status' do

--- a/spec/controllers/portal/students_controller_spec.rb
+++ b/spec/controllers/portal/students_controller_spec.rb
@@ -213,6 +213,42 @@ describe Portal::StudentsController do
     end
   end
 
+  describe "POST move_confirm" do
+    before(:each) do
+      @clazz_params = {
+        :current_class_word => "currentclassword",
+        :new_class_word => "newclassword"
+      }
+      student.add_clazz(clazz_1)
+      student.remove_clazz(clazz_2)
+    end
+
+    let(:teacher)  { FactoryBot.create(:portal_teacher) }
+    let(:student) { FactoryBot.create(:full_portal_student) }
+    let(:clazz_1) { FactoryBot.create(:portal_clazz, teachers: [teacher], :class_word => @clazz_params[:current_class_word]) }
+    let(:clazz_2) { FactoryBot.create(:portal_clazz, teachers: [teacher], :class_word => @clazz_params[:new_class_word]) }
+
+    it 'should ask for confirmation' do
+      post :move_confirm, id: student.id, clazz: @clazz_params
+      expect(response.body).to have_content("Are you sure you want to move")
+    end
+
+    it 'should notify if one or both of the class words are invalid' do
+      post :move_confirm, id: student.id, clazz: {:current_class_word => "wrongclassword1", :new_class_word => "wrongclassword2"}
+      expect(response.body).to have_content("One or more of the class words you entered is invalid.")
+    end
+
+    it 'should notify if the student is already in the class specified to move to' do
+      post :move_confirm, id: student.id, clazz: {:current_class_word => @clazz_params[:current_class_word], :new_class_word => @clazz_params[:current_class_word]}
+      expect(response.body).to have_content("The student is already in the class you are trying to move them to.")
+    end
+
+    it 'should notify if the student is not in the class specified to move from' do
+      post :move_confirm, id: student.id, clazz: {:current_class_word => @clazz_params[:new_class_word], :new_class_word => @clazz_params[:new_class_word]}
+      expect(response.body).to have_content("The student is not in the class you are trying to move them from.")
+    end
+  end
+
   # TODO: auto-generated
   describe '#status' do
     it 'GET status' do


### PR DESCRIPTION
@scytacki: Here's what I've done so far to make it so admins can move a student and their work from one class to another. 

Any work the student has done in assignments in the old class that aren't assigned to the new class is orphaned and inaccessible, though it still exists in the database and reappears if you move the student back to the old class. Not sure what to do about that, if anything.

Related PT story: https://www.pivotaltracker.com/story/show/165216012