### PR TITLE
Set cookies_serializer option to :hybrid [#175171503]

### DIFF
--- a/rails/config/application.rb
+++ b/rails/config/application.rb
@@ -176,6 +176,8 @@ module RailsPortal
       config.assets.initialize_on_precompile = false
     end
 
+    # use json format for serilized cookies
+    config.action_dispatch.cookies_serializer = :hybrid
   end
 
   # ANONYMOUS_USER = User.find_by_login('anonymous')


### PR DESCRIPTION
Applications created before Rails 4.1 uses Marshal to serialize cookie values.  This option enables json serialized cookies.