### PR TITLE
Move student update

### DIFF
--- a/app/assets/stylesheets/web/admin.scss
+++ b/app/assets/stylesheets/web/admin.scss
@@ -137,3 +137,17 @@
     text-transform: none;
   }
 }
+
+.admin-links-cols {
+  column-count: 2;
+  margin-bottom: 30px;
+
+  .col {
+    break-inside: avoid-column;
+  }
+  ul {
+    list-style-position: inside;
+    margin-left: 0;
+    overflow:hidden;
+  }
+}

--- a/app/assets/stylesheets/web/admin.scss
+++ b/app/assets/stylesheets/web/admin.scss
@@ -142,7 +142,7 @@
   column-count: 2;
   margin-bottom: 30px;
 
-  .col {
+  .admin-links-cols__column {
     break-inside: avoid-column;
   }
   ul {

--- a/app/controllers/admin/tools_controller.rb
+++ b/app/controllers/admin/tools_controller.rb
@@ -1,0 +1,82 @@
+class Admin::ToolsController < ApplicationController
+
+  public
+
+  def index
+    authorize Tool
+    @tools = Tool.all
+
+    respond_to do |format|
+      format.html # index.html.erb
+    end
+  end
+
+  # GET /tools/1
+  def show
+    @tool = Tool.find(params[:id])
+    authorize @tool
+
+    respond_to do |format|
+      format.html # show.html.erb
+    end
+  end
+
+  # GET /tools/new
+  def new
+    authorize Tool
+    @tool = Tool.new
+
+    respond_to do |format|
+      format.html # new.html.erb
+    end
+  end
+
+  # GET /tools/1/edit
+  def edit
+    @tool = Tool.find(params[:id])
+    authorize @tool
+  end
+
+  # POST /tools
+  def create
+    authorize Tool
+    @tool = Tool.new(params[:tool])
+
+    respond_to do |format|
+      if @tool.save
+        format.html { redirect_to admin_tools_path, notice: 'Tool was successfully created.' }
+        format.json { render json: @tool, status: :created, location: @tool }
+      else
+        format.html { render action: "new" }
+        format.json { render json: @tool.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PUT /tools/1
+  def update
+    @tool = Tool.find(params[:id])
+    authorize @tool
+
+    respond_to do |format|
+      if @tool.update_attributes(params[:tool])
+        format.html { redirect_to admin_tools_path, notice: 'Tool was successfully updated.' }
+        format.json { head :no_content }
+      else
+        format.html { render action: "edit" }
+        format.json { render json: @tool.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /tools/1
+  def destroy
+    @tool = Tool.find(params[:id])
+    authorize @tool
+    @tool.destroy
+
+    respond_to do |format|
+      format.html { redirect_to(admin_tools_url) }
+    end
+  end
+end

--- a/app/controllers/portal/students_controller.rb
+++ b/app/controllers/portal/students_controller.rb
@@ -273,55 +273,23 @@ class Portal::StudentsController < ApplicationController
   end
 
   def move
-    @portal_student = Portal::Student.find(params[:id])
-    @current_class = Portal::Clazz.find_by_class_word(params[:clazz][:current_class_word])
-    @new_class = Portal::Clazz.find_by_class_word(params[:clazz][:new_class_word])
+    portal_student = Portal::Student.find(params[:id])
+    current_class = Portal::Clazz.find_by_class_word(params[:clazz][:current_class_word])
+    new_class = Portal::Clazz.find_by_class_word(params[:clazz][:new_class_word])
 
-    @portal_student.remove_clazz(@current_class)
-    @portal_student.add_clazz(@new_class)
+    portal_student.remove_clazz(current_class)
+    portal_student.add_clazz(new_class)
 
     # post data to report service, include bearer token in request ENV['REPORT_SERVICE_BEARER_TOKEN']
     req = Net::HTTP::Post.new('/api/move_student_work', {'Authorization' => 'Bearer ' + ENV['REPORT_SERVICE_BEARER_TOKEN'], 'Content-Type' => 'application/json'})
-    req.body = move_student_and_return_config.to_json
+    config = portal_student.move_student_and_return_config(new_class, current_class)
+    req.body = config.to_json
     http = Net::HTTP.new('us-central1-report-service-dev.cloudfunctions.net', '443')
     http.use_ssl = true
     http.request(req)
 
     flash[:notice] = 'Successfully moved student to new class.' # + JSON[@report_json]
-    redirect_to(@portal_student)
-  end
-
-  def move_student_and_return_config
-    # initialize JSON for report API call
-    report_config = {
-      new_class_info_url: @new_class.class_info_url(URI.parse(APP_CONFIG[:site_url]).scheme, URI.parse(APP_CONFIG[:site_url]).host),
-      new_context_id: @new_class.class_hash.to_s,
-      old_context_id: @current_class.class_hash.to_s,
-      platform_id: APP_CONFIG[:site_url].to_s,
-      platform_user_id: @portal_student.user_id.to_s
-    }
-    assignments = []
-
-    # find matches between student learners and new class's offerings. Update offering_id values to match those in new class (student work on assignments that aren't assigned to new class becomes orphaned)
-    @portal_student.learners.each do |sa|
-      @new_class.offerings.each do |nca|
-        if sa.offering.runnable == nca.runnable
-          learner_to_update = Portal::Learner.find(sa.id)
-          learner_to_update.update_attribute('offering_id', nca.id)
-          learner_to_update.report_learner.update_fields
-          # add assignment to JSON for report API call
-          assignments << {
-            new_resource_link_id: nca.id.to_s,
-            old_resource_link_id: sa.offering_id.to_s,
-            tool_id: ENV['TEMP_TOOL_ID']
-          }
-        end
-      end
-    end
-
-    # add learner IDs to JSON for report API
-    report_config[:assignments] = assignments
-    report_config
+    redirect_to(portal_student)
   end
 
   # DELETE /portal_students/1

--- a/app/controllers/portal/students_controller.rb
+++ b/app/controllers/portal/students_controller.rb
@@ -281,9 +281,7 @@ class Portal::StudentsController < ApplicationController
     @portal_student.add_clazz(@new_class)
 
     # initialize JSON for report API call
-    @site_protocol = URI.parse(APP_CONFIG[:site_url]).scheme
-    @site_domain = URI.parse(APP_CONFIG[:site_url]).host
-    @report_json = JSON['{"class_info_url": "' + @new_class.class_info_url(@site_protocol, @site_domain) + '", "context_id": "' + @new_class.class_hash.to_s + '", "current_context_id": "' + @current_class.class_hash.to_s + '", "platform_id": "' + APP_CONFIG[:site_url].to_s + '", "platform_user_id": "' + @portal_student.user_id.to_s + '"}']
+    @report_json = JSON['{"class_info_url": "' + @new_class.class_info_url(URI.parse(APP_CONFIG[:site_url]).scheme, URI.parse(APP_CONFIG[:site_url]).host) + '", "context_id": "' + @new_class.class_hash.to_s + '", "current_context_id": "' + @current_class.class_hash.to_s + '", "platform_id": "' + APP_CONFIG[:site_url].to_s + '", "platform_user_id": "' + @portal_student.user_id.to_s + '"}']
     @assignments = []
 
     # find matches between student learners and new class's offerings. Update offering_id values to match those in new class (student work on assignments that aren't assigned to new class becomes orphaned)

--- a/app/controllers/portal/students_controller.rb
+++ b/app/controllers/portal/students_controller.rb
@@ -1,3 +1,4 @@
+require 'uri'
 class Portal::StudentsController < ApplicationController
   include RestrictedPortalController
 
@@ -283,23 +284,35 @@ class Portal::StudentsController < ApplicationController
     @portal_student.add_clazz(@new_class)
 
     # initialize JSON for report API call
-    @report_json = JSON['{"class_info_url": "' + @new_class.id.to_s + '", "context_id": "' + @new_class.hash.to_s + '", "platform_id": "' + APP_CONFIG[:site_url].to_s + '", "platform_user_id": "' + @portal_student.user_id.to_s + '"}']
+    @site_protocol = URI.parse(APP_CONFIG[:site_url]).scheme
+    @site_domain = URI.parse(APP_CONFIG[:site_url]).host
+    @report_json = JSON['{"class_info_url": "' + @new_class.class_info_url(@site_protocol, @site_domain) + '", "context_id": "' + @new_class.class_hash.to_s + '", "current_context_id": "' + @current_class.class_hash.to_s + '", "platform_id": "' + APP_CONFIG[:site_url].to_s + '", "platform_user_id": "' + @portal_student.user_id.to_s + '"}']
     @assignments = []
     # find matches between student learners and new class's offerings. Update offering_id values to match those in new class (student work on assignments that aren't assigned to new class becomes orphaned)
     @portal_student.learners.each do |sa|
+      puts "testing..."
+      puts sa.inspect
       @new_class.offerings.each do |nca|
         if sa.offering.runnable == nca.runnable
           @learner_to_update = Portal::Learner.find(sa.id)
           @learner_to_update.update_attribute('offering_id', nca.id)
-          @learner_to_update.report_learner.update_fields
+          @learner_to_update.report_learner.update_fields # does this still need to be here?
           # add assignment to JSON for report API call
-          @assignments << JSON['{"new_resource_link_id": "' + nca.id.to_s + '", "old_resource_link_id": "' + sa.id.to_s + '"}']
+          @assignments << JSON['{"new_resource_link_id": "' + nca.id.to_s + '", "current_resource_link_id": "' + sa.offering_id.to_s + '", "tool_id": "' + ENV['TEMP_TOOL_ID'] + '"}']
         end
       end
     end
 
     # add learner IDs to JSON for report API
-    @report_json['new_assignments'] = @assignments
+    @report_json['assignments'] = @assignments
+    puts @report_json.to_json
+
+    # post data to report service, include bearer token in request ENV['REPORT_SERVICE_BEARER_TOKEN']
+    req = Net::HTTP::Post.new('/api/move_student_work', {'Authorization' => 'Bearer ' + ENV['REPORT_SERVICE_BEARER_TOKEN'], 'Content-Type' => 'application/json'})
+    req.body = @report_json.to_json
+    http = Net::HTTP.new('us-central1-report-service-dev.cloudfunctions.net', '443')
+    http.use_ssl = true
+    http.request(req)
 
     flash[:notice] = 'Successfully moved student to new class.' # + JSON[@report_json]
     redirect_to(@portal_student)

--- a/app/controllers/portal/students_controller.rb
+++ b/app/controllers/portal/students_controller.rb
@@ -281,7 +281,7 @@ class Portal::StudentsController < ApplicationController
     @portal_student.add_clazz(@new_class)
 
     # initialize JSON for report API call
-    @report_json = JSON['{"class_info_url": "' + @new_class.class_info_url(URI.parse(APP_CONFIG[:site_url]).scheme, URI.parse(APP_CONFIG[:site_url]).host) + '", "new_context_id": "' + @new_class.class_hash.to_s + '", "old_context_id": "' + @current_class.class_hash.to_s + '", "platform_id": "' + APP_CONFIG[:site_url].to_s + '", "platform_user_id": "' + @portal_student.user_id.to_s + '"}']
+    @report_json = JSON['{"new_class_info_url": "' + @new_class.class_info_url(URI.parse(APP_CONFIG[:site_url]).scheme, URI.parse(APP_CONFIG[:site_url]).host) + '", "new_context_id": "' + @new_class.class_hash.to_s + '", "old_context_id": "' + @current_class.class_hash.to_s + '", "platform_id": "' + APP_CONFIG[:site_url].to_s + '", "platform_user_id": "' + @portal_student.user_id.to_s + '"}']
     @assignments = []
 
     # find matches between student learners and new class's offerings. Update offering_id values to match those in new class (student work on assignments that aren't assigned to new class becomes orphaned)

--- a/app/controllers/portal/students_controller.rb
+++ b/app/controllers/portal/students_controller.rb
@@ -281,7 +281,7 @@ class Portal::StudentsController < ApplicationController
     @portal_student.add_clazz(@new_class)
 
     # initialize JSON for report API call
-    @report_json = JSON['{"class_info_url": "' + @new_class.class_info_url(URI.parse(APP_CONFIG[:site_url]).scheme, URI.parse(APP_CONFIG[:site_url]).host) + '", "context_id": "' + @new_class.class_hash.to_s + '", "current_context_id": "' + @current_class.class_hash.to_s + '", "platform_id": "' + APP_CONFIG[:site_url].to_s + '", "platform_user_id": "' + @portal_student.user_id.to_s + '"}']
+    @report_json = JSON['{"class_info_url": "' + @new_class.class_info_url(URI.parse(APP_CONFIG[:site_url]).scheme, URI.parse(APP_CONFIG[:site_url]).host) + '", "new_context_id": "' + @new_class.class_hash.to_s + '", "old_context_id": "' + @current_class.class_hash.to_s + '", "platform_id": "' + APP_CONFIG[:site_url].to_s + '", "platform_user_id": "' + @portal_student.user_id.to_s + '"}']
     @assignments = []
 
     # find matches between student learners and new class's offerings. Update offering_id values to match those in new class (student work on assignments that aren't assigned to new class becomes orphaned)
@@ -292,7 +292,7 @@ class Portal::StudentsController < ApplicationController
           @learner_to_update.update_attribute('offering_id', nca.id)
           @learner_to_update.report_learner.update_fields # does this still need to be here?
           # add assignment to JSON for report API call
-          @assignments << JSON['{"new_resource_link_id": "' + nca.id.to_s + '", "current_resource_link_id": "' + sa.offering_id.to_s + '", "tool_id": "' + ENV['TEMP_TOOL_ID'] + '"}']
+          @assignments << JSON['{"new_resource_link_id": "' + nca.id.to_s + '", "old_resource_link_id": "' + sa.offering_id.to_s + '", "tool_id": "' + ENV['TEMP_TOOL_ID'] + '"}']
         end
       end
     end

--- a/app/models/default_report_service.rb
+++ b/app/models/default_report_service.rb
@@ -1,11 +1,12 @@
 class DefaultReportService
   def self.default_report_for_offering(offering)
     return nil unless offering.runnable
-    return nil unless offering.runnable.respond_to?(:source_type)
+    return nil unless offering.runnable.respond_to?(:tool)
+    return nil unless offering.runnable.tool
+    source_type = offering.runnable.tool.source_type
     # Activities with nil source_type could accidentally match with External Reports
     # that have default_report_for_source_type = nil.
-    return nil unless offering.runnable.source_type
-    source_type = offering.runnable.source_type
+    return nil unless source_type
     ExternalReport
       .where(
         "default_report_for_source_type = ? AND (report_type = ? OR report_type = ?) AND allowed_for_students = true",

--- a/app/models/external_activity.rb
+++ b/app/models/external_activity.rb
@@ -216,7 +216,7 @@ class ExternalActivity < ActiveRecord::Base
     # Do it as soon as possible, as it includes communication with external system. In case of failure,
     # we can cancel this action earlier, before we create bunch of intermediate objects that would need to be
     # cleaned up too.
-    if source_type === 'LARA'
+    if tool&.source_type === 'LARA'
       unless clone.duplicate_on_lara(root_url)
         # If duplication on LARA fails, destroy clone and return nil.
         clone.destroy

--- a/app/models/external_activity.rb
+++ b/app/models/external_activity.rb
@@ -74,6 +74,8 @@ class ExternalActivity < ActiveRecord::Base
 
   end
 
+  belongs_to :tool
+
   belongs_to :user
 
   has_many :external_activity_reports

--- a/app/models/external_report.rb
+++ b/app/models/external_report.rb
@@ -11,7 +11,8 @@ class ExternalReport < ActiveRecord::Base
   has_many :external_activities, through: :external_activity_reports
 
   attr_accessible :name, :url, :launch_text, :client_id, :client, :report_type, :allowed_for_students,
-    :default_report_for_source_type, :individual_student_reportable, :individual_activity_reportable
+    :default_report_for_source_type, :individual_student_reportable, :individual_activity_reportable,
+    :move_students_api_url, :move_students_api_token
 
   ReportTokenValidFor = 2.hours
 

--- a/app/models/portal/offering.rb
+++ b/app/models/portal/offering.rb
@@ -25,7 +25,7 @@ class Portal::Offering < ActiveRecord::Base
 
   has_many :activity_feedbacks, class_name: "Portal::OfferingActivityFeedback", foreign_key: "portal_offering_id"
 
-  [:name, :short_description, :long_description, :long_description_for_teacher, :icon_image].each { |m| delegate m, :to => :runnable }
+  [:name, :short_description, :long_description, :long_description_for_teacher, :icon_image, :tool_id].each { |m| delegate m, :to => :runnable }
 
   has_many :open_responses, :dependent => :destroy, :class_name => "Saveable::OpenResponse", :foreign_key => "offering_id" do
     def answered

--- a/app/models/portal/offering.rb
+++ b/app/models/portal/offering.rb
@@ -25,7 +25,7 @@ class Portal::Offering < ActiveRecord::Base
 
   has_many :activity_feedbacks, class_name: "Portal::OfferingActivityFeedback", foreign_key: "portal_offering_id"
 
-  [:name, :short_description, :long_description, :long_description_for_teacher, :icon_image, :tool_id].each { |m| delegate m, :to => :runnable }
+  [:name, :short_description, :long_description, :long_description_for_teacher, :icon_image].each { |m| delegate m, :to => :runnable }
 
   has_many :open_responses, :dependent => :destroy, :class_name => "Saveable::OpenResponse", :foreign_key => "offering_id" do
     def answered

--- a/app/models/portal/student.rb
+++ b/app/models/portal/student.rb
@@ -185,7 +185,7 @@ class Portal::Student < ActiveRecord::Base
           assignments << {
             new_resource_link_id: nca.id.to_s,
             old_resource_link_id: sa.offering_id.to_s,
-            tool_id: sa.tool_id.to_s
+            tool_id: nca.tool_id.to_s
           }
         end
       end

--- a/app/models/portal/student.rb
+++ b/app/models/portal/student.rb
@@ -185,7 +185,7 @@ class Portal::Student < ActiveRecord::Base
           assignments << {
             new_resource_link_id: nca.id.to_s,
             old_resource_link_id: sa.offering_id.to_s,
-            tool_id: ENV['TEMP_TOOL_ID']
+            tool_id: nca.runnable.tool&.tool_id
           }
         end
       end

--- a/app/models/portal/student.rb
+++ b/app/models/portal/student.rb
@@ -185,7 +185,7 @@ class Portal::Student < ActiveRecord::Base
           assignments << {
             new_resource_link_id: nca.id.to_s,
             old_resource_link_id: sa.offering_id.to_s,
-            tool_id: nca.tool_id.to_s
+            tool_id: ENV['TEMP_TOOL_ID']
           }
         end
       end

--- a/app/models/portal/student.rb
+++ b/app/models/portal/student.rb
@@ -185,7 +185,7 @@ class Portal::Student < ActiveRecord::Base
           assignments << {
             new_resource_link_id: nca.id.to_s,
             old_resource_link_id: sa.offering_id.to_s,
-            tool_id: ENV['TEMP_TOOL_ID']
+            tool_id: sa.tool_id.to_s
           }
         end
       end

--- a/app/models/portal/student.rb
+++ b/app/models/portal/student.rb
@@ -163,4 +163,37 @@ class Portal::Student < ActiveRecord::Base
     self.clazzes.delete clazz
   end
 
+  def move_student_and_return_config(new_class, current_class)
+    # initialize JSON for report API call
+    report_config = {
+      new_class_info_url: new_class.class_info_url(URI.parse(APP_CONFIG[:site_url]).scheme, URI.parse(APP_CONFIG[:site_url]).host),
+      new_context_id: new_class.class_hash.to_s,
+      old_context_id: current_class.class_hash.to_s,
+      platform_id: APP_CONFIG[:site_url].to_s,
+      platform_user_id: user_id.to_s
+    }
+    assignments = []
+
+    # find matches between student learners and new class's offerings. Update offering_id values to match those in new class (student work on assignments that aren't assigned to new class becomes orphaned)
+    learners.each do |sa|
+      new_class.offerings.each do |nca|
+        if sa.offering.runnable == nca.runnable
+          learner_to_update = Portal::Learner.find(sa.id)
+          learner_to_update.update_attribute('offering_id', nca.id)
+          learner_to_update.report_learner.update_fields
+          # add assignment to JSON for report API call
+          assignments << {
+            new_resource_link_id: nca.id.to_s,
+            old_resource_link_id: sa.offering_id.to_s,
+            tool_id: ENV['TEMP_TOOL_ID']
+          }
+        end
+      end
+    end
+
+    # add learner IDs to JSON for report API
+    report_config[:assignments] = assignments
+    report_config
+  end
+
 end

--- a/app/models/tool.rb
+++ b/app/models/tool.rb
@@ -1,3 +1,9 @@
 class Tool < ActiveRecord::Base
+
+  def self.options_for_tool
+    Tool.all.map { |t| [t.name, t.id] }
+  end
+
   attr_accessible :name, :source_type, :tool_id
+
 end

--- a/app/models/tool.rb
+++ b/app/models/tool.rb
@@ -1,0 +1,3 @@
+class Tool < ActiveRecord::Base
+  attr_accessible :name, :source_type, :tool_id
+end

--- a/app/models/tool.rb
+++ b/app/models/tool.rb
@@ -1,4 +1,5 @@
 class Tool < ActiveRecord::Base
+  has_many :external_activities, dependent: :nullify
 
   def self.options_for_tool
     Tool.all.map { |t| [t.name, t.id] }

--- a/app/policies/tool_policy.rb
+++ b/app/policies/tool_policy.rb
@@ -1,0 +1,15 @@
+class ToolPolicy < ApplicationPolicy
+
+  def index?
+    admin_or_manager?
+  end
+
+  def new_or_create?
+    admin_or_manager?
+  end
+
+  def update_edit_or_destroy?
+    admin_or_manager?
+  end
+
+end

--- a/app/views/admin/external_reports/_form.html.haml
+++ b/app/views/admin/external_reports/_form.html.haml
@@ -9,49 +9,68 @@
       %ul.menu_v
         /:app_id, :app_secret, :name, :site_url, :domain_matchers
         %li
-          Name:
-          = f.text_field :name
+          %label
+            Name
+          %br
+          = f.text_field :name, style: "width: 95%;"
         %li
-          URL:
-          = f.text_field :url
+          %label
+            URL
+          %br
+          = f.text_field :url, style: "width: 95%;"
         %li
-          Launch Text:
-          = f.text_field :launch_text
+          %label
+            Launch Text
+          %br
+          = f.text_field :launch_text, style: "width: 95%;"
         %li
-          Client:
+          %label
+            Client
+          %br
           = f.select :client_id, report.options_for_client, {}, prompt: 'client:'
         %li
-          Report Type:
+          %label
+            Report Type
+          %br
           = f.select :report_type, report.options_for_report_type, {}, prompt: 'report type:'
         %li
-          Allowed for Students:
-          = f.check_box :allowed_for_students
-          %p If the report type is 'offering', then students will see a button to open the report.
-        %li
-          Default report for source type:
+          %label
+            Default report for source type
+          %br
           = f.select :default_report_for_source_type, ExternalActivity::SOURCE_TYPE_OPTIONS
           %p
             If the report type is 'offering' or 'deprecated-report', and report is allowed for students, it can be used
             as a default report for a given activity source type. If another report is already marked as a default one,
             it will be automatically unselected.
         %li
-          Report available for individual students:
-          = f.check_box :individual_student_reportable
+          %label
+            = f.check_box :allowed_for_students
+            Allowed for Students
+          %br
+          %p If the report type is 'offering', then students will see a button to open the report.
+        %li
+          %label
+            = f.check_box :individual_student_reportable
+            Report available for individual students
+          %br
+
           %p
             When report is used as a default report, Portal might generate links for reports focused on individual students.
         %li
-          Report available for individual activities:
-          = f.check_box :individual_activity_reportable
+          %label
+            = f.check_box :individual_activity_reportable
+            Report available for individual activities
+          %br
           %p
             When report is used as a default report, Portal might generate links for reports focused on individual activities.
         %li
           %label
-            Move Students API URL:
+            Move Students API URL
           %br
-          = f.text_field :move_students_api_url, size: "60"
+          = f.text_field :move_students_api_url, style: "width: 95%;"
         %li
           %label
-            Move Students API Token:
+            Move Students API Token
           %br
-          = f.text_field :move_students_api_token, size: "60"
+          = f.text_field :move_students_api_token, style: "width: 95%;"
       = submit_tag

--- a/app/views/admin/external_reports/_form.html.haml
+++ b/app/views/admin/external_reports/_form.html.haml
@@ -44,4 +44,14 @@
           = f.check_box :individual_activity_reportable
           %p
             When report is used as a default report, Portal might generate links for reports focused on individual activities.
+        %li
+          %label
+            Move Students API URL:
+          %br
+          = f.text_field :move_students_api_url, size: "60"
+        %li
+          %label
+            Move Students API Token:
+          %br
+          = f.text_field :move_students_api_token, size: "60"
       = submit_tag

--- a/app/views/admin/external_reports/_show.html.haml
+++ b/app/views/admin/external_reports/_show.html.haml
@@ -39,3 +39,9 @@
           %li
             Report available for individual activities:
             = report.individual_activity_reportable
+          %li
+            Move Students API URL:
+            = report.move_students_api_url
+          %li
+            Move Students API Token:
+            = report.move_students_api_token

--- a/app/views/admin/firebase_apps/_show.html.haml
+++ b/app/views/admin/firebase_apps/_show.html.haml
@@ -7,7 +7,7 @@
         %li
           %a{href:edit_admin_firebase_app_path(admin_firebase_app)} edit
         %li
-          %a{href:url_for(action: :destroy, id:admin_firebase_app.id), data: {method: 'delete', confirm: "Delete this authoring site?"} } delete
+          %a{href:url_for(action: :destroy, id:admin_firebase_app.id), data: {method: 'delete', confirm: "Delete this Firebas app?"} } delete
   %div{id: dom_id_for(admin_firebase_app, :item), class: 'item'}
     %div{id: dom_id_for(admin_firebase_app, :details), class: 'content'}
       %p

--- a/app/views/admin/tools/_form.html.haml
+++ b/app/views/admin/tools/_form.html.haml
@@ -13,7 +13,10 @@
         %li
           = label_tag "source_type", "Source Type:"
           = f.text_field :source_type
+          %br
+          Used for the default reports.
         %li
           = label_tag "tool_id", "Tool ID:"
-          = f.text_area :tool_id, class: 'mceNoEditor'
+          = f.text_area :tool_id, class: 'mceNoEditor', rows: 5
+          Used for moving students between classes. It should be a URI.
       = submit_tag

--- a/app/views/admin/tools/_form.html.haml
+++ b/app/views/admin/tools/_form.html.haml
@@ -1,0 +1,19 @@
+.item
+  .content
+    - if tool.errors.any?
+      %ul.menu_v.error-explanation
+        %li Tool can't be saved, there are errors in form:
+        - tool.errors.full_messages.each do |msg|
+          %li= msg
+    %p
+      %ul.menu_v
+        %li
+          = label_tag "name", "Name:"
+          = f.text_field :name
+        %li
+          = label_tag "source_type", "Source Type:"
+          = f.text_field :source_type
+        %li
+          = label_tag "tool_id", "Tool ID:"
+          = f.text_area :tool_id, class: 'mceNoEditor'
+      = submit_tag

--- a/app/views/admin/tools/_show.html.haml
+++ b/app/views/admin/tools/_show.html.haml
@@ -1,0 +1,23 @@
+%div{id: dom_id_for(tool), class: 'container_element'}
+  .action_menu
+    .action_menu_header_left
+      %h3= tool.name
+    .action_menu_header_right
+      %ul.menu
+        %li
+          %a{href:edit_admin_tool_path(tool)} edit
+        %li
+          %a{href:url_for(action: :destroy, id:tool.id), data: {method: 'delete', confirm: "Delete this tool?"} } delete
+  %div{id: dom_id_for(tool, :item), class: 'item'}
+    %div{id: dom_id_for(tool, :details), class: 'content'}
+      %p
+        %ul.menu_v
+          %li
+            Name:
+            = tool.name
+          %li
+            Source Type:
+            = tool.source_type
+          %li
+            Tool ID:
+            = tool.tool_id

--- a/app/views/admin/tools/edit.html.haml
+++ b/app/views/admin/tools/edit.html.haml
@@ -1,0 +1,6 @@
+%h1 Edit Tool
+
+= form_for(@tool, url: url_for(controller: 'tools', action: 'update'), html: {class: "generic-admin-form"}) do |f|
+  = render :partial => "form", :locals => {:f => f, :tool => @tool}
+
+= link_to 'Back', admin_tools_path

--- a/app/views/admin/tools/index.html.haml
+++ b/app/views/admin/tools/index.html.haml
@@ -1,0 +1,11 @@
+%h1
+  Tools
+- if @tools.length > 0
+  = render partial: 'show', collection: @tools, as: :tool
+- else
+  %div{:style=>"margin:10px 0"}
+    You have no tools.
+    %br
+    To create a tool click the "Create Tool" button.
+
+= link_to 'Create New Tool', new_admin_tool_path, {:class => 'button'}

--- a/app/views/admin/tools/new.html.haml
+++ b/app/views/admin/tools/new.html.haml
@@ -1,0 +1,5 @@
+%h1
+  Create Tool
+
+= form_for(@tool, url: url_for(controller: 'tools', action: 'create'), html: {class: "generic-admin-form"}) do |f|
+  = render partial: 'form', locals: { tool: @tool, f: f }

--- a/app/views/admin/tools/show.html.haml
+++ b/app/views/admin/tools/show.html.haml
@@ -1,0 +1,1 @@
+= render partial: 'show', locals: { tool: @tool }

--- a/app/views/external_activities/_form.html.haml
+++ b/app/views/external_activities/_form.html.haml
@@ -105,8 +105,6 @@
         Do not allow to copy this activity.
     = field_set_tag 'Save Path' do
       = f.text_field :save_path
-    = field_set_tag 'Tool ID' do
-      = f.text_field :tool_id
     = render :partial => 'shared/is_assessment_item', :locals => { :form => f }
     = render :partial => 'shared/material_properties_edit', :locals => { :object => @external_activity }
   -# Partials below can be available for project admins or owners (separate policy methods).

--- a/app/views/external_activities/_form.html.haml
+++ b/app/views/external_activities/_form.html.haml
@@ -36,8 +36,9 @@
           [ Interactive.display_name,   Interactive.name    ] ]
       %br
       = t('authoring.material_type_description')
-    = field_set_tag t('authoring.source_type_label') do
-      = f.select :source_type, ExternalActivity::SOURCE_TYPE_OPTIONS
+    - if ExternalActivity.column_names.include? 'source_type'
+      = field_set_tag t('authoring.source_type_label') do
+        = f.select :source_type, ExternalActivity::SOURCE_TYPE_OPTIONS
     = field_set_tag t('authoring.tool_label') do
       = f.select :tool_id, Tool.options_for_tool, include_blank: 'none'
     = field_set_tag 'License' do

--- a/app/views/external_activities/_form.html.haml
+++ b/app/views/external_activities/_form.html.haml
@@ -36,11 +36,10 @@
           [ Interactive.display_name,   Interactive.name    ] ]
       %br
       = t('authoring.material_type_description')
-    - if ExternalActivity.column_names.include? 'source_type'
-      = field_set_tag t('authoring.source_type_label') do
-        = f.select :source_type, ExternalActivity::SOURCE_TYPE_OPTIONS
     = field_set_tag t('authoring.tool_label') do
       = f.select :tool_id, Tool.options_for_tool, include_blank: 'none'
+      %br
+      The tool should be set to LARA for LARA resources. It is used to find the default report and for moving students.
     = field_set_tag 'License' do
       = f.select :license_code, CommonsLicense.for_select, include_blank: 'none'
     = field_set_tag 'URL' do

--- a/app/views/external_activities/_form.html.haml
+++ b/app/views/external_activities/_form.html.haml
@@ -105,6 +105,8 @@
         Do not allow to copy this activity.
     = field_set_tag 'Save Path' do
       = f.text_field :save_path
+    = field_set_tag 'Tool ID' do
+      = f.text_field :tool_id
     = render :partial => 'shared/is_assessment_item', :locals => { :form => f }
     = render :partial => 'shared/material_properties_edit', :locals => { :object => @external_activity }
   -# Partials below can be available for project admins or owners (separate policy methods).

--- a/app/views/external_activities/_form.html.haml
+++ b/app/views/external_activities/_form.html.haml
@@ -38,6 +38,8 @@
       = t('authoring.material_type_description')
     = field_set_tag t('authoring.source_type_label') do
       = f.select :source_type, ExternalActivity::SOURCE_TYPE_OPTIONS
+    = field_set_tag t('authoring.tool_label') do
+      = f.select :tool_id, Tool.options_for_tool, include_blank: 'none'
     = field_set_tag 'License' do
       = f.select :license_code, CommonsLicense.for_select, include_blank: 'none'
     = field_set_tag 'URL' do

--- a/app/views/home/admin.html.haml
+++ b/app/views/home/admin.html.haml
@@ -5,49 +5,51 @@
 %h2
   Administration and Reports
 
-- if is_admin_or_manager
+%div{:style => 'column-count: 2;'}
+  - if is_admin_or_manager
+    %div{:style => 'break-inside: avoid-column;'}
+      %h3
+        Site Admin Links
+      %ul
+        %li= link_to 'Auth Clients', admin_clients_path
+        %li= link_to 'Authoring Sites', admin_authoring_sites_path
+        %li= link_to 'Districts', portal_districts_path
+        %li= link_to 'External Reports', admin_external_reports_path
+        %li= link_to 'Firebase Apps', admin_firebase_apps_path
+        %li= link_to 'Import Schools and Districts' , import_school_district_status_import_imports_path
+        %li= link_to 'Import Users' , import_user_status_import_imports_path
+        %li= link_to 'Import Activities(Batch)' ,batch_import_status_import_imports_path
+        %li= link_to 'Interactives' , interactives_path
+        %li= link_to 'Learner processing wait times' ,learner_proc_path
+        %li= link_to 'Licenses', admin_commons_licenses_path
+        %li= link_to 'Materials Collections', materials_collections_path
+        %li= link_to 'Notices', admin_site_notices_path
+        %li= link_to 'Projects', admin_projects_path
+        %li= link_to 'Schools', portal_schools_path
+        %li= link_to 'Settings', admin_settings_path
+        %li= link_to 'Tags', admin_tags_path
+        %li= link_to 'Tools', admin_tools_path
+        %li= link_to 'Users', users_path
+
   %h3
-    Site Admin Links
+    Project Admin & Authoring Links
   %ul
-    %li= link_to 'Auth Clients', admin_clients_path
-    %li= link_to 'Authoring Sites', admin_authoring_sites_path
-    %li= link_to 'Districts', portal_districts_path
-    %li= link_to 'External Reports', admin_external_reports_path
-    %li= link_to 'Firebase Apps', admin_firebase_apps_path
-    %li= link_to 'Import Schools and Districts' , import_school_district_status_import_imports_path
-    %li= link_to 'Import Users' , import_user_status_import_imports_path
-    %li= link_to 'Import Activities(Batch)' ,batch_import_status_import_imports_path
-    %li= link_to 'Interactives' , interactives_path
-    %li= link_to 'Learner processing wait times' ,learner_proc_path
-    %li= link_to 'Licenses', admin_commons_licenses_path
-    %li= link_to 'Materials Collections', materials_collections_path
-    %li= link_to 'Notices', admin_site_notices_path
-    %li= link_to 'Projects', admin_projects_path
-    %li= link_to 'Schools', portal_schools_path
-    %li= link_to 'Settings', admin_settings_path
-    %li= link_to 'Tags', admin_tags_path
-    %li= link_to 'Tools', admin_tools_path
-    %li= link_to 'Users', users_path
+    - if current_visitor.has_role?('admin', 'manager', 'researcher', 'author')
+      %li.trail=link_to('Authoring', authoring_path)
+    - if is_admin_or_project_admin_or_project_researcher
+      %li= link_to 'Permission Forms', admin_permission_forms_path
+    - if is_admin_or_project_admin
+      %li= link_to 'Projects', admin_projects_path
+      %li= link_to 'Users', users_path
 
-%h3
-  Project Admin & Authoring Links
-%ul
-  - if current_visitor.has_role?('admin', 'manager', 'researcher', 'author')
-    %li.trail=link_to('Authoring', authoring_path)
-  - if is_admin_or_project_admin_or_project_researcher
-    %li= link_to 'Permission Forms', admin_permission_forms_path
-  - if is_admin_or_project_admin
-    %li= link_to 'Projects', admin_projects_path
-    %li= link_to 'Users', users_path
-
-- if current_visitor.has_role?('admin', 'manager','researcher') || current_visitor.is_project_admin? || current_visitor.is_project_researcher?
-  %h3 Researcher Reports
-  %ul
-    - if ENV['RESEARCHER_REPORT_HOST'].present?
-      %li= link_to 'Learner Reports', "#{ENV['RESEARCHER_REPORT_HOST']}#{auth_login_path(after_sign_in_path: learner_report_path)}",
-                            target: "_blank"
-      %li= link_to 'User Reports', "#{ENV['RESEARCHER_REPORT_HOST']}#{auth_login_path(after_sign_in_path: user_report_path)}",
-                            target: "_blank"
-    - else
-      %li= link_to 'Learner Reports', learner_report_path
-      %li= link_to 'User Reports', user_report_path
+  - if current_visitor.has_role?('admin', 'manager','researcher') || current_visitor.is_project_admin? || current_visitor.is_project_researcher?
+    %h3 Researcher Reports
+    %ul
+      - if ENV['RESEARCHER_REPORT_HOST'].present?
+        %li= link_to 'Learner Reports', "#{ENV['RESEARCHER_REPORT_HOST']}#{auth_login_path(after_sign_in_path: learner_report_path)}",
+                              target: "_blank"
+        %li= link_to 'User Reports', "#{ENV['RESEARCHER_REPORT_HOST']}#{auth_login_path(after_sign_in_path: user_report_path)}",
+                              target: "_blank"
+      - else
+        %li= link_to 'Learner Reports', learner_report_path
+        %li= link_to 'User Reports', user_report_path

--- a/app/views/home/admin.html.haml
+++ b/app/views/home/admin.html.haml
@@ -1,14 +1,48 @@
-%h3
+- is_admin_or_manager = current_visitor.has_role?('admin', 'manager')
+- is_admin_or_project_admin = is_admin_or_manager || current_visitor.is_project_admin?
+- is_admin_or_project_admin_or_project_researcher = is_admin_or_project_admin || current_visitor.is_project_researcher?
+
+%h2
   Administration and Reports
 
-%ul
-  - is_admin_or_manager = current_visitor.has_role?('admin', 'manager')
-  - is_admin_or_project_admin = is_admin_or_manager || current_visitor.is_project_admin?
-  - is_admin_or_project_admin_or_project_researcher = is_admin_or_project_admin || current_visitor.is_project_researcher?
+- if is_admin_or_manager
+  %h3
+    Site Admin Links
+  %ul
+    %li= link_to 'Auth Clients', admin_clients_path
+    %li= link_to 'Authoring Sites', admin_authoring_sites_path
+    %li= link_to 'Districts', portal_districts_path
+    %li= link_to 'External Reports', admin_external_reports_path
+    %li= link_to 'Firebase Apps', admin_firebase_apps_path
+    %li= link_to 'Import Schools and Districts' , import_school_district_status_import_imports_path
+    %li= link_to 'Import Users' , import_user_status_import_imports_path
+    %li= link_to 'Import Activities(Batch)' ,batch_import_status_import_imports_path
+    %li= link_to 'Interactives' , interactives_path
+    %li= link_to 'Learner processing wait times' ,learner_proc_path
+    %li= link_to 'Licenses', admin_commons_licenses_path
+    %li= link_to 'Materials Collections', materials_collections_path
+    %li= link_to 'Notices', admin_site_notices_path
+    %li= link_to 'Projects', admin_projects_path
+    %li= link_to 'Schools', portal_schools_path
+    %li= link_to 'Settings', admin_settings_path
+    %li= link_to 'Tags', admin_tags_path
+    %li= link_to 'Tools', admin_tools_path
+    %li= link_to 'Users', users_path
 
+%h3
+  Project Admin & Authoring Links
+%ul
   - if current_visitor.has_role?('admin', 'manager', 'researcher', 'author')
     %li.trail=link_to('Authoring', authoring_path)
-  - if current_visitor.has_role?('admin', 'manager','researcher') || current_visitor.is_project_admin? || current_visitor.is_project_researcher?
+  - if is_admin_or_project_admin_or_project_researcher
+    %li= link_to 'Permission Forms', admin_permission_forms_path
+  - if is_admin_or_project_admin
+    %li= link_to 'Projects', admin_projects_path
+    %li= link_to 'Users', users_path
+
+- if current_visitor.has_role?('admin', 'manager','researcher') || current_visitor.is_project_admin? || current_visitor.is_project_researcher?
+  %h3 Researcher Reports
+  %ul
     - if ENV['RESEARCHER_REPORT_HOST'].present?
       %li= link_to 'Learner Reports', "#{ENV['RESEARCHER_REPORT_HOST']}#{auth_login_path(after_sign_in_path: learner_report_path)}",
                             target: "_blank"
@@ -17,27 +51,3 @@
     - else
       %li= link_to 'Learner Reports', learner_report_path
       %li= link_to 'User Reports', user_report_path
-  - if is_admin_or_manager
-    %li= link_to 'Districts', portal_districts_path
-    %li= link_to 'Schools', portal_schools_path
-    %li= link_to 'Auth Clients', admin_clients_path
-    %li= link_to 'External Reports', admin_external_reports_path
-  - if is_admin_or_project_admin
-    %li= link_to 'Users', users_path
-    %li= link_to 'Projects', admin_projects_path
-  - if is_admin_or_manager
-    %li= link_to 'Tags', admin_tags_path
-    %li= link_to 'Settings', admin_settings_path
-    %li= link_to 'Notices', admin_site_notices_path
-  - if is_admin_or_project_admin_or_project_researcher
-    %li= link_to 'Permission Forms', admin_permission_forms_path
-  - if is_admin_or_manager
-    %li= link_to 'Materials Collections', materials_collections_path
-    %li= link_to 'Interactives' , interactives_path
-    %li= link_to 'Import Schools and Districts' , import_school_district_status_import_imports_path
-    %li= link_to 'Import Users' , import_user_status_import_imports_path
-    %li= link_to 'Import Activities(Batch)' ,batch_import_status_import_imports_path
-    %li= link_to 'Licences', admin_commons_licenses_path
-    %li= link_to 'Authoring Sites', admin_authoring_sites_path
-    %li= link_to 'Firebase Apps', admin_firebase_apps_path
-  %li= link_to 'Learner processing wait times' ,learner_proc_path

--- a/app/views/home/admin.html.haml
+++ b/app/views/home/admin.html.haml
@@ -5,9 +5,9 @@
 %h2
   Administration and Reports
 
-%div{:class => 'admin-links-cols'}
+%div{ class: 'admin-links-cols' }
   - if is_admin_or_manager
-    %div{:style => 'break-inside: avoid-column;'}
+    %div{ class: 'admin-links-cols__column' }
       %h3
         Site Admin Links
       %ul
@@ -31,7 +31,7 @@
         %li= link_to 'Tools', admin_tools_path
         %li= link_to 'Users', users_path
 
-    %div{:style => 'break-inside: avoid-column;'}
+    %div{ class: 'admin-links-cols__column' }
       %h3
         Project Admin & Authoring Links
       %ul

--- a/app/views/home/admin.html.haml
+++ b/app/views/home/admin.html.haml
@@ -5,7 +5,7 @@
 %h2
   Administration and Reports
 
-%div{:style => 'column-count: 2;'}
+%div{:class => 'admin-links-cols'}
   - if is_admin_or_manager
     %div{:style => 'break-inside: avoid-column;'}
       %h3
@@ -31,25 +31,26 @@
         %li= link_to 'Tools', admin_tools_path
         %li= link_to 'Users', users_path
 
-  %h3
-    Project Admin & Authoring Links
-  %ul
-    - if current_visitor.has_role?('admin', 'manager', 'researcher', 'author')
-      %li.trail=link_to('Authoring', authoring_path)
-    - if is_admin_or_project_admin_or_project_researcher
-      %li= link_to 'Permission Forms', admin_permission_forms_path
-    - if is_admin_or_project_admin
-      %li= link_to 'Projects', admin_projects_path
-      %li= link_to 'Users', users_path
+    %div{:style => 'break-inside: avoid-column;'}
+      %h3
+        Project Admin & Authoring Links
+      %ul
+        - if current_visitor.has_role?('admin', 'manager', 'researcher', 'author')
+          %li.trail=link_to('Authoring', authoring_path)
+        - if is_admin_or_project_admin_or_project_researcher
+          %li= link_to 'Permission Forms', admin_permission_forms_path
+        - if is_admin_or_project_admin
+          %li= link_to 'Projects', admin_projects_path
+          %li= link_to 'Users', users_path
 
-  - if current_visitor.has_role?('admin', 'manager','researcher') || current_visitor.is_project_admin? || current_visitor.is_project_researcher?
-    %h3 Researcher Reports
-    %ul
-      - if ENV['RESEARCHER_REPORT_HOST'].present?
-        %li= link_to 'Learner Reports', "#{ENV['RESEARCHER_REPORT_HOST']}#{auth_login_path(after_sign_in_path: learner_report_path)}",
-                              target: "_blank"
-        %li= link_to 'User Reports', "#{ENV['RESEARCHER_REPORT_HOST']}#{auth_login_path(after_sign_in_path: user_report_path)}",
-                              target: "_blank"
-      - else
-        %li= link_to 'Learner Reports', learner_report_path
-        %li= link_to 'User Reports', user_report_path
+      - if current_visitor.has_role?('admin', 'manager','researcher') || current_visitor.is_project_admin? || current_visitor.is_project_researcher?
+        %h3 Researcher Reports
+        %ul
+          - if ENV['RESEARCHER_REPORT_HOST'].present?
+            %li= link_to 'Learner Reports', "#{ENV['RESEARCHER_REPORT_HOST']}#{auth_login_path(after_sign_in_path: learner_report_path)}",
+                                  target: "_blank"
+            %li= link_to 'User Reports', "#{ENV['RESEARCHER_REPORT_HOST']}#{auth_login_path(after_sign_in_path: user_report_path)}",
+                                  target: "_blank"
+          - else
+            %li= link_to 'Learner Reports', learner_report_path
+            %li= link_to 'User Reports', user_report_path

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,6 +63,7 @@ en:
     launch_url_description: If there is a launch url, it is used when a student starts an activity otherwise the main URL is used. The main URL is used for preview links. Activities with a launch url are assumed to support editing by appending /edit.
     material_type_label: Material Type
     source_type_label: Source Type
+    tool_label: Tool
     material_type_description: Users can see the type of material in various places, use this field to change that type
     external_report_label: External Reporting
     external_report_description: Specify additional report links to be shown to teachers in the offering view. Unless you know what you are doing selecting none is recommended.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -281,6 +281,7 @@ RailsPortal::Application.routes.draw do
       resources :tags
       resources :projects
       resources :clients
+      resources :tools
       resources :external_reports
       resources :permission_forms do
         member do

--- a/db/migrate/20191108202736_add_move_student_fields.rb
+++ b/db/migrate/20191108202736_add_move_student_fields.rb
@@ -1,0 +1,6 @@
+class AddMoveStudentFields < ActiveRecord::Migration
+  def change
+    add_column :external_reports, :move_students_api_url, :text
+    add_column :external_reports, :move_students_api_token, :string
+  end
+end

--- a/db/migrate/20191113201623_add_tool_id.rb
+++ b/db/migrate/20191113201623_add_tool_id.rb
@@ -1,5 +1,0 @@
-class AddToolId < ActiveRecord::Migration
-  def change
-    add_column :external_activities, :tool_id, :text
-  end
-end

--- a/db/migrate/20191113201623_add_tool_id.rb
+++ b/db/migrate/20191113201623_add_tool_id.rb
@@ -1,0 +1,5 @@
+class AddToolId < ActiveRecord::Migration
+  def change
+    add_column :external_activities, :tool_id, :text
+  end
+end

--- a/db/migrate/20191119185103_add_tool_model.rb
+++ b/db/migrate/20191119185103_add_tool_model.rb
@@ -1,0 +1,9 @@
+class AddToolModel < ActiveRecord::Migration
+  def change
+    create_table :tools do |t|
+      t.string :name
+      t.string :source_type
+      t.text :tool_id
+    end
+  end
+end

--- a/db/migrate/20191120015517_add_tool_id_to_external_activities.rb
+++ b/db/migrate/20191120015517_add_tool_id_to_external_activities.rb
@@ -1,0 +1,5 @@
+class AddToolIdToExternalActivities < ActiveRecord::Migration
+  def change
+    add_column :external_activities, :tool_id, :integer
+  end
+end

--- a/db/migrate/20191120184500_migrate_source_type.rb
+++ b/db/migrate/20191120184500_migrate_source_type.rb
@@ -1,0 +1,22 @@
+class MigrateSourceType < ActiveRecord::Migration
+  class Tool < ActiveRecord::Base
+  end
+
+  class ExternalActivity < ActiveRecord::Base
+  end
+
+  def up
+    tool = Tool.where(source_type: 'LARA').first
+    tool = tool ? tool : Tool.create(name: 'LARA', source_type: 'LARA')
+    ExternalActivity.where(source_type: 'LARA').update_all(tool_id: tool.id)
+    remove_column :external_activities, :source_type
+  end
+
+  def down
+    add_column :external_activities, :source_type, :string, default: nil
+    tool = Tool.where(source_type: 'LARA').first
+    if tool
+      ExternalActivity.where(tool_id: tool.id).update_all(source_type: 'LARA')
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20191119185103) do
+ActiveRecord::Schema.define(:version => 20191120015517) do
 
   create_table "access_grants", :force => true do |t|
     t.string   "code"
@@ -535,6 +535,7 @@ ActiveRecord::Schema.define(:version => 20191119185103) do
     t.text     "long_description"
     t.string   "source_type"
     t.text     "keywords"
+    t.integer  "tool_id"
   end
 
   add_index "external_activities", ["is_featured", "publication_status"], :name => "featured_public"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20191120015517) do
+ActiveRecord::Schema.define(:version => 20191120184500) do
 
   create_table "access_grants", :force => true do |t|
     t.string   "code"
@@ -533,7 +533,6 @@ ActiveRecord::Schema.define(:version => 20191120015517) do
     t.boolean  "saves_student_data",                               :default => true
     t.text     "long_description_for_teacher"
     t.text     "long_description"
-    t.string   "source_type"
     t.text     "keywords"
     t.integer  "tool_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20191113201623) do
+ActiveRecord::Schema.define(:version => 20191108202736) do
 
   create_table "access_grants", :force => true do |t|
     t.string   "code"
@@ -535,7 +535,6 @@ ActiveRecord::Schema.define(:version => 20191113201623) do
     t.text     "long_description"
     t.string   "source_type"
     t.text     "keywords"
-    t.text     "tool_id"
   end
 
   add_index "external_activities", ["is_featured", "publication_status"], :name => "featured_public"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20190909124227) do
+ActiveRecord::Schema.define(:version => 20191108202736) do
 
   create_table "access_grants", :force => true do |t|
     t.string   "code"
@@ -563,6 +563,8 @@ ActiveRecord::Schema.define(:version => 20190909124227) do
     t.string   "default_report_for_source_type"
     t.boolean  "individual_student_reportable",  :default => false
     t.boolean  "individual_activity_reportable", :default => false
+    t.text     "move_students_api_url"
+    t.string   "move_students_api_token"
   end
 
   add_index "external_reports", ["client_id"], :name => "index_external_reports_on_client_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20191108202736) do
+ActiveRecord::Schema.define(:version => 20191113201623) do
 
   create_table "access_grants", :force => true do |t|
     t.string   "code"
@@ -535,6 +535,7 @@ ActiveRecord::Schema.define(:version => 20191108202736) do
     t.text     "long_description"
     t.string   "source_type"
     t.text     "keywords"
+    t.text     "tool_id"
   end
 
   add_index "external_activities", ["is_featured", "publication_status"], :name => "featured_public"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20191108202736) do
+ActiveRecord::Schema.define(:version => 20191119185103) do
 
   create_table "access_grants", :force => true do |t|
     t.string   "code"
@@ -2281,6 +2281,12 @@ ActiveRecord::Schema.define(:version => 20191108202736) do
     t.datetime "created_at",                               :null => false
     t.datetime "updated_at",                               :null => false
     t.integer  "user_id"
+  end
+
+  create_table "tools", :force => true do |t|
+    t.string "name"
+    t.string "source_type"
+    t.text   "tool_id"
   end
 
   create_table "users", :force => true do |t|

--- a/factories/external_activity.rb
+++ b/factories/external_activity.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :external_activity do |f|
     f.association :user
     f.url {'http://external.activitiies.org/123'}
-    f.source_type {'LARA'}
+    f.association :tool, factory: :lara_tool
   end
 end

--- a/factories/tool.rb
+++ b/factories/tool.rb
@@ -1,4 +1,9 @@
 FactoryBot.define do
   factory :tool do |f|
   end
+
+  factory :lara_tool, class: Tool do |f|
+    f.source_type 'LARA'
+    f.name 'LARA'
+  end
 end

--- a/factories/tool.rb
+++ b/factories/tool.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
   end
 
   factory :lara_tool, class: Tool do |f|
-    f.source_type 'LARA'
-    f.name 'LARA'
+    f.source_type {"LARA"}
+    f.name {"LARA"}
   end
 end

--- a/factories/tool.rb
+++ b/factories/tool.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :tool do |f|
+  end
+end

--- a/lib/activity_runtime_api.rb
+++ b/lib/activity_runtime_api.rb
@@ -37,11 +37,17 @@ class ActivityRuntimeAPI
 
   private
 
+  def self.create_tool(source_type)
+    tool = Tool.where(source_type: source_type).first
+    return tool if tool
+    Tool.create(source_type: source_type, name: source_type)
+  end
+
   def self.publish_activity(hash, user)
     external_activity = nil
     Investigation.transaction do
       external_activity = ExternalActivity.create(
-        :source_type            => hash["source_type"] || "LARA",
+        :tool                   => create_tool(hash["source_type"] || "LARA"),
         :name                   => hash["name"],
         :url                    => hash["url"],
         :thumbnail_url          => hash["thumbnail_url"],
@@ -142,7 +148,7 @@ class ActivityRuntimeAPI
     external_activity = nil # Why are we initializing this? For the transaction?
     Investigation.transaction do
       external_activity = ExternalActivity.create(
-        :source_type            => hash["source_type"] || "LARA",
+        :tool                   => create_tool(hash["source_type"] || "LARA"),
         :name                   => hash["name"],
         :url                    => hash["url"],
         :thumbnail_url          => hash["thumbnail_url"],

--- a/spec/controllers/admin/tools_controller_spec.rb
+++ b/spec/controllers/admin/tools_controller_spec.rb
@@ -72,6 +72,17 @@ RSpec.describe Admin::ToolsController, type: :controller do
       delete :destroy, id: mock_content_id
       expect(response).to have_http_status(:redirect)
     end
+
+    it "nullifies the tool_id of external activities" do
+      tool = FactoryBot.create(:tool)
+      external_activity = FactoryBot.create(:external_activity, tool: tool)
+
+      expect(external_activity.tool_id).to_not be_nil
+
+      tool.destroy
+      external_activity.reload
+      expect(external_activity.tool_id).to be_nil
+    end
   end
 
 end

--- a/spec/controllers/admin/tools_controller_spec.rb
+++ b/spec/controllers/admin/tools_controller_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: false
+
+require 'spec_helper'
+
+RSpec.describe Admin::ToolsController, type: :controller do
+
+  let(:params_key) { :tool }
+
+  let(:admin_user) {FactoryBot.generate(:admin_user)}
+  let(:stubs) {{}}
+  let(:mock_content) {
+    mock_model Tool, stubs
+  }
+  let(:mock_content_id) do
+    mock_content.id
+  end
+
+  before(:each) do
+    sign_in admin_user
+  end
+
+  describe "GET new" do
+    it "renders the new form" do
+      get :new
+      expect(response).to render_template("new")
+      expect(response).to be_success
+    end
+  end
+
+  describe '#index' do
+    it 'GET index' do
+      get :index
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe '#show' do
+    it 'GET show' do
+      expect(Tool).to receive(:find).and_return(mock_content)
+      get :show, id: mock_content_id
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe '#edit' do
+    it 'GET edit' do
+      expect(Tool).to receive(:find).and_return(mock_content)
+      get :edit, id: mock_content_id
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe '#create' do
+    it "creates a new model, redirects to index" do
+      post :create, {tool: {}}
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+
+  describe '#update' do
+    let(:stubs) {{update_attributes: true}}
+    it "updates the model, redirects to index" do
+      expect(Tool).to receive(:find).and_return(mock_content)
+      put :update, :id => mock_content_id, params_key => {:params => 'params'}
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+
+  describe '#destroy' do
+    it 'DELETE destroy' do
+      expect(Tool).to receive(:find).and_return(mock_content)
+      delete :destroy, id: mock_content_id
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+
+end

--- a/spec/controllers/api/v1/report_users_controller_spec.rb
+++ b/spec/controllers/api/v1/report_users_controller_spec.rb
@@ -57,9 +57,9 @@ describe API::V1::ReportUsersController do
       @teacher4.cohorts << @cohort1
       @teacher5.cohorts << @cohort2
 
-      @runnable1 = FactoryBot.create(:external_activity, source_type: "LARA")
-      @runnable2 = FactoryBot.create(:external_activity, source_type: "LARA")
-      @runnable3 = FactoryBot.create(:external_activity, source_type: "LARA")
+      @runnable1 = FactoryBot.create(:external_activity)
+      @runnable2 = FactoryBot.create(:external_activity)
+      @runnable3 = FactoryBot.create(:external_activity)
 
       @offering1 = FactoryBot.create(:portal_offering, {clazz: @teacher1.clazzes[0], runnable: @runnable1})
       @offering2 = FactoryBot.create(:portal_offering, {clazz: @teacher2.clazzes[0], runnable: @runnable2})

--- a/spec/controllers/portal/students_controller_spec.rb
+++ b/spec/controllers/portal/students_controller_spec.rb
@@ -195,12 +195,26 @@ describe Portal::StudentsController do
 
   describe "POST move" do
     before(:each) do
+
       @clazz_params = {
         :current_class_word => "currentclassword",
         :new_class_word => "newclassword"
       }
       student.add_clazz(clazz_1)
       student.remove_clazz(clazz_2)
+
+      @report_json = JSON['{"class_info_url": "' + clazz_2.class_info_url(URI.parse(APP_CONFIG[:site_url]).scheme, URI.parse(APP_CONFIG[:site_url]).host) + '", "context_id": "' + clazz_2.class_hash.to_s + '", "current_context_id": "' + clazz_1.class_hash.to_s + '", "platform_id": "' + APP_CONFIG[:site_url].to_s + '", "platform_user_id": "' + student.user_id.to_s + '", "assignments":[]}']
+      stub_request(:post, "https://us-central1-report-service-dev.cloudfunctions.net/api/move_student_work").
+        with(
+          body: @report_json.to_json,
+          headers: {
+         'Accept'=>'*/*',
+         'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+         'Authorization'=>'Bearer devtoken',
+         'Content-Type'=>'application/json',
+         'User-Agent'=>'Ruby'
+          }).
+        to_return(status: 200, body: "Success", headers: {})
     end
 
     let(:student) { FactoryBot.create(:full_portal_student) }

--- a/spec/controllers/portal/students_controller_spec.rb
+++ b/spec/controllers/portal/students_controller_spec.rb
@@ -203,6 +203,8 @@ describe Portal::StudentsController do
       student.add_clazz(clazz_1)
       student.remove_clazz(clazz_2)
 
+      allow(ENV).to receive(:[]).with("REPORT_SERVICE_BEARER_TOKEN").and_return('devtoken')
+
       @report_json = JSON['{"class_info_url": "' + clazz_2.class_info_url(URI.parse(APP_CONFIG[:site_url]).scheme, URI.parse(APP_CONFIG[:site_url]).host) + '", "context_id": "' + clazz_2.class_hash.to_s + '", "current_context_id": "' + clazz_1.class_hash.to_s + '", "platform_id": "' + APP_CONFIG[:site_url].to_s + '", "platform_user_id": "' + student.user_id.to_s + '", "assignments":[]}']
       stub_request(:post, "https://us-central1-report-service-dev.cloudfunctions.net/api/move_student_work").
         with(

--- a/spec/controllers/portal/students_controller_spec.rb
+++ b/spec/controllers/portal/students_controller_spec.rb
@@ -205,7 +205,7 @@ describe Portal::StudentsController do
 
       allow(ENV).to receive(:[]).with("REPORT_SERVICE_BEARER_TOKEN").and_return('devtoken')
 
-      @report_json = JSON['{"class_info_url": "' + clazz_2.class_info_url(URI.parse(APP_CONFIG[:site_url]).scheme, URI.parse(APP_CONFIG[:site_url]).host) + '", "context_id": "' + clazz_2.class_hash.to_s + '", "current_context_id": "' + clazz_1.class_hash.to_s + '", "platform_id": "' + APP_CONFIG[:site_url].to_s + '", "platform_user_id": "' + student.user_id.to_s + '", "assignments":[]}']
+      @report_json = JSON['{"class_info_url": "' + clazz_2.class_info_url(URI.parse(APP_CONFIG[:site_url]).scheme, URI.parse(APP_CONFIG[:site_url]).host) + '", "new_context_id": "' + clazz_2.class_hash.to_s + '", "old_context_id": "' + clazz_1.class_hash.to_s + '", "platform_id": "' + APP_CONFIG[:site_url].to_s + '", "platform_user_id": "' + student.user_id.to_s + '", "assignments":[]}']
       stub_request(:post, "https://us-central1-report-service-dev.cloudfunctions.net/api/move_student_work").
         with(
           body: @report_json.to_json,

--- a/spec/controllers/portal/students_controller_spec.rb
+++ b/spec/controllers/portal/students_controller_spec.rb
@@ -203,18 +203,16 @@ describe Portal::StudentsController do
       student.add_clazz(clazz_1)
       student.remove_clazz(clazz_2)
 
-      allow(ENV).to receive(:[]).with("REPORT_SERVICE_BEARER_TOKEN").and_return('devtoken')
+      external_report = FactoryBot.create(:external_report,
+        move_students_api_url: 'http://test.org/api/move_student_work',
+        move_students_api_token: 'abc123'
+      )
 
-      #@report_json = JSON['{"class_info_url": "' + clazz_2.class_info_url(URI.parse(APP_CONFIG[:site_url]).scheme, URI.parse(APP_CONFIG[:site_url]).host) + '", "new_context_id": "' + clazz_2.class_hash.to_s + '", "old_context_id": "' + clazz_1.class_hash.to_s + '", "platform_id": "' + APP_CONFIG[:site_url].to_s + '", "platform_user_id": "' + student.user_id.to_s + '", "assignments":[]}']
-      stub_request(:post, "https://us-central1-report-service-dev.cloudfunctions.net/api/move_student_work").
+      stub_request(:post, "http://test.org/api/move_student_work").
         with(
-          #body: @report_json.to_json,
           headers: {
-         'Accept'=>'*/*',
-         'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-         'Authorization'=>'Bearer devtoken',
-         'Content-Type'=>'application/json',
-         'User-Agent'=>'Ruby'
+           'Authorization'=>'Bearer abc123',
+           'Content-Type'=>'application/json'
           }).
         to_return(status: 200, body: "Success", headers: {})
     end

--- a/spec/controllers/portal/students_controller_spec.rb
+++ b/spec/controllers/portal/students_controller_spec.rb
@@ -193,32 +193,6 @@ describe Portal::StudentsController do
     end
   end
 
-  describe "#move_student_and_return_config" do
-    let!(:student) { FactoryBot.create(:full_portal_student) }
-    let!(:clazz_1) { FactoryBot.create(:portal_clazz, class_hash: 'class1hash') }
-    let!(:clazz_2) { FactoryBot.create(:portal_clazz, class_hash: 'class2hash') }
-    let!(:runnable_a) { FactoryBot.create(:external_activity, name: 'Test Activity') }
-    let!(:offering_a) { FactoryBot.create(:portal_offering, {clazz: clazz_1, runnable: runnable_a}) }
-    let!(:offering_b) { FactoryBot.create(:portal_offering, {clazz: clazz_2, runnable: runnable_a}) }
-    let!(:learner) { FactoryBot.create(:portal_learner, offering: offering_a, student: student) }
-
-    it "should return JSON" do
-      controller.instance_variable_set(:@portal_student, student)
-      controller.instance_variable_set(:@current_class, clazz_1)
-      controller.instance_variable_set(:@new_class, clazz_2)
-      json = controller.move_student_and_return_config
-      expect(json).to include(
-        new_context_id:"class2hash",
-        old_context_id:"class1hash",
-        platform_user_id:student.user_id.to_s,
-        new_class_info_url: /^http.*\/classes\/[0-9]*$/,
-        platform_id: /^http.*/,
-        assignments:[{new_resource_link_id: offering_b.id.to_s, old_resource_link_id: offering_a.id.to_s, tool_id: ENV['TEMP_TOOL_ID']}]
-      )
-
-    end
-  end
-
   describe "POST move" do
     before(:each) do
 

--- a/spec/controllers/portal/students_controller_spec.rb
+++ b/spec/controllers/portal/students_controller_spec.rb
@@ -193,20 +193,25 @@ describe Portal::StudentsController do
     end
   end
 
-  describe "#move_student_work_config" do
+  describe "#move_student_and_return_config" do
     let(:student) { FactoryBot.create(:full_portal_student) }
     let(:clazz_1) { FactoryBot.create(:portal_clazz, class_hash: 'class1hash') }
     let(:clazz_2) { FactoryBot.create(:portal_clazz, class_hash: 'class2hash') }
+    let(:runnable_a) { FactoryBot.create(:external_activity, name: 'Test Activity') }
+    let(:offering_a) { FactoryBot.create(:portal_offering, {clazz: clazz_1, runnable: runnable_a}) }
+    let(:runnable_b) { FactoryBot.create(:external_activity, name: 'Test Activity') }
+    let(:offering_b) { FactoryBot.create(:portal_offering, {clazz: clazz_2, runnable: runnable_b}) }
+    let(:learner) { FactoryBot.create(:portal_learner, offering: offering_a, student: student) }
 
     it "should return JSON" do
       controller.instance_variable_set(:@portal_student, student)
       controller.instance_variable_set(:@current_class, clazz_1)
       controller.instance_variable_set(:@new_class, clazz_2)
-      json = controller.move_student_work_config
+      json = controller.move_student_and_return_config
       expect(json).to include(
         new_context_id:"class2hash",
         old_context_id:"class1hash",
-        assignments:[]
+        assignments:[{new_resource_link_id: offering_b.id, old_resource_link_id: offering_a.id, tool_id: ENV['TEMP_TOOL_ID']}]
       )
 
     end

--- a/spec/controllers/portal/students_controller_spec.rb
+++ b/spec/controllers/portal/students_controller_spec.rb
@@ -194,13 +194,13 @@ describe Portal::StudentsController do
   end
 
   describe "#move_student_and_return_config" do
-    let(:student) { FactoryBot.create(:full_portal_student) }
-    let(:clazz_1) { FactoryBot.create(:portal_clazz, class_hash: 'class1hash') }
-    let(:clazz_2) { FactoryBot.create(:portal_clazz, class_hash: 'class2hash') }
-    let(:runnable_a) { FactoryBot.create(:external_activity, name: 'Test Activity') }
-    let(:offering_a) { FactoryBot.create(:portal_offering, {clazz: clazz_1, runnable: runnable_a}) }
-    let(:offering_b) { FactoryBot.create(:portal_offering, {clazz: clazz_2, runnable: runnable_a}) }
-    let(:learner) { FactoryBot.create(:portal_learner, offering: offering_a, student: student) }
+    let!(:student) { FactoryBot.create(:full_portal_student) }
+    let!(:clazz_1) { FactoryBot.create(:portal_clazz, class_hash: 'class1hash') }
+    let!(:clazz_2) { FactoryBot.create(:portal_clazz, class_hash: 'class2hash') }
+    let!(:runnable_a) { FactoryBot.create(:external_activity, name: 'Test Activity') }
+    let!(:offering_a) { FactoryBot.create(:portal_offering, {clazz: clazz_1, runnable: runnable_a}) }
+    let!(:offering_b) { FactoryBot.create(:portal_offering, {clazz: clazz_2, runnable: runnable_a}) }
+    let!(:learner) { FactoryBot.create(:portal_learner, offering: offering_a, student: student) }
 
     it "should return JSON" do
       controller.instance_variable_set(:@portal_student, student)
@@ -210,7 +210,10 @@ describe Portal::StudentsController do
       expect(json).to include(
         new_context_id:"class2hash",
         old_context_id:"class1hash",
-        assignments:[{new_resource_link_id: offering_b.id, old_resource_link_id: offering_a.id, tool_id: ENV['TEMP_TOOL_ID']}]
+        platform_user_id:student.user_id.to_s,
+        new_class_info_url: /^http.*\/classes\/[0-9]*$/,
+        platform_id: /^http.*/,
+        assignments:[{new_resource_link_id: offering_b.id.to_s, old_resource_link_id: offering_a.id.to_s, tool_id: ENV['TEMP_TOOL_ID']}]
       )
 
     end

--- a/spec/controllers/portal/students_controller_spec.rb
+++ b/spec/controllers/portal/students_controller_spec.rb
@@ -199,8 +199,7 @@ describe Portal::StudentsController do
     let(:clazz_2) { FactoryBot.create(:portal_clazz, class_hash: 'class2hash') }
     let(:runnable_a) { FactoryBot.create(:external_activity, name: 'Test Activity') }
     let(:offering_a) { FactoryBot.create(:portal_offering, {clazz: clazz_1, runnable: runnable_a}) }
-    let(:runnable_b) { FactoryBot.create(:external_activity, name: 'Test Activity') }
-    let(:offering_b) { FactoryBot.create(:portal_offering, {clazz: clazz_2, runnable: runnable_b}) }
+    let(:offering_b) { FactoryBot.create(:portal_offering, {clazz: clazz_2, runnable: runnable_a}) }
     let(:learner) { FactoryBot.create(:portal_learner, offering: offering_a, student: student) }
 
     it "should return JSON" do

--- a/spec/controllers/portal/students_controller_spec.rb
+++ b/spec/controllers/portal/students_controller_spec.rb
@@ -193,6 +193,25 @@ describe Portal::StudentsController do
     end
   end
 
+  describe "#move_student_work_config" do
+    let(:student) { FactoryBot.create(:full_portal_student) }
+    let(:clazz_1) { FactoryBot.create(:portal_clazz, class_hash: 'class1hash') }
+    let(:clazz_2) { FactoryBot.create(:portal_clazz, class_hash: 'class2hash') }
+
+    it "should return JSON" do
+      controller.instance_variable_set(:@portal_student, student)
+      controller.instance_variable_set(:@current_class, clazz_1)
+      controller.instance_variable_set(:@new_class, clazz_2)
+      json = controller.move_student_work_config
+      expect(json).to include(
+        new_context_id:"class2hash",
+        old_context_id:"class1hash",
+        assignments:[]
+      )
+
+    end
+  end
+
   describe "POST move" do
     before(:each) do
 
@@ -205,10 +224,10 @@ describe Portal::StudentsController do
 
       allow(ENV).to receive(:[]).with("REPORT_SERVICE_BEARER_TOKEN").and_return('devtoken')
 
-      @report_json = JSON['{"class_info_url": "' + clazz_2.class_info_url(URI.parse(APP_CONFIG[:site_url]).scheme, URI.parse(APP_CONFIG[:site_url]).host) + '", "new_context_id": "' + clazz_2.class_hash.to_s + '", "old_context_id": "' + clazz_1.class_hash.to_s + '", "platform_id": "' + APP_CONFIG[:site_url].to_s + '", "platform_user_id": "' + student.user_id.to_s + '", "assignments":[]}']
+      #@report_json = JSON['{"class_info_url": "' + clazz_2.class_info_url(URI.parse(APP_CONFIG[:site_url]).scheme, URI.parse(APP_CONFIG[:site_url]).host) + '", "new_context_id": "' + clazz_2.class_hash.to_s + '", "old_context_id": "' + clazz_1.class_hash.to_s + '", "platform_id": "' + APP_CONFIG[:site_url].to_s + '", "platform_user_id": "' + student.user_id.to_s + '", "assignments":[]}']
       stub_request(:post, "https://us-central1-report-service-dev.cloudfunctions.net/api/move_student_work").
         with(
-          body: @report_json.to_json,
+          #body: @report_json.to_json,
           headers: {
          'Accept'=>'*/*',
          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',

--- a/spec/models/default_report_service_spec.rb
+++ b/spec/models/default_report_service_spec.rb
@@ -26,7 +26,7 @@ describe DefaultReportService do
 
     describe "when default report attributes are incorrect" do
       it "returns nil when external activity source type is nil" do
-        external_activity.update_attributes(source_type: nil)
+        external_activity.tool.update_attributes(source_type: nil)
         @default_report.update_attributes(default_report_for_source_type: nil)
         expect(DefaultReportService.default_report_for_offering(offering)).to eql(nil)
       end
@@ -39,7 +39,12 @@ describe DefaultReportService do
         expect(DefaultReportService.default_report_for_offering(offering)).to eql(nil)
       end
       it "returns nil when report source type doesn't match runnable source type" do
-        external_activity.update_attributes(source_type: "NOT-LARA")
+        external_activity.tool.update_attributes(source_type: "NOT-LARA")
+        expect(DefaultReportService.default_report_for_offering(offering)).to eql(nil)
+      end
+      it "returns nil when external activity tool is nil" do
+        external_activity.update_attributes(tool_id: nil)
+        @default_report.update_attributes(default_report_for_source_type: nil)
         expect(DefaultReportService.default_report_for_offering(offering)).to eql(nil)
       end
     end

--- a/spec/models/external_activity_spec.rb
+++ b/spec/models/external_activity_spec.rb
@@ -216,7 +216,7 @@ describe ExternalActivity do
       end
 
       before(:each) do
-        activity.source_type = 'LARA'
+        activity.create_tool(source_type: 'LARA')
         activity.save
 
         WebMock.stub_request(:post, activity.url + '/remote_duplicate')

--- a/spec/models/portal/student_spec.rb
+++ b/spec/models/portal/student_spec.rb
@@ -156,7 +156,7 @@ describe Portal::Student do
     let!(:student) { FactoryBot.create(:full_portal_student) }
     let!(:clazz_1) { FactoryBot.create(:portal_clazz, class_hash: 'class1hash') }
     let!(:clazz_2) { FactoryBot.create(:portal_clazz, class_hash: 'class2hash') }
-    let!(:runnable_a) { FactoryBot.create(:external_activity, name: 'Test Activity') }
+    let!(:runnable_a) { FactoryBot.create(:external_activity, name: 'Test Activity', tool_id: 'https://test.org') }
     let!(:offering_a) { FactoryBot.create(:portal_offering, {clazz: clazz_1, runnable: runnable_a}) }
     let!(:offering_b) { FactoryBot.create(:portal_offering, {clazz: clazz_2, runnable: runnable_a}) }
     let!(:learner) { FactoryBot.create(:portal_learner, offering: offering_a, student: student) }

--- a/spec/models/portal/student_spec.rb
+++ b/spec/models/portal/student_spec.rb
@@ -169,7 +169,7 @@ describe Portal::Student do
         platform_user_id:student.user_id.to_s,
         new_class_info_url: /^http.*\/classes\/[0-9]*$/,
         platform_id: /^http.*/,
-        assignments:[{new_resource_link_id: offering_b.id.to_s, old_resource_link_id: offering_a.id.to_s, tool_id: offering_a.tool_id.to_s}]
+        assignments:[{new_resource_link_id: offering_b.id.to_s, old_resource_link_id: offering_a.id.to_s, tool_id: ENV['TEMP_TOOL_ID']}]
       )
 
     end

--- a/spec/models/portal/student_spec.rb
+++ b/spec/models/portal/student_spec.rb
@@ -169,7 +169,7 @@ describe Portal::Student do
         platform_user_id:student.user_id.to_s,
         new_class_info_url: /^http.*\/classes\/[0-9]*$/,
         platform_id: /^http.*/,
-        assignments:[{new_resource_link_id: offering_b.id.to_s, old_resource_link_id: offering_a.id.to_s, tool_id: ENV['TEMP_TOOL_ID']}]
+        assignments:[{new_resource_link_id: offering_b.id.to_s, old_resource_link_id: offering_a.id.to_s, tool_id: offering_a.tool_id.to_s}]
       )
 
     end

--- a/spec/models/portal/student_spec.rb
+++ b/spec/models/portal/student_spec.rb
@@ -4,7 +4,7 @@ describe Portal::Student do
   before(:each) do
     @student = FactoryBot.create(:portal_student)
   end
-  
+
   describe "when a clazz is added to a students list of clazzes" do
     it "the students clazz list increases by one if the student is not already enrolled in that class" do
       clazz = FactoryBot.create(:portal_clazz)
@@ -15,7 +15,7 @@ describe Portal::Student do
       expect(@student.clazzes).to include(clazz)
       expect(@student.clazzes.size).to eq(1)
     end
-    
+
     it "the students clazz list should stay the same if the same clazz is added multiple times" do
       clazz = FactoryBot.create(:portal_clazz)
       expect(@student.clazzes).to be_empty
@@ -27,10 +27,10 @@ describe Portal::Student do
       expect(@student.clazzes.size).to eq(1)
     end
   end
-  
+
   it "should generate a user name by first initial and last name" do
     expect(Portal::Student.generate_user_login("test", "user")).to eq("tuser")
-    
+
     first_name = "Nametest"
     last_name  = "Testuser"
     @student.user = FactoryBot.create(:user, {
@@ -152,5 +152,27 @@ describe Portal::Student do
     end
   end
 
+  describe "#move_student_and_return_config" do
+    let!(:student) { FactoryBot.create(:full_portal_student) }
+    let!(:clazz_1) { FactoryBot.create(:portal_clazz, class_hash: 'class1hash') }
+    let!(:clazz_2) { FactoryBot.create(:portal_clazz, class_hash: 'class2hash') }
+    let!(:runnable_a) { FactoryBot.create(:external_activity, name: 'Test Activity') }
+    let!(:offering_a) { FactoryBot.create(:portal_offering, {clazz: clazz_1, runnable: runnable_a}) }
+    let!(:offering_b) { FactoryBot.create(:portal_offering, {clazz: clazz_2, runnable: runnable_a}) }
+    let!(:learner) { FactoryBot.create(:portal_learner, offering: offering_a, student: student) }
+
+    it "should return JSON" do
+      json = student.move_student_and_return_config(clazz_2, clazz_1)
+      expect(json).to include(
+        new_context_id:"class2hash",
+        old_context_id:"class1hash",
+        platform_user_id:student.user_id.to_s,
+        new_class_info_url: /^http.*\/classes\/[0-9]*$/,
+        platform_id: /^http.*/,
+        assignments:[{new_resource_link_id: offering_b.id.to_s, old_resource_link_id: offering_a.id.to_s, tool_id: ENV['TEMP_TOOL_ID']}]
+      )
+
+    end
+  end
 
 end


### PR DESCRIPTION
- A new Tool model is added, this replaces the direct source_type on external_activities. 
- External Reports now have two new fields for supporting moving students. These are added to the external report instead of the Tool so the same report service could be used for different tools. And so one tool could have multiple reports. In the future it might be necessary to tell the tool about the move as well. Here are two new fields:
  - move_students_api_token
  - move_students_api_url
- When a student is moved the portal send the following JSON structure to all external reports that have a move_students_api_url
```
{
  new_class_info_url: [portal_url to class info of new class],
  new_context_id: [portal class_hash for the new class],
  old_context_id: [portal class_hash for the old class],
  platform_id: [portal platform_id which is its site_url[,
  platform_user_id: [portal user id]
  assignments: [
    {
      new_resource_link_id: [new portal offering id],
      old_resource_link_id: [old portal offering id],
      tool_id: [url to lara (or whatever tool is specified for the resource)]
    },
    ...
  ]   
}
```

- This PR also improves the admin page of the portal.