### PR TITLE
Add dev docker overlay to skip logstash related services

### DIFF
--- a/docker/dev/docker-compose-no-logstash.yml
+++ b/docker/dev/docker-compose-no-logstash.yml
@@ -1,0 +1,17 @@
+# Prevents Eleasticsearch, Logstash, and Kibana images from running in local
+# Development mode.
+
+# To use this you must edit your .env file and change `COMPOSE_FILE` var
+# to include `docker/dev/docker-compose-no-logstash.yml`
+
+# We Stole this workaround from from a related github issue:
+# https://github.com/docker/compose/issues/3729#issuecomment-438077575
+
+version: '3'
+services:
+  elasticsearch:
+    image: hello-world
+  logstash:
+    image: hello-world
+  kibana:
+    image: hello-world


### PR DESCRIPTION
Prevents Eleasticsearch, Logstash, and Kibana images from running in local development mode.

Approach taken from:
https://github.com/docker/compose/issues/3729#issuecomment-438077575

[#166832517]
https://www.pivotaltracker.com/story/show/166832517