### PR TITLE
174261107 Use lambdas for AR model scopes

### DIFF
--- a/rails/app/models/teacher_project_view.rb
+++ b/rails/app/models/teacher_project_view.rb
@@ -5,5 +5,5 @@ class TeacherProjectView < ActiveRecord::Base
   belongs_to :viewed_project, :class_name => "Admin::Project"
   belongs_to :teacher, :class_name => "Portal::Teacher"
 
-  default_scope joins(:viewed_project).order('teacher_project_views.updated_at DESC')
+  default_scope { joins(:viewed_project).order('teacher_project_views.updated_at DESC') }
 end


### PR DESCRIPTION
Rails 4.0 requires that scopes use a callable object such as a Proc or lambda:

`scope :active, where(active: true)`
becomes
`scope :active, -> { where active: true }`

See this guide:
https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#upgrading-from-rails-3-2-to-rails-4-0-active-record

[#174261107]
https://www.pivotaltracker.com/story/show/174261107