### PR TITLE
Set active_support.test_order to sorted

### DIFF
--- a/rails/config/environments/test.rb
+++ b/rails/config/environments/test.rb
@@ -41,5 +41,8 @@ RailsPortal::Application.configure do
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
 
+  # Keep test order in same order as before Rails 5
+  config.active_support.test_order = :sorted
+
   LogConfig.configure(config, ENV['TEST_LOG_LEVEL'], 'WARN')
 end


### PR DESCRIPTION
This is the current default test order.  Without this setting a deprecation warning in shown pre-Rails 5.