### PR TITLE
fix webdriver and upgrade ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - "2.2.6"
+  - "2.3.7"
 
 dist: trusty
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ dist: trusty
 
 env:
   matrix:
-  - RAILS_ENV=test TEST_SUITE=spec
   - RAILS_ENV=test TEST_SUITE=ci:spec_without_webdriver
+  - RAILS_ENV=test TEST_SUITE=ci:spec_with_webdriver
   - RAILS_ENV=cucumber TEST_SUITE=ci:cucumber_without_javascript
   - RAILS_ENV=cucumber TEST_SUITE=ci:cucumber_javascript
   - RAILS_ENV=cucumber TEST_SUITE=ci:cucumber_search
@@ -54,7 +54,7 @@ jobs:
       install: skip
       script:
         - aws s3 sync "s3://$ARTIFACTS_BUCKET/coverage/$TRAVIS_BUILD_NUMBER" coverage/
-        - ./cc-test-reporter sum-coverage -p 4 coverage/codeclimate.*.json
+        - ./cc-test-reporter sum-coverage -p 5 coverage/codeclimate.*.json
         - ./cc-test-reporter upload-coverage
       after_script:
         - aws s3 rm --recursive "s3://$ARTIFACTS_BUCKET/coverage/$TRAVIS_BUILD_NUMBER"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false # see: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 language: ruby
 rvm:
   - "2.2.6"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM concordconsortium/docker-rails-base-private:ruby-2.2.6-rails-3.2.22.9
+FROM concordconsortium/docker-rails-base-private:ruby-2.3.7-rails-3.2.22.13
 
 # Debian 8 (jessie) is no longer supported
 RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie main" >> /etc/apt/sources.list.d/jessie.list

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM concordconsortium/docker-rails-base-private:ruby-2.2.6-rails-3.2.22.9
+FROM concordconsortium/docker-rails-base-private:ruby-2.3.7-rails-3.2.22.13
 
 # Debian 8 (jessie) is no longer supported
 RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie main" >> /etc/apt/sources.list.d/jessie.list

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -755,8 +755,8 @@ GEM
     capybara-screenshot (1.0.21)
       capybara (>= 1.0, < 4)
       launchy
-    childprocess (0.9.0)
-      ffi (~> 1.0, >= 1.0.11)
+    childprocess (1.0.1)
+      rake (< 13.0)
     chronic (0.10.2)
     chunky_png (1.3.4)
     ci_reporter (2.0.0)
@@ -860,8 +860,8 @@ GEM
     faraday (0.12.1)
       multipart-post (>= 1.2, < 3)
     fattr (2.2.1)
-    ffi (1.9.25)
-    ffi (1.9.25-x86-mingw32)
+    ffi (1.11.1)
+    ffi (1.11.1-x86-mingw32)
     font-awesome-rails (4.7.0.1)
       railties (>= 3.2, < 5.1)
     formatador (0.2.5)
@@ -967,11 +967,10 @@ GEM
     net-ssh (2.6.3)
     net-ssh-gateway (1.1.0)
       net-ssh (>= 1.99.1)
-    net_http_ssl_fix (0.0.10)
     newrelic_rpm (4.4.0.336)
-    nokogiri (1.8.4)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
-    nokogiri (1.8.4-x86-mingw32)
+    nokogiri (1.8.5-x86-mingw32)
       mini_portile2 (~> 2.3.0)
     nokogumbo (1.4.1)
       nokogiri
@@ -1119,7 +1118,7 @@ GEM
     ruby-prof (0.12.1-x86-mingw32)
     ruby-rc4 (0.1.5)
     ruby_dep (1.5.0)
-    rubyzip (1.2.2)
+    rubyzip (1.2.3)
     safe_yaml (1.0.4)
     sanitize (4.0.0)
       crass (~> 1.0.2)
@@ -1130,9 +1129,9 @@ GEM
       railties (~> 3.2.0)
       sass (>= 3.1.10)
       tilt (~> 1.3)
-    selenium-webdriver (3.8.0)
-      childprocess (~> 0.5)
-      rubyzip (~> 1.0)
+    selenium-webdriver (3.142.3)
+      childprocess (>= 0.5, < 2.0)
+      rubyzip (~> 1.2, >= 1.2.2)
     session (3.1.0)
       fattr
     sextant (0.2.4)
@@ -1210,8 +1209,7 @@ GEM
       equalizer (~> 0.0, >= 0.0.9)
     warden (1.2.1)
       rack (>= 1.0)
-    webdrivers (3.7.2)
-      net_http_ssl_fix
+    webdrivers (3.9.4)
       nokogiri (~> 1.6)
       rubyzip (~> 1.0)
       selenium-webdriver (~> 3.0)
@@ -1373,4 +1371,4 @@ DEPENDENCIES
   yui-compressor
 
 BUNDLED WITH
-   1.16.5
+   1.17.3

--- a/features/activity_runtime_api/running.feature
+++ b/features/activity_runtime_api/running.feature
@@ -11,7 +11,10 @@ Feature: External Activities can support a REST api
       | logging           | false                        |
       | returnUrl         | site_url/dataservice/external_activity_data/key |
       | class_info_url    | class_info_url of 'My Class' |
-      | class_hash        | class_hash of 'My Class' |
+      | context_id        | class_hash of 'My Class'     |
+      | platform_id       | http://www.example.com/       |
+      | platform_user_id  | domain_uid of 'student'      |
+      | resource_link_id  | offering.id                  |
     And "activities.com/activity/1/sessions/" GET responds with
       """
       HTTP/1.1 200 OK

--- a/features/step_definitions/activity_runtime_api_steps.rb
+++ b/features/step_definitions/activity_runtime_api_steps.rb
@@ -53,15 +53,23 @@ Given /^"([^"]*)" handles a (POST|GET) with query:$/ do |address, method, table|
   query_data["externalId"] = query_data["externalId"].sub(/999/,"#{@learner.id}")
   query_data["returnUrl"] = query_data["returnUrl"].sub(/site_url/,APP_CONFIG[:site_url])
   query_data["returnUrl"] = query_data["returnUrl"].sub(/key/,"#{@learner.secure_key}")
+  
+  query_data["resource_link_id"] = query_data["resource_link_id"].sub(/offering.id/,@learner.offering.id.to_s)
   # replace domain_uid by user id if it has the pattern "domain_uid of 'login'"
   if /domain_uid of '(.*)'/ =~ query_data["domain_uid"]
     query_data["domain_uid"] = User.find_by_login($~[1]).id.to_s
+  end
+  if /domain_uid of '(.*)'/ =~ query_data["platform_user_id"]
+    query_data["platform_user_id"] = User.find_by_login($~[1]).id.to_s
   end
   if /class_info_url of '(.*)'/ =~ query_data["class_info_url"]
     query_data["class_info_url"] = Portal::Clazz.find_by_name($~[1]).class_info_url("http", "www.example.com")
   end
   if /class_hash of '(.*)'/ =~ query_data["class_hash"]
     query_data["class_hash"] = Portal::Clazz.find_by_name($~[1]).class_hash
+  end
+  if /class_hash of '(.*)'/ =~ query_data["context_id"]
+    query_data["context_id"] = Portal::Clazz.find_by_name($~[1]).class_hash
   end
   stub.with(:query => query_data)
 end

--- a/lib/tasks/continuous_integration.rake
+++ b/lib/tasks/continuous_integration.rake
@@ -20,6 +20,9 @@ namespace :ci do
     end
   end
 
+  RSpec::Core::RakeTask.new(:spec_with_webdriver) do |t|
+    t.rspec_opts = "--tag WebDriver"
+  end
   RSpec::Core::RakeTask.new(:spec_without_webdriver) do |t|
     t.rspec_opts = "--tag ~WebDriver"
   end

--- a/spec/support/capybara_initializer.rb
+++ b/spec/support/capybara_initializer.rb
@@ -48,7 +48,8 @@ class CapybaraInitializer
       # driver_opts can be used to pass options to chromedriver, for example --log-level=DEBUG
       # this approach is deprecated though so you might need to use the newer approach
       # in the future
-      driver_opts: [] }.tap do |a|
+      # driver_opts: [ '--log-level=DEBUG']
+     }.tap do |a|
       a[:url] = 'http://host.docker.internal:9515/' if !headless? && docker?
     end
   end

--- a/spec/support/capybara_initializer.rb
+++ b/spec/support/capybara_initializer.rb
@@ -43,14 +43,25 @@ class CapybaraInitializer
   end
 
   def driver_options
-    { browser: :chrome, desired_capabilities: capabilities }.tap do |a|
+    { browser: :chrome,
+      desired_capabilities: capabilities,
+      # driver_opts can be used to pass options to chromedriver, for example --log-level=DEBUG
+      # this approach is deprecated though so you might need to use the newer approach
+      # in the future
+      driver_opts: [] }.tap do |a|
       a[:url] = 'http://host.docker.internal:9515/' if !headless? && docker?
     end
   end
 
   def capabilities
     Selenium::WebDriver::Remote::Capabilities.chrome(
-      'chromeOptions' => {
+      # This used to be chromeOptions but when w3c standardized the webdriver interface
+      # they required the switch to goog:chromeOptions
+      # instead of defining this key explicitly it would be better to switch to using the
+      # Selenium::WebDriver::Chrome::Options abstraction.
+      # you can see capybara using it in some of its default drivers
+      # https://github.com/teamcapybara/capybara/blob/c7c22789b7aaf6c1515bf6e68f00bfe074cf8fc1/lib/capybara/registrations/drivers.rb#L27
+      'goog:chromeOptions' => {
         'args' => chrome_options
       }
     )


### PR DESCRIPTION
This fixes webdriver by updating webdrivers, and seleinum-webdriver as well as changing the key used to pass the arguments to the chrome browser.

Additionally:
- I updated ruby so it is the same version as what is used by LARA.
- I removed the sudo: false which is no longer needed by travis.
- fixed the test reporter task since we now have 5 parts to the build
- fixed some tests that were failing due to changes made to the portal to support new LTI'ish properties of LARA
- change the split of the spec tests so it is webdriver and non-webdriver tests
