### PR TITLE
Fix validation for project-links

### DIFF
--- a/rails/app/controllers/admin/project_links_controller.rb
+++ b/rails/app/controllers/admin/project_links_controller.rb
@@ -2,7 +2,7 @@ class Admin::ProjectLinksController < ApplicationController
   include RestrictedController
 
   before_filter :check_for_project
-  before_filter :get_scoped_projects, only: ['new', 'edit']
+  before_filter :get_scoped_projects, only: ['new', 'edit', 'create', 'update']
   before_filter :find_project_link, only: ['show', 'edit', 'update', 'destroy']
 
 

--- a/rails/app/views/admin/project_links/_form.html.haml
+++ b/rails/app/views/admin/project_links/_form.html.haml
@@ -14,7 +14,7 @@
           URL:
           =f.text_field :href
         %li
-          Positon:
+          Position:
           =f.text_field :position
         %li
           Pop out:


### PR DESCRIPTION
Just as in the Cohorts:

* When field validation failed, we rendered the new/edit forms again in the update/create actions without first loading the list of projects.

* Fixed a typo in the form for 'position'