### PR TITLE
Fix several issues with running all the migrations from scratch

### DIFF
--- a/docker/portal-image/docker-compose.yml
+++ b/docker/portal-image/docker-compose.yml
@@ -6,7 +6,7 @@ version: '2.1'
 services:
   app:
     # To use a different tag, create an .env file with PORTAL_IMAGE_TAG defined
-    image: concordconsortium/rigse:${PORTAL_IMAGE_TAG:-master}
+    image: concordconsortium/rigse-railslts:${PORTAL_IMAGE_TAG:-master}
     environment:
       DB_HOST: mysql
       DB_USER: root

--- a/rails/db/migrate/20100208172613_add_response_count_to_saveables.rb
+++ b/rails/db/migrate/20100208172613_add_response_count_to_saveables.rb
@@ -2,11 +2,11 @@ class AddResponseCountToSaveables < ActiveRecord::Migration
   def self.up
     add_column :saveable_open_responses,              :response_count, :integer, :default => 0
     add_column :saveable_multiple_choices,            :response_count, :integer, :default => 0
-    
+
     # update new counter_cache attributes ...
     [Saveable::OpenResponse, Saveable::MultipleChoice].each do |klass|
       klass.reset_column_information
-      klass.find(:all, :include => :answers).each do |saveable| 
+      klass.includes(:answers).find_each do |saveable| 
         klass.update_counters(saveable.id, :response_count => saveable.answers.length)
       end
     end

--- a/rails/db/migrate/20120514113009_portal_offerings.rb
+++ b/rails/db/migrate/20120514113009_portal_offerings.rb
@@ -1,8 +1,7 @@
 class PortalOfferings < ActiveRecord::Migration
   def self.up
-    add_column :portal_offerings, :position, :integer, :default=>0 
-    clazzes = Portal::Clazz.find(:all)
-    clazzes.each do|clazz|
+    add_column :portal_offerings, :position, :integer, :default=>0
+    clazzes = Portal::Clazz.find_each do|clazz|
       portal_offerings = clazz.offerings
       position = 1
       portal_offerings.each do|portal_offering|

--- a/rails/db/migrate/20120531150444_add_active_field_to_teacher_clazz.rb
+++ b/rails/db/migrate/20120531150444_add_active_field_to_teacher_clazz.rb
@@ -2,21 +2,21 @@ class AddActiveFieldToTeacherClazz < ActiveRecord::Migration
 
   # faux model for successful migration
   class Portal::TeacherClazz < ActiveRecord::Base
-    set_table_name :portal_teacher_clazzes
+    self.table_name = :portal_teacher_clazzes
   end
-  
-  
+
+
   def self.up
     add_column :portal_teacher_clazzes, :active, :boolean, :default=>true
     Portal::TeacherClazz.reset_column_information
     portal_clazzes = Portal::TeacherClazz.all
     portal_clazzes.each do |teacher_clazz|
-      teacher_clazz.active = true 
+      teacher_clazz.active = true
       teacher_clazz.save!
     end
   end
 
   def self.down
     remove_column :portal_teacher_clazzes, :active
-  end 
+  end
 end

--- a/rails/db/migrate/20120601065824_add_position_field_to_clazz.rb
+++ b/rails/db/migrate/20120601065824_add_position_field_to_clazz.rb
@@ -1,7 +1,7 @@
 class AddPositionFieldToClazz < ActiveRecord::Migration
   
   class Portal::TeacherClazz < ActiveRecord::Base
-    set_table_name :portal_teacher_clazzes
+    self.table_name = :portal_teacher_clazzes
   end 
   
   def self.up

--- a/rails/db/migrate/20120712064000_add_complete_percent_to_report_learner.rb
+++ b/rails/db/migrate/20120712064000_add_complete_percent_to_report_learner.rb
@@ -2,7 +2,7 @@ class AddCompletePercentToReportLearner < ActiveRecord::Migration
 
   # faux model for successful migration
   class Report::Learner < ActiveRecord::Base
-    set_table_name :report_learners
+    self.table_name = :report_learners
     belongs_to   :learner, :class_name => "Portal::Learner", :foreign_key => "learner_id"
   end
 

--- a/rails/db/migrate/20140722115635_cleanup_bookmark_types.rb
+++ b/rails/db/migrate/20140722115635_cleanup_bookmark_types.rb
@@ -10,7 +10,7 @@ class CleanupBookmarkTypes < ActiveRecord::Migration
 
   def up
     Portal::Bookmark.where({ type: 'GenericBookmark' }).update_all({ type: 'Portal::GenericBookmark' })
-    Portal::Bookmark.where({ type: 'PadletBookmark' }}.update_all({ type: 'Portal::PadletBookmark' })
+    Portal::Bookmark.where({ type: 'PadletBookmark' }).update_all({ type: 'Portal::PadletBookmark' })
     # Admin will have to re-enable bookmarks.
     Admin::Project.update_all({ enabled_bookmark_types: [] })
   end

--- a/rails/db/migrate/20140905200154_create_portal_countries.rb
+++ b/rails/db/migrate/20140905200154_create_portal_countries.rb
@@ -7,8 +7,8 @@ class CreatePortalCountries < ActiveRecord::Migration
       t.string  :two_letter,       :limit => 2
       t.string  :three_letter,     :limit => 3
       t.string  :tld,              :limit => 255
-      t.integer :iso_id,           :limit => 255
-      
+      t.integer :iso_id
+
       t.timestamps
     end
 
@@ -17,4 +17,3 @@ class CreatePortalCountries < ActiveRecord::Migration
     add_index :portal_countries, :name
   end
 end
-

--- a/rails/db/migrate/20140918180332_generate_collaborations_using_legacy_collaborations.rb
+++ b/rails/db/migrate/20140918180332_generate_collaborations_using_legacy_collaborations.rb
@@ -43,11 +43,12 @@ class GenerateCollaborationsUsingLegacyCollaborations < ActiveRecord::Migration
 
     # decrease batch size for tempormental hosts.
     # eagerly load associations to be faster
-    Dataservice::BundleContent.find_each(
-    :include => [
+    Dataservice::BundleContent
+    .includes([
        {:bundle_logger => {:learner => :student}},
        :collaborators
-     ], :batch_size => 250) do |bundle|
+     ])
+    .find_each(:batch_size => 250) do |bundle|
        collaborators = bundle.collaborators
        next if collaborators.size == 0
        next if bundle.bundle_logger.learner.nil?

--- a/rails/db/migrate/20170606205853_add_resource_license.rb
+++ b/rails/db/migrate/20170606205853_add_resource_license.rb
@@ -9,7 +9,7 @@ class AddResourceLicense < ActiveRecord::Migration
     # load updated licenses with version numbers
     defs = YAML::load_file(File.join(Rails.root,"config","licenses.yml"));
     defs['licenses'].each do |license_hash|
-      license = CommonsLicense.find_or_create(code: license_hash)
+      license = CommonsLicense.find_or_create_by(license_hash)
       license.update_attributes(license_hash)
       license.save
     end

--- a/rails/db/migrate/20180807215058_add_about_page_content_field.rb
+++ b/rails/db/migrate/20180807215058_add_about_page_content_field.rb
@@ -1,6 +1,6 @@
 class AddAboutPageContentField < ActiveRecord::Migration
   def up
-    add_column :admin_settings, :about_page_content, :mediumtext, :default => "", :null => true
+    add_column :admin_settings, :about_page_content, :text, :limit => 16777215, :null => true
   end
 
   def down


### PR DESCRIPTION
I didn't commit the schema.rb which had several changes after this.
But it seems like the schema is the source of truth now more than the migrations so I didn't want to mess with it.
The differences are around timestamps, limits, and foreign keys. So they all seemed minor.

To test the migrations locally without messing up my main dev database I used this command:
`RAILS_ENV=test bundle exec rake db:drop; RAILS_ENV=test bundle exec rake db:create; RAILS_ENV=test bundle exec rake db:migrate`