### PR TITLE
174363129 — move GraphQL admin to overlay.

### DIFF
--- a/.env-osx-sample
+++ b/.env-osx-sample
@@ -9,7 +9,10 @@
 #   running on the host machine can talk to the capaybara server and you can see the UI
 #   while the test are running.
 #
-COMPOSE_FILE=docker-compose.yml:docker/dev/docker-compose-sync.yml:docker/dev/docker-compose-random-ports.yml:docker/dev/docker-compose-publish-capybara-port.yml
+# docker/dev/docker-compose-graphql.yml: start a graphql back-end server and
+#   a react-admin interface for managing administrative tasks
+#
+COMPOSE_FILE=docker-compose.yml:docker/dev/docker-compose-sync.yml:docker/dev/docker-compose-random-ports.yml:docker/dev/docker-compose-publish-capybara-port.yml:docker/dev/docker-compose-graphql.yml
 
 # The URL for ourselves. This is used when resources are published to the portal.
 SITE_URL=http://app.portal.docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -195,40 +195,6 @@ services:
       - ./logstash/logstash-output-dev.conf:/usr/share/logstash/pipeline/logstash-output.conf
   kibana:
     image: docker.elastic.co/kibana/kibana-oss:6.1.1
-  graphql:
-    build:
-      context: ./admin-panel/graphql-backend
-      dockerfile: Dockerfile
-    command: npm run start
-    environment:
-      MYSQL_ROOT_PASSWORD:
-      MYSQL_USER:
-      JWT_HMAC_SECRET:
-      DB_HOST: mysql
-      PORTAL_JWT_URL: https://app.portal.docker/api/v1/jwt/portal
-      PORTAL_URL: https://app.portal.docker
-      OATUH_CLIENT_NAME: admin-panel
-    volumes:
-      - ./admin-panel/graphql-backend:/graphql
-    # open standard in and turn on tty so we can attach to the container and debug it
-    stdin_open: true
-    tty: true
-  admin:
-    build:
-      context: ./admin-panel/react-admin-interface
-      dockerfile: Dockerfile
-    command: npm run start
-    environment:
-      REACT_APP_GRAPHQL_HOST: graphql.portal.docker
-      REACT_APP_JWT_HMAC_SECRET: ${JWT_HMAC_SECRET}
-      REACT_APP_PORTAL_JWT_URL: https://app.portal.docker/api/v1/jwt/portal
-      REACT_APP_PORTAL_URL: https://app.portal.docker
-      REACT_APP_OATUH_CLIENT_NAME: admin-panel
-    volumes:
-      - ./admin-panel/react-admin-interface:/admin-interface
-    # open standard in and turn on tty so we can attach to the container and debug it
-    stdin_open: true
-    tty: true
 volumes:
   bundle:
   mysql:

--- a/docker/dev/docker-compose-graphql.yml
+++ b/docker/dev/docker-compose-graphql.yml
@@ -1,0 +1,43 @@
+# This is a docker-compose overlay that uses unison for syncing files between the host
+# and containers.  On OS X it is much faster than simple mounting of local files
+
+# A convient way to overlay this file is to add a `.env` file with the contents:
+#  COMPOSE_FILE=docker-compose.yml:docker/dev/docker-compose-sync.yml
+# if you are making changes to docker-compose.yml or this file it is useful to
+# run `docker-compose config` which shows how the two files get merged together
+version: '3'
+services:
+  graphql:
+    build:
+      context: ./admin-panel/graphql-backend
+      dockerfile: Dockerfile
+    command: npm run start
+    environment:
+      MYSQL_ROOT_PASSWORD:
+      MYSQL_USER:
+      JWT_HMAC_SECRET:
+      DB_HOST: mysql
+      PORTAL_JWT_URL: https://app.portal.docker/api/v1/jwt/portal
+      PORTAL_URL: https://app.portal.docker
+      OATUH_CLIENT_NAME: admin-panel
+    volumes:
+      - ./admin-panel/graphql-backend:/graphql
+    # open standard in and turn on tty so we can attach to the container and debug it
+    stdin_open: true
+    tty: true
+  admin:
+    build:
+      context: ./admin-panel/react-admin-interface
+      dockerfile: Dockerfile
+    command: npm run start
+    environment:
+      REACT_APP_GRAPHQL_HOST: graphql.portal.docker
+      REACT_APP_JWT_HMAC_SECRET: ${JWT_HMAC_SECRET}
+      REACT_APP_PORTAL_JWT_URL: https://app.portal.docker/api/v1/jwt/portal
+      REACT_APP_PORTAL_URL: https://app.portal.docker
+      REACT_APP_OATUH_CLIENT_NAME: admin-panel
+    volumes:
+      - ./admin-panel/react-admin-interface:/admin-interface
+    # open standard in and turn on tty so we can attach to the container and debug it
+    stdin_open: true
+    tty: true


### PR DESCRIPTION

Starting too many containers can slow down development.

This commit moves the Admin interfaces into an overlay you can opt-in to.

[#174363129]

https://www.pivotaltracker.com/story/show/174363129