### PR TITLE
Remove use of Model.scoped [#174954960]

### DIFF
--- a/rails/app/policies/application_policy.rb
+++ b/rails/app/policies/application_policy.rb
@@ -61,13 +61,11 @@ class ApplicationPolicy
     end
 
     def all
-      # return scoped instead of all so that methods can be chained after
-      scope.scoped
+      scope.all
     end
 
     def none
-      # hack to return an empty relation pre Rails 4
-      scope.where("1 = 0")
+      scope.none
     end
 
     def resolve


### PR DESCRIPTION
In Rails 4 Model.scoped is deprecated in favor of using Model.all which now returns a relation and thus can be chained.  We were using Model.scoped in the Pundit policy scope to convert all to a relation.

This also updates the none method to use the new Rails 4 Model.none method instead of the empty query hack needed in Rails 3.