### PR TITLE
174935098 — asset packaging changes

### DIFF
--- a/rails/config/environments/development.rb
+++ b/rails/config/environments/development.rb
@@ -29,8 +29,6 @@ RailsPortal::Application.configure do
 
   #### Asset Pipeline:  #####
 
-  # Minify/uglify/compress assets from the pipeline
-  config.assets.compress = false
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation can not be found)

--- a/rails/config/environments/production.rb
+++ b/rails/config/environments/production.rb
@@ -60,7 +60,6 @@ RailsPortal::Application.configure do
   config.assets.compile = true
 
   # Minify/uglify/compress assets from the pipeline
-  config.assets.compress = true
   config.assets.js_compressor = :uglifier
   config.assets.css_compressor = :yui
 

--- a/rails/script/travis_before_script
+++ b/rails/script/travis_before_script
@@ -18,6 +18,6 @@ bundle exec spring binstub --all
 ./bin/rake db:migrate
 ./bin/rake db:test:prepare
 ./bin/rake db:feature_test:prepare
-RAILS_GROUPS=assets ./bin/rake assets:precompile:all
+RAILS_GROUPS=assets ./bin/rake assets:precompile
 RAILS_ENV=test ./bin/rake sunspot:solr:start &
 sleep 10 # give SOLR some time to start and init


### PR DESCRIPTION
change: `assets:precompile:all` to `assets:precompile`

also:

> The `config.assets.compress` option should be changed to `config.assets.js_compressor` like so for instance:
`config.assets.js_compressor = :uglifier`

As per the guide: https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#sprockets-rails

[#174935098]
https://www.pivotaltracker.com/story/show/174935098