### PR TITLE
re-add route used by external apps

### DIFF
--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -17,6 +17,7 @@ RailsPortal::Application.routes.draw do
   match '/oauth/token' => 'auth#access_token', via: [:get, :post]
   get   '/auth/failure' => 'auth#failure'
   get   '/auth/isalive' => 'auth#isalive'
+  get   '/auth/oauth_authorize' => 'auth#oauth_authorize'
   get   '/auth/user' => 'auth#user'
 
   match "search" => 'search#index', :as => :search, via: [:get, :post]


### PR DESCRIPTION
This route is used by the token-service example, glossary authoring, portal-report, vortex, and portal's react-admin-interface
https://github.com/search?q=org%3Aconcord-consortium+auth%2Foauth_authorize&type=code

It is used for OAuth2 from SPAs, so it is just a get request not a post request.