### PR TITLE
174264646  Set logging levels via ENV

### DIFF
--- a/.env-osx-sample
+++ b/.env-osx-sample
@@ -24,4 +24,5 @@ MYSQL_ROOT_PASSWORD=xxxxx
 # Configure rails logging level. Override this in .env
 # Rails logging levels:
 # DEBUG | INFO | WARN | ERROR | FATAL | UNKNOWN
-LOG_LEVEL=WARN
+TEST_LOG_LEVEL=WARN
+DEV_LOG_LEVEL=DEBUG

--- a/.env-osx-sample
+++ b/.env-osx-sample
@@ -20,3 +20,8 @@ SITE_URL=http://app.portal.docker
 # Run the portal in researcher report mode this is used by the researcher portal
 # RESEARCHER_REPORT_ONLY=true
 MYSQL_ROOT_PASSWORD=xxxxx
+
+# Configure rails logging level. Override this in .env
+# Rails logging levels:
+# DEBUG | INFO | WARN | ERROR | FATAL | UNKNOWN
+LOG_LEVEL=WARN

--- a/.env-osx-sample
+++ b/.env-osx-sample
@@ -21,8 +21,7 @@ SITE_URL=http://app.portal.docker
 # RESEARCHER_REPORT_ONLY=true
 MYSQL_ROOT_PASSWORD=xxxxx
 
-# Configure rails logging level. Override this in .env
-# Rails logging levels:
-# DEBUG | INFO | WARN | ERROR | FATAL | UNKNOWN
+# Configure rails logging levels:
+#     DEBUG | INFO | WARN | ERROR | FATAL | UNKNOWN
 TEST_LOG_LEVEL=WARN
 DEV_LOG_LEVEL=DEBUG

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,11 +108,10 @@ services:
       #
       RAILS_STDOUT_LOGGING: "${RAILS_STDOUT_LOGGING:-true}"
 
-      # Configure rails logging levels. Override this in .env
-      # Rails logging levels:
+      # Logging levels. Override this in .env
       # DEBUG | INFO | WARN | ERROR | FATAL | UNKNOWN
-      DEV_LOG_LEVEL: "${DEV_LOG_LEVEL:-DEBUG}"
       TEST_LOG_LEVEL: "${TEST_LOG_LEVEL:-WARN}"
+      DEV_LOG_LEVEL: "${DEV_LOG_LEVEL:-DEBUG}"
 
       #
       # Source for report service lookups

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,10 +108,11 @@ services:
       #
       RAILS_STDOUT_LOGGING: "${RAILS_STDOUT_LOGGING:-true}"
 
-      # Configure rails logging level. Override this in .env
+      # Configure rails logging levels. Override this in .env
       # Rails logging levels:
       # DEBUG | INFO | WARN | ERROR | FATAL | UNKNOWN
-      LOG_LEVEL: "${LOG_LEVEL:-DEBUG}"
+      DEV_LOG_LEVEL: "${DEV_LOG_LEVEL:-DEBUG}"
+      TEST_LOG_LEVEL: "${TEST_LOG_LEVEL:-WARN}"
 
       #
       # Source for report service lookups

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,9 +104,14 @@ services:
       DOCKER: 'true'
 
       #
-      # Enables logging to stdout instead of file.
+      # Enables logging to stdout instead of file. Override this in .env
       #
-      RAILS_STDOUT_LOGGING: "true"
+      RAILS_STDOUT_LOGGING: "${RAILS_STDOUT_LOGGING:-true}"
+
+      # Configure rails logging level. Override this in .env
+      # Rails logging levels:
+      # DEBUG | INFO | WARN | ERROR | FATAL | UNKNOWN
+      LOG_LEVEL: "${LOG_LEVEL:-DEBUG}"
 
       #
       # Source for report service lookups

--- a/rails/config/environments/cucumber.rb
+++ b/rails/config/environments/cucumber.rb
@@ -41,4 +41,9 @@ RailsPortal::Application.configure do
     # Disable logging to file. It might have performance impact while using Docker for Mac (slow filesystem sync).
     config.logger = Logger.new(STDOUT)
   end
+  # Specify developer chosen logging level. See docker-compose.yml and .env
+  # Using to something other than (0) debug makes test output more readable.
+  if (log_level = ENV['LOG_LEVEL'])
+    config.logger.level = log_level
+  end
 end

--- a/rails/config/environments/cucumber.rb
+++ b/rails/config/environments/cucumber.rb
@@ -45,6 +45,9 @@ RailsPortal::Application.configure do
   # DEBUG | INFO | WARN | ERROR | FATAL | UNKNOWN
   log_level = ENV.fetch('TEST_LOG_LEVEL', 'WARN')
   if log_level.present?
-    config.logger.level = log_level
+    config.log_level = log_level
+    if config.logger.present?
+      config.logger.level = log_level
+    end
   end
 end

--- a/rails/config/environments/cucumber.rb
+++ b/rails/config/environments/cucumber.rb
@@ -41,9 +41,10 @@ RailsPortal::Application.configure do
     # Disable logging to file. It might have performance impact while using Docker for Mac (slow filesystem sync).
     config.logger = Logger.new(STDOUT)
   end
-  # Specify developer chosen logging level. See docker-compose.yml and .env
-  # Using to something other than (0) debug makes test output more readable.
-  if (log_level = ENV['TEST_LOG_LEVEL'])
+  # Log levels set by environment variables: TEST_LOG_LEVEL, and DEV_LOG_LEVEL
+  # DEBUG | INFO | WARN | ERROR | FATAL | UNKNOWN
+  log_level = ENV.fetch('TEST_LOG_LEVEL', 'WARN')
+  if log_level.present?
     config.logger.level = log_level
   end
 end

--- a/rails/config/environments/cucumber.rb
+++ b/rails/config/environments/cucumber.rb
@@ -37,17 +37,5 @@ RailsPortal::Application.configure do
   config.i18n.default_locale = 'en'
   config.i18n.fallbacks = true
 
-  if BoolENV["RAILS_STDOUT_LOGGING"]
-    # Disable logging to file. It might have performance impact while using Docker for Mac (slow filesystem sync).
-    config.logger = Logger.new(STDOUT)
-  end
-  # Log levels set by environment variables: TEST_LOG_LEVEL, and DEV_LOG_LEVEL
-  # DEBUG | INFO | WARN | ERROR | FATAL | UNKNOWN
-  log_level = ENV.fetch('TEST_LOG_LEVEL', 'WARN')
-  if log_level.present?
-    config.log_level = log_level
-    if config.logger.present?
-      config.logger.level = log_level
-    end
-  end
+  LogConfig.configure(config, ENV['TEST_LOG_LEVEL'], 'WARN')
 end

--- a/rails/config/environments/cucumber.rb
+++ b/rails/config/environments/cucumber.rb
@@ -43,7 +43,7 @@ RailsPortal::Application.configure do
   end
   # Specify developer chosen logging level. See docker-compose.yml and .env
   # Using to something other than (0) debug makes test output more readable.
-  if (log_level = ENV['LOG_LEVEL'])
+  if (log_level = ENV['TEST_LOG_LEVEL'])
     config.logger.level = log_level
   end
 end

--- a/rails/config/environments/development.rb
+++ b/rails/config/environments/development.rb
@@ -74,4 +74,9 @@ RailsPortal::Application.configure do
     # Disable logging to file. It might have performance impact while using Docker for Mac (slow filesystem sync).
     config.logger = Logger.new(STDOUT)
   end
+  # Specify developer chosen logging level. See docker-compose.yml and .env
+  # Using to something other than (0) debug makes test output more readable.
+  if (log_level = ENV['LOG_LEVEL'])
+    config.logger.level = log_level
+  end
 end

--- a/rails/config/environments/development.rb
+++ b/rails/config/environments/development.rb
@@ -74,9 +74,10 @@ RailsPortal::Application.configure do
     # Disable logging to file. It might have performance impact while using Docker for Mac (slow filesystem sync).
     config.logger = Logger.new(STDOUT)
   end
-  # Specify developer chosen logging level. See docker-compose.yml and .env
-  # Using to something other than (0) debug makes test output more readable.
-  if (log_level = ENV['DEV_LOG_LEVEL'])
+  # Log levels set by environment variables: TEST_LOG_LEVEL, and DEV_LOG_LEVEL
+  # DEBUG | INFO | WARN | ERROR | FATAL | UNKNOWN
+  log_level = ENV.fetch('DEV_LOG_LEVEL', 'WARN')
+  if log_level.present?
     config.logger.level = log_level
   end
 end

--- a/rails/config/environments/development.rb
+++ b/rails/config/environments/development.rb
@@ -76,7 +76,7 @@ RailsPortal::Application.configure do
   end
   # Specify developer chosen logging level. See docker-compose.yml and .env
   # Using to something other than (0) debug makes test output more readable.
-  if (log_level = ENV['LOG_LEVEL'])
+  if (log_level = ENV['DEV_LOG_LEVEL'])
     config.logger.level = log_level
   end
 end

--- a/rails/config/environments/development.rb
+++ b/rails/config/environments/development.rb
@@ -78,6 +78,9 @@ RailsPortal::Application.configure do
   # DEBUG | INFO | WARN | ERROR | FATAL | UNKNOWN
   log_level = ENV.fetch('DEV_LOG_LEVEL', 'WARN')
   if log_level.present?
-    config.logger.level = log_level
+    config.log_level = log_level
+    if config.logger.present?
+      config.logger.level = log_level
+    end
   end
 end

--- a/rails/config/environments/development.rb
+++ b/rails/config/environments/development.rb
@@ -70,17 +70,5 @@ RailsPortal::Application.configure do
   localDevPath = File.expand_path((ENV['LOCAL_DEV_ENVIRONMENT_FILE'] || 'local-development.rb'), File.dirname(__FILE__))
   require(localDevPath) if File.file?(localDevPath)
 
-  if BoolENV["RAILS_STDOUT_LOGGING"]
-    # Disable logging to file. It might have performance impact while using Docker for Mac (slow filesystem sync).
-    config.logger = Logger.new(STDOUT)
-  end
-  # Log levels set by environment variables: TEST_LOG_LEVEL, and DEV_LOG_LEVEL
-  # DEBUG | INFO | WARN | ERROR | FATAL | UNKNOWN
-  log_level = ENV.fetch('DEV_LOG_LEVEL', 'WARN')
-  if log_level.present?
-    config.log_level = log_level
-    if config.logger.present?
-      config.logger.level = log_level
-    end
-  end
+  LogConfig.configure(config, ENV['DEV_LOG_LEVEL'], 'DEBUG')
 end

--- a/rails/config/environments/test.rb
+++ b/rails/config/environments/test.rb
@@ -45,4 +45,9 @@ RailsPortal::Application.configure do
     # Disable logging to file. It might have performance impact while using Docker for Mac (slow filesystem sync).
     config.logger = Logger.new(STDOUT)
   end
+  # Specify developer chosen logging level. See docker-compose.yml and .env
+  # Using to something other than (0) debug makes test output more readable.
+  if (log_level = ENV['LOG_LEVEL'])
+    config.logger.level = log_level
+  end
 end

--- a/rails/config/environments/test.rb
+++ b/rails/config/environments/test.rb
@@ -45,9 +45,10 @@ RailsPortal::Application.configure do
     # Disable logging to file. It might have performance impact while using Docker for Mac (slow filesystem sync).
     config.logger = Logger.new(STDOUT)
   end
-  # Specify developer chosen logging level. See docker-compose.yml and .env
-  # Using to something other than (0) debug makes test output more readable.
-  if (log_level = ENV['TEST_LOG_LEVEL'])
+  # Log levels set by environment variables: TEST_LOG_LEVEL, and DEV_LOG_LEVEL
+  # DEBUG | INFO | WARN | ERROR | FATAL | UNKNOWN
+  log_level = ENV.fetch('TEST_LOG_LEVEL', 'WARN')
+  if log_level.present?
     config.logger.level = log_level
   end
 end

--- a/rails/config/environments/test.rb
+++ b/rails/config/environments/test.rb
@@ -49,6 +49,9 @@ RailsPortal::Application.configure do
   # DEBUG | INFO | WARN | ERROR | FATAL | UNKNOWN
   log_level = ENV.fetch('TEST_LOG_LEVEL', 'WARN')
   if log_level.present?
-    config.logger.level = log_level
+    config.log_level = log_level
+    if config.logger.present?
+      config.logger.level = log_level
+    end
   end
 end

--- a/rails/config/environments/test.rb
+++ b/rails/config/environments/test.rb
@@ -47,7 +47,7 @@ RailsPortal::Application.configure do
   end
   # Specify developer chosen logging level. See docker-compose.yml and .env
   # Using to something other than (0) debug makes test output more readable.
-  if (log_level = ENV['LOG_LEVEL'])
+  if (log_level = ENV['TEST_LOG_LEVEL'])
     config.logger.level = log_level
   end
 end

--- a/rails/config/environments/test.rb
+++ b/rails/config/environments/test.rb
@@ -41,17 +41,5 @@ RailsPortal::Application.configure do
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
 
-  if BoolENV["RAILS_STDOUT_LOGGING"]
-    # Disable logging to file. It might have performance impact while using Docker for Mac (slow filesystem sync).
-    config.logger = Logger.new(STDOUT)
-  end
-  # Log levels set by environment variables: TEST_LOG_LEVEL, and DEV_LOG_LEVEL
-  # DEBUG | INFO | WARN | ERROR | FATAL | UNKNOWN
-  log_level = ENV.fetch('TEST_LOG_LEVEL', 'WARN')
-  if log_level.present?
-    config.log_level = log_level
-    if config.logger.present?
-      config.logger.level = log_level
-    end
-  end
+  LogConfig.configure(config, ENV['TEST_LOG_LEVEL'], 'WARN')
 end

--- a/rails/lib/log_config.rb
+++ b/rails/lib/log_config.rb
@@ -1,0 +1,18 @@
+# Configure rails logging. Checks environment variable: RAILS_STDOUT_LOGGING
+module LogConfig
+  AVAILABLE_LOG_LEVELS = %w[DEBUG INFO WARN ERROR FATAL UNKNOWN].freeze
+
+  def self.configure(conf, level, default_level)
+    conf.log_level = AVAILABLE_LOG_LEVELS[0] # most verbose by default
+    if AVAILABLE_LOG_LEVELS.include? default_level
+      conf.log_level = default_level
+    end
+    conf.log_level = level if AVAILABLE_LOG_LEVELS.include? level
+    # Disable logging to file. It might have performance impact while using
+    # Docker for Mac (slow filesystem sync).
+    if BoolENV['RAILS_STDOUT_LOGGING']
+      conf.logger = Logger.new(STDOUT)
+      conf.logger.level = conf.log_level
+    end
+  end
+end

--- a/rails/spec/libs/log_config_spec.rb
+++ b/rails/spec/libs/log_config_spec.rb
@@ -1,0 +1,45 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+describe LogConfig do
+  before(:each) do
+    # Force STDOUT logging for newly created logs
+    allow(BoolENV).to receive(:[]).with("RAILS_STDOUT_LOGGING").and_return(true)
+  end
+
+  describe 'configure' do
+    let(:valid_levels) { LogConfig::AVAILABLE_LOG_LEVELS }
+    let(:invalid_levels) { ['frog', 0, nil, '', ' '] }
+    let(:config) { OpenStruct.new }
+
+    describe 'With valid default log level' do
+      describe 'with valid log levels' do
+        it 'should return a Log with the correct log level configured' do
+          valid_levels.each_with_index do |level, level_index|
+            LogConfig.configure(config, level, 'INFO')
+            expect(config.logger.level).to eq(level_index)
+            expect(config.log_level).to eq(level)
+          end
+        end
+      end
+
+      describe 'With invalid log levels' do
+        it 'should return the default specified' do
+          invalid_levels.each do |level|
+            LogConfig.configure(config, level, 'INFO')
+            expect(config.logger.level).to eq(1)
+            expect(config.log_level).to eq('INFO')
+          end
+        end
+      end
+    end
+
+    describe 'With invalid default and specd levels' do
+      it 'should use the most verbose log level available (DEBUG)' do
+        LogConfig.configure(config, nil, nil)
+        expect(config.logger.level).to eq(0)
+        expect(config.log_level).to eq(valid_levels[0])
+        expect(config.log_level).to eq('DEBUG')
+      end
+    end
+  end
+end


### PR DESCRIPTION
There is so much logging going to STDOUT by default.

It makes it hard to read test status.

Developers can configure logging verbosity via .env file.

[#174264646 ]
