### PR TITLE
# 175037667 — fix `:conditions` in searchable model.

### DIFF
--- a/rails/lib/searchable_model.rb
+++ b/rails/lib/searchable_model.rb
@@ -66,9 +66,9 @@ module SearchableModel
 
     per_page = self.per_page || 20
     if policy_scope
-      policy_scope.paginate(:per_page => per_page, :page => page, :conditions => conditions, :include => includes)
+      policy_scope.where(conditions).includes(includes).per_page(per_page).page(page)
     else
-      paginate(:per_page => per_page, :page => page, :conditions => conditions, :include => includes)
+      where(conditions).includes(includes).page(page).per_page(per_page)
     end
   end
 


### PR DESCRIPTION
## The `seachable_model` Error:

```
   Failure/Error: policy_scope.paginate(:per_page => per_page, :page => page, :conditions => conditions, :include => includes)

     ArgumentError:
       unsupported parameters: :conditions
     # /bundle/gems/will_paginate-3.3.0/lib/will_paginate/active_record.rb:151:in `paginate'
     # ./lib/searchable_model.rb:69:in `search'
```

## The will_paginate story & solution:
https://github.com/mislav/will_paginate/issues/500

[#175037667]
https://www.pivotaltracker.com/story/show/175037667