### PR TITLE
Added mimemagic gem directly to fix axlsx gem install issue [#177649866]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - cd rails
   - "export DISPLAY=:99.0"
   # the next command is to fix "SSLContext object is not available" error in awscli install
-  - travis_retry pip install requests[security]
+  - travis_retry pip install urllib3[secure]
   - travis_retry pip install --user awscli
   - bundle config gems.railslts.com $RAILS_LTS_USER:$RAILS_LTS_PASSWORD
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,9 @@ env:
 before_install:
   - cd rails
   - "export DISPLAY=:99.0"
-  - pip install --user awscli
+  # the next command is to fix "SSLContext object is not available" error in awscli install
+  - travis_retry pip install requests[security]
+  - travis_retry pip install --user awscli
   - bundle config gems.railslts.com $RAILS_LTS_USER:$RAILS_LTS_PASSWORD
 
 before_script:

--- a/rails/Dockerfile
+++ b/rails/Dockerfile
@@ -15,6 +15,9 @@ RUN apt-get install -qq -y default-jre-headless
 # install foreman
 RUN gem install foreman
 
+# install shared mime info for mimemagic gem
+RUN apt-get install -qq -y shared-mime-info
+
 # if this is changed it also needs to be changed in nginx-sites.conf and unicorn.rb
 ENV APP_HOME /rigse
 

--- a/rails/Dockerfile-dev
+++ b/rails/Dockerfile-dev
@@ -24,6 +24,11 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
   && apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y google-chrome-stable
 
 #
+# Install shared mime info for mimemagic gem
+#
+RUN apt-get install -qq -y shared-mime-info
+
+#
 # Install wait-for-it to support docker-volume-sync
 #
 WORKDIR /usr/local/bin

--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -57,7 +57,7 @@ gem 'in_place_editing', git: 'https://github.com/concord-consortium/in_place_edi
 gem 'json', '~> 1.8.6'
 gem 'jwt'
 gem 'jquery-fileupload-rails'
-gem 'mimemagic', '~> 0.3.7'
+gem 'mimemagic', '0.3.10'
 gem 'mysql2', '~> 0.3.16', platforms: [:ruby, :mingw]
 gem 'nested_form'
 gem 'net-sftp', '~> 2.0', require: 'net/sftp'

--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -57,6 +57,7 @@ gem 'in_place_editing', git: 'https://github.com/concord-consortium/in_place_edi
 gem 'json', '~> 1.8.6'
 gem 'jwt'
 gem 'jquery-fileupload-rails'
+gem 'mimemagic', '~> 0.3.7'
 gem 'mysql2', '~> 0.3.16', platforms: [:ruby, :mingw]
 gem 'nested_form'
 gem 'net-sftp', '~> 2.0', require: 'net/sftp'

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -926,7 +926,9 @@ GEM
       webrobots (>= 0.0.9, < 0.2)
     method_source (0.9.0)
     mime-types (1.25.1)
-    mimemagic (0.3.2)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.3.0)
     minitest (5.14.2)
@@ -1272,6 +1274,7 @@ DEPENDENCIES
   jwt
   launchy
   lol_dba
+  mimemagic (~> 0.3.7)
   mysql2 (~> 0.3.16)
   nested_form
   net-sftp (~> 2.0)

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -1274,7 +1274,7 @@ DEPENDENCIES
   jwt
   launchy
   lol_dba
-  mimemagic (~> 0.3.7)
+  mimemagic (= 0.3.10)
   mysql2 (~> 0.3.16)
   nested_form
   net-sftp (~> 2.0)


### PR DESCRIPTION
The mimemagic gem that the axlsx depended on in the Gemfile.lock was removed from rubygems due to a licensing issue of a database that it directly distributed.
    
This PR adds the GPL licensed database that mimemagic depends on via a apt install and then installs a version of mimemagic that uses that database.

NOTE this PR also fixes an issue in the Travis setup of the awscli.