### PR TITLE
Fixed missing mysql_creation_options function in feature_test prepare rake task [#174946131]

### DIFF
--- a/rails/lib/tasks/db_feature_test_prepare.rake
+++ b/rails/lib/tasks/db_feature_test_prepare.rake
@@ -1,6 +1,12 @@
 namespace :db do
   namespace :feature_test do
 
+    def mysql_creation_options(config)
+      @charset   = ENV['CHARSET']   || 'utf8'
+      @collation = ENV['COLLATION'] || 'utf8_unicode_ci'
+      {:charset => (config['charset'] || @charset), :collation => (config['collation'] || @collation)}
+    end
+
     # This is a subset of active-record/database.rake db:test:purge
     # desc "Empty the feature_test database"
     task :purge => [:environment, 'db:load_config'] do


### PR DESCRIPTION
This looks like it wasn't added in a recent change to the rake task.