### PR TITLE
174913441 — has_many `order` scopes

### DIFF
--- a/rails/app/models/activity.rb
+++ b/rails/app/models/activity.rb
@@ -17,7 +17,7 @@ class Activity < ActiveRecord::Base
 
   has_many :external_activities, :as => :template
 
-  has_many :sections, :order => :position, :dependent => :destroy do
+  has_many :sections, -> { order :position }, :dependent => :destroy do
     def student_only
       where('teacher_only' => false)
     end

--- a/rails/app/models/dataservice/bucket_logger.rb
+++ b/rails/app/models/dataservice/bucket_logger.rb
@@ -2,8 +2,9 @@ class Dataservice::BucketLogger < ActiveRecord::Base
   attr_accessible :learner, :learner_id
 
   belongs_to :learner, :class_name => "Portal::Learner", :foreign_key => "learner_id"
-  has_many :bucket_contents, :dependent => :destroy ,:class_name => "Dataservice::BucketContent", :foreign_key => 'bucket_logger_id', :order => :updated_at
-  has_many :bucket_log_items, :dependent => :destroy, :class_name => "Dataservice::BucketLogItem", :foreign_key => 'bucket_logger_id', :order => :updated_at
+  has_many :bucket_contents, -> { order :updated_at }, :dependent => :destroy ,:class_name => "Dataservice::BucketContent", :foreign_key => 'bucket_logger_id'
+
+  has_many :bucket_log_items, -> { order :updated_at }, :dependent => :destroy, :class_name => "Dataservice::BucketLogItem", :foreign_key => 'bucket_logger_id'
 
   def most_recent_content
     # don't use .last because that has weird interactions with has_many

--- a/rails/app/models/dataservice/bundle_content.rb
+++ b/rails/app/models/dataservice/bundle_content.rb
@@ -12,7 +12,10 @@ class Dataservice::BundleContent < ActiveRecord::Base
   belongs_to :collaboration, :class_name => "Portal::Collaboration"
   has_many :collaborators, :through => :collaboration, :class_name => "Portal::Student", :source => :students
 
-  has_many :launch_process_events, :dependent => :destroy, :class_name => "Dataservice::LaunchProcessEvent", :foreign_key => "bundle_content_id", :order => "id ASC"
+  has_many :launch_process_events, -> { order :id },
+    dependent: :destroy,
+    class_name: "Dataservice::LaunchProcessEvent",
+    foreign_key: "bundle_content_id"
 
   acts_as_list :scope => :bundle_logger_id
 

--- a/rails/app/models/dataservice/bundle_logger.rb
+++ b/rails/app/models/dataservice/bundle_logger.rb
@@ -3,14 +3,13 @@ class Dataservice::BundleLogger < ActiveRecord::Base
 
   has_one    :learner, :class_name => "Portal::Learner"
   belongs_to :in_progress_bundle, :class_name => "Dataservice::BundleContent"
-  has_many   :bundle_contents, :class_name => "Dataservice::BundleContent", :order => :position, :dependent => :destroy
+  has_many   :bundle_contents, -> {order :position}, :class_name => "Dataservice::BundleContent", :dependent => :destroy
 
-  has_many :launch_process_events, :class_name => "Dataservice::LaunchProcessEvent", :through => :bundle_contents, :order => "id ASC"
+  has_many :launch_process_events, -> {order 'id ASC'}, :class_name => "Dataservice::LaunchProcessEvent", :through => :bundle_contents
 
-  has_one :last_non_empty_bundle_content,
+  has_one :last_non_empty_bundle_content, -> { order 'position DESC'},
     :class_name => "Dataservice::BundleContent",
     :conditions => "empty is false and valid_xml is true",
-    :order => 'position DESC'
 
   OPEN_ELEMENT_EPORTFOLIO = "<sailuserdata:EPortfolio xmi:version=\"2.0\" xmlns:xmi=\"http://www.omg.org/XMI\" xmlns:sailuserdata=\"sailuserdata\">\n"
   CLOSE_ELEMENT_EPORTFOLIO = "\n</sailuserdata:EPortfolio>"

--- a/rails/app/models/dataservice/console_logger.rb
+++ b/rails/app/models/dataservice/console_logger.rb
@@ -2,10 +2,11 @@ class Dataservice::ConsoleLogger < ActiveRecord::Base
   self.table_name = :dataservice_console_loggers
   
   has_one  :learner, :class_name => "Portal::Learner"
-  has_many :console_contents, :class_name => "Dataservice::ConsoleContent", :order => :position, :dependent => :destroy
-  has_one :last_console_content, 
+  has_many :console_contents, -> { order :position },
     :class_name => "Dataservice::ConsoleContent",
-    :order => 'position DESC' 
+    :dependent => :destroy
+  has_one :last_console_content, -> { order 'position DESC' }
+    :class_name:  "Dataservice::ConsoleContent"
 
   include Changeable
 
@@ -16,7 +17,7 @@ class Dataservice::ConsoleLogger < ActiveRecord::Base
   self.extend SearchableModel
   
   @@searchable_attributes = %w{updated_at}
-  
+
   class <<self
     def searchable_attributes
       @@searchable_attributes

--- a/rails/app/models/dataservice/periodic_bundle_logger.rb
+++ b/rails/app/models/dataservice/periodic_bundle_logger.rb
@@ -4,8 +4,13 @@ class Dataservice::PeriodicBundleLogger < ActiveRecord::Base
   serialize :imports
 
   belongs_to :learner, :class_name => "Portal::Learner"
-  has_many :periodic_bundle_contents, :class_name => "Dataservice::PeriodicBundleContent", :order => :created_at, :dependent => :destroy
-  has_many :periodic_bundle_parts, :class_name => "Dataservice::PeriodicBundlePart", :order => :created_at, :dependent => :destroy
+  has_many :periodic_bundle_contents, -> { order :created_at },
+    class_name: "Dataservice::PeriodicBundleContent",
+    dependent: :destroy
+
+  has_many :periodic_bundle_parts, -> { order :created_at },
+    class_name: "Dataservice::PeriodicBundlePart",
+    dependent: :destroy
 
   ## FIXME How do we handle launch process events?
 

--- a/rails/app/models/investigation.rb
+++ b/rails/app/models/investigation.rb
@@ -5,7 +5,7 @@ class Investigation < ActiveRecord::Base
   include Archiveable
 
   belongs_to :user
-  has_many :activities, :order => :position, :dependent => :destroy do
+  has_many :activities, -> { order :position }, :dependent => :destroy do
     def student_only
       where('teacher_only' => false)
     end

--- a/rails/app/models/page.rb
+++ b/rails/app/models/page.rb
@@ -12,7 +12,8 @@ class Page < ActiveRecord::Base
 
   # Order by ID is important, see: https://www.pivotaltracker.com/story/show/79237764
   # Some older elements in DB can have always position equal to 1.
-  has_many :page_elements, :order => 'position ASC, id ASC', :dependent => :destroy
+  has_many :page_elements, -> { order 'position ASC, id ASC' },
+    dependent: :destroy
 
   # The array of embeddables is defined in conf/initializers/embeddables.rb
   # The order of this array determines the order they show up in the Add menu

--- a/rails/app/models/portal/clazz.rb
+++ b/rails/app/models/portal/clazz.rb
@@ -5,10 +5,14 @@ class Portal::Clazz < ActiveRecord::Base
 
   belongs_to :course, :class_name => "Portal::Course", :foreign_key => "course_id"
 
+  has_many :offerings, -> { order :position },
+    dependent: :destroy,
+    class_name: 'Portal::Offering',
+    foreign_key: 'clazz_id'
 
-  has_many :offerings, :dependent => :destroy, :class_name => "Portal::Offering", :foreign_key => "clazz_id",
-    :order => :position
-  has_many :active_offerings, -> { where active: true }, :class_name => "Portal::Offering", :foreign_key => 'clazz_id', :order => :position
+  has_many :active_offerings, -> { where(active: true).order(:position) },
+    class_name: 'Portal::Offering',
+    foreign_key: 'clazz_id'
 
   has_many :student_clazzes, :dependent => :destroy, :class_name => "Portal::StudentClazz", :foreign_key => "clazz_id"
   has_many :students, :through => :student_clazzes, :class_name => "Portal::Student"

--- a/rails/app/models/portal/district.rb
+++ b/rails/app/models/portal/district.rb
@@ -3,7 +3,11 @@ class Portal::District < ActiveRecord::Base
 
   acts_as_replicatable
 
-  has_many :schools, :dependent => :destroy, :class_name => "Portal::School", :foreign_key => "district_id", :order => "name"
+  has_many :schools, -> { order :name },
+    dependent: :destroy,
+    class_name: 'Portal::School',
+    foreign_key: 'district_id'
+
   belongs_to :nces_district, :class_name => "Portal::Nces06District", :foreign_key => "nces_district_id"
 
   scope :real,    -> { where('nces_district_id is NOT NULL').includes(:schools).order("name") }

--- a/rails/app/models/saveable/external_link.rb
+++ b/rails/app/models/saveable/external_link.rb
@@ -6,7 +6,9 @@ class Saveable::ExternalLink < ActiveRecord::Base
 
   belongs_to :embeddable,  :polymorphic => true
 
-  has_many :answers, :dependent => :destroy ,:order => :position, :class_name => "Saveable::ExternalLinkUrl"
+  has_many :answers, -> { order :position },
+    dependent: :destroy,
+    class_name: 'Saveable::ExternalLinkUrl'
 
   delegate :name, :to => :embeddable
 

--- a/rails/app/models/saveable/image_question.rb
+++ b/rails/app/models/saveable/image_question.rb
@@ -6,7 +6,9 @@ class Saveable::ImageQuestion < ActiveRecord::Base
 
   belongs_to :image_question,  :class_name => 'Embeddable::ImageQuestion'
 
-  has_many :answers, :dependent => :destroy, :order => :position, :class_name => "Saveable::ImageQuestionAnswer"
+  has_many :answers, -> { order :position },
+    :dependent => :destroy,
+    :class_name => "Saveable::ImageQuestionAnswer"
 
 
   [:prompt, :name, :drawing_prompt].each { |m| delegate m, :to => :image_question, :class_name => 'Embeddable::ImageQuestion' }

--- a/rails/app/models/saveable/interactive.rb
+++ b/rails/app/models/saveable/interactive.rb
@@ -6,7 +6,9 @@ class Saveable::Interactive < ActiveRecord::Base
 
   belongs_to :iframe,  :class_name => 'Embeddable::Iframe'
 
-  has_many :answers, :dependent => :destroy ,:order => :position, :class_name => "Saveable::InteractiveState"
+  has_many :answers, -> { order :position },
+    :dependent => :destroy,
+    :class_name => "Saveable::InteractiveState"
 
   delegate :name, :to => :iframe
 

--- a/rails/app/models/saveable/multiple_choice.rb
+++ b/rails/app/models/saveable/multiple_choice.rb
@@ -6,7 +6,9 @@ class Saveable::MultipleChoice < ActiveRecord::Base
 
   belongs_to :multiple_choice,  :class_name => 'Embeddable::MultipleChoice'
 
-  has_many :answers, :dependent => :destroy , :order => :position, :class_name => "Saveable::MultipleChoiceAnswer"
+  has_many :answers, -> { order :position },
+    :dependent => :destroy,
+    :class_name => "Saveable::MultipleChoiceAnswer"
 
   [ :prompt,
     :name,

--- a/rails/app/models/saveable/multiple_choice_answer.rb
+++ b/rails/app/models/saveable/multiple_choice_answer.rb
@@ -4,7 +4,10 @@ class Saveable::MultipleChoiceAnswer < ActiveRecord::Base
   belongs_to :multiple_choice,  :class_name => 'Saveable::MultipleChoice', :counter_cache => :response_count
   belongs_to :bundle_content, :class_name => 'Dataservice::BundleContent'
 
-  has_many :rationale_choices, :order => :choice_id, :class_name => 'Saveable::MultipleChoiceRationaleChoice', :foreign_key => :answer_id, :dependent => :destroy
+  has_many :rationale_choices, -> { order :choice_id },
+    :class_name => 'Saveable::MultipleChoiceRationaleChoice',
+    :foreign_key => :answer_id,
+    :dependent => :destroy
 
   acts_as_list :scope => :multiple_choice_id
 

--- a/rails/app/models/saveable/open_response.rb
+++ b/rails/app/models/saveable/open_response.rb
@@ -6,11 +6,10 @@ class Saveable::OpenResponse < ActiveRecord::Base
 
   belongs_to :open_response,  :class_name => 'Embeddable::OpenResponse'
 
-  has_many :answers, :dependent => :destroy ,:order => :position, :class_name => "Saveable::OpenResponseAnswer"
+  has_many :answers, -> { order :position },
+    :dependent => :destroy
+    :class_name => "Saveable::OpenResponseAnswer"
 
-  # has_one :answer,
-  #   :class_name => "Saveable::OpenResponseAnswer",
-  #   :order => 'position DESC'
 
   [:prompt, :name].each { |m| delegate m, :to => :open_response, :class_name => 'Embeddable::OpenResponse' }
 

--- a/rails/app/models/saveable/sparks/measuring_resistance.rb
+++ b/rails/app/models/saveable/sparks/measuring_resistance.rb
@@ -4,7 +4,8 @@ class Saveable::Sparks::MeasuringResistance < ActiveRecord::Base
   belongs_to :learner, :class_name => 'Portal::Learner'
   belongs_to :offering,        :class_name => 'Portal::Offering'
 
-  has_many :reports, :order => :position, :class_name => "Saveable::Sparks::MeasuringResistanceReports"
+  has_many :reports, -> { order :position },
+    :class_name => "Saveable::Sparks::MeasuringResistanceReports"
 
   def answer
     self.reports.last.answer

--- a/rails/app/models/section.rb
+++ b/rails/app/models/section.rb
@@ -10,7 +10,7 @@ class Section < ActiveRecord::Base
 
   has_one :investigation, :through => :activity
 
-  has_many :pages ,:order => :position, :dependent => :destroy do
+  has_many :pages, -> { order :position}, :dependent => :destroy do
     def student_only
       where('teacher_only' => false)
     end


### PR DESCRIPTION
Active Record 4 has_many no longer supports the :order parameter. Instead ordering has to happen in the scope with a lambda.

[#174913441]
https://www.pivotaltracker.com/story/show/174913441