### PR TITLE
174934889 — rm best_standards_support

### DIFF
--- a/rails/config/environments/development.rb
+++ b/rails/config/environments/development.rb
@@ -24,8 +24,6 @@ RailsPortal::Application.configure do
   # Print deprecation notices to the Rails logger
   config.active_support.deprecation = :log
 
-  # Only use best-standards-support built into browsers
-  config.action_dispatch.best_standards_support = :builtin
 
   #### Asset Pipeline:  #####
 


### PR DESCRIPTION
As per:
https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#action-pack

> Also check your environment settings for config.action_dispatch.best_standards_support and remove it if present.

[#174934889]
https://www.pivotaltracker.com/story/show/174934889