### PR TITLE
Added protected_attributes gem [#174261083]

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -67,7 +67,7 @@ gem 'open4',                '~> 1.0'
 gem 'paperclip'
 gem 'prawn',                '~> 0.12.0'
 gem 'prawn_rails',          '~> 0.0.6'
-#gem 'protected_attributes'
+gem 'protected_attributes'
 gem 'pundit'
 # cors is allowed for all groups because cors is always enabled for the interactives/export_model_library
 gem 'rack-cors', require: 'rack/cors'

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -1000,6 +1000,8 @@ GEM
     prawn_rails (0.0.8)
       prawn (>= 0.11.1)
       rails (>= 3.0.0)
+    protected_attributes (1.1.4)
+      activemodel (>= 4.0.1, < 5.0)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -1274,6 +1276,7 @@ DEPENDENCIES
   paperclip
   prawn (~> 0.12.0)
   prawn_rails (~> 0.0.6)
+  protected_attributes
   pry
   pry-byebug
   pundit


### PR DESCRIPTION
This re-enables attr_accessible.  This will need to be addressed again in the Rails 5 upgrade.