### PR TITLE
Use latest image for sync container overlay

### DIFF
--- a/docker/dev/docker-compose-sync.yml
+++ b/docker/dev/docker-compose-sync.yml
@@ -19,7 +19,7 @@ services:
       - sync-volume:/rigse
   sync:
     # the version of unison in this container needs to match the verson on your machine
-    image: concordconsortium/docker-volume-sync:latest
+    image: concordconsortium/docker-volume-sync:1.3
     environment:
       # root is used here since the app is running as root so any files it creates
       # will be owned by root, and then unison should be able to override them

--- a/docker/dev/docker-compose-sync.yml
+++ b/docker/dev/docker-compose-sync.yml
@@ -19,7 +19,7 @@ services:
       - sync-volume:/rigse
   sync:
     # the version of unison in this container needs to match the verson on your machine
-    image: concordconsortium/docker-volume-sync:1.1
+    image: concordconsortium/docker-volume-sync:latest
     environment:
       # root is used here since the app is running as root so any files it creates
       # will be owned by root, and then unison should be able to override them


### PR DESCRIPTION
Is there a reason we wouldn't want developers using the latest snyc container?