### PR TITLE
Fix user report domain name

### DIFF
--- a/app/controllers/api/v1/report_users_controller.rb
+++ b/app/controllers/api/v1/report_users_controller.rb
@@ -48,7 +48,7 @@ class API::V1::ReportUsersController < API::APIController
     query = {
       type: "users",
       version: "1.0",
-      domain: URI.parse(root_url).host,
+      domain: URI.parse(APP_CONFIG[:site_url]).host,
       users: users,
       runnables: runnables,
       start_date: params[:start_date],

--- a/db/migrate/20110525194027_add_data_table_id_to_embeddable_data_collector.rb
+++ b/db/migrate/20110525194027_add_data_table_id_to_embeddable_data_collector.rb
@@ -1,37 +1,40 @@
 class AddDataTableIdToEmbeddableDataCollector < ActiveRecord::Migration
   def self.up
     add_column :embeddable_data_collectors, :data_table_id, :integer
-    Embeddable::DataTable.find(:all).each do |dt|
-      unless dt.data_collector_id.nil?
-        begin
-          collector = Embeddable::DataCollector.find(dt.data_collector_id)
-          if collector
-            collector.data_table_id = dt.id
-            collector.save
-            puts "inverted one data table <-> data collector relationship"
-          end
-        rescue
-        end
-      end
-    end
+    #
+    # This object doesn't exist anymore as of 2019
+    # Embeddable::DataTable.find(:all).each do |dt|
+    #   unless dt.data_collector_id.nil?
+    #     begin
+    #       collector = Embeddable::DataCollector.find(dt.data_collector_id)
+    #       if collector
+    #         collector.data_table_id = dt.id
+    #         collector.save
+    #         puts "inverted one data table <-> data collector relationship"
+    #       end
+    #     rescue
+    #     end
+    #   end
+    # end
   end
 
   def self.down
-    Embeddable::DataCollector.find(:all).each do |dc|
-      unless dc.data_table_id.nil?
-        begin
-          table = Embeddable::DataTable.find(dc.data_table_id)
-          if table
-            if table.data_collector_id != dc.id
-              table.data_collector_id = dc.id
-              table.save
-              puts "reverted one data table <-> data collector relationship"
-            end
-          end
-        rescue
-        end
-      end
-    end
+    # This object doesn't exist anymore as of 2019
+    # Embeddable::DataCollector.find(:all).each do |dc|
+    #   unless dc.data_table_id.nil?
+    #     begin
+    #       table = Embeddable::DataTable.find(dc.data_table_id)
+    #       if table
+    #         if table.data_collector_id != dc.id
+    #           table.data_collector_id = dc.id
+    #           table.save
+    #           puts "reverted one data table <-> data collector relationship"
+    #         end
+    #       end
+    #     rescue
+    #     end
+    #   end
+    # end
     remove_column :embeddable_data_collectors, :data_table_id
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -535,6 +535,7 @@ ActiveRecord::Schema.define(:version => 20190515122245) do
     t.boolean  "saves_student_data",                               :default => true
     t.text     "long_description"
     t.string   "source_type"
+    t.text     "keywords"
   end
 
   add_index "external_activities", ["is_featured", "publication_status"], :name => "featured_public"

--- a/spec/controllers/api/v1/report_users_controller_spec.rb
+++ b/spec/controllers/api/v1/report_users_controller_spec.rb
@@ -107,6 +107,15 @@ describe API::V1::ReportUsersController do
       end
     end
     describe "GET external_report_query" do
+      before(:each) do
+        @old_configuration = APP_CONFIG[:site_url]
+        APP_CONFIG[:site_url] = 'http://example.com'
+      end
+
+      after(:each) do
+        APP_CONFIG[:site_url] = @old_configuration
+      end
+
       it "allows index" do
         get :external_report_query
         expect(response.status).to eql(200)
@@ -123,7 +132,7 @@ describe API::V1::ReportUsersController do
         filter = resp["json"]
         expect(filter["type"]).to eq "users"
         expect(filter["version"]).to eq "1.0"
-        expect(filter["domain"]).to eq "test.host"
+        expect(filter["domain"]).to eq "example.com"
         expect(filter["users"].length).to eq 5
         expect(filter["runnables"].length).to eq 3
         expect(filter["start_date"]).to eq "01/02/19"

--- a/spec/libs/bearer_token/jwt_bearer_token_authenticatable_spec.rb
+++ b/spec/libs/bearer_token/jwt_bearer_token_authenticatable_spec.rb
@@ -1,9 +1,6 @@
 require 'spec_helper'
 require 'delorean'
 
-# needed to generate signed portal tokens
-ENV['JWT_HMAC_SECRET'] = 'foo'
-
 describe JwtBearerTokenAuthenticatable::BearerToken do
   let(:strategy)      { JwtBearerTokenAuthenticatable::BearerToken.new(nil) }
   let(:request)       { double('request') }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,8 @@
 ENV["RAILS_ENV"] = 'test'
 
+# needed to generate signed portal tokens
+ENV["JWT_HMAC_SECRET"] = 'foo'
+
 require 'simplecov'
 SimpleCov.start do
   merge_timeout 3600


### PR DESCRIPTION
This should fix an issue Dave and I found when testing out the user report page on staging. Because the domain is different where researchers run reports the previous code was using this report domain instead of the main portal domain.

This PR also includes a fix to the database schema which was breaking the tests. The new keywords field was missing from external_activities.  I'm not sure if this was because it was missed in the original keywords PR, or perhaps it was broken during the work on the new user report page code. 