### PR TITLE
Adds `class_hash` to launch parameters in OfferingsController

### DIFF
--- a/app/controllers/portal/offerings_controller.rb
+++ b/app/controllers/portal/offerings_controller.rb
@@ -66,7 +66,8 @@ class Portal::OfferingsController < ApplicationController
              :returnUrl => learner.remote_endpoint_url,
              :logging => @offering.clazz.logging || @offering.runnable.logging,
              :domain_uid => current_visitor.id,
-             :class_info_url => @offering.clazz.class_info_url(request.protocol, request.host_with_port)
+             :class_info_url => @offering.clazz.class_info_url(request.protocol, request.host_with_port),
+             :class_hash => @offering.clazz.class_hash
            }.to_query
            redirect_to(uri.to_s)
          else

--- a/app/helpers/runnables_helper.rb
+++ b/app/helpers/runnables_helper.rb
@@ -112,6 +112,7 @@ module RunnablesHelper
       # the user id is added to this url to make the url be unique for each user
       # this ought to prevent jnlps from being cached and shared by users
       # the user id is not actually used to generate the response or authorize it
+      # route: portal/offerings#show {:id=>/\d+/, :user_id=>/\d+/}
       user_portal_offering_url(current_visitor, component, params)
     else
       unless component.instance_of? ExternalActivity

--- a/features/activity_runtime_api/running.feature
+++ b/features/activity_runtime_api/running.feature
@@ -11,6 +11,7 @@ Feature: External Activities can support a REST api
       | logging           | false                        |
       | returnUrl         | site_url/dataservice/external_activity_data/key |
       | class_info_url    | class_info_url of 'My Class' |
+      | class_hash        | class_hash of 'My Class' |
     And "activities.com/activity/1/sessions/" GET responds with
       """
       HTTP/1.1 200 OK

--- a/features/step_definitions/activity_runtime_api_steps.rb
+++ b/features/step_definitions/activity_runtime_api_steps.rb
@@ -60,6 +60,9 @@ Given /^"([^"]*)" handles a (POST|GET) with query:$/ do |address, method, table|
   if /class_info_url of '(.*)'/ =~ query_data["class_info_url"]
     query_data["class_info_url"] = Portal::Clazz.find_by_name($~[1]).class_info_url("http", "www.example.com")
   end
+  if /class_hash of '(.*)'/ =~ query_data["class_hash"]
+    query_data["class_hash"] = Portal::Clazz.find_by_name($~[1]).class_hash
+  end
   stub.with(:query => query_data)
 end
 


### PR DESCRIPTION
This is being submitted as part of this PT bug report:
When a sequence is launched from the portal, the class_info_url is not set correctly on the activity runs.

See branch 165217423-class-info-for-sequence-runs  in LARA or this pull request:
https://github.com/concord-consortium/lara/pull/428

[#165217423]
https://www.pivotaltracker.com/story/show/165217423