### PR TITLE
174374504 — Simplify Interactives and Users index

### DIFF
--- a/rails/app/views/interactives/index.html.haml
+++ b/rails/app/views/interactives/index.html.haml
@@ -27,7 +27,6 @@
       %ul.menu
         -if current_visitor.has_role?('admin')
           %li= link_to 'create interactive', new_interactive_path
-        %li= toggle_all 'interactive descriptions'
         %li= link_to 'Export Interactives', export_model_library_interactives_path
 
 .item_collection

--- a/rails/app/views/users/index.html.haml
+++ b/rails/app/views/users/index.html.haml
@@ -4,8 +4,6 @@
       %ul.menu
         %li.menu=link_to 'Account Report', users_account_report_url
     .action_menu_header_right
-      %ul.menu
-        %li= toggle_all 'user descriptions'
     %div.search_users_container
       = form_tag url_for(:action => "index", :page => session[:page] || 1 ), :method => 'get' do
         = content_tag :label do

--- a/rails/spec/features/admin_edits_user_spec.rb
+++ b/rails/spec/features/admin_edits_user_spec.rb
@@ -69,7 +69,7 @@ RSpec.feature 'Admin goes to users page', :WebDriver => true do
 
     scenario 'Project admin can view users page.', js: true do
       expect(current_path).to eq '/users'
-      expect(page.body).to match(%r{#{'Show/Hide User Descriptions'}}i)
+      expect(page.body).to match(%r{Displaying all\s+\d*\s+User}i)
     end
 
     scenario 'Project admin cannot see students in user list before adding a teacher with students to a cohort.', js: true do
@@ -145,7 +145,7 @@ RSpec.feature 'Admin goes to users page', :WebDriver => true do
 
     scenario 'Project admin can view users page.', js: true do
       expect(current_path).to eq '/users'
-      expect(page.body).to match(%r{#{'Show/Hide User Descriptions'}}i)
+      expect(page.body).to match(%r{Displaying all\s+\d*\s+User}i)
     end
 
     scenario 'Project admin cannot see students of teachers who are not in a project cohort.', js: true do

--- a/rails/spec/features/admin_edits_user_spec.rb
+++ b/rails/spec/features/admin_edits_user_spec.rb
@@ -69,7 +69,7 @@ RSpec.feature 'Admin goes to users page', :WebDriver => true do
 
     scenario 'Project admin can view users page.', js: true do
       expect(current_path).to eq '/users'
-      expect(page.body).to match(%r{Displaying all\s+\d*\s+User}i)
+      expect(page.body).to match(%r{Displaying.*all.*User}i)
     end
 
     scenario 'Project admin cannot see students in user list before adding a teacher with students to a cohort.', js: true do
@@ -145,7 +145,7 @@ RSpec.feature 'Admin goes to users page', :WebDriver => true do
 
     scenario 'Project admin can view users page.', js: true do
       expect(current_path).to eq '/users'
-      expect(page.body).to match(%r{Displaying all\s+\d*\s+User}i)
+      expect(page.body).to match(%r{Displaying.*all.*User}i)
     end
 
     scenario 'Project admin cannot see students of teachers who are not in a project cohort.', js: true do


### PR DESCRIPTION
The interactives page has a " Show/Hide Interactive Descriptions" link, this uses prototype-rails.
The users page has a "Show/Hide User Descriptions", this uses prototype-rails.

**These features is not needed, so we should remove it, to make the Rails upgrade possible.**

Example page:
https://learn.staging.concord.org/interactives
https://learn.staging.concord.org/interactives

[#174374504]
https://www.pivotaltracker.com/story/show/174374504