### PR TITLE
174937372 — fix `uninitialized constant Sprockets::Helpers`

### DIFF
--- a/rails/spec/spec_helper_common.rb
+++ b/rails/spec/spec_helper_common.rb
@@ -95,7 +95,7 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.expose_current_running_example_as :example
 
-  config.include Sprockets::Helpers::RailsHelper
+  config.include Sprockets::Rails::Helper
   config.include Devise::TestHelpers, :type => :controller
   config.include VerifyAndResetHelpers
   config.include FeatureHelper


### PR DESCRIPTION
The name of the mixin is now `Sprockets::Rails::Helper`

[#174937372]
https://www.pivotaltracker.com/story/show/174937372