### PR TITLE
175042429 — MySQL fields with null => false should have default values

### DIFF
--- a/rails/spec/controllers/admin/commons_licenses_controller_spec.rb
+++ b/rails/spec/controllers/admin/commons_licenses_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Admin::CommonsLicensesController, type: :controller do
 
   let(:data) {CommonsLicense}
   let(:params_key) { :commons_license }
-  let(:valid_attributes)  { { name: 'name' } }
+  let(:valid_attributes)  { { name: 'name', code: 'code'} }
   let(:admin_user) {FactoryBot.generate(:admin_user)}
   let(:stubs) {{}}
   let(:mock_content) {


### PR DESCRIPTION
## Discovered this in the test log:

./spec/controllers/admin/commons_licenses_controller_spec.rb:62

```
     ActiveRecord::StatementInvalid:
       Mysql2::Error: Field 'code' doesn't have a default value: INSERT INTO `commons_licenses` (`created_at`, `deed`, `image`, `legal`, `name`, `updated_at`) VALUES ('2020-09-29 16:48:54', '', '', '', 'name', '2020-09-29 16:48:54')
     # /bundle/gems/mysql2-0.3.21/lib/mysql2/client.rb:80:in `_query'
```

## Entities to look at:

Security Questions: Has appropriate model validations.
Teacher Project Views: Views are created on the parent object, assigns required fields.

```
→ security_questions:
    t.integer "user_id",                 :null => false  → security_questions
    t.string  "question", :limit => 100, :null => false  → security_questions
    t.string  "answer",   :limit => 100, :null => false  → security_questions

* teacher_project_views:
    t.integer  "viewed_project_id", :null => false
    t.integer  "teacher_id",        :null => false
```

[#175042429]
https://www.pivotaltracker.com/story/show/175042429