### PR TITLE
attempt to fix broken travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,10 @@ before_install:
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
-  - sh -c "if [ '$TRAVIS_BUILD_STAGE_NAME' = 'Test'  ]; then ./script/travis_test_setup; fi"
+  # Travis changed the capitialization of TRAVIS_BUILD_STAGE_NAME the value used to be
+  # capitalized, but recently it is lowercase. The ,, below changes it to always be
+  # lowercase. So even if travis changes it again it should still work.
+  - sh -c "if [ '${TRAVIS_BUILD_STAGE_NAME,,}' = 'test'  ]; then ./script/travis_test_setup; fi"
 
 after_script:
   - RAILS_ENV=test ./bin/rake sunspot:solr:stop


### PR DESCRIPTION
travis appears to have stopped capitalizing TRAVIS_BUILD_STAGE_NAME
The documentation still says it is supposed to be capitalized: https://docs.travis-ci.com/user/environment-variables/

For more context: the travis_test_setup is only run on the test stages which come from the matrix config in the travis file. The other stage is the cc test reporter stage, and in that case we don't need to do the full travis test setup.