### PR TITLE
first attempt to fix broken session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -310,18 +310,22 @@ class ApplicationController < ActionController::Base
     end
 
     if session[:oauth_authorize_params]
-      oauth_redirect = AccessGrant.get_authorize_redirect_uri(current_user, session[:oauth_authorize_params])
-      # the user has been logged in by another auth provider via a popup window:
-      # AutomaticallyClosingPopupLink in that case the other auth provider redirects in the
-      # the window, so the auth_redirect session var is set which is then picked up by the
-      # misc#auth_after action.
-      if session[:auth_popup]
-        session[:auth_popup] = nil
-        session[:auth_redirect] = oauth_redirect
-      else
-        redirect_path = oauth_redirect
+      begin
+        oauth_redirect = AccessGrant.get_authorize_redirect_uri(current_user, session[:oauth_authorize_params])
+        # the user has been logged in by another auth provider via a popup window:
+        # AutomaticallyClosingPopupLink in that case the other auth provider redirects in the
+        # the window, so the auth_redirect session var is set which is then picked up by the
+        # misc#auth_after action.
+        if session[:auth_popup]
+          session[:auth_popup] = nil
+          session[:auth_redirect] = oauth_redirect
+        else
+          redirect_path = oauth_redirect
+        end
+      ensure
+        # make sure to clean up the oauth params even if an exception is raised
+        session[:oauth_authorize_params] = nil
       end
-      session[:oauth_authorize_params] = nil
     end
     redirect_path
   end


### PR DESCRIPTION
if an auth client in portal doesn't have redirect urls for lara, then after LARA tries to log in the session becomes broken.
With this broken session, if the user tries to log directly into the portal (not going through lara), it doesn't work.
The exception raised shows that the oauth code path is still being traversed.
Unfortunately the fix in this commit doesn't actually fix the problem, but it seems like one piece of it.
I think the reason the problem persists is because something is setting the 'user_return_to' session variable.  This session variable can be seen in the exception info printed in the log.
When the exception is raised initially due to the misconfigured auth client, this session variable remains set. I'm not sure yet where that variable gets set.