### PR TITLE
174954984 — Fix deprecation: Relation#all

### DIFF
--- a/rails/app/controllers/api/v1/materials_controller.rb
+++ b/rails/app/controllers/api/v1/materials_controller.rb
@@ -117,8 +117,8 @@ class API::V1::MaterialsController < API::APIController
   #
   def all
 
-    materials = ExternalActivity.includes(:user, :template).all +
-                Interactive.all
+    materials = ExternalActivity.includes(:user, :template).to_a +
+                Interactive.to_a
 
     render json: materials_data(materials)
 

--- a/rails/app/models/portal/offering.rb
+++ b/rails/app/models/portal/offering.rb
@@ -29,16 +29,18 @@ class Portal::Offering < ActiveRecord::Base
 
   has_many :open_responses, :dependent => :destroy, :class_name => "Saveable::OpenResponse", :foreign_key => "offering_id" do
     def answered
-      all.select { |question| question.answered? }
+      where({ answered: true })
     end
   end
 
   has_many :multiple_choices, :dependent => :destroy, :class_name => "Saveable::MultipleChoice", :foreign_key => "offering_id" do
     def answered
-      all.select { |question| question.answered? }
+      where({ answered: true })
     end
+
     def answered_correctly
-      all.select { |question| question.answered? }.select{ |item| item.answered_correctly? }
+      # all.select { |question| question.answered? }.select{ |item| item.answered_correctly? }
+      where({ answered: true, answered_correctly: true })
     end
   end
 

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -404,7 +404,7 @@ class User < ActiveRecord::Base
   end
 
   def role_names
-    roles.select(:title).all.map { |role| role.title }
+    roles.pluck(:title)
   end
 
   def make_user_a_member

--- a/rails/spec/models/portal/offering_spec.rb
+++ b/rails/spec/models/portal/offering_spec.rb
@@ -63,7 +63,7 @@ describe Portal::Offering do
       # from being used
       it "can not be destroyed" do
         expect(offering.destroy).to be false
-        expect {offering.destroy!}.to raise_error(NoMethodError)
+        expect {offering.destroy!}.to raise_error(ActiveRecord::RecordNotDestroyed)
       end
     end
   end

--- a/rails/spec/models/user_spec.rb
+++ b/rails/spec/models/user_spec.rb
@@ -847,21 +847,19 @@ protected
 
   # TODO: auto-generated
   describe '#role_names' do
+    let(:user) { factory.create(:user) }
     it 'role_names' do
-      user = described_class.new
-      result = user.role_names
-
-      expect(result).not_to be_nil
+      user.add_role('1')
+      expect(user.role_names).to include '1'
     end
   end
 
   # TODO: auto-generated
   describe '#make_user_a_member' do
+    let(:user) { factory.create(:user) }
     it 'make_user_a_member' do
-      user = described_class.new
       result = user.make_user_a_member
-
-      expect(result).not_to be_nil
+      expect(user.role_names).to include 'member'
     end
   end
 
@@ -1286,6 +1284,5 @@ protected
       expect(result).not_to be_nil
     end
   end
-
 
 end


### PR DESCRIPTION
### Locatioins updated:

```
/home/travis/build/[secure]-consortium/rigse/rails/app/controllers/api/v1/materials_controller.rb:120
/home/travis/build/[secure]-consortium/rigse/rails/app/models/portal/offering.rb:32
/home/travis/build/[secure]-consortium/rigse/rails/app/models/portal/offering.rb:38
/home/travis/build/[secure]-consortium/rigse/rails/app/models/portal/offering.rb:41
/home/travis/build/[secure]-consortium/rigse/rails/app/models/user.rb:407
```

### Deprecation:
> DEPRECATION WARNING: Relation#all is deprecated. If you want to eager-load a relation, you can call #load (e.g. `Post.where(published: true).load`). If you want to get an array of records from a relation, you can call #to_a (e.g. `Post.where(published: true).to_a`). (called from role_names at /home/travis/build/[secure]-consortium/rigse/rails/app/models/user.rb:407)

### Notes:
`user_spec.rb` is failing all over because of date-parse errors in `users.yml`.
This is being fixed in a sperate story →  https://www.pivotaltracker.com/story/show/175042950

[#174954984]
https://www.pivotaltracker.com/story/show/174954984

174954984-fix-relation-all-deprecations