### PR TITLE
166745764 separate researcher report types

### DIFF
--- a/app/models/external_report.rb
+++ b/app/models/external_report.rb
@@ -2,8 +2,9 @@ class ExternalReport < ActiveRecord::Base
 
   OfferingReport = 'offering'
   ClassReport = 'class'
-  ResearcherReport = 'researcher'
-  ReportTypes = [OfferingReport, ClassReport, ResearcherReport]
+  ResearcherLearnerReport = 'researcher-learner'
+  ResearcherUserReport = 'researcher-user'
+  ReportTypes = [OfferingReport, ClassReport, ResearcherLearnerReport, ResearcherUserReport]
   belongs_to :client
   has_many :external_activities
   attr_accessible :name, :url, :launch_text, :client_id, :client, :report_type, :allowed_for_students

--- a/app/views/report/learner/index.html.haml
+++ b/app/views/report/learner/index.html.haml
@@ -10,8 +10,7 @@
 
 #form-container
 
-- external_reports = ExternalReport.where(report_type: ExternalReport::ResearcherReport).map { |r| {url: "#{r.url}", label: "#{r.launch_text}"} }.to_json
+- external_reports = ExternalReport.where(report_type: ExternalReport::ResearcherLearnerReport).map { |r| {url: "#{r.url}", label: "#{r.launch_text}"} }.to_json
 
 :javascript
   PortalPages.renderLearnerReportForm({externalReports: #{external_reports}}, "form-container")
-

--- a/app/views/report/user/index.html.haml
+++ b/app/views/report/user/index.html.haml
@@ -10,10 +10,9 @@
 
 #form-container
 
-- external_reports = ExternalReport.where(report_type: ExternalReport::ResearcherReport).map { |r| {url: "#{r.url}", label: "#{r.launch_text}"} }.to_json
+- external_reports = ExternalReport.where(report_type: ExternalReport::ResearcherUserReport).map { |r| {url: "#{r.url}", label: "#{r.launch_text}"} }.to_json
 - portal_token = SignedJWT::create_portal_token(current_user, {domain: root_url})
 
 :javascript
   PortalPages.renderUserReportForm({externalReports: #{external_reports}, portalToken
   : "#{portal_token}"}, "form-container")
-

--- a/app/views/shared/_reports_edit.html.haml
+++ b/app/views/shared/_reports_edit.html.haml
@@ -3,7 +3,7 @@
   = field_set_tag t('authoring.external_report_label') do
     .aligned
       = hidden_field_tag :update_external_reports, "true"
-      - ExternalReport.where('report_type !=?', ExternalReport::ResearcherReport).each do | external_report |
+      - ExternalReport.where(report_type: [ExternalReport::OfferingReport, ExternalReport::ClassReport]).each do | external_report |
         %div
           = check_box_tag "external_reports[]", external_report.id, object.external_report_ids.include?(external_report.id), :id => external_report.id
           = label_tag external_report.name, external_report.name

--- a/db/migrate/20190711221406_move_external_reports.rb
+++ b/db/migrate/20190711221406_move_external_reports.rb
@@ -1,20 +1,19 @@
-
-class ExternalReport < ActiveRecord::Base
-end
-
-class ExternalActivityReport < ActiveRecord::Base
-  belongs_to :external_activity
-  belongs_to :external_report
-end
-
-class  ExternalActivity  < ActiveRecord::Base
-  belongs_to :external_report
-  has_many :external_activity_reports
-  has_many :external_reports, through: :external_activity_reports
-end
-
-
 class MoveExternalReports < ActiveRecord::Migration
+
+  class ExternalReport < ActiveRecord::Base
+  end
+
+  class ExternalActivityReport < ActiveRecord::Base
+    belongs_to :external_activity
+    belongs_to :external_report
+  end
+
+  class  ExternalActivity  < ActiveRecord::Base
+    belongs_to :external_report
+    has_many :external_activity_reports
+    has_many :external_reports, through: :external_activity_reports
+  end
+
 
   def up_activity(a)
     if(a.external_report)

--- a/db/migrate/20190725145120_spit_researcher_report_types.rb
+++ b/db/migrate/20190725145120_spit_researcher_report_types.rb
@@ -1,0 +1,12 @@
+class SpitResearcherReportTypes < ActiveRecord::Migration
+  class ExternalReport < ActiveRecord::Base
+  end
+
+  def up
+    ExternalReport.where(report_type: 'researcher').update_all(report_type: 'researcher-learner')
+  end
+
+  def down
+    ExternalReport.where(report_type: 'researcher-learner').update_all(report_type: 'researcher')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20190711221406) do
+ActiveRecord::Schema.define(:version => 20190725145120) do
 
   create_table "access_grants", :force => true do |t|
     t.string   "code"


### PR DESCRIPTION
This splits the ResearcherReport type into a ResearcherLearnerReport and a ResearcherUserReport.
This way reports that only work for users only show up on the user researcher report page.

This PR also fixes a previous migration that was not defining its internal models within the migration class.