### PR TITLE
Fixed broken render on incomplete class setup form submit [#174605466]

### DIFF
--- a/rails/app/views/portal/clazzes/_form.html.haml
+++ b/rails/app/views/portal/clazzes/_form.html.haml
@@ -23,7 +23,7 @@
   PortalComponents.renderPortalClassSetupForm({
     portalClass: #{portal_clazz.to_json},
     portalClassGrades: #{portal_clazz.grades.map {|g| g.name}.to_json},
-    portalClassTeacher: #{portal_clazz.teacher ? {name: portal_clazz.teacher.name, id: portal_clazz.teacher.id}.to_json : nil},
+    portalClassTeacher: #{(portal_clazz.teacher ? {name: portal_clazz.teacher.name, id: portal_clazz.teacher.id} : nil).to_json},
     teachers: {
       current: #{current_teachers.to_json},
       unassigned: #{unassigned_teachers.to_json},


### PR DESCRIPTION
On an incomplete class setup form submit the portal class teacher was not being set which caused the haml to emit an empty string instead of null for the teacher info.