### PR TITLE
# 175026080 — Fix ForbiddenAttributesError

### DIFF
--- a/rails/app/models/admin/cohort.rb
+++ b/rails/app/models/admin/cohort.rb
@@ -4,7 +4,7 @@ class Admin::Cohort < ActiveRecord::Base
   has_many :items, :class_name => 'Admin::CohortItem', :foreign_key => "admin_cohort_id", :dependent => :destroy
 
   validates_presence_of :name, message: "can't be blank"
-
+  attr_accessible :name, :items, :project, :project_id, :email_notifications_enabled
   self.extend SearchableModel
 
   class <<self

--- a/rails/app/models/admin/project.rb
+++ b/rails/app/models/admin/project.rb
@@ -2,6 +2,8 @@ class Admin::Project < ActiveRecord::Base
   include Changeable
 
   self.table_name = 'admin_projects'
+  attr_accessible :name, :landing_page_slug, :landing_page_content,
+  :project_card_image_url, :project_card_description, :public
 
   def changeable?(user)
     # project admins can change the projects they are admins of

--- a/rails/app/models/password.rb
+++ b/rails/app/models/password.rb
@@ -2,10 +2,9 @@ require 'digest/sha1'
 
 class Password < ActiveRecord::Base
   attr_accessor :email
-  
-  # Relationships
+  attr_accessible :email, :user
   belongs_to :user
-  
+
   # Validations
   validates_presence_of :email, :user
   validates_format_of :email, :with => /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, :message => 'is not a valid email address'

--- a/rails/app/models/portal/clazz.rb
+++ b/rails/app/models/portal/clazz.rb
@@ -1,5 +1,6 @@
 class Portal::Clazz < ActiveRecord::Base
-  self.table_name = :portal_clazzes  attr_accessible :name, :description, :class_word, :status, :default_class
+  self.table_name = :portal_clazzes
+  attr_accessible :name, :description, :class_word, :status, :default_class
 
   acts_as_replicatable
 

--- a/rails/app/models/portal/clazz.rb
+++ b/rails/app/models/portal/clazz.rb
@@ -1,5 +1,5 @@
 class Portal::Clazz < ActiveRecord::Base
-  self.table_name = :portal_clazzes
+  self.table_name = :portal_clazzes  attr_accessible :name, :description, :class_word, :status, :default_class
 
   acts_as_replicatable
 

--- a/rails/lib/searchable_model.rb
+++ b/rails/lib/searchable_model.rb
@@ -66,7 +66,7 @@ module SearchableModel
 
     per_page = self.per_page || 20
     if policy_scope
-      policy_scope.where(conditions).includes(includes).per_page(per_page).page(page)
+      policy_scope.where(conditions).includes(includes).page(page).per_page(per_page)
     else
       where(conditions).includes(includes).page(page).per_page(per_page)
     end

--- a/rails/spec/controllers/admin/cohorts_controller_spec.rb
+++ b/rails/spec/controllers/admin/cohorts_controller_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
+
 RegexForAuthFailShow = /can not view the requested resource/
 RegexForAuthFailNew = /can not create the requested resource/
 RegexForAuthFailModify = /can not update the requested resource/

--- a/rails/spec/controllers/passwords_controller_spec.rb
+++ b/rails/spec/controllers/passwords_controller_spec.rb
@@ -70,6 +70,7 @@ describe PasswordsController do
           :user_id => @forgetful_user.id
         }
 
+
         @answers_params = {
           :user_id => @forgetful_user.id,
           :security_questions => {

--- a/rails/spec/models/password_spec.rb
+++ b/rails/spec/models/password_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Password, type: :model do
 
     it 'does  create with proper email' do
       password.email = 'abc@example.com'
+      password.user = user
       expect(password).to be_valid
 
       password.save!


### PR DESCRIPTION
We are using  the `protected_attributes` gem

AR Models which do not specify `attr_accessible` fields, will throw the ForbiddenAttributesError  —unless the controller action explicitly passes :without_protection => true to the update_attributes method.

Here is the Gem we are using:
https://github.com/rails/protected_attributes

### Files to fix:

* admin/projects
* admin/cohorts
* passwords controller
* Clazzes controller

[#175026080]
https://www.pivotaltracker.com/story/show/175026080