### PR TITLE
LARA still uses http in some cases, so our OAuth support needs to allow it

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -43,11 +43,17 @@ class Client < ActiveRecord::Base
       # Wrong redirect URI, we should NOT redirect back to the client.
       raise "redirect_uri must not include fragment"
     end
-    if URI.parse(APP_CONFIG[:site_url]).scheme == "https" && uri.scheme != "https"
-      # Enforce HTTPS when Portal is using HTTPS too.
-      # # Wrong redirect URI, we should NOT redirect back to the client.
-      raise "redirect_uri must use HTTPS protocol"
-    end
+
+    # LARA still needs to run in http because of some interactives and activities
+    # that were authored using http.  So we can't enforce https yet.
+    # Uncomment this once LARA is fully moved to https
+    # If this is uncommented then the test in client_spec.rb needs to be uncommented too
+    #
+    # if URI.parse(APP_CONFIG[:site_url]).scheme == "https" && uri.scheme != "https"
+    #   # Enforce HTTPS when Portal is using HTTPS too.
+    #   # # Wrong redirect URI, we should NOT redirect back to the client.
+    #   raise "redirect_uri must use HTTPS protocol"
+    # end
     if query_params
       query = Rack::Utils.parse_query(uri.query)
       query.merge!(query_params)

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -92,13 +92,13 @@ describe Client do
         expect { client.get_redirect_uri("https://test.client.com#param=test", test_param: "123") }.to raise_error(RuntimeError)
       end
     end
-    describe "when redirect_uri uses HTTP and Portal uses HTTPS" do
-      let(:redirect_uris) { "http://test.client.com?param1=test" }
-      it "should throw an error" do
-        allow(APP_CONFIG).to receive(:[]).with(:site_url).and_return("https://test.portal.com")
-        expect { client.get_redirect_uri("http://test.client.com?param1=test", test_param: "123") }.to raise_error(RuntimeError)
-      end
-    end
+    # describe "when redirect_uri uses HTTP and Portal uses HTTPS" do
+    #   let(:redirect_uris) { "http://test.client.com?param1=test" }
+    #   it "should throw an error" do
+    #     allow(APP_CONFIG).to receive(:[]).with(:site_url).and_return("https://test.portal.com")
+    #     expect { client.get_redirect_uri("http://test.client.com?param1=test", test_param: "123") }.to raise_error(RuntimeError)
+    #   end
+    # end
   end
 
 


### PR DESCRIPTION
For example when a student launches an http based LARA activity. LARA will try to use OAuth to log the student into LARA and this will have an http redirect URL.

I left the code in there so we can easily add this back in if we get LARA switch over. Or perhaps we want to add some hard coded check for `authoring.concord.org` and `authoring.staging.concord.org` urls. That'd at least prevent us from using http with new services.