### PR TITLE
Rake task to export class_hash and learner keys for adding to LARA Runs.

### DIFF
--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -79,19 +79,17 @@ namespace :app do
       filename = ENV["CLASS_EXPORT_FILENAME"] || "clazz-learners.csv"
       # We want to write out class_id, class_hash,learner_key
       File.open(filename, 'w') do |outfile|
-        Portal::Clazz.find_in_batches(batch_size: 20) do |batch|
-          batch.each do |clazz|
-            clazz.offerings.each do |offering|
-              offering.learners.each do |learner|
-                begin
-                  id = clazz.id
-                  hash = clazz.class_hash
-                  lid = learner.id
-                  key = learner.secure_key
-                  outfile.write "#{id},#{hash},#{lid},#{key}\n"
-                rescue => e
-                  Rails.logger.error "Failed to add learner #{e}"
-                end
+        Portal::Clazz.find_each(batch_size: 20) do |clazz|
+          clazz.offerings.each do |offering|
+            offering.learners.find_each(batch_size: 50) do |learner|
+              begin
+                id = clazz.id
+                hash = clazz.class_hash
+                lid = learner.id
+                key = learner.secure_key
+                outfile.write "#{id},#{hash},#{lid},#{key}\n"
+              rescue => e
+                Rails.logger.error "Failed to add learner #{e}"
               end
             end
           end


### PR DESCRIPTION
The idea is to update about ~500K learner-runs in LARA to include
`class_hash` values, which we need for FireStore authorization rules.

This commit is part of that story. Just exporting the values we need to use
later in this format:

 `CLAZZ_ID, CLASS_HASH, LEARNER_ID, LEARNER_KEY`

[#165217423]
https://www.pivotaltracker.com/story/show/165217423
