### PR TITLE
FirebaseJWTs for students when SPA is not launched directly

### DIFF
--- a/rails/app/controllers/api/v1/jwt_controller.rb
+++ b/rails/app/controllers/api/v1/jwt_controller.rb
@@ -3,7 +3,20 @@ class API::V1::JwtController < API::APIController
   require 'digest/md5'
   skip_before_filter :verify_authenticity_token
 
+  # use exceptions to return errors
+  # instead of directly calling APIController#error
+  rescue_from StandardError, with: :error_400
+  rescue_from SignedJWT::Error, with: :error_500
+
   private
+  def error_400(e)
+    error(e.message, 400)
+  end
+
+  def error_500(e)
+    error(e.message, 500)
+  end
+
   def add_admin_claims(user, claims)
     if (user.has_role? 'admin')
       claims[:admin] = 1
@@ -20,11 +33,7 @@ class API::V1::JwtController < API::APIController
 
   public
   def portal
-    begin
-      user, role = check_for_auth_token(params)
-    rescue StandardError => e
-      return error(e.message)
-    end
+    user, role = check_for_auth_token(params)
 
     if role
       learner = role[:learner]
@@ -52,29 +61,21 @@ class API::V1::JwtController < API::APIController
     end
     add_admin_claims(user,claims)
 
-    begin
-      render status: 201, json: {token: SignedJWT::create_portal_token(user, claims, 3600)}
-    rescue StandardError => e
-      return error(e.message, 500)
-    end
+    render status: 201, json: {token: SignedJWT::create_portal_token(user, claims, 3600)}
   end
 
 
   # POST api/v1/jwt/firebase as a logged in user, or
   # GET  api/v1/jwt/firebase?firebase_app=abc with a valid bearer token
   def firebase
-    begin
-      user, role = check_for_auth_token(params)
-    rescue StandardError => e
-      return error(e.message)
-    end
+    user, role = check_for_auth_token(params)
 
     if role
       learner = role[:learner]
       teacher = role[:teacher]
     end
 
-    return error('Missing firebase_app parameter') if params[:firebase_app].blank?
+    raise StandardError, "Missing firebase_app parameter" if params[:firebase_app].blank?
 
     claims = {}
     if learner
@@ -104,7 +105,7 @@ class API::V1::JwtController < API::APIController
       if params[:class_hash].present?
         class_hashes = teacher.clazzes.map {|c| c.class_hash}
         if !class_hashes.include? params[:class_hash]
-          return error('Teacher does not have a class with the requested class_hash')
+          raise StandardError, "Teacher does not have a class with the requested class_hash"
         end
       end
 
@@ -140,11 +141,7 @@ class API::V1::JwtController < API::APIController
     # the firebase uid must be between 1-36 characters and unique across all portals, MD5 yields a 32 byte string
     uid = Digest::MD5.hexdigest(url_for(user))
 
-    begin
-      render status: 201, json: {token: SignedJWT::create_firebase_token(uid, params[:firebase_app], 3600, claims)}
-    rescue StandardError => e
-      return error(e.message, 500)
-    end
+    render status: 201, json: {token: SignedJWT::create_firebase_token(uid, params[:firebase_app], 3600, claims)}
   end
 
 end

--- a/rails/factories/portal_districts.rb
+++ b/rails/factories/portal_districts.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :portal_district, :class => Portal::District do |f|
     f.name {APP_CONFIG[:site_district] || "Test District"}
+    f.state { "MA" }
   end
 end
 

--- a/rails/spec/controllers/api/v1/jwt_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/jwt_controller_spec.rb
@@ -112,114 +112,149 @@ SHlL1Ceaqm35aMguGMBcTs6T5jRJ36K2OPEXU2ZOiRygxcZhFw==
       end
     end
 
-    context "when a valid authentication header token is sent without a learner or teacher" do
-      before(:each) {
-        set_auth_token(user_token)
-        FirebaseApp.create!(firebase_app_attributes)
-      }
+    context "when a valid authentication header token is sent" do
+      context "and the token has no learner or teacher" do
+        before(:each) {
+          set_auth_token(user_token)
+          FirebaseApp.create!(firebase_app_attributes)
+        }
 
-      context "when a firebase_app param is not sent" do
-        it "returns 500" do
-          post :firebase, {:firebase_app => "invalid app"}, :format => :json
-          expect(response.status).to eq(500)
+        context "and a firebase_app param is not sent" do
+          it "returns 500" do
+            post :firebase, {:firebase_app => "invalid app"}, :format => :json
+            expect(response.status).to eq(500)
+          end
+        end
+
+        context "and an invalid firebase_app param is sent" do
+          it "returns 400" do
+            post :firebase, {}, :format => :json
+            expect(response.status).to eq(400)
+          end
+        end
+
+        context "and a firebase_app param is sent" do
+          it "returns a valid JWT" do
+            allow(APP_CONFIG).to receive(:[]).and_call_original
+            allow(APP_CONFIG).to receive(:[]).with(:site_url).and_return("http://test.host/")
+            post :firebase, {:firebase_app => "test app"}, :format => :json
+            expect(response.status).to eq(201)
+
+            body = JSON.parse(response.body)
+            token = body["token"]
+            decoded_token = SignedJWT::decode_firebase_token(token, firebase_app_name)
+            expect(decoded_token[:data]["uid"]).to eql uid
+            expect(decoded_token[:data]["claims"]["platform_id"]).to eq "http://test.host/"
+            expect(decoded_token[:data]["claims"]["platform_user_id"]).to eq user.id
+            expect(decoded_token[:data]["claims"]["user_type"]).to eq "user"
+            expect(decoded_token[:data]["claims"]["user_id"]).to eq url_for_user
+          end
+        end
+
+        context "and firebase_app and resource_link_id params are sent" do
+          context "and the user of the auth header token has a learner with that resource_link_id" do
+            let(:user) { learner.student.user }
+            it "returns a valid JWT with learner params" do
+              post :firebase,
+                {:firebase_app => "test app", :resource_link_id => offering.id.to_s},
+                :format => :json
+              expect(response.status).to eq(201)
+
+              body = JSON.parse(response.body)
+              token = body["token"]
+              decoded_token = SignedJWT::decode_firebase_token(token, firebase_app_name)
+
+              expect(decoded_token[:data]["uid"]).to eql uid
+              expect(decoded_token[:data]["domain"]).to eql root_url
+              expect(decoded_token[:data]["externalId"]).to eql learner.id
+              expect(decoded_token[:data]["returnUrl"]).not_to be_nil
+              expect(decoded_token[:data]["logging"]).to eql true
+              expect(decoded_token[:data]["domain_uid"]).to eql user.id
+              expect(decoded_token[:data]["class_info_url"]).not_to be_nil
+              expect(decoded_token[:data]["claims"]["user_type"]).to eq "learner"
+              expect(decoded_token[:data]["claims"]["user_id"]).to eq url_for_user
+              expect(decoded_token[:data]["claims"]["class_hash"]).not_to be_nil
+              expect(decoded_token[:data]["claims"]["offering_id"]).to eq offering.id
+            end
+          end
         end
       end
 
-      context "when an invalid firebase_app param is sent" do
-        it "returns 400" do
-          post :firebase, {}, :format => :json
-          expect(response.status).to eq(400)
+      context "and the token has a learner" do
+        before(:each) {
+          set_auth_token(learner_token)
+          FirebaseApp.create!(firebase_app_attributes)
+        }
+
+        it "returns a valid JWT with learner params" do
+          post :firebase, {:firebase_app => "test app"}, :format => :json
+          expect(response.status).to eq(201)
+
+          body = JSON.parse(response.body)
+          token = body["token"]
+          decoded_token = SignedJWT::decode_firebase_token(token, firebase_app_name)
+
+          expect(decoded_token[:data]["uid"]).to eql uid
+          expect(decoded_token[:data]["domain"]).to eql root_url
+          expect(decoded_token[:data]["externalId"]).to eql learner.id
+          expect(decoded_token[:data]["returnUrl"]).not_to be_nil
+          expect(decoded_token[:data]["logging"]).to eql true
+          expect(decoded_token[:data]["domain_uid"]).to eql user.id
+          expect(decoded_token[:data]["class_info_url"]).not_to be_nil
+          expect(decoded_token[:data]["claims"]["user_type"]).to eq "learner"
+          expect(decoded_token[:data]["claims"]["user_id"]).to eq url_for_user
+          expect(decoded_token[:data]["claims"]["class_hash"]).not_to be_nil
+          expect(decoded_token[:data]["claims"]["offering_id"]).to eq offering.id
         end
       end
 
-      context "and a firebase_app param is sent" do
-      it "returns a valid JWT" do
-        allow(APP_CONFIG).to receive(:[]).and_call_original
-          allow(APP_CONFIG).to receive(:[]).with(:site_url).and_return("http://test.host/")
-        post :firebase, {:firebase_app => "test app"}, :format => :json
-        expect(response.status).to eq(201)
+      context "and the token has a teacher" do
+        before(:each) {
+          set_auth_token(teacher_token)
+          FirebaseApp.create!(firebase_app_attributes)
+        }
 
-        body = JSON.parse(response.body)
-        token = body["token"]
-        decoded_token = SignedJWT::decode_firebase_token(token, firebase_app_name)
-        expect(decoded_token[:data]["uid"]).to eql uid
-        expect(decoded_token[:data]["claims"]["platform_id"]).to eq "http://test.host/"
-        expect(decoded_token[:data]["claims"]["platform_user_id"]).to eq user.id
-        expect(decoded_token[:data]["claims"]["user_type"]).to eq "user"
-        expect(decoded_token[:data]["claims"]["user_id"]).to eq url_for_user
-      end
-    end
-
-    end
-
-    context "when a valid authentication header token is sent with a learner" do
-      before(:each) {
-        set_auth_token(learner_token)
-        FirebaseApp.create!(firebase_app_attributes)
-      }
-
-      it "returns a valid JWT with learner params" do
-        post :firebase, {:firebase_app => "test app"}, :format => :json
-        expect(response.status).to eq(201)
-
-        body = JSON.parse(response.body)
-        token = body["token"]
-        decoded_token = SignedJWT::decode_firebase_token(token, firebase_app_name)
-
-        expect(decoded_token[:data]["uid"]).to eql uid
-        expect(decoded_token[:data]["domain"]).to eql root_url
-        expect(decoded_token[:data]["externalId"]).to eql learner.id
-        expect(decoded_token[:data]["returnUrl"]).not_to be_nil
-        expect(decoded_token[:data]["logging"]).to eql true
-        expect(decoded_token[:data]["domain_uid"]).to eql user.id
-        expect(decoded_token[:data]["class_info_url"]).not_to be_nil
-        expect(decoded_token[:data]["claims"]["user_type"]).to eq "learner"
-        expect(decoded_token[:data]["claims"]["user_id"]).to eq url_for_user
-        expect(decoded_token[:data]["claims"]["class_hash"]).not_to be_nil
-        expect(decoded_token[:data]["claims"]["offering_id"]).to eq offering.id
-      end
-    end
-
-    context "when a valid authentication header token is sent with a teacher" do
-      before(:each) {
-        set_auth_token(teacher_token)
-        FirebaseApp.create!(firebase_app_attributes)
-      }
-
-      context "and the class hash is invalid" do
-        it "returns 400" do
-          post :firebase, {:firebase_app => "test app", :class_hash => "invalid"}, :format => :json
-          expect(response.status).to eq(400)
+        context "and there is no class hash" do
+          it "returns a valid JWT" do
+            allow(APP_CONFIG).to receive(:[]).and_call_original
+            allow(APP_CONFIG).to receive(:[]).with(:site_url).and_return("http://test.host/")
+            post :firebase, {:firebase_app => "test app"}, :format => :json
+            expect(response.status).to eq(201)
+            body = JSON.parse(response.body)
+            token = body["token"]
+            decoded_token = SignedJWT::decode_firebase_token(token, firebase_app_name)
+            data = OpenStruct.new decoded_token[:data]
+            claims = OpenStruct.new data.claims
+            expect(data.uid).to eql uid
+            expect(data.domain).to eql root_url
+            expect(claims.user_type).to eq "teacher"
+            expect(claims.user_id).to eq url_for_user
+            expect(claims.class_hash).to eq nil
+            expect(claims.platform_id).to eq "http://test.host/"
+          end
         end
-      end
 
-      it "returns a valid JWT with teacher params without a class hash" do
-        allow(APP_CONFIG).to receive(:[]).and_call_original
-        allow(APP_CONFIG).to receive(:[]).with(:site_url).and_return("http://test.host/")
-        post :firebase, {:firebase_app => "test app"}, :format => :json
-        expect(response.status).to eq(201)
-        body = JSON.parse(response.body)
-        token = body["token"]
-        decoded_token = SignedJWT::decode_firebase_token(token, firebase_app_name)
-        data = OpenStruct.new decoded_token[:data]
-        claims = OpenStruct.new data.claims
-        expect(data.uid).to eql uid
-        expect(data.domain).to eql root_url
-        expect(claims.user_type).to eq "teacher"
-        expect(claims.user_id).to eq url_for_user
-        expect(claims.class_hash).to eq nil
-        expect(claims.platform_id).to eq "http://test.host/"
-      end
+        context "and there is a class hash" do
+          context "and the class hash is invalid" do
+            it "returns 400" do
+              post :firebase, {:firebase_app => "test app", :class_hash => "invalid"}, :format => :json
+              expect(response.status).to eq(400)
+            end
+          end
 
-      it "returns a valid JWT with teacher params with a class hash" do
-        post :firebase, {:firebase_app => "test app", :class_hash => clazz.class_hash}, :format => :json
-        expect(response.status).to eq(201)
+          context "and the class_hash is for a class of the teacher" do
+            it "returns a valid JWT with this class hash" do
+              post :firebase, {:firebase_app => "test app", :class_hash => clazz.class_hash}, :format => :json
+              expect(response.status).to eq(201)
 
-        body = JSON.parse(response.body)
-        token = body["token"]
-        decoded_token = SignedJWT::decode_firebase_token(token, firebase_app_name)
+              body = JSON.parse(response.body)
+              token = body["token"]
+              decoded_token = SignedJWT::decode_firebase_token(token, firebase_app_name)
 
-        expect(decoded_token[:data]["claims"]["class_hash"]).to eq clazz.class_hash
+              expect(decoded_token[:data]["claims"]["class_hash"]).to eq clazz.class_hash
+            end
+          end
+        end
       end
     end
   end
@@ -236,116 +271,150 @@ SHlL1Ceaqm35aMguGMBcTs6T5jRJ36K2OPEXU2ZOiRygxcZhFw==
       end
     end
 
-  context "when a valid authentication header token is sent without a learner or teacher" do
-    before(:each) {
-      set_auth_token(user_token)
-    }
+    context "when a valid authentication header token is sent" do
 
-      context "when a HMAC secret is not set" do
-        it "returns 500" do
-          allow(ENV).to receive(:[]).and_call_original
-          allow(ENV).to receive(:[]).with('JWT_HMAC_SECRET').and_return(nil)
+      context "and the token has no learner or teacher" do
+        before(:each) {
+          set_auth_token(user_token)
+        }
+
+        context "and a JWT_HMAC_SECRET is not set" do
+          it "returns 500" do
+            allow(ENV).to receive(:[]).and_call_original
+            allow(ENV).to receive(:[]).with('JWT_HMAC_SECRET').and_return(nil)
+            post :portal, {}, :format => :json
+            expect(response.status).to eq(500)
+          end
+        end
+
+        it "returns a valid JWT" do
           post :portal, {}, :format => :json
-          expect(response.status).to eq(500)
+          expect(response.status).to eq(201)
+
+          body = JSON.parse(response.body)
+          token = body["token"]
+          decoded_token = SignedJWT::decode_portal_token(token)
+          expect(decoded_token[:data]["uid"]).to eql user.id
+        end
+
+        context "and a resource_link_id is sent" do
+          context "and the user of the token has a learner with that resource_link_id" do
+            let(:user) { learner.student.user }
+            it "returns a valid JWT with learner params" do
+              post :portal, {:resource_link_id => offering.id}, :format => :json
+              expect(response.status).to eq(201)
+
+              body = JSON.parse(response.body)
+              token = body["token"]
+              decoded_token = SignedJWT::decode_portal_token(token)
+
+              expect(decoded_token[:data]["uid"]).to eql user.id
+              expect(decoded_token[:data]["domain"]).to eql root_url
+              expect(decoded_token[:data]["user_type"]).to eq "learner"
+              expect(decoded_token[:data]["user_id"]).not_to be_nil
+              expect(decoded_token[:data]["learner_id"]).to eq learner.id
+              expect(decoded_token[:data]["class_info_url"]).not_to be_nil
+              expect(decoded_token[:data]["offering_id"]).to eq offering.id
+            end
+          end
+          context "and the user of the token has a learner without that resource_link_id" do
+            let(:user) { learner.student.user }
+            it "returns a 400" do
+              post :portal, {:resource_link_id => 99999}, :format => :json
+              expect(response.status).to eq(400)
+            end
+          end
+          context "and the user of the token is not a student" do
+            it "returns a 400" do
+              post :portal, {:resource_link_id => offering.id}, :format => :json
+              expect(response.status).to eq(400)
+            end
+          end
         end
       end
 
-    it "returns a valid JWT" do
-      post :portal, {}, :format => :json
-      expect(response.status).to eq(201)
+      context "and the token has a learner" do
+        before(:each) {
+          set_auth_token(learner_token)
+        }
 
-      body = JSON.parse(response.body)
-      token = body["token"]
-      decoded_token = SignedJWT::decode_portal_token(token)
-      expect(decoded_token[:data]["uid"]).to eql user.id
+        it "returns a valid JWT with learner params" do
+          post :portal, {}, :format => :json
+          expect(response.status).to eq(201)
+
+          body = JSON.parse(response.body)
+          token = body["token"]
+          decoded_token = SignedJWT::decode_portal_token(token)
+
+          expect(decoded_token[:data]["uid"]).to eql user.id
+          expect(decoded_token[:data]["domain"]).to eql root_url
+          expect(decoded_token[:data]["user_type"]).to eq "learner"
+          expect(decoded_token[:data]["user_id"]).not_to be_nil
+          expect(decoded_token[:data]["learner_id"]).to eq learner.id
+          expect(decoded_token[:data]["class_info_url"]).not_to be_nil
+          expect(decoded_token[:data]["offering_id"]).to eq offering.id
+        end
+      end
+
+      context "and the token has a teacher" do
+        before(:each) {
+          set_auth_token(teacher_token)
+        }
+
+        it "returns a valid JWT with teacher params without a class hash" do
+          post :portal, {}, :format => :json
+          expect(response.status).to eq(201)
+
+          body = JSON.parse(response.body)
+          token = body["token"]
+          decoded_token = SignedJWT::decode_portal_token(token)
+
+          expect(decoded_token[:data]["uid"]).to eql user.id
+          expect(decoded_token[:data]["domain"]).to eql root_url
+          expect(decoded_token[:data]["user_type"]).to eq "teacher"
+          expect(decoded_token[:data]["user_id"]).not_to be_nil
+          expect(decoded_token[:data]["teacher_id"]).to eq class_teacher.id
+          expect(decoded_token[:data]["admin"]).to eq -1
+        end
+
+        context "and the user is an admin" do
+          before(:each) {
+            user.add_role("admin")
+          }
+
+          it "returns a valid JWT with an admin flag set" do
+            post :portal, {}, :format => :json
+            expect(response.status).to eq(201)
+
+            body = JSON.parse(response.body)
+            token = body["token"]
+            decoded_token = SignedJWT::decode_portal_token(token)
+
+            expect(decoded_token[:data]["admin"]).to eql 1
+            expect(decoded_token[:data]["project_admins"]).to eql []
+          end
+        end
+
+
+        context "and the user is a project admin" do
+          let(:project)         { FactoryBot.create(:project)}
+          before(:each) {
+            user.project_users.create({project_id: project.id, is_admin: true})
+          }
+
+          it "returns a valid JWT with the project in project_admins claim and admin is -1" do
+            post :portal, {}, :format => :json
+            expect(response.status).to eq(201)
+
+            body = JSON.parse(response.body)
+            token = body["token"]
+            decoded_token = SignedJWT::decode_portal_token(token)
+
+            expect(decoded_token[:data]["admin"]).to eql -1
+            expect(decoded_token[:data]["project_admins"]).to eql [project.id]
+          end
+        end
+      end
     end
   end
-
-  context "when a valid authentication header token is sent with a learner" do
-    before(:each) {
-      set_auth_token(learner_token)
-    }
-
-    it "returns a valid JWT with learner params" do
-      post :portal, {}, :format => :json
-      expect(response.status).to eq(201)
-
-      body = JSON.parse(response.body)
-      token = body["token"]
-      decoded_token = SignedJWT::decode_portal_token(token)
-
-      expect(decoded_token[:data]["uid"]).to eql user.id
-      expect(decoded_token[:data]["domain"]).to eql root_url
-      expect(decoded_token[:data]["user_type"]).to eq "learner"
-      expect(decoded_token[:data]["user_id"]).not_to be_nil
-      expect(decoded_token[:data]["learner_id"]).to eq learner.id
-      expect(decoded_token[:data]["class_info_url"]).not_to be_nil
-      expect(decoded_token[:data]["offering_id"]).to eq offering.id
-    end
-  end
-
-  context "when a valid authentication header token is sent with a teacher" do
-    before(:each) {
-      set_auth_token(teacher_token)
-    }
-
-    it "returns a valid JWT with teacher params without a class hash" do
-      post :portal, {}, :format => :json
-      expect(response.status).to eq(201)
-
-      body = JSON.parse(response.body)
-      token = body["token"]
-      decoded_token = SignedJWT::decode_portal_token(token)
-
-      expect(decoded_token[:data]["uid"]).to eql user.id
-      expect(decoded_token[:data]["domain"]).to eql root_url
-      expect(decoded_token[:data]["user_type"]).to eq "teacher"
-      expect(decoded_token[:data]["user_id"]).not_to be_nil
-      expect(decoded_token[:data]["teacher_id"]).to eq class_teacher.id
-      expect(decoded_token[:data]["admin"]).to eq -1
-    end
-  end
-
-  context "when a valid authentication header token is sent with an admin" do
-    let(:user)            { FactoryBot.create(:user) }
-    before(:each) {
-      user.add_role("admin")
-      set_auth_token(teacher_token)
-    }
-
-    it "returns a valid JWT with an admin flag set" do
-      post :portal, {}, :format => :json
-      expect(response.status).to eq(201)
-
-      body = JSON.parse(response.body)
-      token = body["token"]
-      decoded_token = SignedJWT::decode_portal_token(token)
-
-      expect(decoded_token[:data]["admin"]).to eql 1
-      expect(decoded_token[:data]["project_admins"]).to eql []
-    end
-  end
-
-  context "when a valid authentication header token is sent by project admin" do
-    let(:user)            { FactoryBot.create(:user) }
-    let(:project)         { FactoryBot.create(:project)}
-    before(:each) {
-      user.project_users.create({project_id: project.id, is_admin: true})
-      set_auth_token(teacher_token)
-    }
-
-    it "returns a valid JWT with an admin flag set" do
-      post :portal, {}, :format => :json
-      expect(response.status).to eq(201)
-
-      body = JSON.parse(response.body)
-      token = body["token"]
-      decoded_token = SignedJWT::decode_portal_token(token)
-
-      expect(decoded_token[:data]["admin"]).to eql -1
-      expect(decoded_token[:data]["project_admins"]).to eql [project.id]
-    end
-  end
-  end
-
 end

--- a/rails/spec/controllers/api/v1/jwt_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/jwt_controller_spec.rb
@@ -395,7 +395,6 @@ SHlL1Ceaqm35aMguGMBcTs6T5jRJ36K2OPEXU2ZOiRygxcZhFw==
           end
         end
 
-
         context "and the user is a project admin" do
           let(:project)         { FactoryBot.create(:project)}
           before(:each) {

--- a/rails/spec/controllers/api/v1/jwt_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/jwt_controller_spec.rb
@@ -93,6 +93,11 @@ SHlL1Ceaqm35aMguGMBcTs6T5jRJ36K2OPEXU2ZOiRygxcZhFw==
 -----END RSA PRIVATE KEY-----"
         } }
 
+  before(:each) {
+    # prevent warnings about undefined default settings
+    generate_default_settings_and_jnlps_with_mocks
+  }
+
   describe "GET #firebase" do
 
     context "when a valid authentication header token is sent without a learner or teacher" do


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/175765233

The new feature here is that the a client can request a JWT with a `resource_link_id` parameter. The portal will then add the learner claims to the JWT if the current user (based on the token in the header) is a student that has a learner with associated with that resource_link.  

Resource Link is the term used by LTI. In our portal this is an offering_id. I choose resource_link_id so this api will require fewer changes when we pull it out from the portal into its own service which can work with both the portal and generic LTI platforms.

The test output documents the behavior:
```
API::V1::JwtController
  GET #firebase
    when a invalid authentication header token is sent
      returns 400
    when a valid authentication header token is sent
      and the token has no learner or teacher
        and a firebase_app param is not sent
          returns 500
        and an invalid firebase_app param is sent
          returns 400
        and a firebase_app param is sent
          returns a valid JWT
        and firebase_app and resource_link_id params are sent
          and the user of the auth header token has a learner with that resource_link_id
            returns a valid JWT with learner params
      and the token has a learner
        returns a valid JWT with learner params
      and the token has a teacher
        and there is no class hash
          returns a valid JWT
        and there is a class hash
          and the class hash is invalid
            returns 400
          and the class_hash is for a class of the teacher
            returns a valid JWT with this class hash
  GET #portal
    when a invalid authentication header token is sent
      returns 400
    when a valid authentication header token is sent
      and the token has no learner or teacher
        returns a valid JWT
        when a HMAC secret is not set
          returns 500
        and a resource_link_id is sent
          and the user of the token has a learner with that resource_link_id
            returns a valid JWT with learner params
          and the user of the token has a learner without that resource_link_id
            returns a 400
          and the user of the token is not a student
            returns a 400
      and the token has a learner
        returns a valid JWT with learner params
      and the token has a teacher
        returns a valid JWT with teacher params without a class hash
        and the user is an admin
          returns a valid JWT with an admin flag set
        and the user is a project admin
          returns a valid JWT with the project in project_admins claim and admin is -1
```