### PR TITLE
Offerings policy bug when teacher is project admin, but has classes outside that project

### DIFF
--- a/app/policies/portal/teacher_policy.rb
+++ b/app/policies/portal/teacher_policy.rb
@@ -5,16 +5,43 @@ class Portal::TeacherPolicy < ApplicationPolicy
       if user && user.has_role?('manager','admin','researcher')
         all
       elsif user && (user.is_project_admin? || user.is_project_researcher?)
-        # prevents a bunch of unnecessary model loads by not using the user#admin_for_project_teachers and user#researcher_for_project_teachers methods
+        # prevents a bunch of unnecessary model loads by not using the
+        # user#admin_for_project_teachers and user#researcher_for_project_teachers methods.
+        # We have to look through project cohort items, and also check if the
+        # user is a teacher (edge case) in a cohort they are not admin for ...
+        # See this bug: https://www.pivotaltracker.com/story/show/169465198
+        sql = "
+          SELECT DISTINCT `portal_teachers`.* FROM
+          (
+              SELECT portal_teachers.id FROM portal_teachers
+                  INNER JOIN
+                      admin_cohort_items __aci_scope ON (__aci_scope.item_id = portal_teachers.id)
+                  INNER JOIN
+                      admin_cohorts __ac_scope ON (__ac_scope.id = __aci_scope.admin_cohort_id)
+                  INNER JOIN
+                      admin_project_users __apu_scope ON (__apu_scope.project_id = __ac_scope.project_id)
+                  WHERE
+                      __aci_scope.item_type = 'Portal::Teacher'
+                  AND
+                      __apu_scope.user_id = #{user.id}
+                  AND
+                      (__apu_scope.is_admin = 1 OR __apu_scope.is_researcher = 1)
+              UNION
+                  SELECT id
+                  FROM portal_teachers
+                  WHERE user_id = #{user.id}
+          ) as all_teachers
+          JOIN portal_teachers ON portal_teachers.id = all_teachers.id
+        "
+
+        ids = Portal::Teacher.connection.select_all(sql).map { |i| i['id'] }
+        # Return a new scope selecting those records:
         scope
-          .joins("INNER JOIN admin_cohort_items __aci_scope ON __aci_scope.item_id = portal_teachers.id")
-          .joins("INNER JOIN admin_cohorts __ac_scope ON __ac_scope.id = __aci_scope.admin_cohort_id")
-          .joins("INNER JOIN admin_project_users __apu_scope ON __apu_scope.project_id = __ac_scope.project_id")
-          .where("__aci_scope.item_type = 'Portal::Teacher'")
-          .where("__apu_scope.user_id = ? AND (__apu_scope.is_admin = 1 OR __apu_scope.is_researcher = 1)", user.id)
+          .where('portal_teachers.id IN (?)', ids)
           .uniq
-      else
-        none
+
+      elsif (user.portal_teacher)
+        scope.where('user_id = (?)', user.id)
       end
     end
   end

--- a/app/policies/portal/teacher_policy.rb
+++ b/app/policies/portal/teacher_policy.rb
@@ -1,5 +1,27 @@
 class Portal::TeacherPolicy < ApplicationPolicy
 
+  def self.teacher_query(user)
+    return "
+      SELECT portal_teachers.id FROM portal_teachers
+      INNER JOIN
+        admin_cohort_items __aci_scope ON (__aci_scope.item_id = portal_teachers.id)
+      INNER JOIN
+          admin_cohorts __ac_scope ON (__ac_scope.id = __aci_scope.admin_cohort_id)
+      INNER JOIN
+          admin_project_users __apu_scope ON (__apu_scope.project_id = __ac_scope.project_id)
+      WHERE
+          __aci_scope.item_type = 'Portal::Teacher'
+      AND
+          __apu_scope.user_id = #{user.id}
+      AND
+          (__apu_scope.is_admin = 1 OR __apu_scope.is_researcher = 1)
+      UNION
+        SELECT id
+        FROM portal_teachers
+        WHERE user_id = #{user.id}
+    "
+  end
+  
   class Scope < Scope
     def resolve
       if user && user.has_role?('manager','admin','researcher')
@@ -8,26 +30,7 @@ class Portal::TeacherPolicy < ApplicationPolicy
         # prevents a bunch of unnecessary model loads by not using the model scopes
         # Also covers some tricky edge cases.
         # See this bug: https://www.pivotaltracker.com/story/show/169465198
-        sql = "
-          SELECT portal_teachers.id FROM portal_teachers
-            INNER JOIN
-              admin_cohort_items __aci_scope ON (__aci_scope.item_id = portal_teachers.id)
-            INNER JOIN
-                admin_cohorts __ac_scope ON (__ac_scope.id = __aci_scope.admin_cohort_id)
-            INNER JOIN
-                admin_project_users __apu_scope ON (__apu_scope.project_id = __ac_scope.project_id)
-            WHERE
-                __aci_scope.item_type = 'Portal::Teacher'
-            AND
-                __apu_scope.user_id = #{user.id}
-            AND
-                (__apu_scope.is_admin = 1 OR __apu_scope.is_researcher = 1)
-          UNION
-            SELECT id
-            FROM portal_teachers
-            WHERE user_id = #{user.id}
-        "
-
+        sql = Portal::TeacherPolicy::teacher_query(user)
         ids = Portal::Teacher.connection.select_all(sql).map { |i| i['id'] }
         # Return a new scope selecting those records:
         scope

--- a/app/policies/portal/teacher_policy.rb
+++ b/app/policies/portal/teacher_policy.rb
@@ -31,7 +31,7 @@ class Portal::TeacherPolicy < ApplicationPolicy
         # Also covers some tricky edge cases.
         # See this bug: https://www.pivotaltracker.com/story/show/169465198
         sql = Portal::TeacherPolicy::teacher_query(user)
-        ids = Portal::Teacher.connection.select_all(sql).map { |i| i['id'] }
+        ids = Portal::Teacher.connection.select_values(sql)
         # Return a new scope selecting those records:
         scope
           .where('portal_teachers.id IN (?)', ids)

--- a/app/policies/portal/teacher_policy.rb
+++ b/app/policies/portal/teacher_policy.rb
@@ -5,33 +5,27 @@ class Portal::TeacherPolicy < ApplicationPolicy
       if user && user.has_role?('manager','admin','researcher')
         all
       elsif user && (user.is_project_admin? || user.is_project_researcher?)
-        # prevents a bunch of unnecessary model loads by not using the
-        # user#admin_for_project_teachers and user#researcher_for_project_teachers methods.
-        # We have to look through project cohort items, and also check if the
-        # user is a teacher (edge case) in a cohort they are not admin for ...
+        # prevents a bunch of unnecessary model loads by not using the model scopes
+        # Also covers some tricky edge cases.
         # See this bug: https://www.pivotaltracker.com/story/show/169465198
         sql = "
-          SELECT DISTINCT `portal_teachers`.* FROM
-          (
-              SELECT portal_teachers.id FROM portal_teachers
-                  INNER JOIN
-                      admin_cohort_items __aci_scope ON (__aci_scope.item_id = portal_teachers.id)
-                  INNER JOIN
-                      admin_cohorts __ac_scope ON (__ac_scope.id = __aci_scope.admin_cohort_id)
-                  INNER JOIN
-                      admin_project_users __apu_scope ON (__apu_scope.project_id = __ac_scope.project_id)
-                  WHERE
-                      __aci_scope.item_type = 'Portal::Teacher'
-                  AND
-                      __apu_scope.user_id = #{user.id}
-                  AND
-                      (__apu_scope.is_admin = 1 OR __apu_scope.is_researcher = 1)
-              UNION
-                  SELECT id
-                  FROM portal_teachers
-                  WHERE user_id = #{user.id}
-          ) as all_teachers
-          JOIN portal_teachers ON portal_teachers.id = all_teachers.id
+          SELECT portal_teachers.id FROM portal_teachers
+            INNER JOIN
+              admin_cohort_items __aci_scope ON (__aci_scope.item_id = portal_teachers.id)
+            INNER JOIN
+                admin_cohorts __ac_scope ON (__ac_scope.id = __aci_scope.admin_cohort_id)
+            INNER JOIN
+                admin_project_users __apu_scope ON (__apu_scope.project_id = __ac_scope.project_id)
+            WHERE
+                __aci_scope.item_type = 'Portal::Teacher'
+            AND
+                __apu_scope.user_id = #{user.id}
+            AND
+                (__apu_scope.is_admin = 1 OR __apu_scope.is_researcher = 1)
+          UNION
+            SELECT id
+            FROM portal_teachers
+            WHERE user_id = #{user.id}
         "
 
         ids = Portal::Teacher.connection.select_all(sql).map { |i| i['id'] }

--- a/spec/policies/portal/teacher_policy_spec.rb
+++ b/spec/policies/portal/teacher_policy_spec.rb
@@ -29,30 +29,34 @@ RSpec.describe Portal::TeacherPolicy do
 
     context 'teacher' do
       let(:user){ @teacher1.user }
-      # TBD: Maybe should include co-teachers?
       it 'should return their own teacher record' do
-        expect(scope.to_a.length).to eq 1
+        # Even a teacher who is not a project admin should
+        # have access to their own teacher record
+        expect(scope.to_a).to include(@teacher1)
       end
-      context 'is a project_admin for their cohort' do
+      context 'is a project_admin for cohorts1' do
         before(:each) do
           @project = FactoryBot.create(:project)
           @project.cohorts << @cohort1
           user.add_role_for_project('admin', @project)
         end
-        it 'should return their own teacher record' do
+        it 'should return teacher2 and teacher1 (both in chort1)' do
           # teacher1 (cohort 1) and teacher2 (cohort1)
+          expect(scope.to_a).to include(@teacher1, @teacher2)
           expect(scope.to_a.length).to eq 2
         end
       end
 
-      context 'is a project_admin for a different cohort' do
+      context 'is a project_admin for a different cohort (chort2)' do
         before(:each) do
           @project = FactoryBot.create(:project)
           @project.cohorts << @cohort2
           user.add_role_for_project('admin', @project)
         end
-        it 'should return their own teacher record' do
-          expect(scope.first).to eq @teacher1
+        it 'should return their own teacher record (in cohort1)' do
+          # There is also a teacher in Cohort2 (not our cohort)
+          expect(scope.to_a).to include(@teacher1, @teacher3)
+          expect(scope.to_a.length).to eq 2
         end
       end
     end


### PR DESCRIPTION

[see PT Story](https://www.pivotaltracker.com/n/projects/736901/stories/169465198)

We first noticed this Bug when Cynthia wasn't able to get a clue dashboard for her class when a second teacher (Leslie) was.

If the user_id is for the current user and the current_user is a project_admin or a project_researcher for any project, but is not in a cohort associated with one of those projects, the api endpoint will not return any offerings.

see: https://github.com/concord-consortium/rigse/blob/master/app/policies/portal/offering_policy.rb#L15-L32
which uses: https://github.com/concord-consortium/rigse/blob/master/app/policies/portal/teacher_policy.rb#L9-L15

This PR adds failing tests, and then gets the tests passing with a new raw SQL query which finds id selection to apply to the portal_teacher scope.

