### PR TITLE
174913930 — Remove compass: fixes sass bug

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -34,8 +34,8 @@ gem 'aws-sdk',              '~> 3'
 # hopefully this will shortly be remedied
 gem 'axlsx',                '> 2.5'
 gem 'coffee-rails',         "~> 4.0.0" # if running rails 3.1 or greater
-gem 'compass-blueprint'
-gem 'compass-rails'
+# gem 'compass-blueprint'
+# gem 'compass-rails'
 # was sub-dependency of react-rails, needed in test setup code
 gem 'connection_pool'
 gem 'daemons', '~> 1.1.8'
@@ -90,7 +90,8 @@ gem 'sunspot_solr' # optional pre-packaged Solr distribution
 gem 'syntax',               '~> 1.0'
 gem 'test-unit',            '~> 3.0'
 gem 'tinymce-rails',        '~>3.5.6'  # RAILS-4-SPIKE GEMFILE version NOT pinned
-gem 'turbo-sprockets-rails4'
+# gem 'turbo-sprockets-rails4'
+gem 'sprockets-rails', :require => 'sprockets/railtie'
 # this customization is so the digests or fingerprints are correctly added to
 # the assets even when they are from a theme.
 gem 'themes_for_rails',

--- a/rails/app/assets/stylesheets/no-compass.scss
+++ b/rails/app/assets/stylesheets/no-compass.scss
@@ -1,0 +1,18 @@
+@mixin clearfix(){
+  &:before,
+  &:after{
+    content: " "; 
+    display: table; 
+  }
+
+  &:after{
+    display: block;
+    clear: both;
+    height: 1px;
+    margin-top: -1px;
+    visibility: hidden;
+  }
+  &{
+    *zoom: 1;
+  }
+}

--- a/rails/app/assets/stylesheets/print.scss
+++ b/rails/app/assets/stylesheets/print.scss
@@ -1,6 +1,6 @@
-@import "compass/reset";
-@import "blueprint";
-@include blueprint-typography;
+// @import "compass/reset";
+// @import "blueprint";
+// @include blueprint-typography;
 
 h1, h2, h3, h4, h5, h6 {
   margin: 0 0 0.25em 0; }

--- a/rails/app/assets/stylesheets/screen.scss
+++ b/rails/app/assets/stylesheets/screen.scss
@@ -3,4 +3,4 @@
  * Import this file using the following HTML or equivalent:
  * <link href="/stylesheets/screen.css" media="screen, projection" rel="stylesheet" type="text/css" /> */
 
-@import "compass/reset";
+// @import "compass/reset";

--- a/rails/app/assets/stylesheets/web/action_menu_tab.scss
+++ b/rails/app/assets/stylesheets/web/action_menu_tab.scss
@@ -1,5 +1,5 @@
 @import "app_colors";
-@import "compass";
+@import "no-compass";
 /* @import "compass/utilities/general/clearfix"; */
 
 @mixin action_menu_tab($_color: #111111, $_bg_color: $rieps_content_text_color, $_color_hover: white, $_bg_color_hover: black) {

--- a/rails/app/assets/stylesheets/web/app.scss
+++ b/rails/app/assets/stylesheets/web/app.scss
@@ -1,4 +1,4 @@
-@import "compass";
+@import "no-compass";
 /* browser reset */
 
 body, div, h1, h2, h3, h4, h5, h6, p, ul, ol, li, dl, dd, dt, blockquote, button, fieldset, legend, label, input, textarea, form {
@@ -1495,7 +1495,7 @@ ul.quiet_list {
   font: 12px / 1 Arial, Helvetica, sans-serif;
   padding: 4px 5px;
   /* CSS 3 */
-  @include background-image(linear-gradient(#f3951d, #dd6e0d));
+  background-image: linear-gradient(#f3951d, #dd6e0d);
   _background: #f6f2e2;
   border-radius: 12px;
   /* Opera 10.5, IE 9 */

--- a/rails/app/assets/stylesheets/web/instructional_materials.scss
+++ b/rails/app/assets/stylesheets/web/instructional_materials.scss
@@ -1,4 +1,4 @@
-@import "compass";
+// @import "compass";
 
 .scrollertab{
   padding:5px 2px 5px 2px;
@@ -19,7 +19,7 @@
 }
 
 .tab{
-  @include background-image(linear-gradient(#fff, #aaa));
+  background-image: linear-gradient(#fff, #aaa);
   -moz-border-radius: 8px 8px 0px 0px; -webkit-border-radius: 8px 8px 0px 0px;-khtml-border-radius: 8px 8px 0px 0px;border-radius: 8px 8px 0px 0px;
   padding:5px;
   border:solid 1px #666;
@@ -30,7 +30,7 @@
 }
 
 .selected_tab{
-  @include background-image(linear-gradient(#999, #666));
+  background-image: linear-gradient(#999, #666);
   -moz-border-radius:  8px 8px 0px 0px; -webkit-border-radius:  8px 8px 0px 0px;-khtml-border-radius:  8px 8px 0px 0px;border-radius:  8px 8px 0px 0px;
   padding:5px;
   border:solid 1px #666;
@@ -123,7 +123,7 @@
   font: 12px / 1 Arial, Helvetica, sans-serif;
   padding: 4px 14px;
   /* CSS 3 */
-  @include background-image(linear-gradient(#f3951d, #dd6e0d));
+  background-image: linear-gradient(#f3951d, #dd6e0d);
   border-radius: 12px;
   /* Opera 10.5, IE 9 */
   -moz-border-radius: 12px;

--- a/rails/app/stylesheets/screen.scss
+++ b/rails/app/stylesheets/screen.scss
@@ -1,6 +1,2 @@
-/* Welcome to Compass.
- * In this file you should write your main styles. (or centralize your imports)
- * Import this file using the following HTML or equivalent:
- * <link href="/stylesheets/screen.css" media="screen, projection" rel="stylesheet" type="text/css" /> */
-
-@import "compass/reset"
+// 2020-09-21  NP : We arent using compass any more
+// @import "compass/reset"


### PR DESCRIPTION
This PR gets us past this error:

/bundle/gems/sassc-rails-2.1.2/lib/sassc/rails/importer.rb:103:in `join': no implicit conversion of Sass::Importers::Filesystem into String (TypeError)

All of our compass usage was limited to `clearfix`, `background-image`, and `reset`.  
* `clearfix()` — I put in a replacement mixin, this hasn't been well tested.
* `background-image()` — this just works now in CSS 3
* `reset()` — We actually do a manual browser reset in `app.scss`, so probably the compass version wasn't necessary.

I left comments related to compass in the code to help us hunt down any possible CSS issues we might find.

[#174913930]
https://www.pivotaltracker.com/story/show/174913930