### PR TITLE
separate out app:setup:create_default_data

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,10 @@ pass before changing any code.
 
 Prepare a database for use when running the spec tests:
 
+    RAILS_ENV=test rake db:create
     rake db:test:prepare
     rake db:feature_test:prepare
+    RAILS_ENV=cucumber rake app:setup:create_default_data
 
 Start SOLR in test environment (it works with cucumber tests too):
 
@@ -85,6 +87,7 @@ Prepare a database for use when running the cucumber tests:
 
     RAILS_ENV=feature_test rake db:create
     rake db:feature_test:prepare
+    RAILS_ENV=cucumber rake app:setup:create_default_data
 
 Run the cucumber integration tests:
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -193,7 +193,10 @@ https://docs.docker.com/docker-for-mac/networking/#/i-want-to-connect-from-a-con
 ## Running rspec and cucumber tests with docker
 
 1. Connect to the running docker instance of your "app" service.
-> `$ docker-compose exec app bash`
+    docker-compose exec app bash
+2. Then in the container, the first time you need to create the test and feature databases
+    RAILS_ENV=test bundle exec rake db:create
+    RAILS_ENV=cucumber bundle exec rake db:create
 2. Invoke the appropriate `run-<test>.sh` script. This should be one of the following scripts which will be mounted in the `/rigse` directory:
     * `docker/dev/run-spec.sh`
     * `docker/dev/run-cucumber.sh`

--- a/rails/config/initializers/devise.rb
+++ b/rails/config/initializers/devise.rb
@@ -82,9 +82,14 @@ Devise.setup do |config|
   # a value less than 10 in other environments.
   config.stretches = (Rails.env.development? || Rails.env.production? || Rails.env.staging?) ? 10 : 1
   #config.stretches = 10
+
   # Setup a pepper to generate the encrypted password.
   # config.pepper = "c035da42b7b4b6cf6b985bebab88a20d78f62c6593f818992be75dca07cf7f6ad9bf983ee8b71ed56354487055fb8ffba683dca86b80f31072ca8692f55dfbc1"
-  config.pepper = APP_CONFIG[:pepper]
+
+  # In order to run the user specs the encrypted passwords
+  # for the 'quentin' and 'aaron' users in spec/fixtures/users.yml
+  # need to be created with a hard-coded pepper used during testing.
+  config.pepper = (Rails.env.development? || Rails.env.production? || Rails.env.staging?) ? APP_CONFIG[:pepper] : 'sitekeyforrunningtests'
 
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without

--- a/rails/docker/dev/run-cucumber-chrome.sh
+++ b/rails/docker/dev/run-cucumber-chrome.sh
@@ -1,11 +1,18 @@
 #!/bin/bash
 
 #
-# Prepare the cucumber database by checking if there are migrations not
-# run on the development database,
-# then loading the schema.rb into the cucumber database
+# Prepare the cucumber database:
+#  - checking if there are migrations not run on the development database
+#  - drop cucumber database
+#  - create cucumber database
+#  - load schema.rb into cucumber database
 #
 bundle exec rake db:feature_test:prepare
+
+#
+# Add users, students, teachers, classes, resources, and assignments
+#
+RAILS_ENV=cucumber bundle exec rake app:setup:create_default_data
 
 #
 # Run cucumber tests

--- a/rails/docker/dev/run-cucumber-search.sh
+++ b/rails/docker/dev/run-cucumber-search.sh
@@ -1,11 +1,18 @@
 #!/bin/bash
 
 #
-# Prepare the cucumber database by checking if there are migrations not
-# run on the development database,
-# then loading the schema.rb into the cucumber database
+# Prepare the cucumber database:
+#  - checking if there are migrations not run on the development database
+#  - drop cucumber database
+#  - create cucumber database
+#  - load schema.rb into cucumber database
 #
 bundle exec rake db:feature_test:prepare
+
+#
+# Add users, students, teachers, classes, resources, and assignments
+#
+RAILS_ENV=cucumber bundle exec rake app:setup:create_default_data
 
 #
 # Run cucumber tests

--- a/rails/docker/dev/run-cucumber.sh
+++ b/rails/docker/dev/run-cucumber.sh
@@ -4,12 +4,18 @@
 #
 
 #
-# Prepare the cucumber database by checking if there are migrations not
-# run on the development database,
-# then loading the schema.rb into the cucumber database
+# Prepare the cucumber database:
+#  - checking if there are migrations not run on the development database
+#  - drop cucumber database
+#  - create cucumber database
+#  - load schema.rb into cucumber database
 #
 bundle exec rake db:feature_test:prepare
 
+#
+# Add users, students, teachers, classes, resources, and assignments
+#
+RAILS_ENV=cucumber bundle exec rake app:setup:create_default_data
 
 #
 # Run cucumber tests

--- a/rails/docker/dev/run-spec.sh
+++ b/rails/docker/dev/run-spec.sh
@@ -12,7 +12,19 @@
 
 bundle exec rake db:test:prepare
 
+#
+# Prepare the cucumber database:
+#  - checking if there are migrations not run on the development database
+#  - drop cucumber database
+#  - create cucumber database
+#  - load schema.rb into cucumber database
+#
 bundle exec rake db:feature_test:prepare
+
+#
+# Add users, students, teachers, classes, resources, and assignments
+#
+RAILS_ENV=cucumber bundle exec rake app:setup:create_default_data
 
 if [ "$1" == "setup" ]; then
     echo

--- a/rails/lib/tasks/cucumber.rake
+++ b/rails/lib/tasks/cucumber.rake
@@ -14,28 +14,28 @@ begin
   require 'cucumber/rake/task'
 
   namespace :cucumber do
-    Cucumber::Rake::Task.new({:ok => 'db:feature_test:prepare'}, 'Run features that should pass') do |t|
+    Cucumber::Rake::Task.new(:ok, 'Run features that should pass') do |t|
       t.binary = vendored_cucumber_bin # If nil, the gem's binary is used.
       t.fork = true # You may get faster startup if you set this to false
       t.profile = 'default'
       t.cucumber_opts = 'features --format progress'
     end
 
-    Cucumber::Rake::Task.new({:wip => 'db:feature_test:prepare'}, 'Run features that are being worked on') do |t|
+    Cucumber::Rake::Task.new(:wip, 'Run features that are being worked on') do |t|
       t.binary = vendored_cucumber_bin
       t.fork = true # You may get faster startup if you set this to false
       t.profile = 'wip'
       t.cucumber_opts = 'features --format progress'
     end
 
-    Cucumber::Rake::Task.new({:rerun => 'db:feature_test:prepare'}, 'Record failing features and run only them if any exist') do |t|
+    Cucumber::Rake::Task.new(:rerun, 'Record failing features and run only them if any exist') do |t|
       t.binary = vendored_cucumber_bin
       t.fork = true # You may get faster startup if you set this to false
       t.profile = 'rerun'
       t.cucumber_opts = 'features --format progress'
     end
 
-    Cucumber::Rake::Task.new({:javascript => 'db:feature_test:prepare'}, 'Run just the features requiring javascript') do |t|
+    Cucumber::Rake::Task.new(:javascript, 'Run just the features requiring javascript') do |t|
       t.binary = vendored_cucumber_bin
       t.fork = true # You may get faster startup if you set this to false
       t.profile = 'default'

--- a/rails/lib/tasks/db_feature_test_prepare.rake
+++ b/rails/lib/tasks/db_feature_test_prepare.rake
@@ -17,12 +17,6 @@ namespace :db do
       ActiveRecord::Schema.verbose = false
       ActiveRecord::Tasks::DatabaseTasks.load_schema_for ActiveRecord::Base.configurations['feature_test'], :ruby, ENV['SCHEMA']
       # end of db:test_load_schema copy
-
-      require File.expand_path('../../../spec/spec_helper.rb', __FILE__)
-      APP_CONFIG[:password_for_default_users] = 'password'
-
-      puts "Loading default data into database: #{ActiveRecord::Base.connection.current_database}"
-      Rake::Task['app:setup:create_default_data'].invoke
     end
 
   end

--- a/rails/lib/tasks/default_users_roles_and_portal_resources.rake
+++ b/rails/lib/tasks/default_users_roles_and_portal_resources.rake
@@ -74,7 +74,11 @@ namespace :app do
     end
     
     desc "Create default data. It is a blank task that calls other task to create default data."
-    task :create_default_data => [:environment, :create_default_learners_and_learner_attempts] do
+    task :create_default_data => [:environment, :load_factory_bot, :create_default_learners_and_learner_attempts] do
+    end
+
+    task :load_factory_bot do
+      FactoryBot.find_definitions
     end
     
     desc "Deletes the default data"

--- a/rails/script/travis_before_script
+++ b/rails/script/travis_before_script
@@ -18,6 +18,7 @@ bundle exec spring binstub --all
 ./bin/rake db:migrate
 ./bin/rake db:test:prepare
 ./bin/rake db:feature_test:prepare
+RAILS_ENV=cucumber bundle exec rake app:setup:create_default_data
 RAILS_GROUPS=assets ./bin/rake assets:precompile
 RAILS_ENV=test ./bin/rake sunspot:solr:start &
 sleep 10 # give SOLR some time to start and init

--- a/rails/script/travis_before_script
+++ b/rails/script/travis_before_script
@@ -18,7 +18,7 @@ bundle exec spring binstub --all
 ./bin/rake db:migrate
 ./bin/rake db:test:prepare
 ./bin/rake db:feature_test:prepare
-RAILS_ENV=cucumber bundle exec rake app:setup:create_default_data
-RAILS_GROUPS=assets ./bin/rake assets:precompile
 RAILS_ENV=test ./bin/rake sunspot:solr:start &
 sleep 10 # give SOLR some time to start and init
+RAILS_ENV=cucumber bundle exec rake app:setup:create_default_data
+RAILS_GROUPS=assets ./bin/rake assets:precompile

--- a/rails/spec/spec_helper_common.rb
+++ b/rails/spec/spec_helper_common.rb
@@ -108,7 +108,7 @@ begin
 rescue => exception
   puts
   puts "*** pending migrations need to be applied to run the tests"
-  puts "*** run: rake db:migrate; rake db:test:prepare; rake db:feature_test:prepare"
+  puts "*** run: rake db:migrate; rake db:test:prepare; rake db:feature_test:prepare; RAILS_ENV=cucumber rake app:setup:create_default_data"
   puts "RAILS_ENV: #{ENV['RAILS_ENV']}"
   puts "Rails.env: #{Rails.env}"
   puts "Database: #{ActiveRecord::Base.connection.current_database}"

--- a/rails/spec/support/controller_helper.rb
+++ b/rails/spec/support/controller_helper.rb
@@ -1,18 +1,3 @@
-
-# In order to run the user specs the encrypted passwords
-# for the 'quentin' and 'aaron' users in spec/fixtures/users.yml
-# need to be created with a hard-coded pepper used for testing.
-#
-# suppress_warnings is a Kernel extension ...
-# See: config/initializers/00_core_extensions.rb
-#
-suppress_warnings {
-  APP_CONFIG[:pepper] = 'sitekeyforrunningtests'
-  Devise.setup do |config|
-    config.pepper = APP_CONFIG[:pepper]
-  end
-}
-
 # This modification allows stubing helper methods when using integrate views
 # the template object isn't ready until the render method is called, so this code
 # adds a hook to be run before render is run.


### PR DESCRIPTION
This had been broken since I cleaned up db:features_test:prepare
The app:setup:create_default_data task was running in the development environment.
It was populating the cucumber database because of the active record statements in db:features_test:prepare
But the Rails.env was development. This meant the password hashing algorithm was
the same as development so it had 10 stretches. But at the same time the spec_helper was loaded
which meant that pepper was being overridden.

The result of those password issues was that the users created by the rake task had invalid
passwords when the cucumber environment was run directly outside of the tests. Also I think this might have causes problems for some cucumber tests which we bypassed without fixing the problem. 

So now the same password configuration is used during the rake task, running the tests, and when running the rails server with the cucumber environment.