### PR TITLE
Fix/simplify feedback update

### DIFF
--- a/app/models/portal/learner_activity_feedback.rb
+++ b/app/models/portal/learner_activity_feedback.rb
@@ -15,52 +15,18 @@ class Portal::LearnerActivityFeedback < ActiveRecord::Base
 
   default_scope { order('created_at DESC') }
 
-  def self._attribute_ids(*attributes)
-    results = []
-    for attribute in attributes do
-      case attribute
-      when Numeric, String
-        results.push(attribute)
-      else
-        results.push(attribute.id)
-      end
-    end
-    return results
-  end
-
-  def self.for_learner_and_activity_feedback(learner,activity_feedback)
-    learner_id, activity_feedback_id = self._attribute_ids(learner, activity_feedback)
+  def self.for_learner_and_activity_feedback(learner_id, activity_feedback_id)
     self.where({portal_learner_id: learner_id, activity_feedback_id: activity_feedback_id})
         .order("created_at desc") # most recent first
   end
 
-  def self.open_feedback_for(learner, activity_feedback)
-    results = self.for_learner_and_activity_feedback(learner, activity_feedback).where({has_been_reviewed: false})
-      .limit(1)
-      .first
-    if results
-      return results
-    end
-
-    case learner
-    when Numeric, String
-      l = Portal::Learner.find(learner)
-    else
-      l = learner
-    end
-
-    case activity_feedback
-    when Numeric, String
-      f = Portal::OfferingActivityFeedback.find(activity_feedback)
-    else
-      f = activity_feedback
-    end
-
-    return self.create({portal_learner:l, activity_feedback: f})
+  def self.open_feedback_for(learner_id, activity_feedback_id)
+    self.for_learner_and_activity_feedback(learner_id, activity_feedback_id).limit(1).first ||
+    self.create({portal_learner_id: learner_id, activity_feedback_id: activity_feedback_id})
   end
 
-  def self.update_feedback(learner, activity_feedback, attributes)
-    open  = self.open_feedback_for(learner, activity_feedback)
+  def self.update_feedback(learner_id, activity_feedback_id, attributes)
+    open  = self.open_feedback_for(learner_id, activity_feedback_id)
     open.update_attributes(attributes)
   end
 end

--- a/db/migrate/20190828133302_change_feedback_score_default_value.rb
+++ b/db/migrate/20190828133302_change_feedback_score_default_value.rb
@@ -1,0 +1,9 @@
+class ChangeFeedbackScoreDefaultValue < ActiveRecord::Migration
+  def up
+    change_column_default(:portal_learner_activity_feedbacks, :score, 0)
+  end
+
+  def down
+    change_column_default(:portal_learner_activity_feedbacks, :score, 10)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20190820130414) do
+ActiveRecord::Schema.define(:version => 20190828133302) do
 
   create_table "access_grants", :force => true do |t|
     t.string   "code"
@@ -1061,7 +1061,7 @@ ActiveRecord::Schema.define(:version => 20190820130414) do
 
   create_table "portal_learner_activity_feedbacks", :force => true do |t|
     t.text     "text_feedback"
-    t.integer  "score",                :default => 10
+    t.integer  "score",                :default => 0
     t.boolean  "has_been_reviewed",    :default => false
     t.integer  "portal_learner_id"
     t.integer  "activity_feedback_id"

--- a/spec/models/portal/learner_activity_feedback_spec.rb
+++ b/spec/models/portal/learner_activity_feedback_spec.rb
@@ -37,16 +37,6 @@ describe Portal::LearnerActivityFeedback do
   end
 
   # TODO: auto-generated
-  describe '._attribute_ids' do
-    xit '_attribute_ids' do
-      attributes = {}
-      result = described_class._attribute_ids(attributes)
-
-      expect(result).not_to be_nil
-    end
-  end
-
-  # TODO: auto-generated
   describe '.for_learner_and_activity_feedback' do
     it 'for_learner_and_activity_feedback' do
       result = described_class.for_learner_and_activity_feedback(learner, activity_feedback)


### PR DESCRIPTION
We could see that some feedback wasn't updated correctly during yesterday's demo.
I could reproduce a relatively similar issue when I was typing text feedback and quickly checking "Complete" checkbox. Portal Report has some delay of the text feedback update (so we don't update on every keystroke) and it was causing that text feedback was sent **after** "Complete" checkbox API call.

Now, if you follow old logic in `Portal::LearnerActivityFeedback#open_feedback_for`, you'll see that we look for feedback that isn't reviewed, and otherwise, we create a new one.

So, the first request was marking existing feedback complete. But delayed text feedback update was creating a new feedback instance that wasn't reviewed. 

That's why I could see in the UI that my student "needs review" even though it was reviewed. I bet this convoluted logic here could also cause similar issues with score updates.

I guess this bug was around for all the time. And I bet the intention here was to support multiple feedbacks, mark which ones are reviewed and which are not, and so on. But I think it has never been used. And the new report only displays the last feedback anyway, we don't store multiple copies of feedback in Firestore.

Also, I changed the default score to 0 from 10, as that matches default values we use in Portal Report.