### PR TITLE
176661412 questions out of order report

### DIFF
--- a/rails/lib/activity_runtime_api.rb
+++ b/rails/lib/activity_runtime_api.rb
@@ -300,15 +300,16 @@ class ActivityRuntimeAPI
     iq_cache = {} unless iq_cache.kind_of?(Hash)
     if_cache = {} unless if_cache.kind_of?(Hash)
 
-    hash["sections"].each_with_index do |section_data, section_index|
+    hash["sections"].each.with_index(1) do |section_data, section_index|
       section = Section.create(
         :name => section_data["name"],
         :activity => activity,
         :user => user,
         :position => section_index
       )
-
-      section_data["pages"].each_with_index do |page_data, page_index|
+      # acts_as_list uses 1-based indexing on position. A 0 here could
+      # mess things up, see https://github.com/brendon/acts_as_list#more-options
+      section_data["pages"].each.with_index(1) do |page_data, page_index|
         page = Page.create(
           :name => page_data["name"],
           :url => page_data["url"],
@@ -317,7 +318,7 @@ class ActivityRuntimeAPI
           :position => page_index
         )
 
-        page_data["elements"].each_with_index do |element_data, element_index|
+        page_data["elements"].each.with_index(1) do |element_data, element_index|
           embeddable = case element_data["type"]
           when "open_response"
             existant = or_cache.delete(element_data["id"].to_s) # nil if the key doesn't exist - note the key must be string

--- a/rails/spec/libs/activity_runtime_api_spec.rb
+++ b/rails/spec/libs/activity_runtime_api_spec.rb
@@ -64,8 +64,36 @@ RSpec::Matchers.define :have_page_like do |name,url|
   match do |thing|
     activity = thing.respond_to?(:template) ? thing.template : thing
     pages = activity.pages
-    pages.detect{|p| p.name == name &&  p.url == url }
+    pages.detect{ |p| p.name == name &&  p.url == url }
   end
+end
+
+def make_activity_hash(num_pages, questions_per_page)
+  act = OpenStruct.new
+  act.name = 'Activity'
+  act.descripton = 'LARA might still send description, but Portal should ignore it'
+  question_number = 0
+  section = OpenStruct.new
+  section.title="Section 1"
+  section.pages = []
+  (1..num_pages + 1).each do |i|
+    page = OpenStruct.new
+    page.name = "Page #{i}"
+    page.url = "https://pages.com/#{i}"
+    page.elements = []
+    (1..questions_per_page + 1).each do |j|
+      question_number += 1
+      page_index = "P:#{i}-#{j}"
+      question = OpenStruct.new
+      question.type = "open_response"
+      question.prompt = "question #{question_number} #{page_index}"
+      question.id = question_number
+      page.elements.push(question.to_h)
+    end
+    section.pages.push(page.to_h)
+  end
+  act.sections = [section.to_h]
+  act.to_h
 end
 
 describe ActivityRuntimeAPI do


### PR DESCRIPTION
This is ready for a review.

The PT Story: https://www.pivotaltracker.com/n/projects/2441249/stories/176661412

## Steps to reproduce
- Download a details report for any sequence
- Compare question order in the downloaded report to question order in the activities
## Expected
- Question order in the downloaded report should match the question order of the activities.
## Actual
- Question order in the downloaded report does not match the question order in the activities. Additional information detailed in this Slack thread.

Summary:  When we updates to Rails 4, there was an update to the acts-as-list gem.  In our publication code, we were setting the position attribute to "0" which is *not* the top-of-list by default, see: https://github.com/brendon/acts_as_list#more-options


bdf9d60 created a failing test expaction
c666b9e fixed the publication code to index pages and page elements starting at 1, which fixed the test failure.

A local details report I had run previously had incorrect question numbers.  After republishing with the code fix, the report had questions in the correct order.




