### PR TITLE
178181964-fix-dockerfile

### DIFF
--- a/rails/Dockerfile
+++ b/rails/Dockerfile
@@ -51,6 +51,7 @@ ENV RAILS_ENV=production
 # otherwise somewhere in the initializers it tries to connect to the database which will fail
 RUN cp config/settings.sample.yml config/settings.yml
 ENV DOCKER_NO_INIT_ON_PRECOMPILE=true
+ENV RAILS_SECRET_KEY_BASE=FAKE_DOCKER_KEY
 RUN bundle exec rake assets:precompile
 RUN cp docker/prod/config/settings.yml config/settings.yml
 


### PR DESCRIPTION
When we build our Docker Image we need to precompile assets. 

We need to provide a face secret_key_base for the initializer in this step.