### PR TITLE
174497744 fix notification of deleted users

### DIFF
--- a/rails/app/models/portal/clazz_mailer.rb
+++ b/rails/app/models/portal/clazz_mailer.rb
@@ -33,7 +33,8 @@ class Portal::ClazzMailer < ActionMailer::Base
       cohort_admins += cohort_project.project_admins
     end
 
-    cohort_admins.map do |cohort_admin|
+    non_nil_admins = cohort_admins.reject(&:nil?)
+    non_nil_admins.map do |cohort_admin|
       "#{cohort_admin.name} <#{cohort_admin.email}>"
     end
   end

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -50,7 +50,7 @@ class User < ActiveRecord::Base
   has_many :student_cohorts, :through => :portal_student, :source => :cohorts
   has_many :student_cohort_projects, :through => :portal_student, :source => :projects
 
-  has_many :project_users, class_name: 'Admin::ProjectUser'
+  has_many :project_users, class_name: 'Admin::ProjectUser', :dependent => :destroy
 
   has_many :admin_for_projects, :through => :project_users, :class_name => 'Admin::Project', :source => :project, :conditions => ['admin_project_users.is_admin = ?', true]
   has_many :researcher_for_projects, :through => :project_users, :class_name => 'Admin::Project', :source => :project, :conditions => ['admin_project_users.is_researcher = ?', true]

--- a/rails/spec/models/portal/clazz_mailer_spec.rb
+++ b/rails/spec/models/portal/clazz_mailer_spec.rb
@@ -95,6 +95,20 @@ describe Portal::ClazzMailer do
         expect(subject.To.value.join).to include("Second Manager")
       end
     end
+    context "when teacher is in a cohort of a project with a nil admin" do
+      before(:each) do
+        second_admin = FactoryBot.create(:user, :first_name => "Second", :last_name => "Manager")
+        second_admin.add_role_for_project('admin', project)
+        # we use delete here instead of destroy so the project_admin object that was created
+        # should stick around
+        second_admin.delete
+      end
+      it "sends a notification email only to the first admins" do
+        expect(subject).to_not be_a(ActionMailer::Base::NullMail)
+        expect(subject.To.value.join).to include("Project Manager")
+        expect(subject.To.value.join).to_not include("Second Manager")
+      end
+    end
   end
 
   describe "clazz_assignment_notification" do


### PR DESCRIPTION
There was a user that was deleted in learn.staging that was an admin of the "Materials for Testing" project. That was causing the notification code to crash which in turn prevented the portal from responding with a success to the 'assign' api.

This PR adds a dependent destroy to the users model. That way if User#destroy is used then these project_user objects will be cleaned up.  It also adds code to handle the nil user case in the notification code.