### PR TITLE
first pass at removing session variable for oauth flow

### DIFF
--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -2,16 +2,26 @@ class Admin::ProjectsController < ApplicationController
 
   protected
 
+  def humanized_action(map={})
+    super({landing_page: 'view'})
+  end
+
   def not_authorized_error_message
-    super({resource_type: 'project'})
+    if action_name == 'landing_page'
+      super({resource_type: 'collection'})
+    else
+      super({resource_type: 'project'})
+    end
   end
 
   public
 
   # GET /:landing_page_slug
-  def landing_page
-    # no authorization needed ...
+  def landing_page    # no authorization needed ...
     @project = Admin::Project.where(landing_page_slug: params[:landing_page_slug]).first!
+
+    # We want to prevent logged in students from viewing landing pages
+    authorize @project
 
     @landing_page_content = @project.landing_page_content
     # Redirect back to project landing page after user signs in.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,8 +27,9 @@ class ApplicationController < ActionController::Base
     # without the no-store Chrome will cache this redirect in some cases
     # for example if a student tries to access a collection page, and then they
     # log out and try to access it again. In this case Chrome sends them to the
-    # cached location of "/my-classes"
-    response.headers["Cache-Control"] = 'no-store'
+    # cached location of "/my-classes". By default rails adds 'no-cache' but that isn't
+    # strong enough.
+    response.headers['Cache-Control'] = 'no-store'
 
     error_message = not_authorized_error_message
     if request.xhr?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,6 +24,12 @@ class ApplicationController < ActionController::Base
   rescue_from Pundit::NotAuthorizedError, with: :pundit_user_not_authorized
 
   def pundit_user_not_authorized(exception)
+    # without the no-store Chrome will cache this redirect in some cases
+    # for example if a student tries to access a collection page, and then they
+    # log out and try to access it again. In this case Chrome sends them to the
+    # cached location of "/my-classes"
+    response.headers["Cache-Control"] = 'no-store'
+
     error_message = not_authorized_error_message
     if request.xhr?
       render :text => "<div class='flash_error'>#{error_message}</div>", :status => 403

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -318,14 +318,7 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_out_path_for(resource)
-    redirect_url = "#{params[:redirect_uri]}?re_login=true&provider=#{params[:provider]}"
-    if params[:re_login]
-      # It looks to me like this code was only used by LARA in some code that was removed
-      # from there: https://github.com/concord-consortium/lara/pull/216
-      redirect_url
-    else
-      root_path
-    end
+    root_path
   end
 
   def set_locale

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -313,11 +313,17 @@ class ApplicationController < ActionController::Base
       # See pundit_user_not_authorized for the implementation
 
       redirect_uri = URI.parse(params[:after_sign_in_path])
-      query = Rack::Utils.parse_query(redirect_uri.query)
-      # add an extra param to this path, so we don't go in a loop, see pundit_user_not_authorized
-      query["redirecting_after_sign_in"] = '1'
-      redirect_uri.query = Rack::Utils.build_query(query)
-      redirect_path = redirect_uri.to_s
+
+      # Only allow redirecting to paths. If the redirect url has a host do not redirect
+      # this prevents an open redirect. More info about open redirects are here:
+      # https://cwe.mitre.org/data/definitions/601.html
+      if redirect_uri.host.nil?
+        query = Rack::Utils.parse_query(redirect_uri.query)
+        # add an extra param to this path, so we don't go in a loop, see pundit_user_not_authorized
+        query["redirecting_after_sign_in"] = '1'
+        redirect_uri.query = Rack::Utils.build_query(query)
+        redirect_path = redirect_uri.to_s
+      end
     end
 
     redirect_path

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -56,7 +56,8 @@ class ApplicationController < ActionController::Base
           # So instead of showing the error message again, we just send the user to the
           # default login page for that user.
           flash[:alert] = error_message if not params[:redirecting_after_sign_in]
-          redirect_to after_sign_in_path_for(current_user)
+
+          redirect_to view_context.current_user_home_path
         end
       else
         flash[:alert] = error_message
@@ -304,14 +305,12 @@ class ApplicationController < ActionController::Base
       # force all users to try to go to the researcher page on a report only portal
       redirect_path = learner_report_path
     elsif params[:after_sign_in_path].present?
-      # users that aren't student can be redirected to other pages after logging in if
-      # the after_sign_in_path param is provided
-
-      # CHECKME: I think this was restricted to non students because we didn't want
-      # students to access collection pages. So if they are looking at a collection page
-      # and then sign in, we don't want them to see the collection page again.
-      # Instead of blocking the redirect, it seems better to block the students when they
-      # try to access the collection page.
+      # the check for to see if the user has permission to view the after_sigin_in_path
+      # page is handled by the controller of this new page.
+      # if the user doesn't have permission to see the new page they will be sent to their
+      # home page. They will also not see a error message because of the
+      # redirecting_after_sign_in parameter that is added here.
+      # See pundit_user_not_authorized for the implementation
 
       redirect_uri = URI.parse(params[:after_sign_in_path])
       query = Rack::Utils.parse_query(redirect_uri.query)

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -41,12 +41,17 @@ class AuthController < ApplicationController
 
   def oauth_authorize
     if current_user.nil?
-        client = Client.find_by_app_id(params[:client_id])
-        app_name = client ? client.name : nil
-
-        # CHECKME: when app_name is nil, what value gets added to the URL
-        redirect_to auth_login_path(after_sign_in_path: request.fullpath, app_name: app_name)
+      validation = AccessGrant.validate_oauth_authorize(params)
+      if (!validation.valid)
+        redirect_to validation.error_redirect
         return
+      end
+
+      # if the parameters are valid then the validation will have a client
+      # we send the clients name to the login box so it can display a helpful name
+      app_name = validation.client.name
+      redirect_to auth_login_path(after_sign_in_path: request.fullpath, app_name: app_name)
+      return
     end
 
     # Note that we'll get to this point only if user is currently logged in.

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -16,7 +16,6 @@ class AuthController < ApplicationController
 
   def login
     # Renders a nice login form (views/auth/login.haml).
-    # TODO session variables cause weird behaviors try to remove this if possible
     @app_name = params[:app_name]
     @error = flash[:alert]
     @after_sign_in_path = params[:after_sign_in_path]

--- a/app/models/access_grant.rb
+++ b/app/models/access_grant.rb
@@ -22,30 +22,70 @@ class AccessGrant < ActiveRecord::Base
     AccessGrant.where("code = ? AND client_id = ?", code, client_id).first
   end
 
-  # Pretty much perform the 1st step of the OAuth2 authorization.
-  def self.get_authorize_redirect_uri(user, params)
-    client = Client.find_by_app_id(params[:client_id])
+  ValidationResult = Struct.new(:valid, :client, :error_redirect) do
+    def valid?
+      valid
+    end
+  end
+
+  # this will raise an error if:
+  # - the client is not found
+  # - the passed in redirect_uri is not registered with the client
+  def self.validate_oauth_authorize(params)
+    result = ValidationResult.new(false, nil, nil)
+    result.client = client = Client.find_by_app_id(params[:client_id])
     unless client
       raise "Client not found"
     end
     unless SUPPORTED_RESPONSE_TYPES.include?(params[:response_type])
       # https://tools.ietf.org/html/rfc6749#section-4.2.2.1
-      return client.get_redirect_uri(params[:redirect_uri], error: "unsupported_response_type")
+      result.error_redirect =
+        client.get_redirect_uri(params[:redirect_uri], error: "unsupported_response_type")
+      return result
     end
+
+    if client.client_type == Client::PUBLIC && params[:response_type] === "token"
+      # Implicit flow for public clients (e.g. Glossary Authoring).
+      result.valid = true
+    elsif client.client_type == Client::CONFIDENTIAL && params[:response_type] === "code"
+      # Auth code flow (two steps) for confidential clients (e.g. LARA).
+      result.valid = true
+    else
+      # https://tools.ietf.org/html/rfc6749#section-4.2.2.1
+      result.error_redirect =
+        client.get_redirect_uri(params[:redirect_uri], error: "unauthorized_client")
+    end
+
+    result
+  end
+
+  # Pretty much perform the 1st step of the OAuth2 authorization.
+  def self.get_authorize_redirect_uri(user, params)
+    # this validation might have already happened before, if the user wasn't logged in
+    # but if the user was already logged in then this will be first time the validation
+    # is done
+    validation = self.validate_oauth_authorize(params)
+
+    if !validation.valid
+      return validation.error_redirect
+    end
+
+    client = validation.client
 
     AccessGrant.prune!
     access_grant = user.access_grants.create({:client => client, :state => params[:state]}, :without_protection => true)
 
-    if client.client_type == Client::PUBLIC && params[:response_type] === "token"
+    # validate_oauth_authorize already checked that this client settings matched the response_type
+    if params[:response_type] === "token"
       # Implicit flow for public clients (e.g. Glossary Authoring).
       access_grant.start_expiry_period!
       access_grant.implicit_flow_redirect_uri_for(params[:redirect_uri])
-    elsif client.client_type == Client::CONFIDENTIAL && params[:response_type] === "code"
+    elsif params[:response_type] === "code"
       # Auth code flow (two steps) for confidential clients (e.g. LARA).
       access_grant.auth_code_redirect_uri_for(params[:redirect_uri])
     else
-      # https://tools.ietf.org/html/rfc6749#section-4.2.2.1
-      client.get_redirect_uri(params[:redirect_uri], error: "unauthorized_client")
+      # we shouldn't be here because validate_oauth_authorize should have handled this case
+      raise "error validating request"
     end
   end
 

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -61,6 +61,7 @@ class Client < ActiveRecord::Base
 
     check_redirect_uri(redirect_uri, "Requested query_params: #{query_params}, hash_params: #{hash_params}")
 
+    uri = URI.parse(redirect_uri)
     if query_params
       query = Rack::Utils.parse_query(uri.query)
       query.merge!(query_params)

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -32,11 +32,17 @@ class Client < ActiveRecord::Base
     grant
   end
 
-  def get_redirect_uri(redirect_uri, query_params = nil, hash_params = nil)
+  def check_redirect_uri(redirect_uri, extra_error_msg = "")
     unless redirect_uris && redirect_uris.split(" ").include?(redirect_uri)
       # Wrong redirect URI, we should NOT redirect back to the client.
-      raise "Unauthorized redirect_uri: #{redirect_uri}. Requested query_params: #{query_params}, hash_params: #{hash_params}"
+      raise "Unauthorized redirect_uri: #{redirect_uri}. #{extra_error_msg}"
     end
+  end
+
+  def get_redirect_uri(redirect_uri, query_params = nil, hash_params = nil)
+    
+    check_redirect_uri(redirect_uri, "Requested query_params: #{query_params}, hash_params: #{hash_params}")
+
     uri = URI.parse(redirect_uri)
     if uri.fragment
       # Note that redirect_uri is not allowed to include any fragment / hash params.

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -37,17 +37,12 @@ class Client < ActiveRecord::Base
       # Wrong redirect URI, we should NOT redirect back to the client.
       raise "Unauthorized redirect_uri: #{redirect_uri}. #{extra_error_msg}"
     end
-  end
-
-  def get_redirect_uri(redirect_uri, query_params = nil, hash_params = nil)
-    
-    check_redirect_uri(redirect_uri, "Requested query_params: #{query_params}, hash_params: #{hash_params}")
 
     uri = URI.parse(redirect_uri)
     if uri.fragment
       # Note that redirect_uri is not allowed to include any fragment / hash params.
       # Wrong redirect URI, we should NOT redirect back to the client.
-      raise "redirect_uri must not include fragment"
+      raise "redirect_uri must not include fragment. #{extra_error_msg}"
     end
 
     # LARA still needs to run in http because of some interactives and activities
@@ -58,8 +53,14 @@ class Client < ActiveRecord::Base
     # if URI.parse(APP_CONFIG[:site_url]).scheme == "https" && uri.scheme != "https"
     #   # Enforce HTTPS when Portal is using HTTPS too.
     #   # # Wrong redirect URI, we should NOT redirect back to the client.
-    #   raise "redirect_uri must use HTTPS protocol"
+    #   raise "redirect_uri must use HTTPS protocol. #{extra_error_msg}"
     # end
+  end
+
+  def get_redirect_uri(redirect_uri, query_params = nil, hash_params = nil)
+
+    check_redirect_uri(redirect_uri, "Requested query_params: #{query_params}, hash_params: #{hash_params}")
+
     if query_params
       query = Rack::Utils.parse_query(uri.query)
       query.merge!(query_params)

--- a/app/policies/admin/project_policy.rb
+++ b/app/policies/admin/project_policy.rb
@@ -18,6 +18,11 @@ class Admin::ProjectPolicy < ApplicationPolicy
     admin_or_project_admin?
   end
 
+  def landing_page?
+    # students aren't allowed to visit landing pages
+    ! student?
+  end
+
   def update_edit_or_destroy?
     admin_or_project_admin?
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -12,28 +12,5 @@ RSpec.describe ApplicationController, type: :controller do
     it 'runs without error' do
       expect(controller.send(:after_sign_in_path_for, User)).to_not be_nil
     end
-
-    context 'the session contains oauth_authorize_params' do
-      let(:session) { {oauth_authorize_params: {} } }
-      before(:each) do
-        allow(controller).to receive(:session).and_return(session)
-        allow(AccessGrant).to receive(:get_authorize_redirect_uri).and_return('blah')
-      end
-
-      it 'runs without error' do
-        expect(controller.send(:after_sign_in_path_for, User)).to eq('blah')
-      end
-
-      context 'the Auth Client is invalid and raises an error' do
-        before(:each) do
-          allow(AccessGrant).to receive(:get_authorize_redirect_uri).and_raise('invalid')
-        end
-
-        it 'resets the session and re raises the exception' do
-          expect(controller).to receive(:reset_session)
-          expect { controller.send(:after_sign_in_path_for, User) }.to raise_error('invalid')
-        end
-      end
-    end
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -12,5 +12,16 @@ RSpec.describe ApplicationController, type: :controller do
     it 'runs without error' do
       expect(controller.send(:after_sign_in_path_for, User)).to_not be_nil
     end
+
+    it 'redirects to a path without a host' do
+      allow(controller).to receive(:params).and_return({after_sign_in_path: "/somewhere"})
+      expect(controller.send(:after_sign_in_path_for, User)).to eq("/somewhere?redirecting_after_sign_in=1")
+    end
+
+    it 'does not redirect to other domains' do
+      allow(controller).to receive(:params).and_return({after_sign_in_path: "http://evil.domain/somewhere"})
+      expect(controller.send(:after_sign_in_path_for, User)).to eq(
+        controller.view_context.current_user_home_path)
+    end
   end
 end

--- a/spec/controllers/auth_controller_spec.rb
+++ b/spec/controllers/auth_controller_spec.rb
@@ -22,12 +22,36 @@ RSpec.describe AuthController, type: :controller do
     end
   end
 
-  # TODO: auto-generated
   describe '#oauth_authorize' do
-    it 'GET oauth_authorize' do
-      get :oauth_authorize, {}, {}
+    let (:params) { {} }
 
-      expect(response).to have_http_status(:redirect)
+    subject { get :oauth_authorize, params, {} }
+
+    context 'without a logged in user' do
+      it 'redirects' do
+        expect(subject).to have_http_status(:redirect)
+      end
+
+      it 'redicts with an after_sign_in_path' do
+        expect(subject.location).to include('after_sign_in_path')
+      end
+
+      # FIXME: this should actually return an error because we want to validate
+      # the client paramters before redirecting
+      context 'when a client_id is not passed' do
+        it 'redirects without a app_name' do
+          expect(subject.location).not_to include('app_name')
+        end
+      end
+
+      context 'when a client_id param is passed' do
+        let (:client) { FactoryBot.create(:client, name: 'Foo', app_id: 'test-client') }
+        let (:params) { {client_id: client.app_id} }
+
+        it "redirects with the client's app name" do
+          expect(subject.location).to include('app_name=Foo')
+        end
+      end
     end
   end
 

--- a/spec/integration/sign_in_redirect_spec.rb
+++ b/spec/integration/sign_in_redirect_spec.rb
@@ -8,13 +8,4 @@ describe "when user signs in and 'after_sign_in_path' parameter is provided" do
     post "/users/sign_in", user: {login: user.login, password: user.password}, after_sign_in_path: custom_url
     expect(response).to redirect_to("#{custom_url}?redirecting_after_sign_in=1")
   end
-
-  describe "and user is student" do
-    let(:user) { FactoryBot.create(:full_portal_student).user }
-
-    it "user is sent to my classes" do
-      post "/users/sign_in", user: {login: user.login, password: user.password}, after_sign_in_path: custom_url
-      expect(response).to redirect_to(my_classes_url)
-    end
-  end
 end

--- a/spec/models/access_grant_spec.rb
+++ b/spec/models/access_grant_spec.rb
@@ -199,56 +199,6 @@ describe AccessGrant do
           end
         end
       end
-      it "should return redirect_uri with access token when response_type is 'token'" do
-        client.redirect_uris = "http://test.com"
-        client.client_type = Client::PUBLIC
-        client.save!
-        expect(AccessGrant.get_authorize_redirect_uri(user, {client_id: client.app_id, response_type: "token", redirect_uri: "http://test.com"})).to eq(
-          "http://test.com#access_token=#{AccessGrant.last.access_token}&token_type=bearer&expires_in=#{AccessGrant::ExpireTime.to_s}&state"
-        )
-      end
-      it "should return redirect_uri with code when response_type is 'code'" do
-        client.redirect_uris = "http://test.com"
-        client.client_type = Client::CONFIDENTIAL
-        client.save!
-        expect(AccessGrant.get_authorize_redirect_uri(user, {client_id: client.app_id, response_type: "code", redirect_uri: "http://test.com"})).to eq(
-          "http://test.com?code=#{AccessGrant.last.code}&response_type=code&state="
-        )
-      end
-      it "should fail if client is not found" do
-        expect { AccessGrant.get_authorize_redirect_uri(user, {client_id: "123"}) }.to raise_error(RuntimeError)
-      end
-      it "should fail if response_type is not supported and redirect_uri is not registered" do
-        expect { AccessGrant.get_authorize_redirect_uri(user, {client_id: client.app_id, response_type: "foo"}) }.to raise_error(RuntimeError)
-      end
-      it "should return redirect_uri with error code if response_type is not supported and redirect_uri is registered" do
-        client.redirect_uris = "http://test.com"
-        client.save!
-        expect(AccessGrant.get_authorize_redirect_uri(user, {client_id: client.app_id, response_type: "foo", redirect_uri: "http://test.com"})).to eq(
-          "http://test.com?error=unsupported_response_type"
-        )
-      end
-      it "should fail if response_type is not supported by given client_type and redirect_uri is not registered" do
-        client.client_type = Client::CONFIDENTIAL
-        client.save!
-        expect { AccessGrant.get_authorize_redirect_uri(user, {client_id: client.app_id, response_type: "token"}) }.to raise_error(RuntimeError)
-        client.client_type = Client::PUBLIC
-        client.save!
-        expect { AccessGrant.get_authorize_redirect_uri(user, {client_id: client.app_id, response_type: "code"}) }.to raise_error(RuntimeError)
-      end
-      it "should return redirect_uri with error code if response_type is not supported by given client_type and redirect_uri is registered" do
-        client.redirect_uris = "http://test.com"
-        client.client_type = Client::CONFIDENTIAL
-        client.save!
-        expect(AccessGrant.get_authorize_redirect_uri(user, {client_id: client.app_id, response_type: "token", redirect_uri: "http://test.com"})).to eq(
-          "http://test.com?error=unauthorized_client"
-        )
-        client.client_type = Client::PUBLIC
-        client.save!
-        expect(AccessGrant.get_authorize_redirect_uri(user, {client_id: client.app_id, response_type: "code", redirect_uri: "http://test.com"})).to eq(
-          "http://test.com?error=unauthorized_client"
-        )
-      end
     end
 
     describe "#authenticate(code, application_id)" do

--- a/spec/models/access_grant_spec.rb
+++ b/spec/models/access_grant_spec.rb
@@ -88,7 +88,7 @@ describe AccessGrant do
       context "when client_id is not found" do
         let(:params) { {client_id: "123"} }
         it "should raise an error" do
-          expect { subject }.to raise_error(RuntimeError)
+          expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
 


### PR DESCRIPTION
This is missing a few things:

- [x] update the tests and make sure new code is covered
- [x] verify the behavior when students access a collection page anonymously and then log in
- [x] decide if we should remove the 're_login' param handling
- [x] verify the app_name handling in oauth_authorize
- [x] add client verification in oauth_authorize before redirecting
- [x] check if this breaks the ability to use google accounts to sign into the Researcher Report portal instance, it certainly breaks the ability to log into LARA via the researcher portal since it would never redirect back to oauth_authorize. But I think this is separate from logging into the portal with Google.