### PR TITLE
174405761 — Creating a new Image broken

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,10 @@ services:
       #
       REPORT_SERVICE_SOURCE: "app_lara_docker"
 
+      # Used by imagemagick to add attribution to the images in the image library
+      # the DejaVu-Sans font is provided by the docker image this one is built on
+      WATERMARK_FONT: "${WATERMARK_FONT:-DejaVu-Sans}"
+
     # open standard in and turn on tty so we can attach to the container and debug it
     stdin_open: true
     tty: true


### PR DESCRIPTION
* S3 is configured in [rails/docker/prod/config/aws_s3.yml](https://github.com/concord-consortium/rigse/blob/8b54741528526b5f65dc97dc4a17d49a1cb907ea/rails/docker/prod/config/aws_s3.yml#L4)

* These environment vars are configured in the [cloud formation template for portal](https://github.com/concord-consortium/cloud-formation/blob/f9e5b4b8b0adbcb78a33e83fa19ce15349244a09/portal-app-only.yml#L299-L304)

* But we also need to configure the WATERMARK_FONT
* It's specified in [The Dockerfile](https://github.com/concord-consortium/rigse/blob/0cc5002863615de0e86d8645361b3c9943c8e2db/rails/Dockerfile#L59) But apparently that is not enough, as a developer I had to also pass it in as an ENV variable for WATERMARK_FONT through Docker-compose.yml

* WATERMARK_FONT is specified in the [cloud formation template](https://github.com/concord-consortium/rigse/blob/0cc5002863615de0e86d8645361b3c9943c8e2db/rails/Dockerfile#L59),

And after closer inspection, images on staging  is working. See attachment in PT story.

[#174405761]
https://www.pivotaltracker.com/story/show/174405761