### PR TITLE
174387629 — remove `toggle_all` from `shared/collection_menu`

### DIFF
--- a/rails/app/views/shared/_collection_menu.html.haml
+++ b/rails/app/views/shared/_collection_menu.html.haml
@@ -15,4 +15,3 @@
       %ul.menu
         - if policy(collection_class).create?
           %li= link_to "create #{collection_class.display_name}", :controller => collection_class.name.underscore.pluralize, :action => :new
-        %li= toggle_all "#{collection_class.display_name} descriptions"


### PR DESCRIPTION
This view partial is used by many admin views. `toggle_all` uses `link_to_funtion` which is part of prototype_rails.

Here are the views which call into it:

./rails/app/views/portal/grades/index.html.haml
./rails/app/views/portal/districts/index.html.haml
./rails/app/views/portal/grade_levels/index.html.haml
./rails/app/views/portal/learners/index.html.haml
./rails/app/views/portal/schools/index.html.haml
./rails/app/views/installer_reports/index.html.haml
./rails/app/views/embeddable/multiple_choices/index.html.haml
./rails/app/views/embeddable/image_questions/index.html.haml
./rails/app/views/embeddable/open_responses/index.html.haml
./rails/app/views/admin/external_reports/index.html.haml
./rails/app/views/admin/clients/index.html.haml
./rails/app/views/admin/settings/index.html.haml
./rails/app/views/admin/projects/index.html.haml
./rails/app/views/admin/tags/index.html.haml
./rails/app/views/admin/commons_licenses/index.html.haml
./rails/app/views/dataservice/console_loggers/index.html.haml
./rails/app/views/dataservice/bundle_contents/index.html.haml
./rails/app/views/dataservice/blobs/index.html.haml
./rails/app/views/dataservice/bundle_loggers/index.html.haml
./rails/app/views/dataservice/console_contents/index.html.haml
./rails/app/views/materials_collections/index.html.haml

[#174387629]
https://www.pivotaltracker.com/story/show/174387629