### PR TITLE
174373193 — Simplify admin settings form and index

### DIFF
--- a/rails/app/controllers/admin/settings_controller.rb
+++ b/rails/app/controllers/admin/settings_controller.rb
@@ -6,13 +6,6 @@ class Admin::SettingsController < ApplicationController
   # before_filter :setup_object, :except => [:index]
   # before_filter :render_scope, :only => [:show]
 
-  # editing / modifying / deleting require editable-ness
-  # before_filter :can_edit, :except => [:index,:show,:print,:create,:new,:duplicate,:export]
-  # before_filter :can_create, :only => [:new, :create,:duplicate]
-  #
-  # in_place_edit_for :activity, :name
-  # in_place_edit_for :activity, :description
-
   protected
 
   def admin_only
@@ -30,7 +23,6 @@ class Admin::SettingsController < ApplicationController
       raise Pundit::NotAuthorizedError
     end
   end
-
 
   public
 
@@ -82,14 +74,6 @@ class Admin::SettingsController < ApplicationController
   # GET /admin/settings/1/edit
   def edit
     @admin_settings = Admin::Settings.find(params[:id])
-    # NP: 2020-08-19 TODO: This is not working nut it doesn't seem critical
-    # Pull in the current theme default home page content, if it isn't set in the settings.
-    if @admin_settings.home_page_content.nil? || @admin_settings.home_page_content.empty?
-      render_to_string :partial => "home/project_info"
-
-      @admin_settings.home_page_content = view_context.instance_variable_get(:@content_for_project_info)
-      view_context.instance_variable_set(:@content_for_project_info, nil)
-    end
     # renders edit.html.haml
   end
 

--- a/rails/app/controllers/admin/settings_controller.rb
+++ b/rails/app/controllers/admin/settings_controller.rb
@@ -31,17 +31,12 @@ class Admin::SettingsController < ApplicationController
     end
   end
 
+
   public
 
   # GET /admin/settings
   # GET /admin/settings.xml
   def index
-    # PUNDIT_REVIEW_AUTHORIZE
-    # PUNDIT_CHECK_AUTHORIZE
-    # authorize Admin::Setting
-    # PUNDIT_REVIEW_SCOPE
-    # PUNDIT_CHECK_SCOPE (did not find instance)
-    # @settings = policy_scope(Admin::Setting)
     default_settings = Admin::Settings.default_settings
 
     if @manager_role
@@ -79,28 +74,15 @@ class Admin::SettingsController < ApplicationController
   end
 
   # GET /admin/settings/new
-  # GET /admin/settings/new.xml
   def new
-    # PUNDIT_REVIEW_AUTHORIZE
-    # PUNDIT_CHECK_AUTHORIZE
-    # authorize Admin::Setting
     @admin_settings = Admin::Settings.new
-    @scope = nil
-
-
-    respond_to do |format|
-      format.html # new.html.erb
-      format.xml  { render :xml => @admin_settings }
-    end
+    # renders new.html.haml
   end
 
   # GET /admin/settings/1/edit
   def edit
-    # PUNDIT_REVIEW_AUTHORIZE
-    # PUNDIT_CHECK_AUTHORIZE (did not find instance)
-    # authorize @setting
     @admin_settings = Admin::Settings.find(params[:id])
-
+    # NP: 2020-08-19 TODO: This is not working nut it doesn't seem critical
     # Pull in the current theme default home page content, if it isn't set in the settings.
     if @admin_settings.home_page_content.nil? || @admin_settings.home_page_content.empty?
       render_to_string :partial => "home/project_info"
@@ -108,68 +90,37 @@ class Admin::SettingsController < ApplicationController
       @admin_settings.home_page_content = view_context.instance_variable_get(:@content_for_project_info)
       view_context.instance_variable_set(:@content_for_project_info, nil)
     end
-
-    if request.xhr?
-      render :partial => 'remote_form', :locals => { :admin_settings => @admin_settings }
-    end
+    # renders edit.html.haml
   end
 
   # POST /admin/settings
-  # POST /admin/settings.xml
   def create
-    # PUNDIT_REVIEW_AUTHORIZE
-    # PUNDIT_CHECK_AUTHORIZE
-    # authorize Admin::Setting
     @admin_settings = Admin::Settings.new(params[:admin_settings])
-    respond_to do |format|
-      if @admin_settings.save
-        flash[:notice] = 'Admin::Settings was successfully created.'
-        format.html { redirect_to(@admin_settings) }
-        format.xml  { render :xml => @admin_settings, :status => :created, :location => @admin_settings }
-      else
-        format.html { redirect_to(new_admin_setting_url) }
-        format.xml  { render :xml => @admin_settings.errors, :status => :unprocessable_entity }
-      end
+    if @admin_settings.save
+      flash[:notice] = 'Admin::Settings was successfully created.'
+      redirect_to @admin_settings
+    else
+      redirect_to new_admin_setting_url
     end
   end
 
   # PUT /admin/settings/1
-  # PUT /admin/settings/1.xml
   def update
-    # PUNDIT_REVIEW_AUTHORIZE
-    # PUNDIT_CHECK_AUTHORIZE (did not find instance)
-    # authorize @setting
     @admin_settings = Admin::Settings.find(params[:id])
-    if request.xhr?
-      @admin_settings.update_attributes(params[:admin_settings])
-      render :partial => 'show', :locals => { :admin_settings => @admin_settings }
+    if @admin_settings.update_attributes(params[:admin_settings])
+      flash[:notice] = 'Admin::Settings was successfully updated.'
+      redirect_to @admin_settings
     else
-      respond_to do |format|
-        if @admin_settings.update_attributes(params[:admin_settings])
-          flash[:notice] = 'Admin::Settings was successfully updated.'
-          format.html { redirect_to(@admin_settings) }
-          format.xml  { head :ok }
-        else
-          format.html { render :action => "edit" }
-          format.xml  { render :xml => @admin_settings.errors, :status => :unprocessable_entity }
-        end
-      end
+      render action: 'edit'
     end
   end
 
   # DELETE /admin/settings/1
-  # DELETE /admin/settings/1.xml
   def destroy
-    # PUNDIT_REVIEW_AUTHORIZE
-    # PUNDIT_CHECK_AUTHORIZE (did not find instance)
-    # authorize @setting
     @settings = Admin::Settings.find(params[:id])
     @settings.destroy
-
-    respond_to do |format|
-      format.html { redirect_to(admin_settings_url) }
-      format.xml  { head :ok }
-    end
+    flash[:notice] = 'Settings successfully deleted.'
+    redirect_to admin_settings_url
   end
 
 end

--- a/rails/app/controllers/admin/settings_controller.rb
+++ b/rails/app/controllers/admin/settings_controller.rb
@@ -84,7 +84,7 @@ class Admin::SettingsController < ApplicationController
       flash[:notice] = 'Admin::Settings was successfully created.'
       redirect_to @admin_settings
     else
-      redirect_to new_admin_setting_url
+      render action: 'new'
     end
   end
 

--- a/rails/app/views/admin/settings/_form.html.haml
+++ b/rails/app/views/admin/settings/_form.html.haml
@@ -5,7 +5,7 @@
   = render :partial => "form_for_managers", :locals => { :admin_settings => admin_settings, :f => f  }
 - else
   .item
-    = edit_menu_for(admin_settings, f, { :omit_cancel => true })
+    = edit_menu_for(admin_settings, f)
     .content
       %p
         %ul.menu_v

--- a/rails/app/views/admin/settings/_remote_form.html.haml
+++ b/rails/app/views/admin/settings/_remote_form.html.haml
@@ -1,2 +1,0 @@
-= remote_form_for(admin_settings, :before => "if(validate_settings_form_help_page_settings(this)){tinyMCE.triggerSave(true,true)}else return false", :update => dom_id_for(admin_settings)) do |f|
-  = render :partial => "form", :locals => { :admin_settings => admin_settings, :f => f  }

--- a/rails/app/views/admin/settings/_show.html.haml
+++ b/rails/app/views/admin/settings/_show.html.haml
@@ -12,169 +12,166 @@
 - if @manager_role
   = render :partial => 'show_for_managers', :locals => { :admin_settings => admin_settings }
 - else
-  - options = { :complete => mce_init_string, :omit_delete => true }
   %div{ :id => dom_id_for(admin_settings), :class => "container_element" }
-    = show_menu_for(admin_settings, options)
+  .action_menu
+    .action_menu_header_left
+      %h3= link_to admin_settings.name, admin_settings
+    .action_menu_header_right
+      %ul.menu
+        %li= link_to 'edit', edit_admin_setting_path(admin_settings)
+        - if !admin_settings.active
+          %li= link_to 'delete', url_for(action: :destroy, id:admin_settings.id), data: {method: 'delete', confirm: "Delete these settings?"}
 
-    %div{:id => dom_id_for(admin_settings, :item), :class => 'item'}
-      %div{:id => dom_id_for(admin_settings, :details), :class => 'content'}
-        = wrap_edit_link_around_content(admin_settings, options={:complete => mce_init_string}) do
-          %h4= h(admin_settings.name)
-          %p
-            %ul.menu_v
-              %li
-                Settings Active:
-                %b
-                  - if admin_settings.active
-                    Yes
-                  - else
-                    No
-                (This option determines is these settings are used for portal settings.)
-              %li
-                Student Security Questions:
-                %b
-                  - if admin_settings.use_student_security_questions
-                    enabled.
-                  - else
-                    disabled.
-                (This option will allow students to reset their own passwords.)
-              %li
-                Default Class:
-                %b
-                  - if admin_settings.allow_default_class
-                    enabled.
-                  - else
-                    disabled.
-                (This option will allow students to register without a class word.)
-              %li
-                Default Cohort:
-                %b
-                  = admin_settings.default_cohort ? admin_settings.default_cohort.fullname : 'none'
-                (New teachers will be automatically added to this cohort.)
-              %li
-                Grade Levels for Classes:
-                %b
-                  - if admin_settings.enable_grade_levels?
-                    enabled.
-                  - else
-                    disabled.
-                (This option will allow teachers to select grade levels during class creation.)
-              %li
-                Teachers can author:
-                - if admin_settings.teachers_can_author?
-                  %b
-                    Yes
-                  (Teachers are considered authors by default.)
-                - else
-                  %b
-                    No
-                  (Teachers are not considered authors by default and can only author when given the "author" role.)
-              %li
-                Teachers can create schools:
-                - if admin_settings.allow_adhoc_schools?
-                  %b
-                    Yes
-                  (Teachers can create their own schools when registering.)
-                - else
-                  %b
-                    No
-                  (Teachers must choose their school from a list when registering.)
-              %li
-                Ask users to sign
-                consent form:
-                - if admin_settings.require_user_consent?
-                  %b
-                    Yes
-                  (Users will be asked for consent to use their data in reports.)
-                - else
-                  %b
-                    No
-                  (Users will not be asked for consent to use their data in reports.)
-              %li
-                Use periodic bundle uploading:
-                - if admin_settings.use_periodic_bundle_uploading?
-                  %b
-                    Yes
-                  (User data will be uploaded in smaller chunks at intervals throughout the session.)
-                - else
-                  %b
-                    No
-                  (User data will be uploaded in one large chunk at the end of the session.)
-              %li
-                PUB interval seconds:
-                %b
-                  = admin_settings.pub_interval
-                (This option changes the rate at which student data is sent to the
-                server if periodic bundle uploading is trurned on)
-              %li
-                Include External Activities in class materials search:
-                - if admin_settings.include_external_activities?
-                  %b
-                    Yes
-                  (External Activities will appear in the materials search, and be assignable to classes.)
-                - else
-                  %b
-                    No
-                  (External Activities will not appear in the materials search.)
-              %li
-                Anonymous can search instructional materials:
-                - if admin_settings.anonymous_can_browse_materials?
-                  %b
-                    Yes
-                  (Search link will appear in the navbar for anonymous users.)
-                - else
-                  %b
-                    No
-                  (Search link will not appear in the navbar for anonymous users.)
-              %li
-                Show Collections menu:
-                - if admin_settings.show_collections_menu?
-                  %b
-                    Yes
-                  (Collections menu will appear in the navbar if there is more than 1 project.)
-                - else
-                  %b
-                    No
-                  (Collections menu will appear in the navbar.)
-              %li
-                Auto set new teachers as authors:
-                - if admin_settings.auto_set_teachers_as_authors?
-                  %b
-                    Yes
-                  (Teachers will automatically become authors when they register.)
-                - else
-                  %b
-                    No
-                  (Teachers will not automatically become authors when they register.)
-              %li
-                Enabled Bookmark Types:
-                %b= admin_settings.enabled_bookmark_types.join(', ')
-              = content_for "admin_settings_show_#{admin_settings.id || 'new'}"
-
-            = field_set_tag '<b>Jnlp</b>'.html_safe do
-              %p
-                Jnlp URL:
-                = admin_settings.jnlp_url
-              %p
-                Jnlp CDN Hostname:
-                = admin_settings.jnlp_cdn_hostname
-            = field_set_tag 'Settings Description' do
-              %p= admin_settings.description.html_safe
-            - home_page_content = admin_settings.home_page_content
-            - unless home_page_content.nil?
-              %input{:type=>"button", :value=>"Preview Home Page", :onclick=>"preview_home_page(null, '#{ERB::Util.url_encode(home_page_content)}');", :class=>"button", :style=>"margin-top: 10px; font-size: 13px"}
-            %br
-            - case admin_settings.help_type
-            - when 'external url'
-              - external_url = admin_settings.external_url
-              %input{:type=>"button", :value=>"Preview External Help URL" ,:onclick =>"window.open('#{external_url}','HelpPage','height = 700 width = 800, resizable = yes, scrollbars = yes')" ,:class=>"button" , :style=>"margin-top: 10px; font-size: 13px"}
-            - when 'help custom html'
-              - settings_id = admin_settings.id
-              - settings_id =  settings_id.to_s
-              %input{:type=>"button", :value=>"Preview Custom Help Page" ,:onclick =>"openPreviewHelpPage(false,'',false,'#{settings_id}')" ,:class=>"button" , :style=>"margin-top: 10px; font-size: 13px"}
-            - when 'no help'
-              %br
+  %div{:id => dom_id_for(admin_settings, :item), :class => 'item'}
+    %div{:id => dom_id_for(admin_settings, :details), :class => 'content'}
+      %p
+        %ul.menu_v
+          %li
+            Settings Active:
+            %b
+              - if admin_settings.active
+                Yes
+              - else
+                No
+            (This option determines is these settings are used for portal settings.)
+          %li
+            Student Security Questions:
+            %b
+              - if admin_settings.use_student_security_questions
+                enabled.
+              - else
+                disabled.
+            (This option will allow students to reset their own passwords.)
+          %li
+            Default Class:
+            %b
+              - if admin_settings.allow_default_class
+                enabled.
+              - else
+                disabled.
+            (This option will allow students to register without a class word.)
+          %li
+            Default Cohort:
+            %b
+              = admin_settings.default_cohort ? admin_settings.default_cohort.fullname : 'none'
+            (New teachers will be automatically added to this cohort.)
+          %li
+            Grade Levels for Classes:
+            %b
+              - if admin_settings.enable_grade_levels?
+                enabled.
+              - else
+                disabled.
+            (This option will allow teachers to select grade levels during class creation.)
+          %li
+            Teachers can author:
+            - if admin_settings.teachers_can_author?
               %b
-                No Help Page
-            %br
-            %br
+                Yes
+              (Teachers are considered authors by default.)
+            - else
+              %b
+                No
+              (Teachers are not considered authors by default and can only author when given the "author" role.)
+          %li
+            Teachers can create schools:
+            - if admin_settings.allow_adhoc_schools?
+              %b
+                Yes
+              (Teachers can create their own schools when registering.)
+            - else
+              %b
+                No
+              (Teachers must choose their school from a list when registering.)
+          %li
+            Ask users to sign
+            consent form:
+            - if admin_settings.require_user_consent?
+              %b
+                Yes
+              (Users will be asked for consent to use their data in reports.)
+            - else
+              %b
+                No
+              (Users will not be asked for consent to use their data in reports.)
+          %li
+            Use periodic bundle uploading:
+            - if admin_settings.use_periodic_bundle_uploading?
+              %b
+                Yes
+              (User data will be uploaded in smaller chunks at intervals throughout the session.)
+            - else
+              %b
+                No
+              (User data will be uploaded in one large chunk at the end of the session.)
+          %li
+            PUB interval seconds:
+            %b
+              = admin_settings.pub_interval
+            (This option changes the rate at which student data is sent to the
+            server if periodic bundle uploading is trurned on)
+          %li
+            Include External Activities in class materials search:
+            - if admin_settings.include_external_activities?
+              %b
+                Yes
+              (External Activities will appear in the materials search, and be assignable to classes.)
+            - else
+              %b
+                No
+              (External Activities will not appear in the materials search.)
+          %li
+            Anonymous can search instructional materials:
+            - if admin_settings.anonymous_can_browse_materials?
+              %b
+                Yes
+              (Search link will appear in the navbar for anonymous users.)
+            - else
+              %b
+                No
+              (Search link will not appear in the navbar for anonymous users.)
+          %li
+            Show Collections menu:
+            - if admin_settings.show_collections_menu?
+              %b
+                Yes
+              (Collections menu will appear in the navbar if there is more than 1 project.)
+            - else
+              %b
+                No
+              (Collections menu will appear in the navbar.)
+          %li
+            Auto set new teachers as authors:
+            - if admin_settings.auto_set_teachers_as_authors?
+              %b
+                Yes
+              (Teachers will automatically become authors when they register.)
+            - else
+              %b
+                No
+              (Teachers will not automatically become authors when they register.)
+          %li
+            Enabled Bookmark Types:
+            %b= admin_settings.enabled_bookmark_types.join(', ')
+          = content_for "admin_settings_show_#{admin_settings.id || 'new'}"
+
+        = field_set_tag 'Settings Description' do
+          %p= admin_settings.description.html_safe
+        - home_page_content = admin_settings.home_page_content
+        - unless home_page_content.nil?
+          %input{:type=>"button", :value=>"Preview Home Page", :onclick=>"preview_home_page(null, '#{ERB::Util.url_encode(home_page_content)}');", :class=>"button", :style=>"margin-top: 10px; font-size: 13px"}
+        %br
+        - case admin_settings.help_type
+        - when 'external url'
+          - external_url = admin_settings.external_url
+          %input{:type=>"button", :value=>"Preview External Help URL" ,:onclick =>"window.open('#{external_url}','HelpPage','height = 700 width = 800, resizable = yes, scrollbars = yes')" ,:class=>"button" , :style=>"margin-top: 10px; font-size: 13px"}
+        - when 'help custom html'
+          - settings_id = admin_settings.id
+          - settings_id =  settings_id.to_s
+          %input{:type=>"button", :value=>"Preview Custom Help Page" ,:onclick =>"openPreviewHelpPage(false,'',false,'#{settings_id}')" ,:class=>"button" , :style=>"margin-top: 10px; font-size: 13px"}
+        - when 'no help'
+          %br
+          %b
+            No Help Page
+        %br
+        %br

--- a/rails/app/views/admin/settings/_show.html.haml
+++ b/rails/app/views/admin/settings/_show.html.haml
@@ -1,14 +1,6 @@
 - if @additional_partials && @additional_partials.length > 0
   - @additional_partials.each do |p|
     = render :partial => p, :locals => { :admin_settings => admin_settings }
-%script
-  helpLink = $('help')
-  - if admin_settings.help_type == 'no help'
-    helpLink.parentNode.style.display = "none"
-  - else
-    helpLink.href = "javascript: void(0)"
-    helpLink.onclick = function(){window.open('/help/index','help_page','height = 700 width = 800')}
-    helpLink.parentNode.style.display = ""
 - if @manager_role
   = render :partial => 'show_for_managers', :locals => { :admin_settings => admin_settings }
 - else
@@ -18,7 +10,7 @@
       %h3= link_to admin_settings.name, admin_settings
     .action_menu_header_right
       %ul.menu
-        %li= link_to 'edit', edit_admin_setting_path(admin_settings)
+        %li= link_to 'edit settings', url_for(action: :edit, id:admin_settings.id)
         - if !admin_settings.active
           %li= link_to 'delete', url_for(action: :destroy, id:admin_settings.id), data: {method: 'delete', confirm: "Delete these settings?"}
 
@@ -164,11 +156,11 @@
         - case admin_settings.help_type
         - when 'external url'
           - external_url = admin_settings.external_url
-          %input{:type=>"button", :value=>"Preview External Help URL" ,:onclick =>"window.open('#{external_url}','HelpPage','height = 700 width = 800, resizable = yes, scrollbars = yes')" ,:class=>"button" , :style=>"margin-top: 10px; font-size: 13px"}
+          %a{:href=> external_url, target: "_blank", class: "button", style:"margin-top: 10px; font-size: 13px"}
+            preview help
         - when 'help custom html'
-          - settings_id = admin_settings.id
-          - settings_id =  settings_id.to_s
-          %input{:type=>"button", :value=>"Preview Custom Help Page" ,:onclick =>"openPreviewHelpPage(false,'',false,'#{settings_id}')" ,:class=>"button" , :style=>"margin-top: 10px; font-size: 13px"}
+          %a{href:"/help", target:"_blank", class: "button", style:"margin-top: 10px; font-size: 13px"}
+            preview help
         - when 'no help'
           %br
           %b

--- a/rails/app/views/admin/settings/show.html.haml
+++ b/rails/app/views/admin/settings/show.html.haml
@@ -2,4 +2,5 @@
 = javascript_include_tag('preview_about_page.js')
 = javascript_include_tag('preview_help_page.js')
 = javascript_include_tag 'settings_form'
+%h3=link_to "List Settings", action: "index"
 = render :partial => 'show', :locals=> { :admin_settings => @admin_settings }

--- a/rails/spec/controllers/admin/settings_controller_spec.rb
+++ b/rails/spec/controllers/admin/settings_controller_spec.rb
@@ -113,19 +113,19 @@ describe Admin::SettingsController do
   end
 
   describe "POST create" do
-
+    let(:params) { { these: 'params' } }
     describe "with valid params" do
       it "assigns a newly created settings as @settings" do
-        expect(Admin::Settings).to receive(:new).with({'these' => 'params'}).and_return(mock_settings(:save => true))
+        expect(Admin::Settings).to receive(:new).with(params).and_return(mock_settings(:save => true))
         expect(mock_settings).to receive(:save).and_return(mock_settings(:save => true))
-        post :create, :admin_settings => {:these => 'params'}
+        post :create, admin_settings: params
         expect(assigns[:admin_settings]).to equal(mock_settings)
       end
 
       it "redirects to the created settings" do
         expect(Admin::Settings).to receive(:new).and_return(mock_settings(:save => true))
         expect(mock_settings).to receive(:save).and_return(mock_settings(:save => true))
-        post :create, :admin_settings => {}
+        post :create, admin_settings: {}
         expect(response).to redirect_to(admin_setting_url(mock_settings))
       end
     end
@@ -134,15 +134,16 @@ describe Admin::SettingsController do
       it "assigns a newly created but unsaved settings as @settings" do
         expect(Admin::Settings).to receive(:new).with({'these' => 'params'}).and_return(mock_settings(:save => false))
         expect(mock_settings).to receive(:save).and_return(mock_settings(:save => false))
-        post :create, :admin_settings => {:these => 'params'}
+        post :create, admin_settings: params
         expect(assigns[:admin_settings]).to equal(mock_settings)
       end
 
       it "re-renders the 'new' template" do
         expect(Admin::Settings).to receive(:new).and_return(mock_settings(:save => false))
         expect(mock_settings).to receive(:save).and_return(false)
-        post :create, :admin_settings => {}
-        expect(response).to redirect_to(new_admin_setting_url)
+
+        # it should just render the new template:
+        expect(post :create, admin_settings: params).to render_template(:new)
       end
     end
 

--- a/rails/spec/controllers/admin/settings_controller_spec.rb
+++ b/rails/spec/controllers/admin/settings_controller_spec.rb
@@ -77,9 +77,9 @@ describe Admin::SettingsController do
       expect(assigns[:admin_settings]).to equal(mock_settings)
     end
 
-    it "uses default content if home_page_content is empty" do
+    it "no longer uses default content if home_page_content is empty" do
       allow(mock_settings).to receive(:home_page_content).and_return(nil)
-      expect(mock_settings).to receive(:home_page_content=)
+      expect(mock_settings).not_to receive(:home_page_content=)
       get :edit, :id => "37"
     end
 

--- a/rails/spec/features/admin_configures_help_page_spec.rb
+++ b/rails/spec/features/admin_configures_help_page_spec.rb
@@ -1,91 +1,39 @@
 require 'spec_helper'
 
-RSpec.feature 'Admin configures help page', :WebDriver => true do
+describe 'Admin configures help page' do
   before do
     FactoryBot.create(:admin_settings)
     login_as('admin')
     visit admin_settings_path
+  end
+
+  scenario 'Admin can add an external URL for the help page' do
     first(:link, 'edit settings').click
-  end
-
-  scenario 'Admin can preview the help page if it has added HTML', js: true do
-    fill_in('admin_settings[custom_help_page_html]', :with => 'Creating Help Page')
-    click_button('Preview Custom Help Page')
-    in_newly_opened_window do
-      expect(page).to have_content('Creating Help Page')
-      close_window
-    end
-  end
-
-  scenario 'Admin can add an external URL for the help page', js: true do
-    choose('Use external help URL')
-    check('Mark these settings as active:')
-    fill_in('admin_settings[external_url]', :with => 'www.google.com')
+    choose 'Use external help URL'
+    check 'Mark these settings as active:'
+    fill_in('admin_settings[external_url]', with: 'http://google.com/')
     click_save
-    first(:link, 'edit settings').click
-    expect(page).to have_xpath "//input[@name='admin_settings[external_url]' and @value = 'http://www.google.com']"
-    visit '/home'
-    within('div#clazzes_nav') { first(:link, 'Help').click }
-    in_newly_opened_window do
-      expect(page).to have_content('Gmail')
-      close_window
-    end
-  end
-
-  scenario 'Admin can add custom HTML for the help page', js: true do
-    choose('Use custom help page HTML')
-    check('Mark these settings as active:')
-    fill_in('admin_settings[custom_help_page_html]', :with => 'Creating Help Page')
-    click_save
-    visit '/search'
-    first(:link, 'Help').click
-    in_newly_opened_window do
-      expect(page).to have_content('Creating Help Page')
-      close_window
-    end
-  end
-
-  scenario 'Admin can preview the help page if it is an external URL', js: true do
-    fill_in('admin_settings[external_url]', :with => 'www.google.com')
-    click_button('Preview External Help URL')
-    in_newly_opened_window do
-      expect(page).to have_content('Gmail')
-      close_window
-    end
-  end
-
-  scenario 'Admin should see errors on saving the settings if text boxes are blank', js: true do
-    fill_in('admin_settings[custom_help_page_html]', :with => '')
-    choose('Use custom help page HTML')
-    click_button 'Save'
-    expect_text_within_lightbox('Custom HTML cannot be blank if selected as the help page.')
-    visit admin_settings_path
-    first(:link, 'edit settings').click
-    fill_in('admin_settings[external_url]', :with => '')
-    choose('Use external help URL')
-    click_button 'Save'
-    expect_text_within_lightbox('Please enter a valid external help URL.')
-  end
-
-  scenario 'Admin should see errors on previewing the the help page if text boxes are blank', js: true do
-    fill_in('admin_settings[custom_help_page_html]', :with => '')
-    click_button 'Preview Custom Help Page'
-    expect_text_within_lightbox('Please enter some custom help HTML to preview.')
-    visit admin_settings_path
-    first(:link, 'edit settings').click
-    fill_in('admin_settings[external_url]', :with => '')
-    click_button('Preview External Help URL')
-    expect_text_within_lightbox('Please enter a valid external help URL.')
-  end
-
-  scenario 'Admin should be allowed to remove help page link', js: true do
-    choose('No help link')
-    click_save
-    expect(page).to have_content('No Help Page')
     visit '/help'
-    expect(page).to have_content('There is no help available for this site.')
-    visit '/search'
-    within('div#clazzes_nav') { expect(page).not_to have_content('Help') }
+    expect(page.current_url).to eq 'http://google.com/'
+  end
+
+  scenario 'Admin can add custom HTML for the help page' do
+    first(:link, 'edit settings').click
+    choose 'Use custom help page HTML'
+    check 'Mark these settings as active:'
+    fill_in('admin_settings[custom_help_page_html]', with: 'custom help text Page')
+    click_save
+    visit '/help'
+    expect_content 'custom help text Page'
+  end
+
+  scenario 'Admin should be allowed to remove help page link' do
+    first(:link, 'edit settings').click
+    choose 'No help link'
+    click_save
+    expect_content 'No Help Page'
+    visit '/help'
+    expect_content 'There is no help available for this site.'
   end
 
   def click_save
@@ -93,7 +41,7 @@ RSpec.feature 'Admin configures help page', :WebDriver => true do
     expect(page).to have_no_button('Save')
   end
 
-  def expect_text_within_lightbox(text)
-    within('div.ui-window.lightbox.lightbox_focused') { expect(page).to have_content(text) }
+  def expect_content(text)
+    expect(page).to have_content(text)
   end
 end


### PR DESCRIPTION
This removes remote forms and other RJS methods from the admin_settings controller and views.


[#174373193]

https://www.pivotaltracker.com/story/show/174373193