### PR TITLE
Fixed  class sort api url [#177438813]

### DIFF
--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -443,10 +443,12 @@ RailsPortal::Application.routes.draw do
 
         resources :teacher_classes, only: [:show] do
           member do
-            post :sort
             post :set_active
             post :copy
           end
+        end
+        namespace :teacher_classes do
+          post :sort
         end
 
         namespace :jwt do

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -442,13 +442,13 @@ RailsPortal::Application.routes.draw do
         end
 
         resources :teacher_classes, only: [:show] do
+          collection do
+            post :sort
+          end
           member do
             post :set_active
             post :copy
           end
-        end
-        namespace :teacher_classes do
-          post :sort
         end
 
         namespace :jwt do


### PR DESCRIPTION
The class sort api url was set as a member resource in the routes which was not correct (as it pertains to all classes and not a specific class).

This caused the "Manage Class List" to silently fail which wasn't evident until you reloaded the page and saw the class orderings revert.