### PR TITLE
175171538 — Flash structure changes Rails 4.1

### DIFF
--- a/rails/app/controllers/admin/clients_controller.rb
+++ b/rails/app/controllers/admin/clients_controller.rb
@@ -39,7 +39,7 @@ class Admin::ClientsController < ApplicationController
     @client = Client.new(params[:client])
 
     if @client.save
-      flash[:notice]='Client was successfully created.'
+      flash['notice']='Client was successfully created.'
       redirect_to action: :index
     else
       render :action => 'new'
@@ -51,7 +51,7 @@ class Admin::ClientsController < ApplicationController
     authorize Client
     @client = Client.find(params[:id])
     if @client.update_attributes(params[:client])
-      flash[:notice]= 'Client was successfully updated.'
+      flash['notice']= 'Client was successfully updated.'
       redirect_to action: :index
     else
       render :action => 'edit'
@@ -63,7 +63,7 @@ class Admin::ClientsController < ApplicationController
     authorize Client
     @client = Client.find(params[:id])
     @client.destroy
-    flash[:notice]= 'Client was successfully deleted.'
+    flash['notice']= 'Client was successfully deleted.'
     redirect_to action: :index
   end
 

--- a/rails/app/controllers/admin/cohorts_controller.rb
+++ b/rails/app/controllers/admin/cohorts_controller.rb
@@ -89,7 +89,7 @@ class Admin::CohortsController < ApplicationController
   def destroy
     authorize @admin_cohort
     @admin_cohort.destroy
-    flash[:notice] = "Cohort #{@admin_cohort.name} was deleted"
+    flash['notice'] = "Cohort #{@admin_cohort.name} was deleted"
     redirect_back_or admin_cohorts_url
   end
 end

--- a/rails/app/controllers/admin/commons_licenses_controller.rb
+++ b/rails/app/controllers/admin/commons_licenses_controller.rb
@@ -33,7 +33,7 @@ class Admin::CommonsLicensesController < ApplicationController
     @license = CommonsLicense.new(params[:commons_license])
 
     if @license.save
-      flash[:notice]='License was successfully created.'
+      flash['notice']='License was successfully created.'
       redirect_to action: :index
     else
       render :action => 'new'
@@ -44,7 +44,7 @@ class Admin::CommonsLicensesController < ApplicationController
     authorize CommonsLicense
     @license = CommonsLicense.find(params[:code])
     if @license.update_attributes(params[:commons_license])
-      flash[:notice]= 'License was successfully updated.'
+      flash['notice']= 'License was successfully updated.'
       redirect_to action: :index
     else
       render :action => 'edit'
@@ -55,7 +55,7 @@ class Admin::CommonsLicensesController < ApplicationController
     authorize CommonsLicense
     @license = CommonsLicense.find(params[:code])
     @license.destroy
-    flash[:notice]= 'License was successfully deleted.'
+    flash['notice']= 'License was successfully deleted.'
     redirect_to action: :index
   end
 

--- a/rails/app/controllers/admin/external_reports_controller.rb
+++ b/rails/app/controllers/admin/external_reports_controller.rb
@@ -38,7 +38,7 @@ class Admin::ExternalReportsController < ApplicationController
     @report = ExternalReport.new(params[:external_report])
 
     if @report.save
-      flash[:notice]='ExternalReport was successfully created.'
+      flash['notice']='ExternalReport was successfully created.'
       redirect_to action: :index
     else
       render :action => 'new'
@@ -58,7 +58,7 @@ class Admin::ExternalReportsController < ApplicationController
         .update_all(default_report_for_source_type: nil)
     end
     if saved_successfully
-      flash[:notice]= 'ExternalReport was successfully updated.'
+      flash['notice']= 'ExternalReport was successfully updated.'
       redirect_to action: :index
     else
       render :action => 'edit'
@@ -70,7 +70,7 @@ class Admin::ExternalReportsController < ApplicationController
     authorize ExternalReport
     @report = ExternalReport.find(params[:id])
     @report.destroy
-    flash[:notice]= 'ExternalReport was successfully deleted.'
+    flash['notice']= 'ExternalReport was successfully deleted.'
     redirect_to action: :index
   end
 

--- a/rails/app/controllers/admin/project_links_controller.rb
+++ b/rails/app/controllers/admin/project_links_controller.rb
@@ -89,7 +89,7 @@ class Admin::ProjectLinksController < ApplicationController
   def destroy
     authorize @project_link
     @project_link.destroy
-    flash[:notice] = "Link #{@project_link.name} was deleted"
+    flash['notice'] = "Link #{@project_link.name} was deleted"
     redirect_back_or admin_project_links_url
   end
 end

--- a/rails/app/controllers/admin/settings_controller.rb
+++ b/rails/app/controllers/admin/settings_controller.rb
@@ -81,7 +81,7 @@ class Admin::SettingsController < ApplicationController
   def create
     @admin_settings = Admin::Settings.new(params[:admin_settings])
     if @admin_settings.save
-      flash[:notice] = 'Admin::Settings was successfully created.'
+      flash['notice'] = 'Admin::Settings was successfully created.'
       redirect_to @admin_settings
     else
       render action: 'new'
@@ -92,7 +92,7 @@ class Admin::SettingsController < ApplicationController
   def update
     @admin_settings = Admin::Settings.find(params[:id])
     if @admin_settings.update_attributes(params[:admin_settings])
-      flash[:notice] = 'Admin::Settings was successfully updated.'
+      flash['notice'] = 'Admin::Settings was successfully updated.'
       redirect_to @admin_settings
     else
       render action: 'edit'
@@ -103,7 +103,7 @@ class Admin::SettingsController < ApplicationController
   def destroy
     @settings = Admin::Settings.find(params[:id])
     @settings.destroy
-    flash[:notice] = 'Settings successfully deleted.'
+    flash['notice'] = 'Settings successfully deleted.'
     redirect_to admin_settings_url
   end
 

--- a/rails/app/controllers/admin/site_notices_controller.rb
+++ b/rails/app/controllers/admin/site_notices_controller.rb
@@ -55,7 +55,7 @@ class Admin::SiteNoticesController < ApplicationController
     end
 
     if error
-      flash[:error] = error.html_safe
+      flash['error'] = error.html_safe
       respond_to do |format|
         format.html { render :action => "edit" }
       end

--- a/rails/app/controllers/api/v1/site_notices_controller.rb
+++ b/rails/app/controllers/api/v1/site_notices_controller.rb
@@ -60,7 +60,7 @@ class API::V1::SiteNoticesController < API::APIController
     end
 
     if error
-      flash[:error] = error.html_safe
+      flash['error'] = error.html_safe
       respond_to do |format|
         format.html { render :action => "edit" }
       end

--- a/rails/app/controllers/application_controller.rb
+++ b/rails/app/controllers/application_controller.rb
@@ -54,12 +54,12 @@ class ApplicationController < ActionController::Base
           #    saw the message there is no need to show it again.
           # So instead of showing the error message again, we just send the user to the
           # default login page for that user.
-          flash[:alert] = error_message if not params[:redirecting_after_sign_in]
+          flash['alert'] = error_message if not params[:redirecting_after_sign_in]
 
           redirect_to view_context.current_user_home_path
         end
       else
-        flash[:alert] = error_message
+        flash['alert'] = error_message
         # send the anonymous user to the login page, and then try to send the user back
         # to the original page. In the case of a post request this won't always work so
         # well. It will redirect the user to the GET route of the same URL that was posted

--- a/rails/app/controllers/auth_controller.rb
+++ b/rails/app/controllers/auth_controller.rb
@@ -17,7 +17,7 @@ class AuthController < ApplicationController
   def login
     # Renders a nice login form (views/auth/login.haml).
     @app_name = params[:app_name]
-    @error = flash[:alert]
+    @error = flash['alert']
     @after_sign_in_path = params[:after_sign_in_path]
     # If the user is already signed in and there is is a after_sign_in_path set
     # then redirect the user to this page.

--- a/rails/app/controllers/dataservice/blobs_controller.rb
+++ b/rails/app/controllers/dataservice/blobs_controller.rb
@@ -51,7 +51,7 @@ class Dataservice::BlobsController < ApplicationController
 
     respond_to do |format|
       if @dataservice_blob.save
-        flash[:notice] = 'Dataservice::Blob was successfully created.'
+        flash['notice'] = 'Dataservice::Blob was successfully created.'
         format.html { head :ok }
         format.xml  { render :xml => @dataservice_blob, :status => :created, :location => @dataservice_blob }
       else
@@ -68,7 +68,7 @@ class Dataservice::BlobsController < ApplicationController
 
     respond_to do |format|
       if @dataservice_blob.update_attributes(params[:blob])
-        flash[:notice] = 'Dataservice::Blob was successfully updated.'
+        flash['notice'] = 'Dataservice::Blob was successfully updated.'
         format.html { head :ok }
         format.xml  { head :ok }
       else

--- a/rails/app/controllers/external_activities_controller.rb
+++ b/rails/app/controllers/external_activities_controller.rb
@@ -126,7 +126,7 @@ class ExternalActivitiesController < ApplicationController
     respond_to do |format|
       if @external_activity.save
         format.js  # render the js file
-        flash[:notice] = 'ExternalActivity was successfully created.'
+        flash['notice'] = 'ExternalActivity was successfully created.'
         format.html { redirect_to(@external_activity) }
         format.xml  { render :xml => @external_activity, :status => :created, :location => @external_activity }
       else
@@ -181,7 +181,7 @@ class ExternalActivitiesController < ApplicationController
 
     respond_to do |format|
       if @external_activity.update_attributes(params[:external_activity])
-        flash[:notice] = 'ExternalActivity was successfully updated.'
+        flash['notice'] = 'ExternalActivity was successfully updated.'
         # redirect to browse path instead of show page since the show page is deprecated
         format.html { redirect_to(browse_external_activity_path(@external_activity)) }
         format.xml  { head :ok }
@@ -251,14 +251,14 @@ class ExternalActivitiesController < ApplicationController
   def archive
     authorize @external_activity
     @external_activity.archive!
-    flash[:notice]= t("matedit.archive_success", {name: @external_activity.name})
+    flash['notice']= t("matedit.archive_success", {name: @external_activity.name})
     redirect_to :search  #TBD:  Where to go?
   end
 
   def unarchive
     authorize @external_activity
     @external_activity.unarchive!
-    flash[:notice]= t("matedit.unarchive_success", {name: @external_activity.name})
+    flash['notice']= t("matedit.unarchive_success", {name: @external_activity.name})
     redirect_to :search  #TBD:  Where to go?
   end
 
@@ -279,7 +279,7 @@ class ExternalActivitiesController < ApplicationController
     if clone
       redirect_to matedit_external_activity_url(clone.id)
     else
-      flash[:error] = "Copying failed"
+      flash['error'] = "Copying failed"
       redirect_to :back
     end
   end
@@ -306,9 +306,9 @@ class ExternalActivitiesController < ApplicationController
 
     if collection_ids.count > 0
       @external_activity.add_to_collections(collection_ids)
-      flash[:notice] = "#{@external_activity.name} is assigned to the selected collection(s) successfully."
+      flash['notice'] = "#{@external_activity.name} is assigned to the selected collection(s) successfully."
     else
-      flash[:error] = "Select at least one collection to assign this resource."
+      flash['error'] = "Select at least one collection to assign this resource."
     end
 
     redirect_to action: 'edit_collections'

--- a/rails/app/controllers/images_controller.rb
+++ b/rails/app/controllers/images_controller.rb
@@ -67,10 +67,10 @@ class ImagesController < ApplicationController
     @image = Image.new(params[:image])
 
     if @image.save
-      flash[:notice] = 'Image was successfully created.'
+      flash['notice'] = 'Image was successfully created.'
       redirect_to @image
     else
-      flash[:error] = 'There was a problem with your submission. Check what you entered and try again.'
+      flash['error'] = 'There was a problem with your submission. Check what you entered and try again.'
       render action: 'new'
     end
   end
@@ -79,10 +79,10 @@ class ImagesController < ApplicationController
   def update
     authorize @image
     if update_image_attributes
-      flash[:notice] = 'Image was successfully updated.'
+      flash['notice'] = 'Image was successfully updated.'
       redirect_to @image
     else
-      flash[:error] = 'There was a problem with your submission. Check what you entered and try again.'
+      flash['error'] = 'There was a problem with your submission. Check what you entered and try again.'
       render action: 'edit'
     end
   end

--- a/rails/app/controllers/import/imported_login_controller.rb
+++ b/rails/app/controllers/import/imported_login_controller.rb
@@ -13,10 +13,10 @@ class Import::ImportedLoginController < ApplicationController
     write_to_us = "<a href=\"mailto:#{help_email}\">write to us</a> (#{help_email})"
     if password.save
       PasswordMailer.imported_password_reset(password).deliver
-      flash[:alert] = "Your account was imported. A link to set your password has been sent to: <b>#{user.email}.</b><br>" +
+      flash['alert'] = "Your account was imported. A link to set your password has been sent to: <b>#{user.email}.</b><br>" +
                       "If you need help, #{write_to_us}."
     else
-      flash[:error] = "Your account was imported from another site. We need a valid email address to complete the " +
+      flash['error'] = "Your account was imported from another site. We need a valid email address to complete the " +
                       "import process, and your account does not have one. Please #{write_to_us} to access your account."
     end
   end

--- a/rails/app/controllers/import/imports_controller.rb
+++ b/rails/app/controllers/import/imports_controller.rb
@@ -130,7 +130,7 @@ class Import::ImportsController < ApplicationController
     user_import = Import::Import.where(:import_type => Import::Import::IMPORT_TYPE_USER).last
     duplicate_users = Import::DuplicateUser.where(:import_id => user_import.id)
     if duplicate_users.length == 0
-      flash[:alert] = "No duplicate users found in the import."
+      flash['alert'] = "No duplicate users found in the import."
       redirect_to :back
     else
       send_data duplicate_users.to_json,
@@ -300,7 +300,7 @@ class Import::ImportsController < ApplicationController
         :type => "application/json",
         :x_sendfile => true
     else
-      flash[:alert] = "No failed imports."
+      flash['alert'] = "No failed imports."
       redirect_to :back
     end
   end

--- a/rails/app/controllers/interactives_controller.rb
+++ b/rails/app/controllers/interactives_controller.rb
@@ -87,7 +87,7 @@ class InteractivesController < ApplicationController
     respond_to do |format|
       if @interactive.save
         format.js  # render the js file
-        flash[:notice] = 'Interactive was successfully created.'
+        flash['notice'] = 'Interactive was successfully created.'
         format.html { redirect_to(@interactive) }
         format.xml  { render :xml => @interactive, :status => :created, :location => @interactive }
       else
@@ -162,7 +162,7 @@ class InteractivesController < ApplicationController
     else
       respond_to do |format|
         if @interactive.update_attributes(params[:interactive])
-          flash[:notice] = 'Interactive was successfully updated.'
+          flash['notice'] = 'Interactive was successfully updated.'
           format.html { redirect_to(@interactive) }
           format.xml  { head :ok }
         else

--- a/rails/app/controllers/passwords_controller.rb
+++ b/rails/app/controllers/passwords_controller.rb
@@ -14,7 +14,7 @@ class PasswordsController < ApplicationController
 
     if @password.user && @password.user.is_oauth_user?
       provider      =   @password.user.authentications[0].provider.titleize
-      flash[:error] =   "This is a #{provider} authenticated account. " <<
+      flash['error'] =   "This is a #{provider} authenticated account. " <<
                         "Please use #{provider} to make password changes."
       render :action => :email
       return
@@ -22,13 +22,13 @@ class PasswordsController < ApplicationController
 
     if @password.save
       PasswordMailer.forgot_password(@password).deliver
-      flash[:notice] = "A link to change your password has been sent to #{@password.email}."
+      flash['notice'] = "A link to change your password has been sent to #{@password.email}."
       redirect_to :action => :email
     else
       # If this fails, we probably didn't find the user by email. Perhaps we should use a friendly custom error
       # message, instead of displaying the Rails error_for content for the failed save? -- Cantina-CMH 6/18/10
       if @password.user.nil?
-        flash[:error] = "Sorry, we could not find a user with that email address. Please verify the address and try again."
+        flash['error'] = "Sorry, we could not find a user with that email address. Please verify the address and try again."
         @password.errors.clear # Ideally, we would only clear the error on :user, but there is no built-in method for that.
       end
       render :action => :email
@@ -39,11 +39,11 @@ class PasswordsController < ApplicationController
     user = User.find_by_login(params[:login])
 
     if user.nil?
-      flash[:error] = "User '#{params[:login]}' not found."
+      flash['error'] = "User '#{params[:login]}' not found."
 
     elsif user.is_oauth_user?
       provider      =   user.authentications[0].provider.titleize
-      flash[:error] =   "This is a #{provider} authenticated account. " <<
+      flash['error'] =   "This is a #{provider} authenticated account. " <<
                         "Please use #{provider} to make password changes."
       return
 
@@ -52,19 +52,19 @@ class PasswordsController < ApplicationController
         redirect_to password_questions_path(user)
         return
       elsif current_settings.use_student_security_questions
-        flash[:error] = "This account has not set any security questions. Please contact your teacher to reset your password for you."
+        flash['error'] = "This account has not set any security questions. Please contact your teacher to reset your password for you."
       else
-        flash[:error] = "Please contact your teacher to reset your password for you."
+        flash['error'] = "Please contact your teacher to reset your password for you."
       end
     elsif user.email
       @password = Password.new(:user => user, :email => user.email)
       if @password.save
         PasswordMailer.forgot_password(@password).deliver
-        flash[:notice] = "A link to change your password has been sent to #{@password.email}."
+        flash['notice'] = "A link to change your password has been sent to #{@password.email}."
         redirect_to root_path
         return
       else
-        flash[:error] = "This account has not set a valid email address. Please contact your school manager to access your account."
+        flash['error'] = "This account has not set a valid email address. Please contact your school manager to access your account."
       end
     end
 
@@ -96,7 +96,7 @@ class PasswordsController < ApplicationController
     end
 
     # TODO: limit the number of wrong attempts for a single user
-    flash[:error] = "Sorry, you did not answer all of your questions correctly."
+    flash['error'] = "Sorry, you did not answer all of your questions correctly."
     redirect_to password_questions_path(@user_check_questions.id)
   end
 
@@ -117,7 +117,7 @@ class PasswordsController < ApplicationController
     @user_reset_password.save
 
     if @user_reset_password.errors.empty?
-      flash[:notice] = "Password for #{@user_reset_password.login} was successfully updated."
+      flash['notice'] = "Password for #{@user_reset_password.login} was successfully updated."
       @user_reset_password.require_password_reset=false
       @user_reset_password.save
 
@@ -133,7 +133,7 @@ class PasswordsController < ApplicationController
       end
       redirect_to(session[:return_to] || root_path)
     else
-      # flash[:error] = 'Password could not be updated'
+      # flash['error'] = 'Password could not be updated'
       # redirect_to :action => :reset, :reset_code => params[:reset_code], :user_errors => @user.errors
       render 'reset'
     end
@@ -142,7 +142,7 @@ class PasswordsController < ApplicationController
   def update
     @password = Password.find(params[:id])
     if @password.update_attributes(params[:password])
-      flash[:notice] = 'Password was successfully updated.'
+      flash['notice'] = 'Password was successfully updated.'
       redirect_back_or activities_url
     else
       render :action => :edit
@@ -157,7 +157,7 @@ class PasswordsController < ApplicationController
       @user_find = Password.where('reset_code = ? and expiration_date > ?', params[:reset_code], Time.now).first.user
       return @user_find
     rescue
-      flash[:notice] = 'The change password URL you visited is either invalid or expired.'
+      flash['notice'] = 'The change password URL you visited is either invalid or expired.'
       redirect_to root_path
     end
   end

--- a/rails/app/controllers/portal/clazzes_controller.rb
+++ b/rails/app/controllers/portal/clazzes_controller.rb
@@ -123,12 +123,12 @@ class Portal::ClazzesController < ApplicationController
     okToCreate = true
     if !school_id
       # This should never happen, since the schools dropdown should consist of the default site school if the current user has no schools
-      flash[:error] = "You need to belong to a school in order to create classes. Please join a school and try again."
+      flash['error'] = "You need to belong to a school in order to create classes. Please join a school and try again."
       okToCreate = false
     end
 
     if current_visitor.anonymous?
-      flash[:error] = "Anonymous can't create classes. Please log in and try again."
+      flash['error'] = "Anonymous can't create classes. Please log in and try again."
       okToCreate = false
     end
 
@@ -138,7 +138,7 @@ class Portal::ClazzesController < ApplicationController
         @portal_clazz.grades << grade if grade
       end if grade_levels
       if @portal_clazz.grades.empty?
-        flash[:error] = "You need to select at least one grade level for this class."
+        flash['error'] = "You need to select at least one grade level for this class."
         okToCreate = false
       end
     end
@@ -154,7 +154,7 @@ class Portal::ClazzesController < ApplicationController
           @portal_clazz.teacher = teacher
           @portal_clazz.teacher.schools << Portal::School.find_by_name(APP_CONFIG[:site_school])
         else
-          flash[:error] = "There was an error trying to associate you with this class. Please try again."
+          flash['error'] = "There was an error trying to associate you with this class. Please try again."
           okToCreate = false
         end
       end
@@ -173,7 +173,7 @@ class Portal::ClazzesController < ApplicationController
         # This will finally tie this clazz to a course and a school
         @portal_clazz.course = course
       else
-        flash[:error] = "There was an error trying to create your new class. Please try again."
+        flash['error'] = "There was an error trying to create your new class. Please try again."
         okToCreate = false
       end
     end
@@ -183,7 +183,7 @@ class Portal::ClazzesController < ApplicationController
         # send email notifications about class creation
         Portal::ClazzMailer.clazz_creation_notification(@current_user, @portal_clazz).deliver
 
-        flash[:notice] = 'Class was successfully created.'
+        flash['notice'] = 'Class was successfully created.'
         format.html { redirect_to(url_for([:materials, @portal_clazz])) }
         format.xml  { render :xml => @portal_clazz, :status => :created, :location => @portal_clazz }
       else
@@ -243,14 +243,14 @@ class Portal::ClazzesController < ApplicationController
 
         if Admin::Settings.default_settings.enable_grade_levels?
           if !grade_levels
-            flash[:error] = "You need to select at least one grade level for this class."
+            flash['error'] = "You need to select at least one grade level for this class."
             okToUpdate = false
           end
         end
 
         if okToUpdate && @portal_clazz.update_attributes(object_params)
           update_teachers.call
-          flash[:notice] = 'Class was successfully updated.'
+          flash['notice'] = 'Class was successfully updated.'
           format.html { redirect_to(url_for([:materials, @portal_clazz])) }
           format.xml  { head :ok }
         else

--- a/rails/app/controllers/portal/courses_controller.rb
+++ b/rails/app/controllers/portal/courses_controller.rb
@@ -70,7 +70,7 @@ class Portal::CoursesController < ApplicationController
 
     respond_to do |format|
       if @course.save
-        flash[:notice] = 'Portal::Course was successfully created.'
+        flash['notice'] = 'Portal::Course was successfully created.'
         format.html { redirect_to(@course) }
         format.xml  { render :xml => @course, :status => :created, :location => @course }
       else
@@ -90,7 +90,7 @@ class Portal::CoursesController < ApplicationController
 
     respond_to do |format|
       if @course.update_attributes(params[:portal_course])
-        flash[:notice] = 'Portal::Course was successfully updated.'
+        flash['notice'] = 'Portal::Course was successfully updated.'
         format.html { redirect_to(@course) }
         format.xml  { head :ok }
       else

--- a/rails/app/controllers/portal/districts_controller.rb
+++ b/rails/app/controllers/portal/districts_controller.rb
@@ -65,7 +65,7 @@ class Portal::DistrictsController < ApplicationController
     cancel = params[:commit] == "Cancel"
 
     if @portal_district.save
-      flash[:notice] = 'Portal::District was successfully created.'
+      flash['notice'] = 'Portal::District was successfully created.'
       redirect_to @portal_district
     else
       render :action => "new"
@@ -82,7 +82,7 @@ class Portal::DistrictsController < ApplicationController
     @portal_district = Portal::District.find(params[:id])
 
     if @portal_district.update_attributes(params[:portal_district])
-      flash[:notice] = 'Portal::District was successfully updated.'
+      flash['notice'] = 'Portal::District was successfully updated.'
       redirect_to @portal_district
     else
       render :action => "edit"

--- a/rails/app/controllers/portal/learners_controller.rb
+++ b/rails/app/controllers/portal/learners_controller.rb
@@ -218,7 +218,7 @@ class Portal::LearnersController < ApplicationController
 
     respond_to do |format|
       if @portal_learner.save
-        flash[:notice] = 'Portal::Learner was successfully created.'
+        flash['notice'] = 'Portal::Learner was successfully created.'
         format.html { redirect_to(@portal_learner) }
         format.xml  { render :xml => @portal_learner, :status => :created, :location => @portal_learner }
       else
@@ -238,7 +238,7 @@ class Portal::LearnersController < ApplicationController
 
     respond_to do |format|
       if @portal_learner.update_attributes(params[:learner])
-        flash[:notice] = 'Portal::Learner was successfully updated.'
+        flash['notice'] = 'Portal::Learner was successfully updated.'
         format.html { redirect_to(@portal_learner) }
         format.xml  { head :ok }
       else

--- a/rails/app/controllers/portal/nces06_districts_controller.rb
+++ b/rails/app/controllers/portal/nces06_districts_controller.rb
@@ -93,7 +93,7 @@ class Portal::Nces06DistrictsController < ApplicationController
 
     respond_to do |format|
       if @nces06_district.save
-        flash[:notice] = 'Portal::Nces06District was successfully created.'
+        flash['notice'] = 'Portal::Nces06District was successfully created.'
         format.html { redirect_to(@nces06_district) }
         format.xml  { render :xml => @nces06_district, :status => :created, :location => @nces06_district }
       else
@@ -113,7 +113,7 @@ class Portal::Nces06DistrictsController < ApplicationController
 
     respond_to do |format|
       if @nces06_district.update_attributes(params[:nces06_district])
-        flash[:notice] = 'Portal::Nces06District was successfully updated.'
+        flash['notice'] = 'Portal::Nces06District was successfully updated.'
         format.html { redirect_to(@nces06_district) }
         format.xml  { head :ok }
       else

--- a/rails/app/controllers/portal/nces06_schools_controller.rb
+++ b/rails/app/controllers/portal/nces06_schools_controller.rb
@@ -94,7 +94,7 @@ class Portal::Nces06SchoolsController < ApplicationController
 
     respond_to do |format|
       if @nces06_school.save
-        flash[:notice] = 'Portal::Nces06School was successfully created.'
+        flash['notice'] = 'Portal::Nces06School was successfully created.'
         format.html { redirect_to(@nces06_school) }
         format.xml  { render :xml => @nces06_school, :status => :created, :location => @nces06_school }
       else
@@ -114,7 +114,7 @@ class Portal::Nces06SchoolsController < ApplicationController
 
     respond_to do |format|
       if @nces06_school.update_attributes(params[:nces06_school])
-        flash[:notice] = 'Portal::Nces06School was successfully updated.'
+        flash['notice'] = 'Portal::Nces06School was successfully updated.'
         format.html { redirect_to(@nces06_school) }
         format.xml  { head :ok }
       else

--- a/rails/app/controllers/portal/offerings_controller.rb
+++ b/rails/app/controllers/portal/offerings_controller.rb
@@ -107,7 +107,7 @@ class Portal::OfferingsController < ApplicationController
     end
     respond_to do |format|
       if update_successful
-        flash[:notice] = 'Portal::Offering was successfully updated.'
+        flash['notice'] = 'Portal::Offering was successfully updated.'
         format.html { redirect_to(@offering) }
         format.xml  { head :ok }
       else
@@ -160,7 +160,7 @@ class Portal::OfferingsController < ApplicationController
         learner.report_learner.last_run = DateTime.now
         learner.report_learner.update_fields
       end
-      flash[:notice] = "Your answers have been saved."
+      flash['notice'] = "Your answers have been saved."
       redirect_to :root
     else
       render :text => 'problem loading offering', :status => 500

--- a/rails/app/controllers/portal/school_memberships_controller.rb
+++ b/rails/app/controllers/portal/school_memberships_controller.rb
@@ -68,7 +68,7 @@ class Portal::SchoolMembershipsController < ApplicationController
 
     respond_to do |format|
       if @school_membership.save
-        flash[:notice] = 'Portal::SchoolMembership was successfully created.'
+        flash['notice'] = 'Portal::SchoolMembership was successfully created.'
         format.html { redirect_to(@school_membership) }
         format.xml  { render :xml => @school_membership, :status => :created, :location => @school_membership }
       else
@@ -88,7 +88,7 @@ class Portal::SchoolMembershipsController < ApplicationController
 
     respond_to do |format|
       if @school_membership.update_attributes(params[:portal_school_membership])
-        flash[:notice] = 'Portal::SchoolMembership was successfully updated.'
+        flash['notice'] = 'Portal::SchoolMembership was successfully updated.'
         format.html { redirect_to(@school_membership) }
         format.xml  { head :ok }
       else

--- a/rails/app/controllers/portal/schools_controller.rb
+++ b/rails/app/controllers/portal/schools_controller.rb
@@ -75,7 +75,7 @@ class Portal::SchoolsController < ApplicationController
     end
 
     if @portal_school.save
-      flash[:notice] = 'Portal::School was successfully created.'
+      flash['notice'] = 'Portal::School was successfully created.'
       redirect_to @portal_school
     else
       render :action => 'new'
@@ -88,7 +88,7 @@ class Portal::SchoolsController < ApplicationController
     cancel = params[:commit] == 'Cancel'
     @portal_school = Portal::School.find(params[:id])
     if @portal_school.update_attributes(params[:portal_school])
-      flash[:notice] = 'Portal::School was successfully updated.'
+      flash['notice'] = 'Portal::School was successfully updated.'
       redirect_to action: :index
     else
       render :action => 'edit'

--- a/rails/app/controllers/portal/student_clazzes_controller.rb
+++ b/rails/app/controllers/portal/student_clazzes_controller.rb
@@ -66,7 +66,7 @@ class Portal::StudentClazzesController < ApplicationController
 
     respond_to do |format|
       if @portal_student_clazz.save
-        flash[:notice] = 'Portal::StudentClazz was successfully created.'
+        flash['notice'] = 'Portal::StudentClazz was successfully created.'
         format.html { redirect_to(@portal_student_clazz) }
         format.xml  { render :xml => @portal_student_clazz, :status => :created, :location => @portal_student_clazz }
       else
@@ -86,7 +86,7 @@ class Portal::StudentClazzesController < ApplicationController
 
     respond_to do |format|
       if @portal_student_clazz.update_attributes(params[:portal_student_clazz])
-        flash[:notice] = 'Portal::StudentClazz was successfully updated.'
+        flash['notice'] = 'Portal::StudentClazz was successfully updated.'
         format.html { redirect_to(@portal_student_clazz) }
         format.xml  { head :ok }
       else

--- a/rails/app/controllers/portal/students_controller.rb
+++ b/rails/app/controllers/portal/students_controller.rb
@@ -159,7 +159,7 @@ class Portal::StudentsController < ApplicationController
           You have successfully registered #{@user.name} with the username <span class="big">#{@user.login}</span>.
           <br/>
           EOF
-          flash[:info] = msg.html_safe
+          flash['info'] = msg.html_safe
           format.html { redirect_to(@portal_clazz) }
         end
       else  # something didn't get created or referenced correctly
@@ -191,7 +191,7 @@ class Portal::StudentsController < ApplicationController
     @portal_student = Portal::Student.find(params[:id])
     respond_to do |format|
       if @portal_student.update_attributes(params[:portal_student])
-        flash[:notice] = 'Portal::Student was successfully updated.'
+        flash['notice'] = 'Portal::Student was successfully updated.'
         format.html { redirect_to(@portal_student) }
         format.xml  { head :ok }
       else
@@ -232,7 +232,7 @@ class Portal::StudentsController < ApplicationController
 
       }
 
-      flash[:notice] = 'Successfully moved student to new class.'
+      flash['notice'] = 'Successfully moved student to new class.'
       redirect_to(portal_student)
     end
   end

--- a/rails/app/controllers/portal/subjects_controller.rb
+++ b/rails/app/controllers/portal/subjects_controller.rb
@@ -66,7 +66,7 @@ class Portal::SubjectsController < ApplicationController
 
     respond_to do |format|
       if @subject.save
-        flash[:notice] = 'Portal::Subject was successfully created.'
+        flash['notice'] = 'Portal::Subject was successfully created.'
         format.html { redirect_to(@subject) }
         format.xml  { render :xml => @subject, :status => :created, :location => @subject }
       else
@@ -86,7 +86,7 @@ class Portal::SubjectsController < ApplicationController
 
     respond_to do |format|
       if @subject.update_attributes(params[:subject])
-        flash[:notice] = 'Portal::Subject was successfully updated.'
+        flash['notice'] = 'Portal::Subject was successfully updated.'
         format.html { redirect_to(@subject) }
         format.xml  { head :ok }
       else

--- a/rails/app/controllers/report/learner_controller.rb
+++ b/rails/app/controllers/report/learner_controller.rb
@@ -205,7 +205,7 @@ class Report::LearnerController < ApplicationController
   end
 
   def alert_and_reload(message)
-    flash[:alert] = message
+    flash['alert'] = message
     redirect_to request.GET.except(:commit)
   end
 

--- a/rails/app/controllers/saveable/sparks/measuring_resistances_controller.rb
+++ b/rails/app/controllers/saveable/sparks/measuring_resistances_controller.rb
@@ -46,7 +46,7 @@ class Saveable::Sparks::MeasuringResistancesController < ApplicationController
 
     respond_to do |format|
       if @measuring_resistance.save
-        flash[:notice] = 'Saveable::Sparks::MeasuringResistance.was successfully created.'
+        flash['notice'] = 'Saveable::Sparks::MeasuringResistance.was successfully created.'
         format.html { redirect_to(@measuring_resistance) }
         format.json { redirect_to(@measuring_resistance) }
         format.json  { render :xml => @measuring_resistance, :status => :created, :location => @measuring_resistance }
@@ -64,7 +64,7 @@ class Saveable::Sparks::MeasuringResistancesController < ApplicationController
 
     respond_to do |format|
       if @measuring_resistance.update_attributes(params[:measuring_resistance])
-        flash[:notice] = 'Saveable::Sparks::MeasuringResistance.was successfully updated.'
+        flash['notice'] = 'Saveable::Sparks::MeasuringResistance.was successfully updated.'
         format.html { redirect_to(@measuring_resistance) }
         format.json  { head :ok }
       else

--- a/rails/app/controllers/security_questions_controller.rb
+++ b/rails/app/controllers/security_questions_controller.rb
@@ -21,10 +21,10 @@ class SecurityQuestionsController < ApplicationController
     errors = SecurityQuestion.errors_for_questions_list!(@security_questions)
     if (!errors) || errors.empty?
       current_visitor.update_security_questions!(@security_questions)
-      flash[:notice] = "Your security questions have been successfully updated."
+      flash['notice'] = "Your security questions have been successfully updated."
       redirect_to(root_path)
     else
-      flash[:error] = errors.join(", ")
+      flash['error'] = errors.join(", ")
       @security_questions = SecurityQuestion.fill_array(@security_questions)
       render :action => "edit"
     end

--- a/rails/app/controllers/users_controller.rb
+++ b/rails/app/controllers/users_controller.rb
@@ -67,7 +67,7 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
     authorize @user
     @user.destroy
-    flash[:notice] = "User: #{@user.name} successfully deleted!"
+    flash['notice'] = "User: #{@user.name} successfully deleted!"
     redirect_to users_url
   end
 
@@ -166,7 +166,7 @@ class UsersController < ApplicationController
             @user.portal_teacher.set_cohorts_by_id(params[:user][:cohort_ids] || [])
           end
 
-          flash[:notice] = "User: #{@user.name} was successfully updated."
+          flash['notice'] = "User: #{@user.name} was successfully updated."
           format.html do
             if params[:user][:redirect_user_edit_form] == 'users'
               redirect_to users_path
@@ -220,7 +220,7 @@ class UsersController < ApplicationController
       user.make_user_a_member
 
       # assume this type of user just activated someone from somewhere else in the app
-      flash[:notice] = "Activation of #{user.name_and_login} complete."
+      flash['notice'] = "Activation of #{user.name_and_login} complete."
       redirect_to(session[:return_to] || root_path)
     end
   end
@@ -252,7 +252,7 @@ class UsersController < ApplicationController
         if @user.portal_teacher && params[:user][:has_cohorts_in_form] && policy(@current_user).add_teachers_to_cohorts?
           @user.portal_teacher.set_cohorts_by_id(params[:user][:cohort_ids] || [])
         end
-        flash[:notice] = "User: #{@user.name} was successfully updated."
+        flash['notice'] = "User: #{@user.name} was successfully updated."
         format.html do
           redirect_to users_path
         end

--- a/rails/app/views/layouts/_flashes.html.haml
+++ b/rails/app/views/layouts/_flashes.html.haml
@@ -1,11 +1,11 @@
-- unless (flash[:notice].blank? && flash[:warning].blank?)
+- unless (flash['notice'].blank? && flash['warning'].blank?)
   #flash
     .padded_contents
-      %div.flash{:class => flash[:notice] ? "notice" : "warning"}
-        - if flash[:notice] 
-          = flash[:notice]
+      %div.flash{:class => flash['notice'] ? "notice" : "warning"}
+        - if flash['notice'] 
+          = flash['notice']
         - else 
-          = flash[:warning]
+          = flash['warning']
         %span.close
           %i.fa.fa-times
 

--- a/rails/app/views/layouts/activity_steps.html.erb
+++ b/rails/app/views/layouts/activity_steps.html.erb
@@ -9,7 +9,7 @@
 </head>
 <body>
 
-<p style="color: green"><%= flash[:notice] %></p>
+<p style="color: green"><%= flash['notice'] %></p>
 
 <%= yield  %>
 

--- a/rails/lib/clipboard.rb
+++ b/rails/lib/clipboard.rb
@@ -36,7 +36,7 @@ module Clipboard
       rescue NameError
         error_message = "unknown object in clipboard #{clipboard_data_type} (id:#{clipboard_data_id})"
         logger.warn(error_message)
-        flash[:warn]=error_message
+        flash['warn']=error_message
       end
     end
     return results

--- a/rails/spec/controllers/admin/cohorts_controller_spec.rb
+++ b/rails/spec/controllers/admin/cohorts_controller_spec.rb
@@ -38,7 +38,7 @@ describe Admin::CohortsController do
           get :show, id: cohort.id
           # Redirect, and show error when not allowed:
           expect(response).to have_http_status(:redirect)
-          expect(request.flash[:alert]).to match(RegexForAuthFailShow)
+          expect(request.flash['alert']).to match(RegexForAuthFailShow)
         end
       end
     end
@@ -48,7 +48,7 @@ describe Admin::CohortsController do
         get :new
         # Redirect, and show error when not allowed:
         expect(response).to have_http_status(:redirect)
-        expect(request.flash[:alert]).to match(RegexForAuthFailNew)
+        expect(request.flash['alert']).to match(RegexForAuthFailNew)
       end
     end
 
@@ -57,7 +57,7 @@ describe Admin::CohortsController do
         put :create
         # Redirect, and show error when not allowed:
         expect(response).to have_http_status(:redirect)
-        expect(request.flash[:alert]).to match(RegexForAuthFailNew)
+        expect(request.flash['alert']).to match(RegexForAuthFailNew)
       end
     end
 
@@ -66,7 +66,7 @@ describe Admin::CohortsController do
         put :update, id:@cohort_1.id
         # Redirect, and show error when not allowed:
         expect(response).to have_http_status(:redirect)
-        expect(request.flash[:alert]).to match(RegexForAuthFailModify)
+        expect(request.flash['alert']).to match(RegexForAuthFailModify)
       end
     end
     describe 'Destroy' do
@@ -74,7 +74,7 @@ describe Admin::CohortsController do
         delete :destroy, id: @cohort_1.id
         # Redirect, and show error when not allowed:
         expect(response).to have_http_status(:redirect)
-        expect(request.flash[:alert]).to match(RegexForAuthFailDestroy)
+        expect(request.flash['alert']).to match(RegexForAuthFailDestroy)
       end
     end
   end
@@ -139,7 +139,7 @@ describe Admin::CohortsController do
           get :show, id:@cohort_2.id
           # Redirect, and show error when not allowed:
           expect(response).to have_http_status(:redirect)
-          expect(request.flash[:alert]).to match(RegexForAuthFailShow)
+          expect(request.flash['alert']).to match(RegexForAuthFailShow)
         end
       end
     end
@@ -235,7 +235,7 @@ describe Admin::CohortsController do
           post :create, valid_params
           # Redirect, and show error when not allowed:
           expect(response).to have_http_status(:redirect)
-          expect(request.flash[:alert]).to match(RegexForAuthFailNew)
+          expect(request.flash['alert']).to match(RegexForAuthFailNew)
         end
       end
 

--- a/rails/spec/controllers/admin/project_links_controller_spec.rb
+++ b/rails/spec/controllers/admin/project_links_controller_spec.rb
@@ -25,7 +25,7 @@ describe Admin::ProjectLinksController do
     it 'it should NOT let them' do
       put :update, full_params
       expect(response).to have_http_status(:redirect)
-      expect(request.flash[:alert]).to match(RegexForAuthFailModify)
+      expect(request.flash['alert']).to match(RegexForAuthFailModify)
     end
   end
 
@@ -43,7 +43,7 @@ describe Admin::ProjectLinksController do
           get :show, id: link.id
           # Redirect, and show error when not allowed:
           expect(response).to have_http_status(:redirect)
-          expect(request.flash[:alert]).to match(RegexForAuthFailShow)
+          expect(request.flash['alert']).to match(RegexForAuthFailShow)
         end
       end
     end
@@ -52,7 +52,7 @@ describe Admin::ProjectLinksController do
         get :new
         # Redirect, and show error when not allowed:
         expect(response).to have_http_status(:redirect)
-        expect(request.flash[:alert]).to match(RegexForAuthFailNew)
+        expect(request.flash['alert']).to match(RegexForAuthFailNew)
       end
     end
 
@@ -61,7 +61,7 @@ describe Admin::ProjectLinksController do
         put :create
         # Redirect, and show error when not allowed:
         expect(response).to have_http_status(:redirect)
-        expect(request.flash[:alert]).to match(RegexForAuthFailNew)
+        expect(request.flash['alert']).to match(RegexForAuthFailNew)
       end
     end
 
@@ -70,7 +70,7 @@ describe Admin::ProjectLinksController do
         put :update, id: @link_1.id
         # Redirect, and show error when not allowed:
         expect(response).to have_http_status(:redirect)
-        expect(request.flash[:alert]).to match(RegexForAuthFailModify)
+        expect(request.flash['alert']).to match(RegexForAuthFailModify)
       end
     end
 
@@ -79,7 +79,7 @@ describe Admin::ProjectLinksController do
         delete :destroy, id: @link_1.id
         # Redirect, and show error when not allowed:
         expect(response).to have_http_status(:redirect)
-        expect(request.flash[:alert]).to match(RegexForAuthFailDestroy)
+        expect(request.flash['alert']).to match(RegexForAuthFailDestroy)
       end
     end
   end
@@ -126,7 +126,7 @@ describe Admin::ProjectLinksController do
           get :show, id:@link_2.id
           # Redirect, and show error when not allowed:
           expect(response).to have_http_status(:redirect)
-          expect(request.flash[:alert]).to match(RegexForAuthFailShow)
+          expect(request.flash['alert']).to match(RegexForAuthFailShow)
         end
       end
     end
@@ -231,7 +231,7 @@ describe Admin::ProjectLinksController do
           post :create, params
           # Redirect, and show error when not allowed:
           expect(response).to have_http_status(:redirect)
-          expect(request.flash[:alert]).to match(RegexForAuthFailNew)
+          expect(request.flash['alert']).to match(RegexForAuthFailNew)
         end
       end
     end
@@ -341,7 +341,7 @@ describe Admin::ProjectLinksController do
           delete :destroy, id: link.id
           # Redirect, and show error when not allowed:
           expect(response).to have_http_status(:redirect)
-          expect(request.flash[:notice]).to match(RegexDeleteSuccess)
+          expect(request.flash['notice']).to match(RegexDeleteSuccess)
         end
       end
     end
@@ -563,7 +563,7 @@ describe Admin::ProjectLinksController do
             post :create, params
             # Redirect, and show error when not allowed:
             expect(response).to have_http_status(:redirect)
-            expect(request.flash[:alert]).to match(RegexForAuthFailNew)
+            expect(request.flash['alert']).to match(RegexForAuthFailNew)
           end
         end
       end

--- a/rails/spec/controllers/admin/projects_controller_spec.rb
+++ b/rails/spec/controllers/admin/projects_controller_spec.rb
@@ -207,7 +207,7 @@ describe Admin::ProjectsController do
       it "is unavailable to project admins" do
         get :new, {}
         expect(response).to have_http_status(:redirect)
-        expect(request.flash[:alert]).to match(RegexForAuthFailNew)
+        expect(request.flash['alert']).to match(RegexForAuthFailNew)
       end
     end
 
@@ -226,7 +226,7 @@ describe Admin::ProjectsController do
           other_projects.each do |proj|
             get :edit, { id: proj.id }
             expect(response).to have_http_status(:redirect)
-            expect(request.flash[:alert]).to match(RegexForAuthFailEdit)
+            expect(request.flash['alert']).to match(RegexForAuthFailEdit)
           end
         end
       end
@@ -243,7 +243,7 @@ describe Admin::ProjectsController do
         it "redirects with warning" do
           post :create, {:admin_project => valid_attributes}
           expect(response).to have_http_status(:redirect)
-          expect(request.flash[:alert]).to match(RegexForAuthFailNew)
+          expect(request.flash['alert']).to match(RegexForAuthFailNew)
         end
       end
     end
@@ -300,7 +300,7 @@ describe Admin::ProjectsController do
         it "redirects to the projects list" do
           delete :destroy, {:id => project.id}
           expect(response).to have_http_status(:redirect)
-          expect(request.flash[:alert]).to match(RegexForAuthFailDestroy)
+          expect(request.flash['alert']).to match(RegexForAuthFailDestroy)
         end
       end
     end

--- a/rails/spec/controllers/admin/site_notices_controller_spec.rb
+++ b/rails/spec/controllers/admin/site_notices_controller_spec.rb
@@ -81,13 +81,13 @@ describe Admin::SiteNoticesController do
       post :update, @post_params
       notice = Admin::SiteNotice.find_by_notice_html(@post_params[:notice_html])
       expect(notice).to be_nil
-      expect(flash[:error]).to match(/Notice text is blank/i)
+      expect(flash['error']).to match(/Notice text is blank/i)
 
       @post_params[:notice_html] = "       "
       post :update, @post_params
       notice = Admin::SiteNotice.find_by_notice_html(@post_params[:notice_html])
       expect(notice).to be_nil
-      expect(flash[:error]).to match(/Notice text is blank/i)
+      expect(flash['error']).to match(/Notice text is blank/i)
     end
   end
 

--- a/rails/spec/controllers/api/v1/site_notices_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/site_notices_controller_spec.rb
@@ -29,13 +29,13 @@ describe API::V1::SiteNoticesController do
       post :create, @post_params
       notice = Admin::SiteNotice.find_by_notice_html(@post_params[:notice_html])
       expect(notice).to be_nil
-      expect(flash[:error]).to match(/Notice text is blank/i)
+      expect(flash['error']).to match(/Notice text is blank/i)
 
       @post_params[:notice_html] = ' '
       post :create, @post_params
       notice = Admin::SiteNotice.find_by_notice_html(@post_params[:notice_html])
       expect(notice).to be_nil
-      expect(flash[:error]).to match(/Notice text is blank/i)
+      expect(flash['error']).to match(/Notice text is blank/i)
     end
   end
 

--- a/rails/spec/controllers/external_activities_controller_spec.rb
+++ b/rails/spec/controllers/external_activities_controller_spec.rb
@@ -245,8 +245,8 @@ describe ExternalActivitiesController do
 
       materials_collection_items = MaterialsCollectionItem.where(materials_collection_id: materials_collection.id)
       expect(materials_collection_items.length).to be(1)
-      expect(flash[:notice]).to be_present
-      expect(flash[:notice]).to match(/is assigned to the selected collection\(s\) successfully/)
+      expect(flash['notice']).to be_present
+      expect(flash['notice']).to match(/is assigned to the selected collection\(s\) successfully/)
     end
 
     it "should return an error if a collection is not specified" do
@@ -257,8 +257,8 @@ describe ExternalActivitiesController do
       sign_in admin
       put :update_collections, post_params
 
-      expect(flash[:error]).to be_present
-      expect(flash[:error]).to match(/Select at least one collection to assign this resource/)
+      expect(flash['error']).to be_present
+      expect(flash['error']).to match(/Select at least one collection to assign this resource/)
     end
   end
 

--- a/rails/spec/controllers/interactives_controller_spec.rb
+++ b/rails/spec/controllers/interactives_controller_spec.rb
@@ -52,7 +52,7 @@ describe InteractivesController do
           }
         }
 
-        expect(flash[:notice]).to eq("Interactive was successfully created.")
+        expect(flash['notice']).to eq("Interactive was successfully created.")
         expect(assigns(:interactive).publication_status).to be publication_status
         expect(response).to redirect_to(interactive_path(assigns(:interactive)))
       end
@@ -72,7 +72,7 @@ describe InteractivesController do
             :credits => credits
           }
         }
-        expect(flash[:notice]).to eq("Interactive was successfully created.")
+        expect(flash['notice']).to eq("Interactive was successfully created.")
         expect(assigns(:interactive).publication_status).to eq("draft")
         expect(response).to redirect_to(interactive_path(assigns(:interactive)))
       end
@@ -98,7 +98,7 @@ describe InteractivesController do
           :update_subject_areas => "true",
           :subject_areas => ["Physical Science"]
         }
-        expect(flash[:notice]).to eq("Interactive was successfully created.")
+        expect(flash['notice']).to eq("Interactive was successfully created.")
         expect(assigns(:interactive).model_type_list).to match_array(["model_type_1"])
         expect(assigns(:interactive).grade_level_list).to match_array(["1","5"])
         expect(assigns(:interactive).subject_area_list).to match_array(["Physical Science"])
@@ -135,7 +135,7 @@ describe InteractivesController do
 
       updated = Interactive.find(test_interactive.id)
       expect(updated.model_type_list).to match_array(["model_type_2"])
-      expect(flash[:notice]).to eq("Interactive was successfully updated.")
+      expect(flash['notice']).to eq("Interactive was successfully updated.")
     end
   end
 

--- a/rails/spec/controllers/passwords_controller_spec.rb
+++ b/rails/spec/controllers/passwords_controller_spec.rb
@@ -26,7 +26,7 @@ describe PasswordsController do
       post :create_by_login, @params
 
       expect(response).to be_success
-      expect(flash[:error]).not_to be_nil
+      expect(flash['error']).not_to be_nil
     end
 
     it "will fail gracefully for students without security questions" do
@@ -35,7 +35,7 @@ describe PasswordsController do
       post :create_by_login, @params
 
       expect(response).to be_success
-      expect(flash[:error]).not_to be_nil
+      expect(flash['error']).not_to be_nil
     end
 
     it "will send an email reset notification for non-students with email" do
@@ -47,7 +47,7 @@ describe PasswordsController do
       post :create_by_login, @params
 
       expect(@response).to redirect_to(root_path)
-      expect(flash[:error]).to be_nil
+      expect(flash['error']).to be_nil
     end
 
     it "will ask security questions for students" do
@@ -59,7 +59,7 @@ describe PasswordsController do
       post :create_by_login, @params
 
       expect(@response).to redirect_to(password_questions_path(@forgetful_user))
-      expect(flash[:error]).to be_nil
+      expect(flash['error']).to be_nil
     end
 
     describe "security questions" do
@@ -103,7 +103,7 @@ describe PasswordsController do
         post :check_questions, @answers_params
 
         expect(@response).to redirect_to(password_questions_path(@forgetful_user))
-        expect(flash[:error]).not_to be_nil
+        expect(flash['error']).not_to be_nil
       end
 
       it "will raise an error if the user submits an answer to a question that does not belong to the current user" do
@@ -134,7 +134,7 @@ describe PasswordsController do
 
       post :create_by_email, @params
 
-      expect(flash[:error]).to be_nil
+      expect(flash['error']).to be_nil
     end
 
   end

--- a/rails/spec/controllers/portal/clazzes_controller_spec.rb
+++ b/rails/spec/controllers/portal/clazzes_controller_spec.rb
@@ -235,7 +235,7 @@ describe Portal::ClazzesController do
 
       post :create, @post_params
 
-      assert flash[:error]
+      assert flash['error']
       expect(Portal::Clazz.count).to eq(current_count)
     end
 
@@ -261,7 +261,7 @@ describe Portal::ClazzesController do
 
       post :create, @post_params
 
-      assert flash[:error]
+      assert flash['error']
       expect(Portal::Clazz.count).to equal(current_count)
     end
 
@@ -319,7 +319,7 @@ describe Portal::ClazzesController do
 
       put :update, @post_params
 
-      assert flash[:error]
+      assert flash['error']
     end
 
     it "should let me update a class with no grade levels when grade levels are disabled" do

--- a/rails/spec/controllers/portal/students_controller_spec.rb
+++ b/rails/spec/controllers/portal/students_controller_spec.rb
@@ -228,7 +228,7 @@ describe Portal::StudentsController do
           to_return(status: 200, body: "Success", headers: {})
 
         post :move, id: @student.id, clazz: @clazz_params
-        expect(flash[:notice]).to match(/Successfully moved student to new class./)
+        expect(flash['notice']).to match(/Successfully moved student to new class./)
       end
     end
 

--- a/rails/spec/controllers/security_questions_controller_spec.rb
+++ b/rails/spec/controllers/security_questions_controller_spec.rb
@@ -78,7 +78,7 @@ describe SecurityQuestionsController do
 
       put :update, @params_for_update
 
-      expect(flash[:error]).to include("Wicked bad errors!")
+      expect(flash['error']).to include("Wicked bad errors!")
       expect(response).to render_template("edit")
     end
   end

--- a/rails/spec/controllers/users_controller_spec.rb
+++ b/rails/spec/controllers/users_controller_spec.rb
@@ -134,30 +134,30 @@ describe UsersController do
       expect(User.authenticate('aaron', 'monkey')).to be_nil
       get :activate, :activation_code => users(:aaron).activation_code
       expect(response).to redirect_to('/login')
-      expect(flash[:notice]).not_to be_nil
-      expect(flash[:error ]).to     be_nil
+      expect(flash['notice']).not_to be_nil
+      expect(flash['error']).to     be_nil
       expect(User.authenticate('aaron', 'monkey')).to eq(users(:aaron))
     end
 
     it 'does not activate user without key' do
       skip "Broken example"
       get :activate
-      expect(flash[:notice]).to     be_nil
-      expect(flash[:error ]).not_to be_nil
+      expect(flash['notice']).to     be_nil
+      expect(flash['error']).not_to be_nil
     end
 
     it 'does not activate user with blank key' do
       skip "Broken example"
       get :activate, :activation_code => ''
-      expect(flash[:notice]).to     be_nil
-      expect(flash[:error ]).not_to be_nil
+      expect(flash['notice']).to     be_nil
+      expect(flash['error']).not_to be_nil
     end
 
     it 'does not activate user with bogus key' do
       skip "Broken example"
       get :activate, :activation_code => 'i_haxxor_joo'
-      expect(flash[:notice]).to     be_nil
-      expect(flash[:error ]).not_to be_nil
+      expect(flash['notice']).to     be_nil
+      expect(flash['error']).not_to be_nil
     end
 
     it 'shows thank you page to teacher on successful registration' do
@@ -185,8 +185,8 @@ describe UsersController do
 
       assert_select "*#clazzes_nav", false
 
-      expect(flash[:error]).to be_nil
-      expect(flash[:notice]).to be_nil
+      expect(flash['error']).to be_nil
+      expect(flash['notice']).to be_nil
     end
   end
 


### PR DESCRIPTION
## Description:
> Flash message keys are normalized to strings. They can still be accessed using either symbols or strings. Looping through the flash will always yield string keys:

```

flash["string"] = "a string"
flash[:symbol] = "a symbol"

# Rails < 4.1
flash.keys # => ["string", :symbol]

# Rails >= 4.1
flash.keys # => ["string", "symbol"]
```

### See Upgrade Guide:
https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#flash-structure-changes

### Story
[#175171538]
https://www.pivotaltracker.com/story/show/175171538