### PR TITLE
Test what breaks when dynamic route is removed

### DIFF
--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -561,7 +561,8 @@ RailsPortal::Application.routes.draw do
     # the controller catch-all and the root route
     get '/:landing_page_slug' => 'admin/projects#landing_page', :as => :project_page, :constraints => { :landing_page_slug => /[a-z0-9\-]+/ }
 
-    get '/:controller(/:action(/:id))'
+    # this is going to be deprecated in Rails 5.2
+    # get '/:controller(/:action(/:id))'
 
     root :to => 'home#index'
   end


### PR DESCRIPTION
Dynamic routes (dynamic :controller or :action segments) are deprecated in Rails 5.2.  This is a test to see what breaks in the tests of master (Rails 4) when this route is removed.