### PR TITLE
174422943 — Handle missing cohort name in forms

### DIFF
--- a/rails/app/controllers/admin/cohorts_controller.rb
+++ b/rails/app/controllers/admin/cohorts_controller.rb
@@ -4,7 +4,7 @@ class Admin::CohortsController < ApplicationController
   before_filter :check_for_project
 
   # Note that we have to assign @projects even for create and update
-  # becuase they might render the edit or new templates (on vlidation error)
+  # because they might render the edit or new templates (on validation error)
   before_filter :get_scoped_projects, only: ['new', 'edit', 'create', 'update']
   before_filter :find_cohort, only: ['show', 'edit', 'update', 'destroy']
 

--- a/rails/app/controllers/admin/cohorts_controller.rb
+++ b/rails/app/controllers/admin/cohorts_controller.rb
@@ -2,7 +2,10 @@ class Admin::CohortsController < ApplicationController
   include RestrictedController
 
   before_filter :check_for_project
-  before_filter :get_scoped_projects, only: ['new', 'edit']
+
+  # Note that we have to assign @projects even for create and update
+  # becuase they might render the edit or new templates (on vlidation error)
+  before_filter :get_scoped_projects, only: ['new', 'edit', 'create', 'update']
   before_filter :find_cohort, only: ['show', 'edit', 'update', 'destroy']
 
   private

--- a/rails/spec/controllers/admin/cohorts_controller_spec.rb
+++ b/rails/spec/controllers/admin/cohorts_controller_spec.rb
@@ -6,6 +6,8 @@ RegexForAuthFailModify = /can not update the requested resource/
 
 describe Admin::CohortsController do
   before(:each) do
+    # This isn't required but silinces warnings in the console when running
+    generate_default_settings_and_jnlps_with_mocks
     allow(controller).to receive(:current_user).and_return(user)
     @cohort_1 = FactoryBot.create(:admin_cohort, name: 'cohort 1', project: project_1)
     @cohort_2 = FactoryBot.create(:admin_cohort, name: 'cohort 2', project: project_2)
@@ -85,6 +87,24 @@ describe Admin::CohortsController do
     before(:each) do
       user.add_role_for_project('admin', project_1)
     end
+    let(:project_id) { project_1.id }
+    let(:valid_params) do
+      {
+        admin_cohort: {
+          project_id: project_id,
+          name: 'name'
+        }
+      }
+    end
+
+    let(:invalid_params) do
+      {
+        admin_cohort: {
+          project_id: project_id,
+          name: nil
+        }
+      }
+    end
 
     describe 'GET index' do
       it 'can only see cohort 1' do
@@ -131,38 +151,69 @@ describe Admin::CohortsController do
 
     describe 'Edit' do
       before(:each) do
-        allow(Admin::Cohort).to receive(:find).and_return(@cohort1)
+        allow(Admin::Cohort).to receive(:find).and_return(@cohort_1)
       end
+
       it 'it should show the Edit form' do
         expect(get :edit).to render_template('edit')
-        # Redirect, and show error when not allowed:
       end
+
       it 'should display only the projects for which the user is an admin' do
         get :edit
         expect(assigns(:projects)).to include(project_1)
         expect(assigns(:projects)).not_to include(project_2)
         expect(assigns(:projects)).not_to include(project_3)
       end
+
       it 'should return an OK http status' do
+        get :edit
         expect(response).to have_http_status(:ok)
       end
     end
 
-    describe 'Create' do
-      let(:params) do
-        {
-          admin_cohort: {
-            project_id: project_id,
-            name: 'name'
-          }
-        }
+    describe 'Update' do
+      describe 'a project they are admin for' do
+        let(:project_id) { project_1.id }
+        before(:each) do
+          allow(Admin::Cohort).to receive(:find).and_return(@cohort_1)
+        end
+
+        describe 'when no name has been provided' do
+          let(:params) { invalid_params }
+
+          it 'should return an OK http status' do
+            post :update, params
+            expect(response).to have_http_status(:ok)
+          end
+
+          it 'should show an error on the name field' do
+            post :update, params
+            cohort = assigns[:admin_cohort]
+            expect(cohort.errors.messages[:name]).to include("can't be blank")
+          end
+
+          it 'should re-render the edit form' do
+            post :update, params
+            expect(response).to render_template('edit')
+          end
+
+          it 'should assign a projects dropdown list' do
+            post :update, params
+            expect(assigns[:projects]).not_to be_nil
+          end
+        end
       end
+    end
+
+
+    describe 'Create' do
+
       describe 'when creating a cohort for project 1 which they ARE admin for' do
         let(:project_id) { project_1.id }
         it 'it SHOULD let them' do
-          post :create, params
+          post :create, valid_params
           cohort = assigns(:admin_cohort)
-          expect(assigns(:admin_cohort)).to be_valid
+          expect(cohort).to be_valid
           expect(response).to redirect_to(admin_cohort_path(cohort))
         end
       end
@@ -170,10 +221,30 @@ describe Admin::CohortsController do
       describe 'when creating a cohort for project 2 (NOT their project)' do
         let(:project_id) { project_2.id }
         it 'it should NOT let them' do
-          post :create, params
+          post :create, valid_params
           # Redirect, and show error when not allowed:
           expect(response).to have_http_status(:redirect)
           expect(request.flash[:alert]).to match(RegexForAuthFailNew)
+        end
+      end
+
+      context 'with invalid parameters (missing name)' do
+        it 'it should display errors' do
+          post :create, invalid_params
+          cohort = assigns(:admin_cohort)
+          expect(cohort).not_to be_valid
+          expect(cohort.errors.messages[:name]).to include("can't be blank")
+        end
+
+        it 'it should re-render the new form' do
+          post :create, invalid_params
+          expect(response).to render_template('new')
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'the new form should assign a list of projects' do
+          post :create, invalid_params
+          expect(assigns(:projects)).not_to be_nil
         end
       end
     end
@@ -213,7 +284,6 @@ describe Admin::CohortsController do
     describe 'New' do
       it 'it should show the New form' do
         expect(get :new).to render_template('new')
-        # Redirect, and show error when not allowed:
         expect(response).to have_http_status(:ok)
       end
     end
@@ -236,6 +306,16 @@ describe Admin::CohortsController do
           expect(response).to redirect_to(admin_cohort_path(cohort))
         end
       end
+      describe 'for a cohort in project 2' do
+        let(:project_id) { project_2.id }
+        it 'should let them' do
+          post :create, params
+          cohort = assigns(:admin_cohort)
+          expect(assigns(:admin_cohort)).to be_valid
+          expect(response).to redirect_to(admin_cohort_path(cohort))
+        end
+      end
+    end
 
 
     describe 'New' do
@@ -256,7 +336,7 @@ describe Admin::CohortsController do
 
     describe 'Edit' do
       before(:each) do
-        allow(Admin::Cohort).to receive(:find).and_return(@cohort1)
+        allow(Admin::Cohort).to receive(:find).and_return(@cohort_1)
       end
       it 'it should show the Edit form' do
         expect(get :edit).to render_template('edit')
@@ -273,16 +353,7 @@ describe Admin::CohortsController do
       end
     end
 
-      describe 'for a cohort in project 2' do
-        let(:project_id) { project_2.id }
-        it 'should let them' do
-          post :create, params
-          cohort = assigns(:admin_cohort)
-          expect(assigns(:admin_cohort)).to be_valid
-          expect(response).to redirect_to(admin_cohort_path(cohort))
-        end
-      end
-    end
+
   end
 
   describe 'Nested controller methods' do

--- a/rails/spec/controllers/admin/cohorts_controller_spec.rb
+++ b/rails/spec/controllers/admin/cohorts_controller_spec.rb
@@ -6,7 +6,7 @@ RegexForAuthFailModify = /can not update the requested resource/
 
 describe Admin::CohortsController do
   before(:each) do
-    # This isn't required but silinces warnings in the console when running
+    # This isn't required but silences warnings in the console when running
     generate_default_settings_and_jnlps_with_mocks
     allow(controller).to receive(:current_user).and_return(user)
     @cohort_1 = FactoryBot.create(:admin_cohort, name: 'cohort 1', project: project_1)
@@ -391,4 +391,3 @@ describe Admin::CohortsController do
     end
   end
 end
-


### PR DESCRIPTION

The bug here was that the projects list, required by the form was not being setup when controller actions rendered other actions that didn't have the same before_filter (eg: the `update` action wasn't configured to run the `get_scoped_projects` filter, because it wouldn't have to (normally) render a drop-down list of projects.  But when a model fails validation we call `render :action 'edit'` -- this won't invoke the before_filters for the edit action howerver. 

We used to call redirect :action 'edit' which would invoke those before filters. 

The solution I chose was to run the `get_scoped_projects` before_action on the 'update' and 'create' actions too.

Added controller tests to cover this


[#174422943]
https://www.pivotaltracker.com/story/show/174422943