### PR TITLE
Set production log level [#175289201]

### DIFF
--- a/rails/config/environments/production.rb
+++ b/rails/config/environments/production.rb
@@ -21,8 +21,8 @@ RailsPortal::Application.configure do
   # If you have no front-end server that supports something like X-Sendfile,
   # just comment this out and Rails will serve the files
 
-  # See everything in the log (default is :info)
-  # config.log_level = :debug
+  # See info messages and above in the log (default is :debug in Rails 5)
+  config.log_level = :info
 
   # Use a different logger for distributed setups
   # config.logger = SyslogLogger.new


### PR DESCRIPTION
Removes a deprecation - in Rails 5 the default log level changes to :debug.