### PR TITLE
add an optional parameter to change the size of the query sent to ES

### DIFF
--- a/app/models/report/learner/selector.rb
+++ b/app/models/report/learner/selector.rb
@@ -12,7 +12,10 @@ class Report::Learner::Selector
     @learners = []
     @runnable_names = []
 
-    options['show_learners'] = 5000   # get learners, up to this max
+    # include the learners in the results, this flag also disables the aggregrations
+    # by default it includes up to 5000 learners, but this can overridden with the
+    # size_limit parameter
+    options['show_learners'] = options['size_limit'].present? ?  options['size_limit'].to_i : 5000
     esResponse = API::V1::ReportLearnersEsController.query_es(options, current_visitor)
     hits = esResponse['hits']['hits']
 


### PR DESCRIPTION
It isn't clear to us where the 5000 came from before. So we didn't want to just increase it.
With this change we an play around with different values on production.

### Some context for this change

`API::V1::ReportLearnersEsController.query_es` is used in two places: 
- when getting the metrics that show at the top of the report filter page this is done in `API::V1::ReportLearnersEsController#index`
- from the code of this PR: `Report::Learner::Selector#initialize`

In both cases the query parameters are passed into query_es as options. In `Report::Learner::Selector#initialize` these parameters/options are modified to include the `'show_learners'` value. 

`Report::Learner::Selector#initialize` is used in two places:
- when getting the learners for an external_report
- when running an internal usage or details report

As the comment in the code describes show_learners does 2 things `query_es`.  It disables the aggregations in the query and it sets the value for the `size` parameter in the query.