### PR TITLE
we allow get requests to the jwt controller

### DIFF
--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -465,7 +465,9 @@ RailsPortal::Application.routes.draw do
 
         namespace :jwt do
           post :portal
+          get  :portal
           post :firebase
+          get  :firebase
         end
 
         resources :external_activities, :only => [:create] do


### PR DESCRIPTION
I tried adding a spec test for this, but the controller specs don't go through the router
And it doesn't seem worthwhile to add a routing spec just for this one file when
the router is so sparsely covered already.
Ideally this will be covered by one of the upcoming cypress integration tests which
are going to try launching the activity-player from the portal.