### PR TITLE
Travis: run spec tests without chrome headless

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ dist: trusty
 env:
   matrix:
   - RAILS_ENV=test TEST_SUITE=spec
+  - RAILS_ENV=test TEST_SUITE=ci:spec_without_webdriver
   - RAILS_ENV=cucumber TEST_SUITE=ci:cucumber_without_javascript
   - RAILS_ENV=cucumber TEST_SUITE=ci:cucumber_javascript
   - RAILS_ENV=cucumber TEST_SUITE=ci:cucumber_search

--- a/Guardfile
+++ b/Guardfile
@@ -17,6 +17,7 @@ guard :rspec,
   spring: true,
   bundler: false,
   cli: "--color --format nested --fail-fast",
+  cmd: "bundle exec rspec --tag ~WebDriver",
   failed_mode: :none,
   all_after_pass: false,
   all_on_start: false    do

--- a/lib/tasks/continuous_integration.rake
+++ b/lib/tasks/continuous_integration.rake
@@ -1,9 +1,9 @@
 
 namespace :ci do
+  require 'rspec/core/rake_task'
 
   if defined? Cucumber
     require 'cucumber/rake/task'
-
     # previously this also used `--tags ~@dialog ` to skip the dialog tests
     opts = %{--profile default --tags 'not @pending' --format progress}
     Cucumber::Rake::Task.new(:cucumber) do |t|
@@ -20,4 +20,7 @@ namespace :ci do
     end
   end
 
+  RSpec::Core::RakeTask.new(:spec_without_webdriver) do |t|
+    t.rspec_opts = "--tag ~WebDriver"
+  end
 end

--- a/spec/features/admin_configures_help_page_spec.rb
+++ b/spec/features/admin_configures_help_page_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.feature 'Admin configures help page' do
+RSpec.feature 'Admin configures help page', :WebDriver => true do
   before do
     FactoryBot.create(:admin_settings)
     login_as('admin')

--- a/spec/features/author_edits_activity_spec.rb
+++ b/spec/features/author_edits_activity_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.feature 'Admin configures help page' do
+RSpec.feature 'Admin configures help page', :WebDriver => true do
   let (:authored_activity) {
     # find activity owned by author
     user = User.where(login: 'author').first

--- a/spec/features/student_should_see_latest_class_information_spec.rb
+++ b/spec/features/student_should_see_latest_class_information_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.feature 'Student should see latest class information' do
+RSpec.feature 'Student should see latest class information', :WebDriver => true do
   before do
     generate_default_settings_and_jnlps_with_factories
 


### PR DESCRIPTION
Add `spec_without_webdriver` travis test matrix item for running spec tests without the `WebDriver` tag.

[#167381402]
https://www.pivotaltracker.com/story/show/167381402