### PR TITLE
Fixed N+1 queries by adding includes to user admin page search query [#176874032]

### DIFF
--- a/rails/app/controllers/users_controller.rb
+++ b/rails/app/controllers/users_controller.rb
@@ -40,6 +40,9 @@ class UsersController < ApplicationController
       "LEFT JOIN admin_project_users ON users.id = admin_project_users.user_id "
 
     search_scope = policy_scope(User)
+    search_scope = search_scope
+      .includes(:imported_user, :portal_student, :authentications, :teacher_cohorts, :student_cohorts, :roles)
+      .includes({ portal_teacher: [:schools, teacher_clazzes: [:clazz]] })
     search_scope = search_scope.joins(join_string).where(user_types).distinct()
     @users = search_scope.search(params[:search], params[:page], nil)
     respond_to do |format|


### PR DESCRIPTION
This reduced the query count on my local install from 202 to 50 for the first page.

NOTE: There are extra includes within the portal_teacher that are not used.