### PR TITLE
Extend Reports API so Firestore-based Portal Report can send feedback data to Portal

### DIFF
--- a/app/controllers/api/v1/reports_controller.rb
+++ b/app/controllers/api/v1/reports_controller.rb
@@ -55,6 +55,10 @@ class API::V1::ReportsController < API::APIController
       # Activity feedback coming from new, firestore-based Portal Report.
       API::V1::Report.submit_activity_feedback_v2(offering, params[:activity_feedback_v2])
     end
+    if params[:rubric_v2]
+      # Rubric coming from new, firestore-based Portal Report.
+      API::V1::Report.update_rubric_v2(offering, params[:rubric_v2])
+    end
 
     offering.update_attributes!(report_params)
     head :ok

--- a/app/controllers/api/v1/reports_controller.rb
+++ b/app/controllers/api/v1/reports_controller.rb
@@ -33,8 +33,8 @@ class API::V1::ReportsController < API::APIController
     if params[:feedback_opts]
       API::V1::Report.update_feedback_settings(offering, params[:feedback_opts])
     end
-    if params[:actvity_feedback_opts]
-      API::V1::Report.update_activity_feedback_settings(params[:actvity_feedback_opts])
+    if params[:actvity_feedback_opts] # actvity -> this typo can't be fixed to keep API backward-compatible
+      API::V1::Report.update_activity_feedback_settings(params[:actvity_feedback_opts]) # actvity -> this typo can't be fixed to keep API backward-compatible
     end
     if params[:feedback]
       API::V1::Report.submit_feedback(params[:feedback])
@@ -42,6 +42,20 @@ class API::V1::ReportsController < API::APIController
     if params[:activity_feedback]
       API::V1::Report.submit_activity_feedback(params[:activity_feedback])
     end
+
+    # These actions have been added to support new Firestore-based Portal Report. Data format is a bit different
+    # than it used to be. New Portal Report still has to post activity feedback settings and content, so it can be
+    # displayed in the progress table. Note that progress table only shows activity-level feedback, so question
+    # feedback can be ignored. Once progress table is redone, this code can be removed.
+    if params[:activity_feedback_opts_v2]
+      # Activity feedback coming from new, firestore-based Portal Report.
+      API::V1::Report.update_activity_feedback_settings_v2(offering, params[:activity_feedback_opts_v2])
+    end
+    if params[:activity_feedback_v2]
+      # Activity feedback coming from new, firestore-based Portal Report.
+      API::V1::Report.submit_activity_feedback_v2(offering, params[:activity_feedback_v2])
+    end
+
     offering.update_attributes!(report_params)
     head :ok
   end

--- a/app/models/api/v1/report.rb
+++ b/app/models/api/v1/report.rb
@@ -383,13 +383,13 @@ class API::V1::Report
   # than it used to be. New Portal Report still has to post activity feedback settings and content, so it can be
   # displayed in the progress table. Note that progress table only shows activity-level feedback, so question
   # feedback can be ignored. Once progress table is redone, this code can be removed.
-  def self.update_activity_feedback_settings_v2(offering, activity_feedback_hash)
-    activity_index = activity_feedback_hash.delete('activity_index')
+  def self.update_activity_feedback_settings_v2(offering, options_hash)
+    activity_index = options_hash.delete('activity_index')
     template = offering.runnable.template
     activity = template.is_a?(Investigation) ? template.activities[activity_index] : template
     activity_feedback = Portal::OfferingActivityFeedback.where(portal_offering_id: offering.id, activity_id: activity.id).first
     return false unless activity_feedback
-    activity_feedback.set_feedback_options(activity_feedback_hash.symbolize_keys)
+    activity_feedback.set_feedback_options(options_hash.symbolize_keys)
   end
 
   def self.submit_activity_feedback_v2(offering, activity_feedback_hash)
@@ -403,4 +403,10 @@ class API::V1::Report
     Portal::LearnerActivityFeedback.update_feedback(learner.id, activity_feedback.id, activity_feedback_hash.symbolize_keys)
   end
 
+  def self.update_rubric_v2(offering, options_hash)
+    rubric = options_hash.delete('rubric')
+    Portal::OfferingActivityFeedback.where(portal_offering_id: offering.id).each do |activity_feedback|
+      activity_feedback.set_feedback_options(rubric: rubric)
+    end
+  end
 end

--- a/app/models/portal/learner_activity_feedback.rb
+++ b/app/models/portal/learner_activity_feedback.rb
@@ -63,6 +63,4 @@ class Portal::LearnerActivityFeedback < ActiveRecord::Base
     open  = self.open_feedback_for(learner, activity_feedback)
     open.update_attributes(attributes)
   end
-
-
 end

--- a/app/models/portal/offering_activity_feedback.rb
+++ b/app/models/portal/offering_activity_feedback.rb
@@ -30,6 +30,10 @@ class Portal::OfferingActivityFeedback < ActiveRecord::Base
     self.create(portal_offering_id: offering.id, activity_id: activity.id)
   end
 
+  def self.find_or_create_for_offering_and_activity(offering, activity)
+    self.for_offering_and_activity(offering, activity) || self.create_for_offering_and_activity(offering, activity)
+  end
+
   def rubric_url
     if portal_offering.runnable.respond_to? :rubric_url
       portal_offering.runnable.rubric_url


### PR DESCRIPTION
We need to do that because the old Portal Report was relying on the internal Portal IDs (e.g. IDs of `Portal::OfferingActivityFeedback`). A new report is using Firestore, there's much less connection to Portal internals. In most cases it's fine, but sometimes we need to use activity index. Also, the way how Rubric is saved/cached was updated, so the new API was necessary.