### PR TITLE
Devs can set theme using `.env` vars like production.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,7 +135,7 @@ services:
       # Log manager endpoint (defaults to staging)
       #
       LOGGER_URI: "${LOGGER_URI:-//cc-log-manager-dev.herokuapp.com/api/logs}"
-
+      THEME: "${THEME:-learn}"
     # open standard in and turn on tty so we can attach to the container and debug it
     stdin_open: true
     tty: true

--- a/rails/config/settings.sample.yml
+++ b/rails/config/settings.sample.yml
@@ -33,7 +33,7 @@ development: &non_production_settings
     - "11"
     - "12"
     - "Higher Ed"
-  :theme: learn
+  :theme: <%= ENV["THEME"] || 'learn' %>
   :help_email: rails-portal@concord.org
   :dont_sanitize_xhtml: true
   :tiny_mce:
@@ -84,6 +84,7 @@ staging:
       - justifyleft,justifycenter,justifyright
       - code
   :pepper: 7ed5d246-cc1a-11e1-81dd-0800270eb79b
+  :theme: <%= ENV["THEME"] || 'learn' %>
 
 production:
   :site_name: Rails Portal
@@ -113,3 +114,4 @@ production:
       - justifyleft,justifycenter,justifyright
       - code
   :pepper: 7ed5d246-cc1a-11e1-81dd-0800270eb79b
+  :theme: <%= ENV["THEME"] || 'learn' %>


### PR DESCRIPTION
@scytacki -- as we discussed yesterday. 

More work needs to be done to manage the Theme and assets, but this allows developers to set the theme from the environment, following the pattern of production configuration.

[#176802099]