### PR TITLE
include project name the cohort list on user researcher page

### DIFF
--- a/rails/app/controllers/api/v1/report_users_controller.rb
+++ b/rails/app/controllers/api/v1/report_users_controller.rb
@@ -200,8 +200,9 @@ class API::V1::ReportUsersController < API::APIController
     end
 
     query_scope
+      .joins("LEFT OUTER JOIN admin_projects ON admin_projects.id = admin_cohorts.project_id")
       .uniq
-      .select("admin_cohorts.id, admin_cohorts.name as label")
+      .select("admin_cohorts.id, CONCAT(COALESCE(admin_projects.name,'No Project'), ': ', admin_cohorts.name) as label")
   end
 
   def runnables_query(options, user, scopes, ids)

--- a/rails/app/controllers/api/v1/report_users_controller.rb
+++ b/rails/app/controllers/api/v1/report_users_controller.rb
@@ -203,6 +203,7 @@ class API::V1::ReportUsersController < API::APIController
       .joins("LEFT OUTER JOIN admin_projects ON admin_projects.id = admin_cohorts.project_id")
       .uniq
       .select("admin_cohorts.id, CONCAT(COALESCE(admin_projects.name,'No Project'), ': ', admin_cohorts.name) as label")
+      .order("label")
   end
 
   def runnables_query(options, user, scopes, ids)

--- a/rails/spec/controllers/api/v1/report_users_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/report_users_controller_spec.rb
@@ -5,6 +5,11 @@ describe API::V1::ReportUsersController do
   let(:admin_user)        { FactoryBot.generate(:admin_user)     }
   let(:simple_user)       { FactoryBot.create(:confirmed_user, :login => "authorized_student") }
 
+  before(:each) {
+    # This silences warnings in the console when running
+    generate_default_settings_and_jnlps_with_mocks
+  }
+
   describe "anonymous' access" do
     before (:each) do
       logout_user
@@ -50,8 +55,10 @@ describe API::V1::ReportUsersController do
       @teacher5 = FactoryBot.create(:portal_teacher)
       @teacher6 = FactoryBot.create(:portal_teacher)
 
+      @project1 = FactoryBot.create(:project, name: 'Project 1')
+
       @cohort1 = FactoryBot.create(:admin_cohort)
-      @cohort2 = FactoryBot.create(:admin_cohort)
+      @cohort2 = FactoryBot.create(:admin_cohort, project: @project1)
 
       @teacher3.cohorts << @cohort1
       @teacher4.cohorts << @cohort1
@@ -98,6 +105,9 @@ describe API::V1::ReportUsersController do
         json = JSON.parse(response.body)
         expect(response.status).to eql(200)
         expect(json["hits"]["cohorts"].length).to eql(2)
+        # fixme the id
+        expect(json["hits"]["cohorts"][0]).to eql({"id"=>@cohort1.id, "label"=>"No Project: test cohort"})
+        expect(json["hits"]["cohorts"][1]).to eql({"id"=>@cohort2.id, "label"=>"Project 1: test cohort"})
       end
       it "gets all runnables" do
         get :index, { load_all: "runnables" }


### PR DESCRIPTION
Cohort names are often generic like Default or Support. So the project name is necessary to identify them.
In other places the `Cohort.fullname` function is used for this, but here we seem to be going for speed so I did it with SQL.

The logic of the two approach is slightly different. `Cohort.fullname` will not put the `"No Project: "` in front of the cohort name. There are no cohorts without projects in learn.concord.org (they are kind of pointless) so this is an edge case that doesn't seem important to unify.

TODO:
- [x] add spec test