### PR TITLE
174934840 —  update `:confirm` link_to options

### DIFF
--- a/rails/app/views/admin/permission_forms/_permission_forms.html.haml
+++ b/rails/app/views/admin/permission_forms/_permission_forms.html.haml
@@ -28,4 +28,4 @@
                 %span.delete
                   =link_to "✖",
                     remove_form_admin_permission_form_path(perm),
-                    :confirm => raw("Delete Permission Form?&#10;&#10;WARNING: All related student permissions will be removed and researchers will no longer be able to view the students' data in reports if you delete this form.")
+                    data: {:confirm => raw("Delete Permission Form?&#10;&#10;WARNING: All related student permissions will be removed and researchers will no longer be able to view the students' data in reports if you delete this form.")}

--- a/rails/app/views/images/show.html.haml
+++ b/rails/app/views/images/show.html.haml
@@ -40,5 +40,5 @@
   - if @image.changeable?(current_visitor)
     = button_to 'Edit', edit_image_path(@image), :method => :get
     - unless @image.public?
-      = button_to "Delete", image_path(@image), :method => :delete, :confirm => "are you sure?"
+      = button_to "Delete", image_path(@image), :method => :delete, data: {:confirm => "are you sure?"}
   = button_to 'List', images_path, :method => :get

--- a/rails/app/views/portal/nces06_districts/index.html.erb
+++ b/rails/app/views/portal/nces06_districts/index.html.erb
@@ -8,7 +8,7 @@
   <tr>
     <td><%= link_to 'Show', nces06_district %></td>
     <td><%= link_to 'Edit', edit_portal_nces06_district_path(nces06_district) %></td>
-    <td><%= link_to 'Destroy', nces06_district, :confirm => 'Are you sure?', :method => :delete %></td>
+    <td><%= link_to 'Destroy', nces06_district, data: { :confirm => 'Are you sure?'}, :method => :delete %></td>
   </tr>
 <% end %>
 </table>

--- a/rails/app/views/portal/nces06_schools/index.html.erb
+++ b/rails/app/views/portal/nces06_schools/index.html.erb
@@ -8,7 +8,7 @@
   <tr>
     <td><%= link_to 'Show', nces06_school %></td>
     <td><%= link_to 'Edit', edit_portal_nces06_school_path(nces06_school) %></td>
-    <td><%= link_to 'Destroy', nces06_school, :confirm => 'Are you sure?', :method => :delete %></td>
+    <td><%= link_to 'Destroy', nces06_school, data: {:confirm => 'Are you sure?'}, :method => :delete %></td>
   </tr>
 <% end %>
 </table>

--- a/rails/app/views/portal/school_memberships/index.html.erb
+++ b/rails/app/views/portal/school_memberships/index.html.erb
@@ -8,7 +8,7 @@
   <tr>
     <td><%= link_to 'Show', school_membership %></td>
     <td><%= link_to 'Edit', edit_portal_school_membership_path(school_membership) %></td>
-    <td><%= link_to 'Destroy', school_membership, :confirm => 'Are you sure?', :method => :delete %></td>
+    <td><%= link_to 'Destroy', school_membership, data: {:confirm => 'Are you sure?'}, :method => :delete %></td>
   </tr>
 <% end %>
 </table>

--- a/rails/app/views/portal/student_clazzes/index.html.erb
+++ b/rails/app/views/portal/student_clazzes/index.html.erb
@@ -8,7 +8,7 @@
   <tr>
     <td><%= link_to 'Show', portal_student_clazz %></td>
     <td><%= link_to 'Edit', edit_portal_student_clazz_path(portal_student_clazz) %></td>
-    <td><%= link_to 'Destroy', portal_student_clazz, :confirm => 'Are you sure?', :method => :delete %></td>
+    <td><%= link_to 'Destroy', portal_student_clazz, data: {:confirm => 'Are you sure?'}, :method => :delete %></td>
   </tr>
 <% end %>
 </table>

--- a/rails/app/views/portal/students/index.html.erb
+++ b/rails/app/views/portal/students/index.html.erb
@@ -8,7 +8,7 @@
   <tr>
     <td><%= link_to 'Show', portal_student %></td>
     <td><%= link_to 'Edit', edit_portal_student_path(portal_student) %></td>
-    <td><%= link_to 'Destroy', portal_student, :confirm => 'Are you sure?', :method => :delete %></td>
+    <td><%= link_to 'Destroy', portal_student, data: {:confirm => 'Are you sure?'}, :method => :delete %></td>
   </tr>
 <% end %>
 </table>

--- a/rails/app/views/portal/subjects/index.html.erb
+++ b/rails/app/views/portal/subjects/index.html.erb
@@ -8,7 +8,7 @@
   <tr>
     <td><%= link_to 'Show', subject %></td>
     <td><%= link_to 'Edit', edit_portal_subject_path(subject) %></td>
-    <td><%= link_to 'Destroy', subject, :confirm => 'Are you sure?', :method => :delete %></td>
+    <td><%= link_to 'Destroy', subject, data: {:confirm => 'Are you sure?'}, :method => :delete %></td>
   </tr>
 <% end %>
 </table>


### PR DESCRIPTION
as per:

https://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#action-pack

Rails 4.0 deprecates the :confirm option for the link_to helper. You should instead rely on a data attribute (e.g. data: { confirm: 'Are you sure?' }). This deprecation also concerns the helpers based on this one (such as link_to_if or link_to_unless).

[#174934840]
https://www.pivotaltracker.com/story/show/174934840