### PR TITLE
fix permission check of student running external_report

### DIFF
--- a/app/policies/portal/offering_policy.rb
+++ b/app/policies/portal/offering_policy.rb
@@ -78,9 +78,10 @@ class Portal::OfferingPolicy < ApplicationPolicy
       class_student? &&
       record &&
       record.runnable &&
-      record.runnable.respond_to?(:external_report) &&
-      record.runnable.external_report &&
-      record.runnable.external_report.allowed_for_students
+      record.runnable.respond_to?(:external_reports) &&
+      params[:report_id] &&
+      (report = record.runnable.external_reports.find(params[:report_id])) &&
+      report.allowed_for_students
     end
   end
 


### PR DESCRIPTION
previously this was just finding the first external_report and would fail if that report
wasn't allowed_for_students