### PR TITLE
174937913 — `has_many`  `:select` must be a scope function

### DIFF
--- a/rails/app/models/portal/nces06_district.rb
+++ b/rails/app/models/portal/nces06_district.rb
@@ -3,8 +3,7 @@ class Portal::Nces06District < ActiveRecord::Base
   
   has_many :nces_schools, :dependent => :destroy,:class_name => "Portal::Nces06School", :foreign_key => "nces_district_id"
 
-  has_many :minimized_nces_schools, :dependent => :destroy, :class_name => "Portal::Nces06School", :foreign_key => "nces_district_id", 
-    :select => "id, nces_district_id, NCESSCH, LEAID, SCHNO, STID, SEASCH, SCHNAM, GSLO, GSHI, PHONE, MEMBER, FTE, TOTFRL, AM, ASIAN, HISP, BLACK, WHITE, LATCOD, LONCOD, MCITY, MSTREE, MSTATE, MZIP"
+  has_many :minimized_nces_schools, :dependent => :destroy, :class_name => "Portal::Nces06School", :foreign_key => "nces_district_id", -> { select "id, nces_district_id, NCESSCH, LEAID, SCHNO, STID, SEASCH, SCHNAM, GSLO, GSHI, PHONE, MEMBER, FTE, TOTFRL, AM, ASIAN, HISP, BLACK, WHITE, LATCOD, LONCOD, MCITY, MSTREE, MSTATE, MZIP" }
 
   has_one :district, :class_name => "Portal::District", :foreign_key => "nces_district_id"
 


### PR DESCRIPTION
Fixes:

DEPRECATION WARNING: The following options in your Portal::Nces06District.has_many :minimized_nces_schools declaration are deprecated: :select. Please use a scope block instead.

[#174937913]
https://www.pivotaltracker.com/story/show/174937913