### PR TITLE
Remove trailing slash from `platform_id`

### DIFF
--- a/app/controllers/api/v1/jwt_controller.rb
+++ b/app/controllers/api/v1/jwt_controller.rb
@@ -66,7 +66,7 @@ class API::V1::JwtController < API::APIController
         # Firebase auth rules expect all the claims to be in a sub-object named "claims".
         # All the new properties should go there. Other apps can still read them.
         :claims => {
-          :platform_id => platform_id, # see `application_controller.rb#platform_id`
+          :platform_id => APP_CONFIG[:site_url]
           :platform_user_id => user.id,
           :user_type => "learner",
           :user_id => url_for(user),
@@ -95,7 +95,7 @@ class API::V1::JwtController < API::APIController
         # Firebase auth rules expect all the claims to be in a sub-object named "claims".
         # All the new properties should go there. Other apps can still read them.
         :claims => {
-          :platform_id => platform_id, # see `application_controller.rb#platform_id`
+          :platform_id => APP_CONFIG[:site_url]
           :platform_user_id => user.id,
           :user_type => "teacher",
           :user_id => url_for(user),

--- a/app/controllers/api/v1/jwt_controller.rb
+++ b/app/controllers/api/v1/jwt_controller.rb
@@ -3,10 +3,6 @@ class API::V1::JwtController < API::APIController
   require 'digest/md5'
   skip_before_filter :verify_authenticity_token
 
-  def platform_id
-    root_url.sub(/\/$/, "")
-  end
-
   def portal
     begin
       user, role = check_for_auth_token(params)
@@ -70,7 +66,7 @@ class API::V1::JwtController < API::APIController
         # Firebase auth rules expect all the claims to be in a sub-object named "claims".
         # All the new properties should go there. Other apps can still read them.
         :claims => {
-          :platform_id => platform_id,
+          :platform_id => platform_id, # see `application_controller.rb#platform_id`
           :platform_user_id => user.id,
           :user_type => "learner",
           :user_id => url_for(user),
@@ -99,7 +95,7 @@ class API::V1::JwtController < API::APIController
         # Firebase auth rules expect all the claims to be in a sub-object named "claims".
         # All the new properties should go there. Other apps can still read them.
         :claims => {
-          :platform_id => platform_id,
+          :platform_id => platform_id, # see `application_controller.rb#platform_id`
           :platform_user_id => user.id,
           :user_type => "teacher",
           :user_id => url_for(user),

--- a/app/controllers/api/v1/jwt_controller.rb
+++ b/app/controllers/api/v1/jwt_controller.rb
@@ -66,7 +66,7 @@ class API::V1::JwtController < API::APIController
         # Firebase auth rules expect all the claims to be in a sub-object named "claims".
         # All the new properties should go there. Other apps can still read them.
         :claims => {
-          :platform_id => APP_CONFIG[:site_url]
+          :platform_id => APP_CONFIG[:site_url],
           :platform_user_id => user.id,
           :user_type => "learner",
           :user_id => url_for(user),
@@ -95,7 +95,7 @@ class API::V1::JwtController < API::APIController
         # Firebase auth rules expect all the claims to be in a sub-object named "claims".
         # All the new properties should go there. Other apps can still read them.
         :claims => {
-          :platform_id => APP_CONFIG[:site_url]
+          :platform_id => APP_CONFIG[:site_url],
           :platform_user_id => user.id,
           :user_type => "teacher",
           :user_id => url_for(user),

--- a/app/controllers/api/v1/jwt_controller.rb
+++ b/app/controllers/api/v1/jwt_controller.rb
@@ -3,6 +3,10 @@ class API::V1::JwtController < API::APIController
   require 'digest/md5'
   skip_before_filter :verify_authenticity_token
 
+  def platform_id
+    root_url.sub(/\/$/, "")
+  end
+
   def portal
     begin
       user, role = check_for_auth_token(params)
@@ -66,7 +70,7 @@ class API::V1::JwtController < API::APIController
         # Firebase auth rules expect all the claims to be in a sub-object named "claims".
         # All the new properties should go there. Other apps can still read them.
         :claims => {
-          :platform_id => root_url,
+          :platform_id => platform_id,
           :platform_user_id => user.id,
           :user_type => "learner",
           :user_id => url_for(user),
@@ -95,7 +99,7 @@ class API::V1::JwtController < API::APIController
         # Firebase auth rules expect all the claims to be in a sub-object named "claims".
         # All the new properties should go there. Other apps can still read them.
         :claims => {
-          :platform_id => root_url,
+          :platform_id => platform_id,
           :platform_user_id => user.id,
           :user_type => "teacher",
           :user_id => url_for(user),

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -362,4 +362,7 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def platform_id
+    root_url.sub(/\/$/, "")
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -362,8 +362,4 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def platform_id
-    # Removes trailing slash from url if present.
-    (APP_CONFIG[:site_url] || "").gsub(/\/$/,"")
-  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -363,6 +363,7 @@ class ApplicationController < ActionController::Base
   end
 
   def platform_id
-    root_url.sub(/\/$/, "")
+    # Removes trailing slash from url if present.
+    (APP_CONFIG[:site_url] || "").gsub(/\/$/,"")
   end
 end

--- a/app/controllers/portal/offerings_controller.rb
+++ b/app/controllers/portal/offerings_controller.rb
@@ -68,10 +68,12 @@ class Portal::OfferingsController < ApplicationController
              :domain_uid => current_visitor.id,
              :class_info_url => @offering.clazz.class_info_url(request.protocol, request.host_with_port),
              :context_id => @offering.clazz.class_hash,
-             # platform_id and platform_user_id seems like duplicates of domain and domain_uid.
-             # However, LARA uses domain and domain_uid to auth user, removes them from URI and performs redirect.
-             # So, these params won't be available later to setup LARA run.
-             :platform_id => platform_id, # see `application_controller.rb#platform_id`
+             # platform_id and platform_user_id are similiar to domain and domain_uid.
+             # However, LARA uses domain and domain_uid to authenticate the user,
+             # while the platform params are moving towards LTI compatible launching
+             # More specifically LARA removes domain and domain_uid from URL,
+             # so it is harder to use the domain params to setup the run in LARA.
+             :platform_id => APP_CONFIG[:site_url],
              :platform_user_id => current_visitor.id,
              :resource_link_id => @offering.id
            }.to_query

--- a/app/controllers/portal/offerings_controller.rb
+++ b/app/controllers/portal/offerings_controller.rb
@@ -71,7 +71,7 @@ class Portal::OfferingsController < ApplicationController
              # platform_id and platform_user_id seems like duplicates of domain and domain_uid.
              # However, LARA uses domain and domain_uid to auth user, removes them from URI and performs redirect.
              # So, these params won't be available later to setup LARA run.
-             :platform_id => root_url,
+             :platform_id => platform_id, # see `application_controller.rb#platform_id`
              :platform_user_id => current_visitor.id,
              :resource_link_id => @offering.id
            }.to_query

--- a/features/activity_runtime_api/running.feature
+++ b/features/activity_runtime_api/running.feature
@@ -12,7 +12,7 @@ Feature: External Activities can support a REST api
       | returnUrl         | site_url/dataservice/external_activity_data/key |
       | class_info_url    | class_info_url of 'My Class' |
       | context_id        | class_hash of 'My Class'     |
-      | platform_id       | http://www.example.com/       |
+      | platform_id       | site_url                     |
       | platform_user_id  | domain_uid of 'student'      |
       | resource_link_id  | offering.id                  |
     And "activities.com/activity/1/sessions/" GET responds with

--- a/features/step_definitions/activity_runtime_api_steps.rb
+++ b/features/step_definitions/activity_runtime_api_steps.rb
@@ -62,6 +62,9 @@ Given /^"([^"]*)" handles a (POST|GET) with query:$/ do |address, method, table|
   if /domain_uid of '(.*)'/ =~ query_data["platform_user_id"]
     query_data["platform_user_id"] = User.find_by_login($~[1]).id.to_s
   end
+  if /site_url/ =~ query_data["platform_id"]
+    query_data["platform_id"] = APP_CONFIG[:site_url]
+  end
   if /class_info_url of '(.*)'/ =~ query_data["class_info_url"]
     query_data["class_info_url"] = Portal::Clazz.find_by_name($~[1]).class_info_url("http", "www.example.com")
   end

--- a/spec/controllers/api/v1/jwt_controller_spec.rb
+++ b/spec/controllers/api/v1/jwt_controller_spec.rb
@@ -165,7 +165,7 @@ SHlL1Ceaqm35aMguGMBcTs6T5jRJ36K2OPEXU2ZOiRygxcZhFw==
         expect(claims.user_type).to eq "teacher"
         expect(claims.user_id).to eq url_for_user
         expect(claims.class_hash).to eq nil
-        expect(claims.platform_id).to eq "http://test.host" # strips trailing "/"
+        expect(claims.platform_id).to eq "http://test.host/"
       end
 
       it "returns a valid JWT with teacher params with a class hash" do

--- a/spec/controllers/api/v1/jwt_controller_spec.rb
+++ b/spec/controllers/api/v1/jwt_controller_spec.rb
@@ -144,15 +144,17 @@ SHlL1Ceaqm35aMguGMBcTs6T5jRJ36K2OPEXU2ZOiRygxcZhFw==
     end
 
     context "when a valid authentication header token is sent with a teacher" do
+      let(:application_url) { "http://test.host/" }
       before(:each) {
         set_auth_token(teacher_token)
         FirebaseApp.create!(firebase_app_attributes)
       }
 
       it "returns a valid JWT with teacher params without a class hash" do
+        allow(APP_CONFIG).to receive(:[]).and_call_original
+        allow(APP_CONFIG).to receive(:[]).with(:site_url).and_return(application_url)
         post :firebase, {:firebase_app => "test app"}, :format => :json
         expect(response.status).to eq(201)
-
         body = JSON.parse(response.body)
         token = body["token"]
         decoded_token = SignedJWT::decode_firebase_token(token, firebase_app_name)
@@ -163,7 +165,7 @@ SHlL1Ceaqm35aMguGMBcTs6T5jRJ36K2OPEXU2ZOiRygxcZhFw==
         expect(claims.user_type).to eq "teacher"
         expect(claims.user_id).to eq url_for_user
         expect(claims.class_hash).to eq nil
-        expect(claims.platform_id).to eq "http://test.host"
+        expect(claims.platform_id).to eq "http://test.host" # strips trailing "/"
       end
 
       it "returns a valid JWT with teacher params with a class hash" do

--- a/spec/controllers/api/v1/jwt_controller_spec.rb
+++ b/spec/controllers/api/v1/jwt_controller_spec.rb
@@ -156,12 +156,14 @@ SHlL1Ceaqm35aMguGMBcTs6T5jRJ36K2OPEXU2ZOiRygxcZhFw==
         body = JSON.parse(response.body)
         token = body["token"]
         decoded_token = SignedJWT::decode_firebase_token(token, firebase_app_name)
-
-        expect(decoded_token[:data]["uid"]).to eql uid
-        expect(decoded_token[:data]["domain"]).to eql root_url
-        expect(decoded_token[:data]["claims"]["user_type"]).to eq "teacher"
-        expect(decoded_token[:data]["claims"]["user_id"]).to eq url_for_user
-        expect(decoded_token[:data]["claims"]["class_hash"]).to eq nil
+        data = OpenStruct.new decoded_token[:data]
+        claims = OpenStruct.new data.claims
+        expect(data.uid).to eql uid
+        expect(data.domain).to eql root_url
+        expect(claims.user_type).to eq "teacher"
+        expect(claims.user_id).to eq url_for_user
+        expect(claims.class_hash).to eq nil
+        expect(claims.platform_id).to eq "http://test.host/"
       end
 
       it "returns a valid JWT with teacher params with a class hash" do

--- a/spec/controllers/api/v1/jwt_controller_spec.rb
+++ b/spec/controllers/api/v1/jwt_controller_spec.rb
@@ -163,7 +163,7 @@ SHlL1Ceaqm35aMguGMBcTs6T5jRJ36K2OPEXU2ZOiRygxcZhFw==
         expect(claims.user_type).to eq "teacher"
         expect(claims.user_id).to eq url_for_user
         expect(claims.class_hash).to eq nil
-        expect(claims.platform_id).to eq "http://test.host/"
+        expect(claims.platform_id).to eq "http://test.host"
       end
 
       it "returns a valid JWT with teacher params with a class hash" do


### PR DESCRIPTION
We might *not* want to merge this PR. This change is one which was proposed, but we didn't really finalize.  But because it was top of mind, I thought I would at least drop in the PR, incase we want it.

If we do merge this, it would mean that we have to be sure to re-run the run export / import tasks on Portal and Lara staging before we QA again.

We discussed in [PT #166241318](https://www.pivotaltracker.com/story/show/166241318) remove the trailing slash from the `platform_id`.  The main advantage was that it might be able to concatenate with other strings maybe.

This PR basically adds a method to the ApplicationController `platform_id` which just returns `root_url` with the trailing slash removed.

It also adds a spec test, and updates the two controllers which publish `platform_id` values. They delegate that responsibility to `ApplicationController#platform_id`


