### PR TITLE
174935633 — view template resolving with themes_on_rails

### DIFF
--- a/rails/app/controllers/application_controller.rb
+++ b/rails/app/controllers/application_controller.rb
@@ -85,22 +85,11 @@ class ApplicationController < ActionController::Base
   end
 
   theme :get_theme
-
+  layout 'application'
   def test
     render :text => mce_in_place_tag(Page.create,'description','none')
   end
 
-  def self.set_theme(name)
-    @@theme = name
-  end
-
-  def get_theme
-    @@theme ||= ( APP_CONFIG[:theme] || 'default' )
-  end
-
-  def self.get_theme
-    @@theme ||= ( APP_CONFIG[:theme] || 'default' )
-  end
 
   # helper :all # include all helpers, all the time
   rescue_from ActiveRecord::RecordNotFound, :with => :record_not_found
@@ -354,4 +343,16 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  private
+  def self.set_theme(name)
+    @@theme = name
+  end
+
+  def get_theme
+    @@theme ||= ( APP_CONFIG[:theme] || 'default' )
+  end
+
+  def self.get_theme
+    @@theme ||= ( APP_CONFIG[:theme] || 'default' )
+  end
 end

--- a/rails/app/controllers/help_controller.rb
+++ b/rails/app/controllers/help_controller.rb
@@ -1,5 +1,4 @@
 class HelpController < ApplicationController
-  theme "rites"
 
   def get_help_page(help_type)
     case help_type

--- a/rails/app/controllers/home_controller.rb
+++ b/rails/app/controllers/home_controller.rb
@@ -9,8 +9,6 @@ class HomeController < ApplicationController
 
   public
 
-  theme "rites"
-
   def index
     homePage = HomePage.new(current_visitor, current_settings)
     flash.keep


### PR DESCRIPTION
This fixes issues with missing layouts when using themes_on_rails.

The theme attempts to set the layout for the application controllers to the current theme name. See:
https://github.com/chamnap/themes_on_rails/blob/master/lib/themes_on_rails/action_controller.rb

To change this behavior we set the layout in ApplicationController to 'application'

@scytacki @emcelroy do you think that we could or should remove theme support completely from the portal? 

Also, this PR removes places where the theme was manually set to 'rites' which isn't actually a defined theme anymore.

[#174935633]
https://www.pivotaltracker.com/story/show/174935633