### PR TITLE
Add support of "add_external_report" URL param

### DIFF
--- a/app/controllers/api/v1/offerings_controller.rb
+++ b/app/controllers/api/v1/offerings_controller.rb
@@ -68,7 +68,7 @@ class API::V1::OfferingsController < API::APIController
 
     filtered_offerings = offerings.reject { |o| o.archived? }
     filtered_offerings = filtered_offerings.map do |offering|
-      API::V1::Offering.new(offering, request.protocol, request.host_with_port, current_user)
+      API::V1::Offering.new(offering, request.protocol, request.host_with_port, current_user, params[:add_external_report])
     end
     render :json => filtered_offerings.to_json, :callback => params[:callback]
   end

--- a/app/controllers/api/v1/offerings_controller.rb
+++ b/app/controllers/api/v1/offerings_controller.rb
@@ -13,7 +13,7 @@ class API::V1::OfferingsController < API::APIController
       return error('offering not found', 404)
     end
     authorize offering, :api_show?
-    offering_api = API::V1::Offering.new(offering, request.protocol, request.host_with_port, current_user)
+    offering_api = API::V1::Offering.new(offering, request.protocol, request.host_with_port, current_user, params[:add_external_report])
     render :json => offering_api.to_json, :callback => params[:callback]
   end
 

--- a/app/models/api/v1/offering.rb
+++ b/app/models/api/v1/offering.rb
@@ -131,9 +131,7 @@ class API::V1::Offering
     end
     if additional_external_report_id
       additional_report = ExternalReport.find_by_id(additional_external_report_id)
-      puts "additional"
       if additional_report
-        puts "additional found"
         self.external_reports << report_attributes(additional_report, offering, protocol, host_with_port)
       end
     end

--- a/app/models/api/v1/offering.rb
+++ b/app/models/api/v1/offering.rb
@@ -105,7 +105,7 @@ class API::V1::Offering
     }
   end
 
-  def initialize(offering, protocol, host_with_port, current_user)
+  def initialize(offering, protocol, host_with_port, current_user, additional_external_report_id)
     runnable = offering.runnable
     self.id = offering.id
     self.teacher = offering.clazz.teacher.name
@@ -129,6 +129,15 @@ class API::V1::Offering
         self.external_reports << report_attributes(report, offering, protocol, host_with_port)
       end
     end
+    if additional_external_report_id
+      additional_report = ExternalReport.find_by_id(additional_external_report_id)
+      puts "additional"
+      if additional_report
+        puts "additional found"
+        self.external_reports << report_attributes(additional_report, offering, protocol, host_with_port)
+      end
+    end
+
     if offering.reportable?
       # Cache feedback activity objects and pass them to student model.
       activity_feedbacks = {}

--- a/app/views/shared/_offering_for_student.html.haml
+++ b/app/views/shared/_offering_for_student.html.haml
@@ -59,6 +59,9 @@
                 %br
 
               - external_reports = offering.runnable.external_reports.where(allowed_for_students: true)
+              - if params[:add_external_report]
+                - additional_report = ExternalReport.find_by_id(params[:add_external_report])
+                - external_reports << additional_report if additional_report && additional_report.allowed_for_students
               - external_reports.each do |external_report|
                 %span.lightbox_report_link
                   = link_to external_report.launch_text, portal_external_report_url(id: offering.id, report_id: external_report.id), target: "_blank"

--- a/spec/controllers/api/v1/offerings_controller_spec.rb
+++ b/spec/controllers/api/v1/offerings_controller_spec.rb
@@ -258,16 +258,34 @@ describe API::V1::OfferingsController do
 
       before (:each) do
         sign_in teacher.user
-        runnable.external_reports = [ external_report ] 
+        runnable.external_reports = [ external_report ]
         runnable.save
       end
+
       it "returns information about external report" do
         get :show, id: offering.id
         expect(response.status).to eq 200
         json = JSON.parse(response.body)
-        expect(json["external_report"]).not_to eq nil
-        expect(json["external_report"]["url"]).to eq portal_external_report_url(id: offering.id, report_id: external_report.id, host: 'test.host')
-        expect(json["external_report"]["launch_text"]).to eq external_report.launch_text
+        expect(json["external_reports"][0]).not_to eq nil
+        expect(json["external_reports"][0]["url"]).to eq portal_external_report_url(id: offering.id, report_id: external_report.id, host: 'test.host')
+        expect(json["external_reports"][0]["launch_text"]).to eq external_report.launch_text
+      end
+    end
+
+    describe "when add_external_report parameter is provided" do
+      let (:external_report) { FactoryBot.create(:external_report) }
+
+      before (:each) do
+        sign_in teacher.user
+      end
+
+      it "adds this report to the external_reports list" do
+        get :show, id: offering.id, add_external_report: external_report.id
+        expect(response.status).to eq 200
+        json = JSON.parse(response.body)
+        expect(json["external_reports"][0]).not_to eq nil
+        expect(json["external_reports"][0]["url"]).to eq portal_external_report_url(id: offering.id, report_id: external_report.id, host: 'test.host')
+        expect(json["external_reports"][0]["launch_text"]).to eq external_report.launch_text
       end
     end
   end


### PR DESCRIPTION
[#167761386]

On following pages:
- /recent_activity
- /portal/classes/[class_id]/materials (teacher page)
- /my_classes (student page)
- /portal/classes/[class_id] (student page)

Note that teacher pages are rendered portal pages, so I only updated Offering API to support this param too. I'll open a separate PR in Portal Pages repo.