### PR TITLE
Add wait before entering search text in test [#174381940]

### DIFF
--- a/rails/features/teacher_searches_groups_and_previews_instructional_materials.feature
+++ b/rails/features/teacher_searches_groups_and_previews_instructional_materials.feature
@@ -132,6 +132,7 @@ Feature: Teacher can search instructional materials grouped by material type, so
     And I should not see "Geometry sequence"
     And I check "Sequence"
     And I uncheck "Activity"
+    And I wait 1 second
     When I enter search text "Radioactivity" on the search instructional materials page
     And I press "GO"
     And I wait 2 seconds


### PR DESCRIPTION
This fixes the existing search cucumber test.  This seems like a race condition in the change in the outer form value (which causes the input to re-render with initially empty suggestions) and the search text change.

I'm going to restart the Travis build for this PR 3 times to ensure this fixes the test break.