### PR TITLE
174422989 — Controller and views for project_link

### DIFF
--- a/rails/app/controllers/admin/project_links_controller.rb
+++ b/rails/app/controllers/admin/project_links_controller.rb
@@ -1,9 +1,10 @@
 class Admin::ProjectLinksController < ApplicationController
   include RestrictedController
 
+  before_filter :check_for_project
   before_filter :get_scoped_projects, only: ['new', 'edit']
   before_filter :find_project_link, only: ['show', 'edit', 'update', 'destroy']
-  before_filter :check_for_project
+
 
   def check_for_project
     return unless params[:project_id]
@@ -16,6 +17,7 @@ class Admin::ProjectLinksController < ApplicationController
 
   def get_scoped_projects
     @projects = policy_scope(Admin::Project)
+    @projects = @projects.where(id: @project.id) if @project
   end
 
   def find_project_link
@@ -27,8 +29,9 @@ class Admin::ProjectLinksController < ApplicationController
   # GET /project_links
   def index
     authorize Admin::ProjectLink
-
-    @project_links = Admin::ProjectLink.search(params[:search], params[:page], nil, nil, policy_scope(Admin::ProjectLink))
+    search_scope = policy_scope(Admin::ProjectLink)
+    search_scope = search_scope.where(project_id: @project.id) if @project
+    @project_links = Admin::ProjectLink.search(params[:search], params[:page], nil, nil, search_scope)
     # render index.html.haml
   end
 
@@ -42,6 +45,7 @@ class Admin::ProjectLinksController < ApplicationController
   def new
     authorize Admin::ProjectLink
     @project_link = Admin::ProjectLink.new
+    @project_link.project_id = @project.id if @project
     # render new.html.haml
   end
 

--- a/rails/app/controllers/admin/project_links_controller.rb
+++ b/rails/app/controllers/admin/project_links_controller.rb
@@ -1,0 +1,81 @@
+class Admin::ProjectLinksController < ApplicationController
+  include RestrictedController
+
+  before_filter :get_scoped_projects, only: ['new', 'edit']
+  before_filter :find_project_link, only: ['show', 'edit', 'update', 'destroy']
+  before_filter :check_for_project
+
+  def check_for_project
+    return unless params[:project_id]
+
+    @project = Admin::Project.find(params[:project_id])
+    authorize @project
+  end
+
+  private
+
+  def get_scoped_projects
+    @projects = policy_scope(Admin::Project)
+  end
+
+  def find_project_link
+    @project_link = Admin::ProjectLink.find(params[:id])
+  end
+
+  public
+
+  # GET /project_links
+  def index
+    authorize Admin::ProjectLink
+
+    @project_links = Admin::ProjectLink.search(params[:search], params[:page], nil, nil, policy_scope(Admin::ProjectLink))
+    # render index.html.haml
+  end
+
+  # GET /project_links/1
+  def show
+    authorize @project_link
+    # render show.html.haml
+  end
+
+  # GET /project_links/new
+  def new
+    authorize Admin::ProjectLink
+    @project_link = Admin::ProjectLink.new
+    # render new.html.haml
+  end
+
+  # GET /project_links/1/edit
+  def edit
+    authorize @project_link
+    # render edit.html.haml
+  end
+
+  # POST /project_links
+  def create
+    @project_link = Admin::ProjectLink.new(params[:admin_project_link])
+    authorize @project_link
+    if @project_link.save
+      redirect_to @project_link, notice: 'Admin::ProjectLink was successfully created.'
+    else
+      render action: 'new'
+    end
+  end
+
+  # PUT /project_links/1
+  def update
+    authorize @project_link
+    if @project_link.update_attributes(params[:admin_project_link])
+      redirect_to @project_link, notice: 'Admin::ProjectLink was successfully updated.'
+    else
+      render action: 'edit'
+    end
+  end
+
+  # DELETE /project_links/1
+  def destroy
+    authorize @project_link
+    @project_link.destroy
+    redirect_to admin_project_links_url, notice: "Tag #{@project_link.name} was deleted"
+  end
+end

--- a/rails/app/controllers/admin/project_links_controller.rb
+++ b/rails/app/controllers/admin/project_links_controller.rb
@@ -76,6 +76,6 @@ class Admin::ProjectLinksController < ApplicationController
   def destroy
     authorize @project_link
     @project_link.destroy
-    redirect_to admin_project_links_url, notice: "Tag #{@project_link.name} was deleted"
+    redirect_to admin_project_links_url, notice: "Link #{@project_link.name} was deleted"
   end
 end

--- a/rails/app/models/admin/project_link.rb
+++ b/rails/app/models/admin/project_link.rb
@@ -3,4 +3,13 @@ class Admin::ProjectLink < ActiveRecord::Base
   belongs_to :project, :class_name => 'Admin::Project'
   attr_accessible :href, :name, :project_id, :link_id, :pop_out, :position
   validates :href, :name, :link_id, :presence => true
+
+  self.extend SearchableModel
+
+  class <<self
+    def searchable_attributes
+      %w{name href link_id}
+    end
+  end
+
 end

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -412,9 +412,9 @@ class User < ActiveRecord::Base
 
   def is_project_admin?(project=nil)
     if project
-      self.admin_for_projects.include? project
+      self.admin_for_projects.where(id: project.id).exists?
     else
-      self.admin_for_projects.length > 0
+      self.admin_for_projects.exists?
     end
   end
 

--- a/rails/app/policies/admin/project_link_policy.rb
+++ b/rails/app/policies/admin/project_link_policy.rb
@@ -5,7 +5,6 @@ class Admin::ProjectLinkPolicy < ApplicationPolicy
       if user && user.has_role?('admin')
         all
       elsif user
-        # prevents a bunch of unnecessary model loads by not using the user#admin_for_project_cohorts method
         scope
           .joins("INNER JOIN admin_project_users __apu_scope ON __apu_scope.project_id = admin_project_links.project_id")
           .where("__apu_scope.user_id = ? AND __apu_scope.is_admin = 1", user.id)
@@ -20,22 +19,22 @@ class Admin::ProjectLinkPolicy < ApplicationPolicy
   end
 
   def create?
-    # if the cohort has a project already, require membership
+    # if the project_link has a project already, require membership
     if(record.project)
       (admin? || user.is_project_admin?(record.project))
-    # inprocess cohort perhaps?
     else
-      admin_or_project_admin?
+      # don't allow creation of project links without projects
+      false
     end
   end
 
   def update?
-    # if the cohort has a project already, require membership
+    # if the project_link has a project already, require membership
     if(record.project)
       admin? || user.is_project_admin?(record.project)
-    # inprocess cohort perhaps?
     else
-      admin_or_project_admin?
+      # only admins can fix project_links that don't have a project
+      admin?
     end
   end
 
@@ -43,7 +42,8 @@ class Admin::ProjectLinkPolicy < ApplicationPolicy
     if(record.project)
       admin? || user.is_project_member?(record.project)
     else
-      admin_or_project_admin?
+      # only admins can view project_links that don't have a project
+      admin?
     end
   end
 

--- a/rails/app/policies/admin/project_link_policy.rb
+++ b/rails/app/policies/admin/project_link_policy.rb
@@ -1,2 +1,51 @@
 class Admin::ProjectLinkPolicy < ApplicationPolicy
+
+  class Scope < Scope
+    def resolve
+      if user && user.has_role?('admin')
+        all
+      elsif user
+        # prevents a bunch of unnecessary model loads by not using the user#admin_for_project_cohorts method
+        scope
+          .joins("INNER JOIN admin_project_users __apu_scope ON __apu_scope.project_id = admin_cohorts.project_id")
+          .where("__apu_scope.user_id = ? AND __apu_scope.is_admin = 1", user.id)
+      else
+        none
+      end
+    end
+  end
+
+  def new?
+    admin_or_project_admin?
+  end
+
+  def create?
+    # if the cohort has a project already, require membership
+    if(record.project)
+      (admin? || user.is_project_admin?(record.project))
+    # inprocess cohort perhaps?
+    else
+      admin_or_project_admin?
+    end
+  end
+
+  def update?
+    # if the cohort has a project already, require membership
+    if(record.project)
+      admin? || user.is_project_admin?(record.project)
+    # inprocess cohort perhaps?
+    else
+      admin_or_project_admin?
+    end
+  end
+
+  def show?
+    if(record.project)
+      admin? || user.is_project_member?(record.project)
+    else
+      admin_or_project_admin?
+    end
+  end
+
+
 end

--- a/rails/app/policies/admin/project_link_policy.rb
+++ b/rails/app/policies/admin/project_link_policy.rb
@@ -7,7 +7,7 @@ class Admin::ProjectLinkPolicy < ApplicationPolicy
       elsif user
         # prevents a bunch of unnecessary model loads by not using the user#admin_for_project_cohorts method
         scope
-          .joins("INNER JOIN admin_project_users __apu_scope ON __apu_scope.project_id = admin_cohorts.project_id")
+          .joins("INNER JOIN admin_project_users __apu_scope ON __apu_scope.project_id = admin_project_links.project_id")
           .where("__apu_scope.user_id = ? AND __apu_scope.is_admin = 1", user.id)
       else
         none

--- a/rails/app/policies/admin/project_policy.rb
+++ b/rails/app/policies/admin/project_policy.rb
@@ -50,7 +50,7 @@ class Admin::ProjectPolicy < ApplicationPolicy
   end
 
   def update_edit_or_destroy?
-    admin_or_project_admin?
+    user.has_role?('admin') || user.is_project_admin?(record)
   end
 
   def not_anonymous?

--- a/rails/app/policies/admin/project_policy.rb
+++ b/rails/app/policies/admin/project_policy.rb
@@ -50,7 +50,7 @@ class Admin::ProjectPolicy < ApplicationPolicy
   end
 
   def update_edit_or_destroy?
-    user.has_role?('admin') || user.is_project_admin?(record)
+    user.present? && (user.has_role?('admin') || user.is_project_admin?(record))
   end
 
   def not_anonymous?

--- a/rails/app/views/admin/project_links/_form.html.haml
+++ b/rails/app/views/admin/project_links/_form.html.haml
@@ -1,0 +1,25 @@
+.item
+  = edit_menu_for(project_link, f, { :omit_cancel => true })
+  = error_messages_for :project_link
+  .content
+    %p
+      %ul.menu_v
+        %li
+          Name:
+          =f.text_field :name
+        %li
+          Id:
+          =f.text_field :link_id
+        %li
+          URL:
+          =f.text_field :href
+        %li
+          Positon:
+          =f.text_field :position
+        %li
+          Pop out:
+          =f.check_box :pop_out
+        %li
+          Project:
+          =f.collection_select(:project_id, projects, :id, :name)
+

--- a/rails/app/views/admin/project_links/_show.html.haml
+++ b/rails/app/views/admin/project_links/_show.html.haml
@@ -1,0 +1,34 @@
+- display_name = "#{project_link.name}"
+%div{id: dom_id_for(project_link), class: 'container_element'}
+  .action_menu
+    .action_menu_header_left
+      %h3
+        %a{href:admin_project_link_path(project_link)}=display_name
+
+    .action_menu_header_right
+      %ul.menu
+        %li
+          %a{href:edit_admin_project_link_path(project_link)} edit
+        %li
+          %a{href:url_for(action: :destroy, id:project_link.id), data: {method: 'delete', confirm: "Delete this Link?"} } delete
+  %div{:id => dom_id_for(project_link, :item), :class => 'item'}
+    %div{:id => dom_id_for(project_link, :details), :class => 'content'}
+      %p
+        %span
+          Name:
+          = h(project_link.name)
+        %span
+          ID:
+          = project_link.link_id
+      %p
+        URL:
+        = project_link.href
+      %p
+        Project:
+        - if project_link.project
+          = project_link.project.name
+        - else
+          None
+      - if project_link.pop_out
+        %p
+          This link opens in a pop-out

--- a/rails/app/views/admin/project_links/edit.html.haml
+++ b/rails/app/views/admin/project_links/edit.html.haml
@@ -1,0 +1,2 @@
+= form_for(@project_link) do |f|
+  = render partial: 'form', locals: { project_link: @project_link, projects: @projects, f: f }

--- a/rails/app/views/admin/project_links/index.html.haml
+++ b/rails/app/views/admin/project_links/index.html.haml
@@ -1,0 +1,2 @@
+= render :partial => 'shared/collection_menu', :locals => { :collection => @project_links, :collection_class => Admin::ProjectLink }
+= render :partial => 'show', :collection => @project_links, :as => :project_link

--- a/rails/app/views/admin/project_links/new.html.haml
+++ b/rails/app/views/admin/project_links/new.html.haml
@@ -1,0 +1,2 @@
+= form_for(@project_link) do |f|
+  = render partial: 'form', locals: { project_link: @project_link, projects: @projects, f: f }

--- a/rails/app/views/admin/project_links/show.html.haml
+++ b/rails/app/views/admin/project_links/show.html.haml
@@ -1,0 +1,2 @@
+%h3=link_to "List project links", action: 'index'
+= render :partial => 'show', :locals=> { :project_link => @project_link }

--- a/rails/app/views/home/admin.html.haml
+++ b/rails/app/views/home/admin.html.haml
@@ -26,6 +26,7 @@
         %li= link_to 'Notices', admin_site_notices_path
         %li= link_to 'Projects', admin_projects_path
         %li= link_to 'Cohorts', admin_cohorts_path
+        %li= link_to 'Project Links', admin_project_links_path
         %li= link_to 'Schools', portal_schools_path
         %li= link_to 'Settings', admin_settings_path
         %li= link_to 'Tags', admin_tags_path

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -268,6 +268,7 @@ RailsPortal::Application.routes.draw do
       resources :tags
       resources :projects do
         resources :cohorts
+        resources :project_links
       end
       resources :cohorts
       resources :project_links

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -270,6 +270,7 @@ RailsPortal::Application.routes.draw do
         resources :cohorts
       end
       resources :cohorts
+      resources :project_links
       resources :clients
       resources :tools
       resources :external_reports

--- a/rails/factories/admin_project_link.rb
+++ b/rails/factories/admin_project_link.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :admin_project_link, class: Admin::ProjectLink do |f|
+    f.name {'test project link'}
+    f.href {'http://projectlink.com/'}
+    f.link_id {'test'}
+  end
+end

--- a/rails/spec/controllers/admin/project_links_controller_spec.rb
+++ b/rails/spec/controllers/admin/project_links_controller_spec.rb
@@ -1,0 +1,325 @@
+require 'spec_helper'
+
+RegexForAuthFailShow = /can not view the requested resource/
+RegexForAuthFailNew = /can not create the requested resource/
+RegexForAuthFailModify = /can not update the requested resource/
+
+describe Admin::ProjectLinksController do
+  before(:each) do
+    allow(controller).to receive(:current_user).and_return(user)
+    @link_1 = FactoryBot.create(:project_link, link_id: 'link1', href: 'http://link1.com', name: 'link 1', project: project_1)
+    @link_2 = FactoryBot.create(:project_link, link_id: 'link2', href: 'http://link2.com', name: 'link 2', project: project_2)
+    @link_3 = FactoryBot.create(:project_link, link_id: 'link3', href: 'http://link3.com', name: 'link 3', project: project_3)
+  end
+
+  let(:project_1) { FactoryBot.create(:admin_project, name: 'project_1') }
+  let(:project_2) { FactoryBot.create(:admin_project, name: 'project_2') }
+  let(:project_3) { FactoryBot.create(:admin_project, name: 'project_3') }
+
+  let(:admin_user) { FactoryBot.generate(:admin_user) }
+  let(:user) { FactoryBot.create(:user) }
+
+  describe 'A user not affiliated with a project' do
+    describe 'GET index' do
+      it 'wont see any links' do
+        get :index
+        expect(assigns[:project_links]).to eq([])
+      end
+    end
+
+    describe 'Show' do
+      it 'wont let them see any links' do
+        [@link_1, @link_2, @link_3].each do |link|
+          get :show, id: link.id
+          # Redirect, and show error when not allowed:
+          expect(response).to have_http_status(:redirect)
+          expect(request.flash[:alert]).to match(RegexForAuthFailShow)
+        end
+      end
+    end
+
+    describe 'New' do
+      it 'it wont let them create a new link' do
+        get :new
+        # Redirect, and show error when not allowed:
+        expect(response).to have_http_status(:redirect)
+        expect(request.flash[:alert]).to match(RegexForAuthFailNew)
+      end
+    end
+
+    describe 'create' do
+      it 'it wont let them create a new link' do
+        put :create
+        # Redirect, and show error when not allowed:
+        expect(response).to have_http_status(:redirect)
+        expect(request.flash[:alert]).to match(RegexForAuthFailNew)
+      end
+    end
+
+    describe 'update' do
+      it 'it wont let them update an existing link' do
+        put :update, id:@link_1.id
+        # Redirect, and show error when not allowed:
+        expect(response).to have_http_status(:redirect)
+        expect(request.flash[:alert]).to match(RegexForAuthFailModify)
+      end
+    end
+  end
+
+  describe 'A user who is an admin for project 2' do
+    before(:each) do
+      user.add_role_for_project('admin', project_2)
+    end
+
+    describe 'GET index' do
+      it 'can only see link 2' do
+        get :index
+        expect(assigns[:project_links]).not_to include(@link_1)
+        expect(assigns[:project_links]).to include(@link_2)
+        expect(assigns[:project_links]).not_to include(@link_3)
+      end
+    end
+  end
+
+  describe 'A user who is an admin for project 1' do
+    before(:each) do
+      user.add_role_for_project('admin', project_1)
+    end
+
+    describe 'GET index' do
+      it 'can only see link 1' do
+        get :index
+        expect(assigns[:project_links]).to include(@link_1)
+        expect(assigns[:project_links]).not_to include(@link_2)
+        expect(assigns[:project_links]).not_to include(@link_3)
+      end
+    end
+
+    describe 'Show' do
+      describe 'link 1 (user IS a project admin)' do
+        it 'lets them see it' do
+          get :show, id:@link_1.id
+          expect(assigns[:project_link]).to eq(@link_1)
+          expect(response).to have_http_status(:ok)
+        end
+      end
+      describe 'link 2 (user is NOT a project admin)' do
+        it 'wont let them see it' do
+          get :show, id:@link_2.id
+          # Redirect, and show error when not allowed:
+          expect(response).to have_http_status(:redirect)
+          expect(request.flash[:alert]).to match(RegexForAuthFailShow)
+        end
+      end
+    end
+
+    describe 'New' do
+      it 'it should show the New form' do
+        expect(get :new).to render_template('new')
+        # Redirect, and show error when not allowed:
+      end
+      it 'should display only the projects for which the user is an admin' do
+        get :new
+        expect(assigns(:projects)).to include(project_1)
+        expect(assigns(:projects)).not_to include(project_2)
+        expect(assigns(:projects)).not_to include(project_3)
+      end
+      it 'should return an OK http status' do
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe 'Edit' do
+      before(:each) do
+        allow(Admin::ProjectLink).to receive(:find).and_return(@link_1)
+      end
+      it 'it should show the Edit form' do
+        expect(get :edit).to render_template('edit')
+        # Redirect, and show error when not allowed:
+      end
+      it 'should display only the projects for which the user is an admin' do
+        get :edit
+        expect(assigns(:projects)).to include(project_1)
+        expect(assigns(:projects)).not_to include(project_2)
+        expect(assigns(:projects)).not_to include(project_3)
+      end
+      it 'should return an OK http status' do
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe 'Create' do
+      let(:params) do
+        {
+          admin_project_link: {
+            project_id: project_id,
+            name: 'name',
+            href: 'http://foo.com/',
+            link_id: 'foo'
+          }
+        }
+      end
+
+      describe 'when creating a link for project 1 which they ARE admin for' do
+        let(:project_id) { project_1.id }
+        it 'it SHOULD let them' do
+          post :create, params
+          link = assigns(:project_link)
+          expect(assigns(:project_link)).to be_valid
+          expect(response).to redirect_to(admin_project_link_path(link))
+        end
+      end
+
+      describe 'when creating a link for project 2 (NOT their project)' do
+        let(:project_id) { project_2.id }
+        it 'it should NOT let them' do
+          post :create, params
+          # Redirect, and show error when not allowed:
+          expect(response).to have_http_status(:redirect)
+          expect(request.flash[:alert]).to match(RegexForAuthFailNew)
+        end
+      end
+    end
+  end
+
+  describe 'A site admin' do
+    let(:user) { admin_user }
+
+    describe 'GET index' do
+      it 'can see all of the links in the index' do
+        get :index
+        expect(assigns[:project_links]).to include(@link_1)
+        expect(assigns[:project_links]).to include(@link_2)
+        expect(assigns[:project_links]).to include(@link_3)
+      end
+    end
+
+    describe 'Show' do
+      describe 'link 1' do
+        it 'can see it' do
+          get :show, id: @link_1.id
+          expect(assigns[:project_link]).to eq(@link_1)
+          expect(response).to have_http_status(:ok)
+        end
+      end
+      describe 'link 2' do
+        it 'can see it' do
+          get :show, id: @link_2.id
+          expect(assigns[:project_link]).to eq(@link_2)
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+
+    describe 'New' do
+      it 'it should show the New form' do
+        expect(get :new).to render_template('new')
+        # Redirect, and show error when not allowed:
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe 'Create' do
+      let(:params) do
+        {
+          admin_project_link: {
+            project_id: project_id,
+            name: 'name',
+            href: 'http://foo.com/',
+            link_id: 'foo'
+          }
+        }
+      end
+      describe 'for a link in project 1' do
+        let(:project_id) { project_1.id }
+        it 'it SHOULD let them create a new link' do
+          post :create, params
+          link = assigns(:project_link)
+          expect(assigns(:project_link)).to be_valid
+          expect(response).to redirect_to(admin_project_link_path(link))
+        end
+      end
+
+
+    describe 'New' do
+      it 'it should show the New form' do
+        expect(get :new).to render_template('new')
+        # Redirect, and show error when not allowed:
+      end
+      it 'should display all the projects in the project dropdown' do
+        get :new
+        expect(assigns(:projects)).to include(project_1)
+        expect(assigns(:projects)).to include(project_2)
+        expect(assigns(:projects)).to include(project_3)
+      end
+      it 'should return an OK http status' do
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe 'Edit' do
+      before(:each) do
+        allow(Admin::ProjectLink).to receive(:find).and_return(@link_1)
+      end
+      it 'it should show the Edit form' do
+        expect(get :edit).to render_template('edit')
+        # Redirect, and show error when not allowed:
+      end
+      it 'should display all the projects in the project dropdown' do
+        get :edit
+        expect(assigns(:projects)).to include(project_1)
+        expect(assigns(:projects)).to include(project_2)
+        expect(assigns(:projects)).to include(project_3)
+      end
+      it 'should return an OK http status' do
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+      describe 'for a link in project 2' do
+        let(:project_id) { project_2.id }
+        it 'should let them' do
+          post :create, params
+          link = assigns(:project_link)
+          expect(assigns(:project_link)).to be_valid
+          expect(response).to redirect_to(admin_project_link_path(link))
+        end
+      end
+    end
+  end
+
+  describe 'Nested controller methods' do
+    let(:user) { admin_user }
+    let(:project) { project_2 }
+
+    context 'when nested under project route' do
+      context 'get index' do
+        it 'should restrict the list of links to that project' do
+          get 'index', project_id: project.id
+          expect(assigns('project_links')).to include(@link_2)
+          expect(assigns('project_links')).not_to include(@link_1)
+          expect(assigns('project_links')).not_to include(@link_3)
+          expect(response).to have_http_status(:ok)
+        end
+      end
+      context 'get new' do
+        it 'should only display the selected project in the drop down' do
+          get 'new', project_id: project.id
+          expect(assigns('projects')).to include(project_2)
+          expect(assigns('projects')).not_to include(project_1)
+          expect(assigns('projects')).not_to include(project_3)
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'should pre-select the correct project from the route' do
+          [project_1, project_2, project_3].each do |chosen_project|
+            get 'new', project_id: chosen_project.id
+            new_project_link = assigns('project_link')
+            expect(new_project_link.project_id).to eq(chosen_project.id)
+            expect(response).to have_http_status(:ok)
+          end
+        end
+      end
+    end
+  end
+end

--- a/rails/spec/models/user_spec.rb
+++ b/rails/spec/models/user_spec.rb
@@ -875,14 +875,62 @@ protected
     end
   end
 
-  # TODO: auto-generated
   describe '#is_project_admin?' do
-    it 'is_project_admin?' do
-      user = described_class.new
-      project = FactoryBot.create(:project)
-      result = user.is_project_admin?(project)
+    let(:user_role) { nil }
+    let(:user_project) { nil }
+    let(:user) {
+      _user = FactoryBot.create(:user)
+      if (user_role && user_project)
+        _user.add_role_for_project(user_role, user_project)
+      end
+      _user
+    }
 
-      expect(result).not_to be_nil
+    context 'when no project is passed in and user is' do
+      subject { user.is_project_admin? }
+
+      context 'not an admin of any projects' do
+        it { is_expected.to be false}
+      end
+
+      context 'an admin of a project' do
+        let(:user_role) { 'admin' }
+        let(:user_project) { FactoryBot.create(:project) }
+        it { is_expected.to be true}
+      end
+
+      context 'a researcher of a project' do
+        let(:user_role) { 'researcher' }
+        let(:user_project) { FactoryBot.create(:project) }
+        it { is_expected.to be false}
+      end
+
+    end
+    context 'when a project is passed in and user is' do
+      let (:target_project) { FactoryBot.create(:project) }
+      subject { user.is_project_admin?(target_project) }
+
+      context 'not an admin of any projects' do
+        it { is_expected.to be false}
+      end
+
+      context 'an admin of a different project' do
+        let(:user_role) { 'admin' }
+        let(:user_project) { FactoryBot.create(:project) }
+        it { is_expected.to be false}
+      end
+
+      context 'an admin of the same project' do
+        let(:user_role) { 'admin' }
+        let(:user_project) { target_project }
+        it { is_expected.to be true}
+      end
+
+      context 'a researcher of the same project' do
+        let(:user_role) { 'researcher' }
+        let(:user_project) { target_project }
+        it { is_expected.to be false}
+      end
     end
   end
 

--- a/rails/spec/policies/admin/project_link_policy_spec.rb
+++ b/rails/spec/policies/admin/project_link_policy_spec.rb
@@ -4,4 +4,87 @@ require 'spec_helper'
 
 RSpec.describe Admin::ProjectLinkPolicy do
 
+  before(:each) do
+    @project_link1 = FactoryBot.create(:admin_project_link)
+    @project_link2 = FactoryBot.create(:admin_project_link)
+    @project_link3 = FactoryBot.create(:admin_project_link)
+  end
+
+  let(:user) { FactoryBot.create(:user) }
+  let(:scope) { Pundit.policy_scope!(user, Admin::ProjectLink) }
+
+  describe "Scope" do
+    context 'normal user' do
+      it 'does not allow access to any project_links' do
+        expect(scope.to_a.length).to eq 0
+      end
+    end
+
+    context 'project researcher' do
+      before(:each) do
+        @project = FactoryBot.create(:project)
+        @project.links << @project_link1
+        user.add_role_for_project('researcher', @project)
+      end
+
+      it 'does not allow access to any project_links' do
+        expect(scope.to_a.length).to eq 0
+      end
+    end
+
+    context 'project admin' do
+      before(:each) do
+        @project = FactoryBot.create(:project)
+        @project.links << @project_link1
+        user.add_role_for_project('admin', @project)
+      end
+
+      it 'allows access to project project_links' do
+        expect(scope.to_a).to match_array([@project_link1])
+      end
+    end
+
+    context 'admin user' do
+      let(:user) { FactoryBot.generate(:admin_user) }
+      it 'allows access to all project_links' do
+        expect(scope.to_a).to match_array([@project_link1, @project_link2, @project_link3])
+      end
+    end
+  end
+
+  describe 'create' do
+    let(:project_link_stubs) { {project: 'project' } }
+    let(:proj_user) { FactoryBot.create(:user) }
+    let(:project_link) { double('project_link', project_link_stubs) }
+
+    context 'as project admin' do
+      before(:each) do
+        allow(proj_user).to receive(:is_project_admin?).and_return(true)
+      end
+
+      it 'should allow create' do
+        expect(Admin::ProjectLinkPolicy.new(proj_user, project_link)).to permit(:create)
+      end
+
+      it 'should allow update' do
+        expect(Admin::ProjectLinkPolicy.new(proj_user, project_link)).to permit(:update)
+      end
+    end
+
+    context 'not as project admin' do
+      before(:each) do
+        allow(proj_user).to receive(:is_project_admin?).and_return(false)
+      end
+
+      it 'should not allow create' do
+        expect(Admin::ProjectLinkPolicy.new(proj_user, project_link)).to_not permit(:create)
+      end
+
+      it 'should not allow update' do
+        expect(Admin::ProjectLinkPolicy.new(proj_user, project_link)).to_not permit(:update)
+      end
+    end
+
+  end
 end
+

--- a/rails/spec/policies/admin/project_policy_spec.rb
+++ b/rails/spec/policies/admin/project_policy_spec.rb
@@ -14,13 +14,12 @@ RSpec.describe Admin::ProjectPolicy do
     end
   end
 
-  # TODO: auto-generated
   describe '#update_edit_or_destroy?' do
     it 'update_edit_or_destroy?' do
       project_policy = described_class.new(nil, nil)
       result = project_policy.update_edit_or_destroy?
 
-      expect(result).to be_nil
+      expect(result).to be_falsey
     end
   end
 

--- a/rails/spec/views/external_activities/edit.html.haml_spec.rb
+++ b/rails/spec/views/external_activities/edit.html.haml_spec.rb
@@ -22,7 +22,7 @@ describe "/external_activities/edit.html.haml" do
   it 'should not show the offical checkbox to project admins of the project material' do
     common_projects = [mock_model(Admin::Project, cohorts: [])]
     auth_user = FactoryBot.generate(:author_user)
-    allow(auth_user).to receive_messages(admin_for_projects: common_projects)
+    allow(auth_user).to receive_messages(is_project_admin?: true)
     allow(ext_act).to receive_messages(projects: common_projects)
     allow(view).to receive(:current_user).and_return(auth_user)
     render


### PR DESCRIPTION
Controller and views for project_link

In order to replace the nested forms on the projects edit form with something more simple, we want to have a new, and edit page for project links. An index page is not needed.

Adds:

* Add routes (non-nested for now) for project_links
* Add controller
* Add crud views
* Auth via pundit

[#174422989]
https://www.pivotaltracker.com/story/show/174422989