### PR TITLE
Support multiple external reports for ExternalActivities

### DIFF
--- a/app/controllers/api/v1/external_activities_controller.rb
+++ b/app/controllers/api/v1/external_activities_controller.rb
@@ -24,22 +24,21 @@ class API::V1::ExternalActivitiesController < API::APIController
       return error("Invalid url", 422)
     end
 
-    external_report_id = 0
-    if params[:external_report_url]
-      external_report = ExternalReport.find_by_url(params[:external_report_url])
-      if external_report
-        external_report_id = external_report.id
-      end
-    end
-
     external_activity = ExternalActivity.create(
       :name               => name,
       :url                => url,
       :publication_status => params[:publication_status] || "private",
       :user               => user,
-      :append_auth_token  => params[:append_auth_token] || false,
-      :external_report_id => external_report_id
+      :append_auth_token  => params[:append_auth_token] || false
     )
+
+    if params[:external_report_url]
+      external_report = ExternalReport.find_by_url(params[:external_report_url])
+      if external_report
+        external_activity.external_reports=[external_report]
+        external_activity.save
+      end
+    end
 
     if !external_activity.valid?
       return error("Unable to create external activity", 422)

--- a/app/controllers/external_activities_controller.rb
+++ b/app/controllers/external_activities_controller.rb
@@ -207,6 +207,12 @@ class ExternalActivitiesController < ApplicationController
       @external_activity.save
     end
 
+    if params[:update_external_reports]
+      # set the external reports
+      @external_activity.external_report_ids= (params[:external_reports] || [])
+      @external_activity.save
+    end
+
     if request.xhr?
       if cancel || @external_activity.update_attributes(params[:external_activity])
         render :partial => 'shared/external_activity_header', :locals => { :external_activity => @external_activity }

--- a/app/models/external_activity.rb
+++ b/app/models/external_activity.rb
@@ -327,10 +327,6 @@ class ExternalActivity < ActiveRecord::Base
     return external_reports.first
   end
 
-  def external_report=(report)
-    self.external_reports=[report]
-  end
-
   private
 
   def append_query(uri, query_str)

--- a/app/models/external_activity.rb
+++ b/app/models/external_activity.rb
@@ -68,7 +68,9 @@ class ExternalActivity < ActiveRecord::Base
   end
 
   belongs_to :user
-  belongs_to :external_report
+
+  has_many :external_activity_reports
+  has_many :external_reports, through: :external_activity_reports
 
   has_many :favorites, as: :favoritable
 
@@ -316,6 +318,13 @@ class ExternalActivity < ActiveRecord::Base
     return long_description_for_teacher if user && user.portal_teacher && long_description_for_teacher.present?
     return long_description if long_description.present?
     short_description
+  end
+
+  # 2019-07-12 NP: Backwards compatibility note
+  # We removed external_report from the table, but support many via
+  # external_activity_reports
+  def external_report
+    return external_reports.first
   end
 
   private

--- a/app/models/external_activity.rb
+++ b/app/models/external_activity.rb
@@ -327,6 +327,10 @@ class ExternalActivity < ActiveRecord::Base
     return external_reports.first
   end
 
+  def external_report=(report)
+    self.external_reports=[report]
+  end
+
   private
 
   def append_query(uri, query_str)

--- a/app/models/external_activity_report.rb
+++ b/app/models/external_activity_report.rb
@@ -1,0 +1,4 @@
+class ExternalActivityReport < ActiveRecord::Base
+  belongs_to :external_activity
+  belongs_to :external_report
+end

--- a/app/models/external_report.rb
+++ b/app/models/external_report.rb
@@ -5,7 +5,9 @@ class ExternalReport < ActiveRecord::Base
   ResearcherReport = 'researcher'
   ReportTypes = [OfferingReport, ClassReport, ResearcherReport]
   belongs_to :client
-  has_many :external_activities
+  has_many :external_activity_reports
+  has_many :external_activities, through: :external_activity_reports
+
   attr_accessible :name, :url, :launch_text, :client_id, :client, :report_type, :allowed_for_students
 
   ReportTokenValidFor = 2.hours

--- a/app/models/portal/clazz.rb
+++ b/app/models/portal/clazz.rb
@@ -287,8 +287,8 @@ class Portal::Clazz < ActiveRecord::Base
 
   def external_class_reports
     self.offerings.includes(:runnable)
-      .select{ |o| o.runnable && o.runnable.respond_to?(:external_report) && o.runnable.external_report }
-      .map{ |o| o.runnable.external_report }
+      .select{ |o| o.runnable && o.runnable.respond_to?(:external_reports) && o.runnable.external_reports }
+      .flat_map{ |o| o.runnable.external_reports }
       .select{ |r| r.report_type == "class" }
       .uniq{ |r| r.id }
       .sort{ |r1, r2| r1.launch_text <=> r2.launch_text }

--- a/app/views/external_activities/_form.html.haml
+++ b/app/views/external_activities/_form.html.haml
@@ -48,10 +48,8 @@
       = f.text_field :launch_url, :size => 60
       %br
       = t('authoring.launch_url_description')
-    = field_set_tag t('authoring.external_report_label') do
-      = f.select :external_report_id, @external_activity.options_for_external_report, include_blank: 'none'
-      %br
-      = t('authoring.external_report_description')
+
+    = render :partial => 'shared/reports_edit', :locals => { :object => @external_activity }
     = field_set_tag 'Teacher Guide (URL)' do
       = f.text_field :teacher_guide_url, :size => 60
     = field_set_tag t('authoring.rubric_url_label') do

--- a/app/views/shared/_reports_edit.html.haml
+++ b/app/views/shared/_reports_edit.html.haml
@@ -1,0 +1,11 @@
+-# Expects locals: object
+- if object && object.respond_to?("external_reports")
+  = field_set_tag t('authoring.external_report_label') do
+    .aligned
+      = hidden_field_tag :update_external_reports, "true"
+      - ExternalReport.all.each do | external_report |
+        %div
+          = check_box_tag "external_reports[]", external_report.id, object.external_report_ids.include?(external_report.id), :id => external_report.id
+          = label_tag external_report.name, external_report.name
+      %br
+      = t('authoring.external_report_description')

--- a/app/views/shared/_reports_edit.html.haml
+++ b/app/views/shared/_reports_edit.html.haml
@@ -3,7 +3,7 @@
   = field_set_tag t('authoring.external_report_label') do
     .aligned
       = hidden_field_tag :update_external_reports, "true"
-      - ExternalReport.all.each do | external_report |
+      - ExternalReport.where('report_type !=?', ExternalReport::ResearcherReport).each do | external_report |
         %div
           = check_box_tag "external_reports[]", external_report.id, object.external_report_ids.include?(external_report.id), :id => external_report.id
           = label_tag external_report.name, external_report.name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,7 +65,7 @@ en:
     source_type_label: Source Type
     material_type_description: Users can see the type of material in various places, use this field to change that type
     external_report_label: External Reporting
-    external_report_description: Specify and alternate report link to be shown to teachers in the offering view. Unless you know what you are doing 'none' is recommended.
+    external_report_description: Specify additional report links to be shown to teachers in the offering view. Unless you know what you are doing selecting none is recommended.
     report_client: Report Auth Client
     rubric_url_label: Rubric (URL)
     short_description_description: Shown in search results, student listings, and used as a fallback for long descrption. It is recommended that every activity has this value provided.

--- a/db/migrate/20190711205857_create_external_activities_reports_table.rb
+++ b/db/migrate/20190711205857_create_external_activities_reports_table.rb
@@ -1,0 +1,22 @@
+
+
+class CreateExternalActivitiesReportsTable < ActiveRecord::Migration
+  def up
+    create_table :external_activity_reports, id: false do |t|
+      t.references :external_activity
+      t.references :external_report
+    end
+    add_index :external_activity_reports,
+      [:external_activity_id, :external_report_id],
+      name: "activity_reports_activity_index"
+    add_index :external_activity_reports,
+      :external_report_id,
+      name: "activity_reports_index"
+    move_external_reports_to_join_table
+  end
+
+  def down
+    drop_table :external_activity_reports
+  end
+
+end

--- a/db/migrate/20190711205857_create_external_activities_reports_table.rb
+++ b/db/migrate/20190711205857_create_external_activities_reports_table.rb
@@ -12,7 +12,6 @@ class CreateExternalActivitiesReportsTable < ActiveRecord::Migration
     add_index :external_activity_reports,
       :external_report_id,
       name: "activity_reports_index"
-    move_external_reports_to_join_table
   end
 
   def down

--- a/db/migrate/20190711221406_move_external_reports.rb
+++ b/db/migrate/20190711221406_move_external_reports.rb
@@ -1,0 +1,50 @@
+
+class ExternalReport < ActiveRecord::Base
+end
+
+class ExternalActivityReport < ActiveRecord::Base
+  belongs_to :external_activity
+  belongs_to :external_report
+end
+
+class  ExternalActivity  < ActiveRecord::Base
+  belongs_to :external_report
+  has_many :external_activity_reports
+  has_many :external_reports, through: :external_activity_reports
+end
+
+
+class MoveExternalReports < ActiveRecord::Migration
+
+  def up_activity(a)
+    if(a.external_report)
+      a.external_reports=[a.external_report]
+      a.save
+      putc "."
+    end
+  end
+
+  def down_activity(a)
+    if(a.external_reports.length > 0)
+      report = a.external_reports[0]
+      a.update_attribute(:external_report_id, report.id)
+      putc "."
+    end
+  end
+
+  def up
+    ExternalActivity.find_in_batches do |batch|
+      batch.each { |a| up_activity(a) }
+    end
+    remove_column :external_activities, :external_report_id
+    puts
+  end
+
+  def down
+    add_column :external_activities, :external_report_id,  :integer
+    ExternalActivity.find_in_batches do |batch|
+      batch.each { |a| down_activity(a) }
+    end
+    puts
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20190620172718) do
+ActiveRecord::Schema.define(:version => 20190711221406) do
 
   create_table "access_grants", :force => true do |t|
     t.string   "code"
@@ -518,7 +518,6 @@ ActiveRecord::Schema.define(:version => 20190620172718) do
     t.boolean  "is_locked"
     t.boolean  "logging",                                          :default => false
     t.boolean  "is_assessment_item",                               :default => false
-    t.integer  "external_report_id"
     t.text     "author_url"
     t.text     "print_url"
     t.boolean  "is_archived",                                      :default => false
@@ -541,6 +540,14 @@ ActiveRecord::Schema.define(:version => 20190620172718) do
   add_index "external_activities", ["save_path"], :name => "index_external_activities_on_save_path"
   add_index "external_activities", ["template_id", "template_type"], :name => "index_external_activities_on_template_id_and_template_type"
   add_index "external_activities", ["user_id"], :name => "index_external_activities_on_user_id"
+
+  create_table "external_activity_reports", :id => false, :force => true do |t|
+    t.integer "external_activity_id"
+    t.integer "external_report_id"
+  end
+
+  add_index "external_activity_reports", ["external_activity_id", "external_report_id"], :name => "activity_reports_activity_index"
+  add_index "external_activity_reports", ["external_report_id"], :name => "activity_reports_index"
 
   create_table "external_reports", :force => true do |t|
     t.string   "url"

--- a/features/activity_runtime_api/publish.feature
+++ b/features/activity_runtime_api/publish.feature
@@ -326,7 +326,7 @@ Feature: External Activities can support a REST publishing api
       | print_url       | http://activity.com/activity/1/print_blank |
     And the external activity should not have any description set
     And the external activity should have a template
-    And the external activity should have a external report at "https://reports.concord.org/act"
+    And the external activity should not have an external report
     And the portal should create an activity with the following attributes:
       | name            | Cool Activity |
     And the portal should create a section with the following attributes:
@@ -347,15 +347,13 @@ Feature: External Activities can support a REST publishing api
   Scenario: External REST activity is published the second time
     Given the external runtime published the activity "Fun Stuff" before
     When the external runtime publishes the activity "Fun Stuff" again
-    Then the published activity "Fun Stuff" should be correctly modified by the API
-    And the portal should create an external activity with the following attributes:
+    Then the portal should create an external activity with the following attributes:
       | name            | Cool Activity |
       | url             | http://activity.com/activity/1 |
       | launch_url      | http://activity.com/activity/1/sessions/ |
       | author_url      | http://activity.com/activity/1/edit_new |
       | print_url       | http://activity.com/activity/1/print_blank_new |
-      | description     | This description is still provided by LARA but it should be ignored! |
-    And the external activity should have a external report at "https://reports.concord.org/act/changed"
+    And the external activity should not have an external report
     And the external activity should not have any description set
 
   @mechanize
@@ -369,7 +367,7 @@ Feature: External Activities can support a REST publishing api
       | author_url      | http://activity.com/sequence/1/edit |
       | print_url       | http://activity.com/sequence/1/print_blank |
     And the external activity should have a template
-    And the external activity should have a external report at "https://reports.concord.org/seq"
+    And the external activity should not have an external report
     And the portal should create an investigation with the following attributes:
       | name            | Many fun things |
     And the portal should create an activity with the following attributes:
@@ -391,10 +389,9 @@ Feature: External Activities can support a REST publishing api
   Scenario: External REST sequence is published the second time
     Given the external runtime published the sequence "Many fun things" before
     When the external runtime publishes the sequence "Many fun things" again
-    Then the published activity "Many fun things" should be correctly modified by the API
-    And the portal should create an external activity with the following attributes:
-      | name            | Many fun things |
+    Then the portal should create an external activity with the following attributes:
+      | name            | This has a different name |
       | launch_url      | http://activity.com/sequence/1 |
       | author_url      | http://activity.com/sequence/1/edit_new |
       | print_url       | http://activity.com/sequence/1/print_blank_new |
-    And the external activity should have a external report at "https://reports.concord.org/seq/changed"
+    And the external activity should not have an external report

--- a/features/step_definitions/activity_runtime_api_publish_steps.rb
+++ b/features/step_definitions/activity_runtime_api_publish_steps.rb
@@ -135,9 +135,8 @@ Given /^the external runtime published the (activity|sequence) "([^"]*)" before$
   end
 end
 
-Then(/^the (.*) should have a external report at "(.*)"$/) do |ignored_param, report_url|
-  expect(@external_activity.external_report).not_to be_nil
-  expect(@external_activity.external_report.url).to eq(report_url)
+Then(/^the (.*) should not have an external report$/) do |ignored_param|
+  expect(@external_activity.external_report).to be_nil
 end
 
 Then(/^the external activity should not have any description set/) do
@@ -149,4 +148,3 @@ end
 Given(/^an external_report with the URL "(.*?)"$/) do | report_url|
   ExternalReport.create(url:report_url)
 end
-

--- a/lib/activity_runtime_api.rb
+++ b/lib/activity_runtime_api.rb
@@ -55,7 +55,8 @@ class ActivityRuntimeAPI
         :is_locked              => hash["is_locked"]
       )
       self.setup_activity_template(external_activity, hash)
-      self.update_external_report(external_activity,hash["external_report_url"])
+      # 2019-07-12 NP: Lara no longer manages external reports ...
+      # self.update_external_report(external_activity,hash["external_report_url"])
     end
     return external_activity
   end
@@ -94,7 +95,10 @@ class ActivityRuntimeAPI
     ['author_email', 'is_locked', 'print_url', 'author_url', 'student_report_enabled'].each do |attribute|
       external_activity.update_attribute(attribute,hash[attribute])
     end
-    self.update_external_report(external_activity,hash["external_report_url"])
+
+    # 2019-07-12 NP: Lara no longer manages external reports ...
+    # self.update_external_report(external_activity,hash["external_report_url"])
+
     # save the embeddables
     mc_cache = {}
     or_cache = {}
@@ -151,7 +155,8 @@ class ActivityRuntimeAPI
         :is_locked              => hash["is_locked"]
       )
       self.setup_sequence_template(external_activity, hash)
-      self.update_external_report(external_activity, hash["external_report_url"])
+      # 2019-07-12 NP: Lara no longer manages external reports ...
+      # self.update_external_report(external_activity, hash["external_report_url"])
     end
     return external_activity
   end
@@ -199,7 +204,9 @@ class ActivityRuntimeAPI
       external_activity.update_attribute(attribute,hash[attribute]) if hash.has_key?(attribute)
     end
 
-    self.update_external_report(external_activity, hash["external_report_url"])
+    # 2019-07-12 NP: Lara no longer manages external reports ...
+    # self.update_external_report(external_activity, hash["external_report_url"])
+
     # save the embeddables
     mc_cache = {}
     or_cache = {}
@@ -473,14 +480,5 @@ class ActivityRuntimeAPI
     filters.each { |filter| filter.clear }
   end
 
-
-  def self.update_external_report(external_activity, report_url)
-    external_report = nil
-    if report_url
-      external_report = ExternalReport.find_by_url(report_url)
-    end
-    external_activity.external_report = external_report
-    external_activity.save
-  end
 
 end

--- a/spec/controllers/api/v1/offerings_controller_spec.rb
+++ b/spec/controllers/api/v1/offerings_controller_spec.rb
@@ -258,7 +258,7 @@ describe API::V1::OfferingsController do
 
       before (:each) do
         sign_in teacher.user
-        runnable.external_report = external_report
+        runnable.external_reports = [ external_report ] 
         runnable.save
       end
       it "returns information about external report" do

--- a/spec/models/external_activity_spec.rb
+++ b/spec/models/external_activity_spec.rb
@@ -547,6 +547,16 @@ describe ExternalActivity do
       activity.external_reports.create(report_b_props)
       expect(activity.external_report).to eql activity.external_reports.first
     end
+
+    describe "legacy code behavior in `external_report=` method" do
+      it "should assign one and only one external_report to the external_activity" do
+        expect(activity).to be_valid
+        expect(activity.external_reports).to be_empty
+        activity.external_report=report_a
+        expect(activity.external_reports).to have(1).report
+      end
+    end
   end
+
 
 end

--- a/spec/models/external_activity_spec.rb
+++ b/spec/models/external_activity_spec.rb
@@ -510,15 +510,54 @@ describe ExternalActivity do
     end
   end
 
-  # TODO: auto-generated
-  describe '#options_for_external_report' do
-    it 'options_for_external_report' do
-      external_activity = described_class.new
-      result = external_activity.options_for_external_report
+  describe "external_reports" do
+    let(:activity) { described_class.create(valid_attributes) }
 
-      expect(result).not_to be_nil
+    let(:report_a_props) do
+      {
+        url: "http://a/report.html",
+        name: "a",
+        launch_text: "a"
+      }
+    end
+
+    let(:report_b_props) do
+      {
+        url: "http://b/report.html",
+        name: "b",
+        launch_text: "b"
+      }
+    end
+
+    let(:report_a) { ExternalReport.create(report_a_props) }
+    let(:report_b) { ExternalReport.create(report_b_props) }
+    it "doesn't have an external_report at first" do
+      expect(activity).to be_valid
+      expect(activity.external_reports).to be_empty
+    end
+
+    it "can have multiple external reports" do
+      activity.external_reports.create(report_a_props)
+      activity.external_reports.create(report_b_props)
+      expect(activity.external_reports).to have(2).reports
+    end
+
+    it "will return the first external report when asked for just one" do
+      activity.external_reports.create(report_a_props)
+      activity.external_reports.create(report_b_props)
+      expect(activity.external_report).to eql activity.external_reports.first
+    end
+
+    describe "adding new reports" do
+      it "should not add the same report twice" do
+        activity.add_external_report_by_url(report_a)
+        activity.add_external_report_by_url(report_a)
+        activity.add_external_report_by_url(report_a)
+        activity.reload
+        expect(activity.external_reports).to have(1).report
+      end
+
     end
   end
-
 
 end

--- a/spec/models/external_activity_spec.rb
+++ b/spec/models/external_activity_spec.rb
@@ -275,7 +275,7 @@ describe ExternalActivity do
       expect(activity.lara_activity?).to be false
     end
   end
- 
+
   # TODO: auto-generated
   describe '.published' do # scope test
     it 'supports named scope published' do
@@ -548,14 +548,6 @@ describe ExternalActivity do
       expect(activity.external_report).to eql activity.external_reports.first
     end
 
-    describe "legacy code behavior in `external_report=` method" do
-      it "should assign one and only one external_report to the external_activity" do
-        expect(activity).to be_valid
-        expect(activity.external_reports).to be_empty
-        activity.external_report=report_a
-        expect(activity.external_reports).to have(1).report
-      end
-    end
   end
 
 

--- a/spec/models/external_activity_spec.rb
+++ b/spec/models/external_activity_spec.rb
@@ -547,17 +547,6 @@ describe ExternalActivity do
       activity.external_reports.create(report_b_props)
       expect(activity.external_report).to eql activity.external_reports.first
     end
-
-    describe "adding new reports" do
-      it "should not add the same report twice" do
-        activity.add_external_report_by_url(report_a)
-        activity.add_external_report_by_url(report_a)
-        activity.add_external_report_by_url(report_a)
-        activity.reload
-        expect(activity.external_reports).to have(1).report
-      end
-
-    end
   end
 
 end


### PR DESCRIPTION
This PR changes the `ExternalActivity` model property `external_report` and makes it an association `external_reports`.

Includes:

* model changes
* migration for schema changes
* migrations for converting old data
* controller &  form changes 
* API controller changes
* spec tests for `external_reports`
* cherry pick of d677276c8 for Guard & Travis test updates.

Code from this commit will continue to work with with older portal-pages branches, because the ExternalActivity model includes backwards compatible `external_report` and `external_report=` methods.

In order to see the multiple reports, concord-consortium/portal-pages will also have to be updated. 

The Related Portal Pages PR is here: https://github.com/concord-consortium/portal-pages/pull/97

