### PR TITLE
Report service data/ids refactoring

### DIFF
--- a/app/controllers/api/v1/classes_controller.rb
+++ b/app/controllers/api/v1/classes_controller.rb
@@ -122,6 +122,7 @@ class API::V1::ClassesController < API::APIController
       :teachers => clazz.teachers.includes(:user).map { |teacher|
         {
           :id => url_for(teacher.user),
+          :user_id => teacher.user.id,
           :first_name => teacher.user.first_name,
           :last_name => teacher.user.last_name
         }
@@ -129,6 +130,7 @@ class API::V1::ClassesController < API::APIController
       :students => clazz.students.includes(:user).map { |student|
         {
           :id => url_for(student.user),
+          :user_id => student.user.id,
           :email => student.user.email,
           :first_name => student.user.first_name,
           :last_name => student.user.last_name

--- a/app/controllers/api/v1/jwt_controller.rb
+++ b/app/controllers/api/v1/jwt_controller.rb
@@ -66,7 +66,7 @@ class API::V1::JwtController < API::APIController
         # Firebase auth rules expect all the claims to be in a sub-object named "claims".
         # All the new properties should go there. Other apps can still read them.
         :claims => {
-          :platform_id => URI.parse(root_url).host,
+          :platform_id => root_url,
           :platform_user_id => user.id,
           :user_type => "learner",
           :user_id => url_for(user),
@@ -95,7 +95,7 @@ class API::V1::JwtController < API::APIController
         # Firebase auth rules expect all the claims to be in a sub-object named "claims".
         # All the new properties should go there. Other apps can still read them.
         :claims => {
-          :platform_id => URI.parse(root_url).host,
+          :platform_id => root_url,
           :platform_user_id => user.id,
           :user_type => "teacher",
           :user_id => url_for(user),

--- a/app/controllers/api/v1/jwt_controller.rb
+++ b/app/controllers/api/v1/jwt_controller.rb
@@ -63,18 +63,24 @@ class API::V1::JwtController < API::APIController
     if learner
       offering = learner.offering
       claims = {
+        # Firebase auth rules expect all the claims to be in a sub-object named "claims".
+        # All the new properties should go there. Other apps can still read them.
+        :claims => {
+          :platform_id => URI.parse(root_url).host,
+          :platform_user_id => user.id,
+          :user_type => "learner",
+          :user_id => url_for(user),
+          :class_hash => offering.clazz.class_hash,
+          :offering_id => offering.id
+        },
+        # Depreciated, used by some CC client apps. Do not add more data here, it's better to add that to claims
+        # object above, as then Firebase auth rules can read these properties too.
         :domain => root_url,
         :externalId => learner.id,
         :returnUrl => learner.remote_endpoint_url,
         :logging => offering.clazz.logging || offering.runnable.logging,
         :domain_uid => user.id,
         :class_info_url => offering.clazz.class_info_url(request.protocol, request.host_with_port),
-        :claims => { # need claims sub-namespace for firebase auth rules
-          :user_type => "learner",
-          :user_id => url_for(user),
-          :class_hash => offering.clazz.class_hash,
-          :offering_id => offering.id
-        }
       }
     elsif teacher
       # verify if the optional passed class_hash is valid
@@ -86,13 +92,19 @@ class API::V1::JwtController < API::APIController
       end
 
       claims = {
-        :domain => root_url,
-        :domain_uid => user.id,
-        :claims => { # need claims sub-namespace for firebase auth rules
+        # Firebase auth rules expect all the claims to be in a sub-object named "claims".
+        # All the new properties should go there. Other apps can still read them.
+        :claims => {
+          :platform_id => URI.parse(root_url).host,
+          :platform_user_id => user.id,
           :user_type => "teacher",
           :user_id => url_for(user),
           :class_hash => params[:class_hash]
-        }
+        },
+        # Depreciated, used by some CC client apps. Do not add more data here, it's better to add that to claims
+        # object above, as then Firebase auth rules can read these properties too.
+        :domain => root_url,
+        :domain_uid => user.id,
       }
     end
 

--- a/app/controllers/portal/offerings_controller.rb
+++ b/app/controllers/portal/offerings_controller.rb
@@ -68,7 +68,10 @@ class Portal::OfferingsController < ApplicationController
              :domain_uid => current_visitor.id,
              :class_info_url => @offering.clazz.class_info_url(request.protocol, request.host_with_port),
              :context_id => @offering.clazz.class_hash,
-             :platform_id => URI.parse(root_url).host,
+             # platform_id and platform_user_id seems like duplicates of domain and domain_uid.
+             # However, LARA uses domain and domain_uid to auth user, removes them from URI and performs redirect.
+             # So, these params won't be available later to setup LARA run.
+             :platform_id => root_url,
              :platform_user_id => current_visitor.id,
              :resource_link_id => @offering.id
            }.to_query

--- a/app/controllers/portal/offerings_controller.rb
+++ b/app/controllers/portal/offerings_controller.rb
@@ -67,7 +67,9 @@ class Portal::OfferingsController < ApplicationController
              :domain => root_url,
              :domain_uid => current_visitor.id,
              :class_info_url => @offering.clazz.class_info_url(request.protocol, request.host_with_port),
-             :class_hash => @offering.clazz.class_hash,
+             :context_id => @offering.clazz.class_hash,
+             :platform_id => URI.parse(root_url).host,
+             :platform_user_id => current_visitor.id,
              :resource_link_id => @offering.id
            }.to_query
            redirect_to(uri.to_s)

--- a/app/controllers/portal/offerings_controller.rb
+++ b/app/controllers/portal/offerings_controller.rb
@@ -61,13 +61,14 @@ class Portal::OfferingsController < ApplicationController
          if external_activity.launch_url.present?
            uri = URI.parse(external_activity.launch_url)
            uri.query = {
-             :domain => root_url,
              :externalId => learner.id,
              :returnUrl => learner.remote_endpoint_url,
              :logging => @offering.clazz.logging || @offering.runnable.logging,
+             :domain => root_url,
              :domain_uid => current_visitor.id,
              :class_info_url => @offering.clazz.class_info_url(request.protocol, request.host_with_port),
-             :class_hash => @offering.clazz.class_hash
+             :class_hash => @offering.clazz.class_hash,
+             :resource_link_id => @offering.id
            }.to_query
            redirect_to(uri.to_s)
          else

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -73,22 +73,20 @@ namespace :app do
     # Part of: https://www.pivotaltracker.com/story/show/165217423
     # The idea is to update about ~500K learner-runs in LARA to include
     # `class_hash` values, which we need for FireStore authorization Rules
-    # LINE FORMAT: CLAZZ_ID, CLASS_HASH, USER_ID, LEARNER_KEY
+    # LINE FORMAT: CLAZZ_ID, CLASS_HASH, LEARNER_ID, LEARNER_KEY, USER_ID, OFFERING_ID
     desc "export clazz-learner keys to clazz-learners.csv. Import into LARA Runs"
     task :write_class_and_learner_keys => :environment do
       filename = ENV["CLASS_EXPORT_FILENAME"] || "clazz-learners.csv"
-      # We want to write out class_id, class_hash,learner_key,offering_id
       File.open(filename, 'w') do |outfile|
         Portal::Clazz.find_each(batch_size: 20) do |clazz|
           clazz.offerings.each do |offering|
             offering.learners.find_each(batch_size: 50) do |learner|
               begin
-                id = clazz.id
                 class_hash = clazz.class_hash
                 uid = learner.user.id
                 learner_key = learner.secure_key
                 offering_id = learner.offering_id
-                outfile.write "#{id},#{class_hash},#{uid},#{learner_key},#{offering_id}\n"
+                outfile.write "#{clazz.id},#{class_hash},#{learner.id},#{learner_key},#{uid},#{offering_id}\n"
               rescue => e
                 Rails.logger.error "Failed to add learner #{e}"
               end

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -73,21 +73,22 @@ namespace :app do
     # Part of: https://www.pivotaltracker.com/story/show/165217423
     # The idea is to update about ~500K learner-runs in LARA to include
     # `class_hash` values, which we need for FireStore authorization Rules
-    # LINE FORMAT: CLAZZ_ID, CLASS_HASH, LEARNER_ID, LEARNER_KEY
+    # LINE FORMAT: CLAZZ_ID, CLASS_HASH, USER_ID, LEARNER_KEY
     desc "export clazz-learner keys to clazz-learners.csv. Import into LARA Runs"
     task :write_class_and_learner_keys => :environment do
       filename = ENV["CLASS_EXPORT_FILENAME"] || "clazz-learners.csv"
-      # We want to write out class_id, class_hash,learner_key
+      # We want to write out class_id, class_hash,learner_key,offering_id
       File.open(filename, 'w') do |outfile|
         Portal::Clazz.find_each(batch_size: 20) do |clazz|
           clazz.offerings.each do |offering|
             offering.learners.find_each(batch_size: 50) do |learner|
               begin
                 id = clazz.id
-                hash = clazz.class_hash
-                lid = learner.id
-                key = learner.secure_key
-                outfile.write "#{id},#{hash},#{lid},#{key}\n"
+                class_hash = clazz.class_hash
+                uid = learner.user.id
+                learner_key = learner.secure_key
+                offering_id = learner.offering_id
+                outfile.write "#{id},#{class_hash},#{uid},#{learner_key},#{offering_id}\n"
               rescue => e
                 Rails.logger.error "Failed to add learner #{e}"
               end


### PR DESCRIPTION
- Provide “user_id” (number) for students and teacher in the Class API response.
- Provide “user_id” (number) for students and teachers in Firebase JWT claims.
- Provide “platform_id” (string, hostname) in Firebase JWT claims.
- Add comments in JWT code that the top-level claims are depreciated and all new claims should go to “claims” hash (so they can be read by Firebase/Firestore too).
- Update “write_class_and_learner_keys” rake task to also include “offering_id” and “user_id” for every learner/run.
- Send offering_id as “resource_link_id”, "platform_id" and "platform_user_id" parameters when launching resources as students from the portal (comments explain why "platform_id" and "platform_user_id" were necessary).
