### PR TITLE
Added portal token to PortalPages user report form render [#166472275]

### DIFF
--- a/app/views/report/user/index.html.haml
+++ b/app/views/report/user/index.html.haml
@@ -11,7 +11,9 @@
 #form-container
 
 - external_reports = ExternalReport.where(report_type: ExternalReport::ResearcherReport).map { |r| {url: "#{r.url}", label: "#{r.launch_text}"} }.to_json
+- portal_token = SignedJWT::create_portal_token(current_user, {domain: root_url})
 
 :javascript
-  PortalPages.renderUserReportForm({externalReports: #{external_reports}}, "form-container")
+  PortalPages.renderUserReportForm({externalReports: #{external_reports}, portalToken
+  : "#{portal_token}"}, "form-container")
 


### PR DESCRIPTION
Tbis allows the teacher edition report to call back to the portal.  The domain claim in the portal token contains the root url of the portal and can be used to compose call back urls.