### PR TITLE
175078001-add-image-question-to-has-embeddables

### DIFF
--- a/rails/lib/has_embeddables.rb
+++ b/rails/lib/has_embeddables.rb
@@ -37,6 +37,13 @@ module HasEmbeddables
         through: :page_elements,
         source: :embeddable,
         source_type: Embeddable::OpenResponse.to_s
+
+
+      has_many :image_questions,
+        -> { order id: :asc },
+        through: :page_elements,
+        source: :embeddable,
+        source_type: Embeddable::ImageQuestion.to_s
     end
   end
 


### PR DESCRIPTION
When we did the has_embeddables work, we failed to include
images questions as an embeddable association.

See https://github.com/concord-consortium/rigse/pull/861/files

[#/175078001]
https://www.pivotaltracker.com/story/show/175078001