### PR TITLE
Remove is_member set when portal admins add a user to a project [#176436014]

### DIFF
--- a/rails/app/controllers/users_controller.rb
+++ b/rails/app/controllers/users_controller.rb
@@ -158,7 +158,6 @@ class UsersController < ApplicationController
               all_projects = Admin::Project.all
               @user.set_role_for_projects('admin', all_projects, params[:user][:admin_project_ids] || [])
               @user.set_role_for_projects('researcher', all_projects, params[:user][:researcher_project_ids] || [])
-              @user.set_role_for_projects('member', all_projects, params[:user][:member_project_ids] || [])
             end
           elsif current_visitor.is_project_admin?
             if params[:user][:has_projects_in_form]

--- a/rails/spec/models/user_spec.rb
+++ b/rails/spec/models/user_spec.rb
@@ -389,19 +389,43 @@ describe User do
     let(:user)             { FactoryBot.create(:user)    }
     let(:selected_projects){ [ projects.first] }
 
-    before(:each) do
-      user.set_role_for_projects('admin', projects, selected_projects.map(&:id) )
+    describe "for admins" do
+      before(:each) do
+        user.set_role_for_projects('admin', projects, selected_projects.map(&:id) )
+      end
+
+      it "should be a project admin for the first project now " do
+        expect(user.is_project_admin?(projects.first)).to eq true
+      end
+
+      it "should list one admin_project" do
+        expect(user.admin_for_projects.size).to eq(1)
+        expect(user.admin_for_projects).to include(projects.first)
+      end
     end
 
-    it "should be a project admin for the first project now " do
-      expect(user.is_project_admin?(projects.first)).to eq true
+    describe "for researchers" do
+      before(:each) do
+        user.set_role_for_projects('researcher', projects, selected_projects.map(&:id) )
+      end
+
+      it "should be a project researcher for the first project now " do
+        expect(user.is_project_researcher?(projects.first)).to eq true
+      end
+
+      it "should list one researcher project" do
+        expect(user.researcher_for_projects.size).to eq(1)
+        expect(user.researcher_for_projects).to include(projects.first)
+      end
     end
 
-    it "should list one admin_project" do
-      expect(user.admin_for_projects.size).to eq(1)
-      expect(user.admin_for_projects).to include(projects.first)
+    describe "for members" do
+      it "should fail as it is no longer a valid role" do
+        expect {
+          user.set_role_for_projects('member', projects, selected_projects.map(&:id) )
+        }.to raise_error(ActiveModel::MissingAttributeError)
+      end
     end
-
   end
 
   describe "find_for_omniauth" do


### PR DESCRIPTION
The is_member attribute is no longer an attribute on the project users model.