### PR TITLE
Add "allow_for_students" option to external report and handle its launching for students

### DIFF
--- a/app/policies/portal/offering_policy.rb
+++ b/app/policies/portal/offering_policy.rb
@@ -1,7 +1,7 @@
 class Portal::OfferingPolicy < ApplicationPolicy
   # Used by API::V1::OfferingsController:
   def api_show?
-    class_teacher_or_admin?
+    class_teacher_or_admin? || class_student?
   end
 
   def api_index?
@@ -72,7 +72,7 @@ class Portal::OfferingPolicy < ApplicationPolicy
   end
 
   def external_report?
-    class_teacher_or_admin?
+    class_teacher_or_admin? || (record.runnable.external_report && record.runnable.external_report.allowed_for_students && class_student?)
   end
 
   def offering_collapsed_status?

--- a/app/views/admin/external_reports/_form.html.haml
+++ b/app/views/admin/external_reports/_form.html.haml
@@ -23,4 +23,7 @@
         %li
           Report Type:
           = f.select :report_type, report.options_for_report_type, {}, prompt: 'report type:'
+        %li
+          Allowed for Students:
+          = f.check_box :allowed_for_students
       = submit_tag

--- a/app/views/admin/external_reports/_form.html.haml
+++ b/app/views/admin/external_reports/_form.html.haml
@@ -26,4 +26,5 @@
         %li
           Allowed for Students:
           = f.check_box :allowed_for_students
+          %p If the report type is 'offering', then students will see a button to open the report.
       = submit_tag

--- a/app/views/admin/external_reports/_show.html.haml
+++ b/app/views/admin/external_reports/_show.html.haml
@@ -27,3 +27,6 @@
           %li
             Report Type:
             = report.report_type
+          %li
+            Allowed For Students:
+            = report.allowed_for_students

--- a/app/views/shared/_offering_for_student.html.haml
+++ b/app/views/shared/_offering_for_student.html.haml
@@ -56,4 +56,11 @@
                     =link_to t("StudentProgress.GenerateReport.Done"), student_report_portal_offering_url(offering), target: "_blank"
                   - else
                     =link_to t("StudentProgress.GenerateReport.NotDone"), student_report_portal_offering_url(offering)
+                  %br
+
+              - external_report = offering.runnable.external_report
+              - if external_report.present? && external_report.allowed_for_students
+                %span.lightbox_report_link
+                  = link_to external_report.launch_text, portal_external_report_url(id: offering.id, report_id: external_report.id), target: "_blank"
+
 

--- a/db/migrate/20190620172718_add_allowed_for_students_to_external_reports.rb
+++ b/db/migrate/20190620172718_add_allowed_for_students_to_external_reports.rb
@@ -1,0 +1,5 @@
+class AddAllowedForStudentsToExternalReports < ActiveRecord::Migration
+  def change
+    add_column :external_reports, :allowed_for_students, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20190515122245) do
+ActiveRecord::Schema.define(:version => 20190620172718) do
 
   create_table "access_grants", :force => true do |t|
     t.string   "code"
@@ -445,8 +445,6 @@ ActiveRecord::Schema.define(:version => 20190515122245) do
     t.boolean  "show_in_featured_question_report",                     :default => true
   end
 
-  add_index "embeddable_image_questions", ["external_id"], :name => "index_embeddable_image_questions_on_external_id"
-
   create_table "embeddable_multiple_choice_choices", :force => true do |t|
     t.text     "choice",             :limit => 16777215
     t.integer  "multiple_choice_id"
@@ -510,7 +508,6 @@ ActiveRecord::Schema.define(:version => 20190515122245) do
     t.string   "launch_url"
     t.boolean  "is_official",                                      :default => false
     t.boolean  "student_report_enabled",                           :default => true
-    t.text     "long_description_for_teacher", :limit => 16777215
     t.string   "teacher_guide_url"
     t.string   "thumbnail_url"
     t.boolean  "is_featured",                                      :default => false
@@ -533,6 +530,7 @@ ActiveRecord::Schema.define(:version => 20190515122245) do
     t.string   "material_type",                                    :default => "Activity"
     t.string   "rubric_url"
     t.boolean  "saves_student_data",                               :default => true
+    t.text     "long_description_for_teacher"
     t.text     "long_description"
     t.string   "source_type"
     t.text     "keywords"
@@ -549,9 +547,10 @@ ActiveRecord::Schema.define(:version => 20190515122245) do
     t.string   "name"
     t.string   "launch_text"
     t.integer  "client_id"
-    t.datetime "created_at",                          :null => false
-    t.datetime "updated_at",                          :null => false
-    t.string   "report_type", :default => "offering"
+    t.datetime "created_at",                                   :null => false
+    t.datetime "updated_at",                                   :null => false
+    t.string   "report_type",          :default => "offering"
+    t.boolean  "allowed_for_students", :default => false
   end
 
   add_index "external_reports", ["client_id"], :name => "index_external_reports_on_client_id"


### PR DESCRIPTION
[#166241118]

Changes to make that working:

1. Add "allow_for_students" to external report type (`false` by default).
1. Add learner to access grant while launching external report if the report is allowed for students and the user is a student. I was confused why I couldn't get any learner info in JWT, this part was necessary for that.
1. Open access to Offering API for students (offering_policy.rb), as the client app has to download offering info.
1. Let students launch external report for offering if `allow_for_students` is true (offering_policy.rb).
1. Add `studentId=` URL param when the report is launched for a student. The client app will use it to filter out data. Theoretically, we could use info from JWT token, but teachers can also run reports for individual students. We need more flexibility. It's all safe, as the client app is using JWT info both to query for answers for student and to restrict access to them. So, even if the student manually changes `studentId=` param in the URL, he'll only see a blank report.