### PR TITLE
Reset loading to false on search results load [#173780068]

### DIFF
--- a/react-components/src/library/components/search/result-group.js
+++ b/react-components/src/library/components/search/result-group.js
@@ -37,7 +37,7 @@ export default class SearchResultGroup extends React.Component {
   }
 
   updateState (groupData) {
-    this.setState({ group: groupData.results[0] })
+    this.setState({ loading: false, group: groupData.results[0] })
   }
 
   renderLoading () {


### PR DESCRIPTION
The initial fix changed the deprecated `replaceState` with `setState` but the `setState` update left the `loading` flag set to true causing to always render 'Loading...'.