### PR TITLE
update rails base image

### DIFF
--- a/rails/Dockerfile
+++ b/rails/Dockerfile
@@ -1,4 +1,4 @@
-FROM concordconsortium/docker-rails-base-private:ruby-2.3.7-rails-3.2.22.19
+FROM concordconsortium/docker-rails-base-private:2.3.7-4.2.11.17
 
 # Debian 8 (jessie) is no longer supported
 RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie main" >> /etc/apt/sources.list.d/jessie.list

--- a/rails/Dockerfile-dev
+++ b/rails/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM concordconsortium/docker-rails-base-private:ruby-2.3.7-rails-3.2.22.19
+FROM concordconsortium/docker-rails-base-private:2.3.7-4.2.11.17
 
 # Debian 8 (jessie) is no longer supported
 RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie main" >> /etc/apt/sources.list.d/jessie.list


### PR DESCRIPTION
Without I was getting an error:
E: Failed to fetch http://security.debian.org/debian-security/pool/updates/main/o/openjdk-8/openjdk-8-jre-headless_8u265-b01-0+deb9u1_amd64.deb  404  Not Found
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
ERROR: Service 'app' failed to build: The command '/bin/sh -c apt-get install -qq -y default-jre-headless' returned a non-zero code: 100