### PR TITLE
Fixed save of enabled bookmark types in admin settings [#177438793]

### DIFF
--- a/rails/app/controllers/admin/settings_controller.rb
+++ b/rails/app/controllers/admin/settings_controller.rb
@@ -110,9 +110,11 @@ class Admin::SettingsController < ApplicationController
   def admin_settings_strong_params(params)
     params && params.permit(:about_page_content, :active, :allow_adhoc_schools, :allow_default_class, :anonymous_can_browse_materials,
                             :auto_set_teachers_as_authors, :custom_help_page_html, :custom_search_path, :default_cohort_id, :description,
-                            :enable_grade_levels, :enable_member_registration, :enabled_bookmark_types, :external_url, :help_type,
+                            :enable_grade_levels, :enable_member_registration, :external_url, :help_type,
                             :home_page_content, :include_external_activities, :jnlp_cdn_hostname, :jnlp_url, :pub_interval,
                             :require_user_consent, :show_collections_menu, :teacher_home_path, :teachers_can_author, :use_bitmap_snapshots,
-                            :use_periodic_bundle_uploading, :use_student_security_questions, :user_id, :wrap_home_page_content)
+                            :use_periodic_bundle_uploading, :use_student_security_questions, :user_id, :wrap_home_page_content,
+                            # array value for this field
+                            :enabled_bookmark_types => [])
   end
 end


### PR DESCRIPTION
The strong  params setting for enabled_bookmark_types was not set as an array value so it was being dropped before it reached the update_attributes method in the settings model which used it.

I checked the other models and this is the only field that is serialized as an array so no other strong params need to be updated.