### PR TITLE
174945873 — Fix The :finder_sql association option is deprecated

### DIFF
--- a/rails/app/models/activity.rb
+++ b/rails/app/models/activity.rb
@@ -23,11 +23,7 @@ class Activity < ActiveRecord::Base
     end
   end
 
-  has_many :pages, :through => :sections do
-    def student_only
-      where('teacher_only' => false)
-    end
-  end
+  has_many :pages, :through => :sections
 
   has_many :project_materials, :class_name => "Admin::ProjectMaterial", :as => :material, :dependent => :destroy
   has_many :projects, :class_name => "Admin::Project", :through => :project_materials

--- a/rails/app/models/activity.rb
+++ b/rails/app/models/activity.rb
@@ -1,7 +1,7 @@
 class Activity < ActiveRecord::Base
   include Cohorts
   include JnlpLaunchable
-
+  include HasEmbeddables
   belongs_to :user
   belongs_to :investigation
   belongs_to :original
@@ -22,27 +22,17 @@ class Activity < ActiveRecord::Base
       where('teacher_only' => false)
     end
   end
-  has_many :pages, :through => :sections
+
+  has_many :pages, :through => :sections do
+    def student_only
+      where('teacher_only' => false)
+    end
+  end
+
   has_many :project_materials, :class_name => "Admin::ProjectMaterial", :as => :material, :dependent => :destroy
   has_many :projects, :class_name => "Admin::Project", :through => :project_materials
 
-  # BASE_EMBEDDABLES is defined in config/initializers/embeddables.rb
-  # This block adds a has_many for each embeddable type to this model.
-  # TODO We don't want Embeddable::Iframe showing up in any menus, so inject it here. It's used by LARA.
-  (BASE_EMBEDDABLES + ["Embeddable::Iframe"]).each do |klass|
-      eval %!has_many :#{klass[/::(\w+)$/, 1].underscore.pluralize}, :class_name => '#{klass}',
-      :finder_sql => proc { "SELECT #{klass.constantize.table_name}.* FROM #{klass.constantize.table_name}
-      INNER JOIN page_elements ON #{klass.constantize.table_name}.id = page_elements.embeddable_id AND page_elements.embeddable_type = '#{klass}'
-      INNER JOIN pages ON page_elements.page_id = pages.id
-      INNER JOIN sections ON pages.section_id = sections.id
-      WHERE sections.activity_id = \#\{id\}" }!
-  end
-
-  has_many :page_elements,
-    :finder_sql => proc { "SELECT page_elements.* FROM page_elements
-    INNER JOIN pages ON page_elements.page_id = pages.id
-    INNER JOIN sections ON pages.section_id = sections.id
-    WHERE sections.activity_id = #{id}" }
+  has_many :page_elements, :through => :pages
 
   include ResponseTypes
   acts_as_replicatable

--- a/rails/app/models/investigation.rb
+++ b/rails/app/models/investigation.rb
@@ -3,7 +3,7 @@ class Investigation < ActiveRecord::Base
   include Cohorts
   include ResponseTypes
   include Archiveable
-
+  include HasEmbeddables
   belongs_to :user
   has_many :activities, -> { order :position }, :dependent => :destroy do
     def student_only
@@ -18,46 +18,28 @@ class Investigation < ActiveRecord::Base
 
   has_many :external_activities, :as => :template
 
-  # BASE_EMBEDDABLES is defined in config/initializers/embeddables.rb
-  # TODO We don't want Embeddable::Iframe showing up in any menus, so inject it here. It's used by LARA.
-  (BASE_EMBEDDABLES + ["Embeddable::Iframe"]).each do |klass|
-    eval %!has_many :#{klass[/::(\w+)$/, 1].underscore.pluralize}, :class_name => '#{klass}',
-      :finder_sql => proc { "SELECT #{klass.constantize.table_name}.* FROM #{klass.constantize.table_name}
-      INNER JOIN page_elements ON #{klass.constantize.table_name}.id = page_elements.embeddable_id AND page_elements.embeddable_type = '#{klass}'
-      INNER JOIN pages ON page_elements.page_id = pages.id
-      INNER JOIN sections ON pages.section_id = sections.id
-      INNER JOIN activities ON sections.activity_id = activities.id
-      WHERE activities.investigation_id = \#\{id\}" }!
+  has_many :sections, :through => :activities
+
+  has_many :pages, :through => :sections
+
+  has_many :page_elements, :through => :pages
+
+  def student_sections
+    query = [
+      "#{Activity.table_name}.teacher_only=0",
+      "#{Section.table_name}.teacher_only=0"
+    ].join(" AND ")
+    sections.where(query)
   end
 
-  has_many :page_elements,
-    :finder_sql => proc { "SELECT page_elements.* FROM page_elements
-    INNER JOIN pages ON page_elements.page_id = pages.id
-    INNER JOIN sections ON pages.section_id = sections.id
-    INNER JOIN activities ON sections.activity_id = activities.id
-    WHERE activities.investigation_id = #{id}" }
-
-  has_many :sections,
-    :finder_sql => proc { "SELECT sections.* FROM sections
-    INNER JOIN activities ON sections.activity_id = activities.id
-    WHERE activities.investigation_id = #{id}" }
-
-  has_many :student_sections, :class_name => Section.to_s,
-    :finder_sql => proc { "SELECT sections.* FROM sections
-    INNER JOIN activities ON sections.activity_id = activities.id AND activities.teacher_only = 0
-    WHERE activities.investigation_id = #{id} AND sections.teacher_only = 0" }
-
-  has_many :pages,
-    :finder_sql => proc { "SELECT pages.* FROM pages
-    INNER JOIN sections ON pages.section_id = sections.id
-    INNER JOIN activities ON sections.activity_id = activities.id
-    WHERE activities.investigation_id = #{id}" }
-
-  has_many :student_pages, :class_name => Page.to_s,
-    :finder_sql => proc { "SELECT pages.* FROM pages
-    INNER JOIN sections ON pages.section_id = sections.id AND sections.teacher_only = 0
-    INNER JOIN activities ON sections.activity_id = activities.id AND activities.teacher_only = 0
-    WHERE activities.investigation_id = #{id} AND pages.teacher_only = 0" }
+  def student_pages
+    query = [
+      "#{Activity.table_name}.teacher_only=0",
+      "#{Section.table_name}.teacher_only=0",
+      "#{Page.table_name}.teacher_only=0"
+    ].join(" AND ")
+    pages.where(query)
+  end
 
   has_many :project_materials, :class_name => "Admin::ProjectMaterial", :as => :material, :dependent => :destroy
   has_many :projects, :class_name => "Admin::Project", :through => :project_materials

--- a/rails/app/models/section.rb
+++ b/rails/app/models/section.rb
@@ -16,20 +16,13 @@ class Section < ActiveRecord::Base
     end
   end
 
-  has_many :page_elements,
-    :finder_sql => proc { "SELECT page_elements.* FROM page_elements
-    INNER JOIN pages ON page_elements.page_id = pages.id
-    WHERE pages.section_id = #{id}" }
+  # Generates: SELECT `page_elements`.* FROM `page_elements`
+  # INNER JOIN `pages` ON `page_elements`.`page_id` = `pages`.`id`
+  # WHERE `pages`.`section_id` = 2
+  # ORDER BY page_elements.position ASC, page_elements.id ASC, `pages`.`position` ASC
+  has_many :page_elements, :through => :pages
 
-  # BASE_EMBEDDABLES is defined in config/initializers/embeddables.rb
-  BASE_EMBEDDABLES.each do |klass|
-      eval %!has_many :#{klass[/::(\w+)$/, 1].underscore.pluralize}, :class_name => '#{klass}',
-      :finder_sql => proc { "SELECT #{klass.constantize.table_name}.* FROM #{klass.constantize.table_name}
-      INNER JOIN page_elements ON #{klass.constantize.table_name}.id = page_elements.embeddable_id AND page_elements.embeddable_type = '#{klass}'
-      INNER JOIN pages ON page_elements.page_id = pages.id
-      WHERE pages.section_id = \#\{id\}" }!
-  end
-
+  include HasEmbeddables
   include ResponseTypes
 
   acts_as_list :scope => :activity_id

--- a/rails/lib/has_embeddables.rb
+++ b/rails/lib/has_embeddables.rb
@@ -16,7 +16,7 @@ module HasEmbeddables
         source: :embeddable,
         source_type: Embeddable::Iframe.to_s
 
-      # Generates Query:
+      # Called by Investigation, this generates a Query like this:
       # SELECT `embeddable_open_responses`.* FROM `embeddable_open_responses`
       #   INNER JOIN `page_elements` ON `embeddable_open_responses`.`id` = `page_elements`.`embeddable_id`
       #   INNER JOIN `pages` ON `page_elements`.`page_id` = `pages`.`id`

--- a/rails/lib/has_embeddables.rb
+++ b/rails/lib/has_embeddables.rb
@@ -1,0 +1,43 @@
+module HasEmbeddables
+
+  # Classes mixing in this module must provide `page_elements` association
+  def self.included(clazz)
+
+    clazz.class_eval do
+      has_many :multiple_choices,
+        -> { order id: :asc },
+        through: :page_elements,
+        source: :embeddable,
+        source_type: Embeddable::MultipleChoice.to_s
+
+      has_many :iframes,
+        -> { order id: :asc },
+        through: :page_elements,
+        source: :embeddable,
+        source_type: Embeddable::Iframe.to_s
+
+      # Generates Query:
+      # SELECT `embeddable_open_responses`.* FROM `embeddable_open_responses`
+      #   INNER JOIN `page_elements` ON `embeddable_open_responses`.`id` = `page_elements`.`embeddable_id`
+      #   INNER JOIN `pages` ON `page_elements`.`page_id` = `pages`.`id`
+      #   INNER JOIN `sections` ON `pages`.`section_id` = `sections`.`id`
+      #   INNER JOIN `activities` ON `sections`.`activity_id` = `activities`.`id`
+      # WHERE
+      #   `page_elements`.`embeddable_type` = 'Embeddable::OpenResponse'
+      #   AND `activities`.`investigation_id` = 1
+      # ORDER BY
+      #   `embeddable_open_responses`.`id` ASC,
+      #   page_elements.position ASC,
+      #   page_elements.id ASC,
+      #   `pages`.`position` ASC,
+      #   `sections`.`position` ASC,
+      #   `activities`.`position` ASC
+      has_many :open_responses,
+        -> { order id: :asc },
+        through: :page_elements,
+        source: :embeddable,
+        source_type: Embeddable::OpenResponse.to_s
+    end
+  end
+
+end


### PR DESCRIPTION
* removed `:finder_sql` from investigations and activities
* removed `:finder_sql` from pages
* removed `:finder_sql` from sections

Most of the `finder_sql` was from some meta-programming that dynamically created AR associations for embeddables.  I pulled these common relations up into a `has_embeddable` mixin. 

Some older hand-crafted proc scopes generated SQL that is identical to clean chained scoped relations.

I added @scytacki to this PR because it touched many models.

[#174945873]
https://www.pivotaltracker.com/story/show/174945873