### PR TITLE
Upgrade gems to rails 4.0.13 [#174302547]

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -4,20 +4,22 @@ YAML::ENGINE.yamler= 'psych' if defined?(YAML::ENGINE)
 source 'http://rubygems.org'
 
 #### COMMON
-source 'https://gems.railslts.com' do
-  gem 'rails', '~> 3.2.22'
-  gem 'actionmailer',     require: false
-  gem 'activemodel',      require: false
-  gem 'actionpack',       require: false
-  gem 'activerecord',     require: false
-  gem 'activeresource',   require: false
-  gem 'activesupport',    require: false
-  gem 'railties',         require: false
-  gem 'railslts-version', require: false
-end
+# source 'https://gems.railslts.com' do
+  gem 'rails', '4.0.13'
+  # TODO: remove pinned versions of following block when done with upgrade
+  gem 'actionmailer',     '4.0.13', :require => false
+  gem 'actionpack',       '4.0.13', :require => false
+  gem 'activemodel',      '4.0.13', :require => false
+  gem 'activerecord',     '4.0.13', :require => false
+  # gem 'activeresource',   '4.0.13', :require => false
+  gem 'activesupport',    '4.0.13', :require => false
+  gem 'railties',         '4.0.13', :require => false
+  # gem 'railslts-version', '4.0.13', :require => false
+# end
 
 gem 'aasm', '~> 2.2.1'
-gem 'activerecord-import', '~> 0.2.8'
+gem 'activerecord-import'   # RAILS-4-SPIKE GEMFILE: "0.28.2"
+# gem "activerecord-session_store"  # RAILS-4-SPIKE GEMFILE: this was in the spike branch
 gem 'acts-as-taggable-on', '~> 2.4.1'
 gem 'acts_as_list', '~> 0.1.6'
 gem 'arrayfields'
@@ -31,9 +33,9 @@ gem 'aws-sdk',              '~> 3'
 # currently (2017-06-13) axlsx requires an older version of rubyzip,
 # hopefully this will shortly be remedied
 gem 'axlsx',                '> 2.5'
-gem 'coffee-rails' # if running rails 3.1 or greater
+gem 'coffee-rails',         "~> 4.0.0" # if running rails 3.1 or greater
 gem 'compass-blueprint'
-gem 'compass-rails', '~> 2.0.4'
+gem 'compass-rails'
 # was sub-dependency of react-rails, needed in test setup code
 gem 'connection_pool'
 gem 'daemons', '~> 1.1.8'
@@ -41,7 +43,7 @@ gem 'default_value_for', '~> 2.0.3'
 gem 'delayed_job', '~> 4.1.1'
 gem 'delayed_job_active_record', '~> 4.1.0'
 gem 'delayed_job_web'
-gem 'devise', '~>3.1.0'
+gem 'devise'  # RAILS-4-SPIKE GEMFILE: "~> 3.0.0"
 gem 'devise-encryptable'
 gem 'dynamic_form', '~> 1.1.4'
 gem 'exception_notification', '~> 2.5.2'
@@ -62,9 +64,10 @@ gem 'omniauth'
 gem 'omniauth-google-oauth2' # For google login integration.
 gem 'omniauth-oauth' # For schoology integration.
 gem 'open4',                '~> 1.0'
-gem 'paperclip',            '~> 3.4.0'
+gem 'paperclip'
 gem 'prawn',                '~> 0.12.0'
 gem 'prawn_rails',          '~> 0.0.6'
+# gem 'protected_attributes'  # RAILS-4-SPIKE GEMFILE: this was in the spike branch
 gem 'pundit'
 # cors is allowed for all groups because cors is always enabled for the interactives/export_model_library
 gem 'rack-cors', require: 'rack/cors'
@@ -78,15 +81,15 @@ gem 'rollbar'
 gem 'rubyzip',              '~> 1.2.2'
 gem 'rush',                 git: 'git://github.com/concord-consortium/rush'
 gem 'sanitize'
-gem 'sass'
+gem 'sass',                 '~> 3.4.0'
 gem 'sass-rails' # if running rails 3.1 or greater
-gem 'strong_parameters'
+# gem 'strong_parameters'  # RAILS-4-SPIKE GEMFILE REMOVE as part of rails 4.0 upgrade
 gem 'sunspot_rails'
 gem 'sunspot_solr' # optional pre-packaged Solr distribution
 gem 'syntax',               '~> 1.0'
 gem 'test-unit',            '~> 3.0'
-gem 'tinymce-rails',        '~>3.5.6'
-gem 'turbo-sprockets-rails3', '~> 0.3.6'
+gem 'tinymce-rails',        '~>3.5.6'  # RAILS-4-SPIKE GEMFILE version NOT pinned
+gem 'turbo-sprockets-rails4'
 # this customization is so the digests or fingerprints are correctly added to
 # the assets even when they are from a theme.
 gem 'themes_for_rails',
@@ -99,6 +102,9 @@ gem 'virtus',               '~>1.0.3'
 gem 'will_paginate',        '~> 3.0.0'
 gem 'yui-compressor'
 
+## Upgrade crutches:
+# gem "rails-observers"   # RAILS-4-SPIKE GEMFILE: this was in the spike branch
+
 # see above; for production asset compilation.
 # as per http://guides.rubyonrails.org/asset_pipeline.html#precompiling-assets
 # when compressing assets without a javascript runtime:
@@ -109,17 +115,17 @@ end
 
 # Feature enabling groups
 group :genigames_data do
-  gem 'genigames_connector', '0.0.4', git: 'git://github.com/concord-consortium/genigames-connector'
+  gem 'genigames_connector', git: 'git://github.com/concord-consortium/genigames-connector', branch: 'spike-rails4-support'
   # gem 'genigames_connector', path: '../genigames-connector'
 end
 group :geniverse_backend do
-  gem 'geniverse_portal_integration', git: 'git://github.com/concord-consortium/geniverse-portal-integration'
+  gem 'geniverse_portal_integration', git: 'git://github.com/concord-consortium/geniverse-portal-integration', branch: 'spike-rails4-support'
 end
 group :geniverse_remote_auth do
-  gem 'cc_portal_remote_auth', git: 'git://github.com/concord-consortium/cc_portal_remote_auth'
+  gem 'cc_portal_remote_auth', git: 'git://github.com/concord-consortium/cc_portal_remote_auth', branch: 'spike-rails4-support'
 end
 group :geniverse_wordpress do
-  gem 'cc_portal_wordpress_integration', git: 'git://github.com/concord-consortium/cc_portal_wordpress_integration'
+  gem 'cc_portal_wordpress_integration', git: 'git://github.com/concord-consortium/cc_portal_wordpress_integration', branch: 'spikes-rails4-support'
 end
 
 
@@ -142,7 +148,7 @@ group :development do
   gem 'spring', '~> 1.7.2'
   gem 'what_methods'
   gem 'wirble'
-  gem 'xray-rails', '~> 0.1.18' # shows rendered views in browser w cmd+shift+x
+  # gem 'xray-rails', '~> 0.1.18' # shows rendered views in browser w cmd+shift+x
 end
 
 group :test, :cucumber do

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -1,37 +1,41 @@
 GIT
   remote: git://github.com/concord-consortium/cc_portal_remote_auth
-  revision: a7fa776e705a27d47e73eeda0e5eaf21b117db64
+  revision: 03f5695f83c9c84dadfb965925e2f20058a6d35f
+  branch: spike-rails4-support
   specs:
-    cc_portal_remote_auth (0.0.3)
-      devise (~> 3.1.0)
-      rails (~> 3.2.11)
+    cc_portal_remote_auth (0.0.5)
+      devise (>= 3.0.0)
+      rails (> 3.2.11)
 
 GIT
   remote: git://github.com/concord-consortium/cc_portal_wordpress_integration
-  revision: 9ba1c324a1f8eb2e991b44bba7d28441ceedeb0f
+  revision: fa3e1f21e62b8950eed2c486d8a4bdab0be3915e
+  branch: spikes-rails4-support
   specs:
-    cc_portal_wordpress_integration (0.0.5)
-      devise (~> 3.1.0)
+    cc_portal_wordpress_integration (0.0.7)
+      devise (>= 3.0.0)
       haml (~> 4.0)
-      rails (~> 3.2.11)
+      rails (> 3.2.11)
 
 GIT
   remote: git://github.com/concord-consortium/genigames-connector
-  revision: d46d31cad789dd806377a8e28feecf387a9020ee
+  revision: 77fc52645b3280fe18f1f8383291e417bf362f82
+  branch: spike-rails4-support
   specs:
-    genigames_connector (0.0.4)
+    genigames_connector (0.0.5)
       haml (~> 4.0)
       json (~> 1.8.6)
-      rails (~> 3.2.11)
+      rails (> 3.2.11)
 
 GIT
   remote: git://github.com/concord-consortium/geniverse-portal-integration
-  revision: fec985b8a8086598ca70514ddba0b70c53f4a676
+  revision: f8b869a26523a280b70b6704aca7e009667fe4a6
+  branch: spike-rails4-support
   specs:
-    geniverse_portal_integration (0.0.7)
+    geniverse_portal_integration (0.0.8)
       haml (~> 4.0)
       json (~> 1.8.6)
-      rails (~> 3.2.19)
+      rails (> 3.2.19)
 
 GIT
   remote: git://github.com/concord-consortium/in_place_editing.git
@@ -64,7 +68,6 @@ GIT
 
 GEM
   remote: http://rubygems.org/
-  remote: https://gems.railslts.com/
   specs:
     Ascii85 (1.0.1)
     POpen4 (0.1.4)
@@ -74,41 +77,38 @@ GEM
     RedCloth (4.2.9)
     RedCloth (4.2.9-x86-mingw32)
     aasm (2.2.1)
-    actionmailer (3.2.22.19)
-      actionpack (= 3.2.22.19)
-      mail (~> 2.5.4)
-    actionpack (3.2.22.19)
-      activemodel (= 3.2.22.19)
-      activesupport (= 3.2.22.19)
-      builder (~> 3.0)
+    actionmailer (4.0.13)
+      actionpack (= 4.0.13)
+      mail (~> 2.5, >= 2.5.4)
+    actionpack (4.0.13)
+      activesupport (= 4.0.13)
+      builder (~> 3.1.0)
       erubis (~> 2.7.0)
-      journey (~> 1.0.4)
-      rack (~> 1.4.5)
-      rack-cache (~> 1.2)
-      rack-test (~> 0.6.1)
-      sprockets (= 2.2.3)
-    activemodel (3.2.22.19)
-      activesupport (= 3.2.22.19)
-      builder (~> 3.0)
-    activerecord (3.2.22.19)
-      activemodel (= 3.2.22.19)
-      activesupport (= 3.2.22.19)
-      arel (~> 3.0.2)
-      tzinfo (~> 0.3.29)
-    activerecord-import (0.2.9)
-      activerecord (~> 3.0)
-    activeresource (3.2.22.19)
-      activemodel (= 3.2.22.19)
-      activesupport (= 3.2.22.19)
-    activesupport (3.2.22.19)
-      i18n (~> 0.6, >= 0.6.4)
-      multi_json (~> 1.0)
+      rack (~> 1.5.2)
+      rack-test (~> 0.6.2)
+    activemodel (4.0.13)
+      activesupport (= 4.0.13)
+      builder (~> 3.1.0)
+    activerecord (4.0.13)
+      activemodel (= 4.0.13)
+      activerecord-deprecated_finders (~> 1.0.2)
+      activesupport (= 4.0.13)
+      arel (~> 4.0.0)
+    activerecord-deprecated_finders (1.0.4)
+    activerecord-import (1.0.6)
+      activerecord (>= 3.2)
+    activesupport (4.0.13)
+      i18n (~> 0.6, >= 0.6.9)
+      minitest (~> 4.2)
+      multi_json (~> 1.3)
+      thread_safe (~> 0.1)
+      tzinfo (~> 0.3.37)
     acts-as-taggable-on (2.4.1)
       rails (>= 3, < 5)
     acts_as_list (0.1.6)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    arel (3.0.3)
+    arel (4.0.2)
     arrayfields (4.7.4)
     awesome_print (1.0.2)
     aws-eventstream (1.0.1)
@@ -713,15 +713,11 @@ GEM
       nokogiri (~> 1.8, >= 1.8.2)
       rubyzip (~> 1.2, >= 1.2.1)
     backports (3.11.4)
-    bcrypt (3.1.15)
-    bcrypt-ruby (3.1.5)
-      bcrypt (>= 3.1.3)
-    bcrypt-ruby (3.1.5-x86-mingw32)
-      bcrypt (>= 3.1.3)
+    bcrypt (3.1.16)
     better_errors (1.1.0)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
-    builder (3.2.4)
+    builder (3.1.4)
     bullet (4.14.0)
       activesupport (>= 3.0.0)
       uniform_notifier (>= 1.6.0)
@@ -742,20 +738,22 @@ GEM
     childprocess (1.0.1)
       rake (< 13.0)
     chronic (0.10.2)
-    chunky_png (1.3.4)
+    chunky_png (1.3.12)
     ci_reporter (2.0.0)
       builder (>= 2.1.2)
-    cocaine (0.4.2)
+    climate_control (0.2.0)
+    cocaine (0.5.8)
+      climate_control (>= 0.0.3, < 1.0)
     coderay (1.1.2)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
-    coffee-rails (3.2.2)
+    coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
-      railties (~> 3.2.0)
+      railties (>= 4.0.0, < 5.0)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
-    coffee-script-source (1.9.1.1)
+    coffee-script-source (1.12.2)
     columnize (0.9.0)
     compass (1.0.3)
       chunky_png (~> 1.2)
@@ -771,10 +769,8 @@ GEM
       sass (>= 3.3.0, < 3.5)
     compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
-    compass-rails (2.0.4)
+    compass-rails (2.0.1)
       compass (~> 1.0.0)
-      sass-rails (<= 5.0.1)
-      sprockets (< 2.13)
     concurrent-ruby (1.1.7)
     connection_pool (2.2.2)
     crack (0.4.3)
@@ -819,10 +815,11 @@ GEM
       chronic
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    devise (3.1.2)
-      bcrypt-ruby (~> 3.0)
+    devise (3.5.10)
+      bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 3.2.6, < 5)
+      responders
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
     devise-encryptable (0.1.1)
@@ -845,8 +842,8 @@ GEM
     faraday (0.12.1)
       multipart-post (>= 1.2, < 3)
     fattr (2.2.1)
-    ffi (1.11.1)
-    ffi (1.11.1-x86-mingw32)
+    ffi (1.13.1)
+    ffi (1.13.1-x86-mingw32)
     font-awesome-rails (4.7.0.1)
       railties (>= 3.2, < 5.1)
     formatador (0.2.5)
@@ -878,7 +875,6 @@ GEM
     hashdiff (0.3.7)
     hashie (2.0.3)
     highline (1.6.15)
-    hike (1.2.3)
     hirb (0.6.2)
     htmlentities (4.3.4)
     http-cookie (1.0.3)
@@ -893,7 +889,6 @@ GEM
     interactive_editor (0.0.10)
       spoon (>= 0.0.1)
     jmespath (1.4.0)
-    journey (1.0.4)
     jquery-fileupload-rails (0.4.5)
       actionpack (>= 3.1)
       railties (>= 3.1)
@@ -917,9 +912,8 @@ GEM
       activerecord (>= 3.0)
       railties (>= 3.0)
     lumberjack (1.0.13)
-    mail (2.5.5)
-      mime-types (~> 1.16)
-      treetop (~> 1.4.8)
+    mail (2.7.1)
+      mini_mime (>= 0.1.1)
     mechanize (2.7.6)
       domain_name (~> 0.5, >= 0.5.1)
       http-cookie (~> 1.0)
@@ -934,6 +928,7 @@ GEM
     mimemagic (0.3.2)
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
+    minitest (4.7.5)
     multi_json (1.15.0)
     multi_test (0.1.2)
     multi_xml (0.5.1)
@@ -979,16 +974,15 @@ GEM
       omniauth (~> 1.0)
     open4 (1.3.0)
     orm_adapter (0.5.0)
-    paperclip (3.4.0)
-      activemodel (>= 3.0.0)
-      activerecord (>= 3.0.0)
-      activesupport (>= 3.0.0)
-      cocaine (~> 0.4.0)
+    paperclip (4.2.4)
+      activemodel (>= 3.2.0)
+      activesupport (>= 3.2.0)
+      cocaine (~> 0.5.5)
       mime-types
+    parallel (1.19.2)
     pdf-reader (1.1.1)
       Ascii85 (~> 1.0.0)
       ruby-rc4
-    polyglot (0.3.5)
     posix-spawn (0.3.6)
     power_assert (0.2.2)
     pr_geohash (1.0.0)
@@ -1007,43 +1001,34 @@ GEM
     public_suffix (3.0.3)
     pundit (1.0.1)
       activesupport (>= 3.0.0)
-    rack (1.4.7)
-    rack-cache (1.12.0)
-      rack (>= 0.4)
+    rack (1.5.5)
     rack-cors (0.2.9)
     rack-mini-profiler (0.9.2)
       rack (>= 1.1.3)
     rack-protection (1.5.3)
       rack
-    rack-ssl (1.3.4)
-      rack
     rack-test (0.6.3)
       rack (>= 1.0)
-    rails (3.2.22.19)
-      actionmailer (= 3.2.22.19)
-      actionpack (= 3.2.22.19)
-      activemodel (= 3.2.22.19)
-      activerecord (= 3.2.22.19)
-      activeresource (= 3.2.22.19)
-      activesupport (= 3.2.22.19)
-      bundler (~> 1.0)
-      railslts-version (= 3.2.22.19)
-      railties (= 3.2.22.19)
-    railslts-version (3.2.22.19)
-    railties (3.2.22.19)
-      actionpack (= 3.2.22.19)
-      activesupport (= 3.2.22.19)
-      rack-ssl (~> 1.3.2)
+    rails (4.0.13)
+      actionmailer (= 4.0.13)
+      actionpack (= 4.0.13)
+      activerecord (= 4.0.13)
+      activesupport (= 4.0.13)
+      bundler (>= 1.3.0, < 2.0)
+      railties (= 4.0.13)
+      sprockets-rails (~> 2.0)
+    railties (4.0.13)
+      actionpack (= 4.0.13)
+      activesupport (= 4.0.13)
       rake (>= 0.8.7)
-      rdoc (~> 3.4)
-      thor (>= 0.14.6, < 2.0)
+      thor (>= 0.18.1, < 2.0)
     raindrops (0.16.0)
     rake (0.9.6)
     rb-fchange (0.0.6)
       ffi
-    rb-fsevent (0.10.3)
-    rb-inotify (0.9.10)
-      ffi (>= 0.5.0, < 2)
+    rb-fsevent (0.10.4)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
     rbx-require-relative (0.0.9)
     rdoc (3.9.5)
     redcarpet (2.1.1)
@@ -1053,6 +1038,8 @@ GEM
     remarkable_activerecord (3.1.13)
       remarkable (~> 3.1.13)
       rspec (>= 1.2.0)
+    responders (1.1.2)
+      railties (>= 3.2, < 4.2)
     rollbar (2.15.5)
       multi_json
     rsolr (1.1.1)
@@ -1099,11 +1086,17 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.4.4)
       nokogumbo (= 1.4.1)
-    sass (3.3.14)
-    sass-rails (3.2.5)
-      railties (~> 3.2.0)
-      sass (>= 3.1.10)
-      tilt (~> 1.3)
+    sass (3.4.25)
+    sass-rails (6.0.0)
+      sassc-rails (~> 2.1, >= 2.1.1)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     selenium-webdriver (3.142.3)
       childprocess (>= 0.5, < 2.0)
       rubyzip (~> 1.2, >= 1.2.2)
@@ -1127,16 +1120,13 @@ GEM
       spring (>= 0.9.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
-    sprockets (2.2.3)
-      hike (~> 1.2)
-      multi_json (~> 1.0)
-      rack (~> 1.0)
-      tilt (~> 1.1, != 1.3.0)
-    strong_parameters (0.2.3)
-      actionpack (~> 3.0)
-      activemodel (~> 3.0)
-      activesupport (~> 3.0)
-      railties (~> 3.0)
+    sprockets (3.7.2)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
+    sprockets-rails (2.3.3)
+      actionpack (>= 3.0)
+      activesupport (>= 3.0)
+      sprockets (>= 2.8, < 4.0)
     sunspot (2.2.5)
       pr_geohash (~> 1.0)
       rsolr (~> 1.1.1)
@@ -1152,17 +1142,15 @@ GEM
       libv8 (~> 3.16.14.0)
       ref
     thor (1.0.1)
-    thread_safe (0.3.4)
+    thread_safe (0.3.6)
     tilt (1.4.1)
-    tinymce-rails (3.5.6)
+    tinymce-rails (3.5.11.1)
       railties (>= 3.1.1)
-    treetop (1.4.15)
-      polyglot
-      polyglot (>= 0.3.1)
     ttfunk (1.0.3)
-    turbo-sprockets-rails3 (0.3.6)
-      railties (> 3.2.8, < 4.0.0)
-      sprockets (>= 2.0.0)
+    turbo-sprockets-rails4 (1.2.5)
+      parallel (~> 1.0)
+      railties (>= 4)
+      sprockets (~> 3.0)
     tzinfo (0.3.57)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
@@ -1197,9 +1185,6 @@ GEM
     wirble (0.1.3)
     xpath (2.1.0)
       nokogiri (~> 1.3)
-    xray-rails (0.1.18)
-      coffee-rails
-      rails (>= 3.1.0)
     yui-compressor (0.9.6)
       POpen4 (>= 0.1.4)
 
@@ -1210,13 +1195,12 @@ PLATFORMS
 DEPENDENCIES
   RedCloth (~> 4.2.8)
   aasm (~> 2.2.1)
-  actionmailer!
-  actionpack!
-  activemodel!
-  activerecord!
-  activerecord-import (~> 0.2.8)
-  activeresource!
-  activesupport!
+  actionmailer (= 4.0.13)
+  actionpack (= 4.0.13)
+  activemodel (= 4.0.13)
+  activerecord (= 4.0.13)
+  activerecord-import
+  activesupport (= 4.0.13)
   acts-as-taggable-on (~> 2.4.1)
   acts_as_list (~> 0.1.6)
   arrayfields
@@ -1232,9 +1216,9 @@ DEPENDENCIES
   cc_portal_remote_auth!
   cc_portal_wordpress_integration!
   ci_reporter
-  coffee-rails
+  coffee-rails (~> 4.0.0)
   compass-blueprint
-  compass-rails (~> 2.0.4)
+  compass-rails
   connection_pool
   cucumber
   cucumber-rails
@@ -1246,14 +1230,14 @@ DEPENDENCIES
   delayed_job_active_record (~> 4.1.0)
   delayed_job_web
   delorean
-  devise (~> 3.1.0)
+  devise
   devise-encryptable
   dynamic_form (~> 1.1.4)
   email_spec
   exception_notification (~> 2.5.2)
   factory_bot
   font-awesome-rails
-  genigames_connector (= 0.0.4)!
+  genigames_connector!
   geniverse_portal_integration!
   grit (~> 2.4)
   guard
@@ -1281,7 +1265,7 @@ DEPENDENCIES
   omniauth-google-oauth2
   omniauth-oauth
   open4 (~> 1.0)
-  paperclip (~> 3.4.0)
+  paperclip
   prawn (~> 0.12.0)
   prawn_rails (~> 0.0.6)
   pry
@@ -1290,9 +1274,8 @@ DEPENDENCIES
   rack-cors
   rack-mini-profiler
   rack-secure_samesite_cookies!
-  rails (~> 3.2.22)!
-  railslts-version!
-  railties!
+  rails (= 4.0.13)
+  railties (= 4.0.13)
   rake (~> 0.9.2)
   rb-fchange
   rb-fsevent
@@ -1310,7 +1293,7 @@ DEPENDENCIES
   rubyzip (~> 1.2.2)
   rush!
   sanitize
-  sass
+  sass (~> 3.4.0)
   sass-rails
   selenium-webdriver
   sextant
@@ -1318,7 +1301,6 @@ DEPENDENCIES
   spring (~> 1.7.2)
   spring-commands-cucumber
   spring-commands-rspec
-  strong_parameters
   sunspot_rails
   sunspot_solr
   syntax (~> 1.0)
@@ -1326,7 +1308,7 @@ DEPENDENCIES
   themes_for_rails!
   therubyracer (~> 0.12.1)
   tinymce-rails (~> 3.5.6)
-  turbo-sprockets-rails3 (~> 0.3.6)
+  turbo-sprockets-rails4
   uglifier
   unicorn
   useragent
@@ -1337,7 +1319,6 @@ DEPENDENCIES
   what_methods
   will_paginate (~> 3.0.0)
   wirble
-  xray-rails (~> 0.1.18)
   yui-compressor
 
 BUNDLED WITH


### PR DESCRIPTION
After comparing the Gemfile with the one in the spike branch and updating the version numbers in the file I ran the following:

```
bundle update rails actionmailer actionpack activemodel activerecord activesupport railties activerecord-import coffee-rails compass-rails devise paperclip sass tinymce-rails genigames_connector geniverse_portal_integration cc_portal_remote_auth cc_portal_wordpress_integration
```