### PR TITLE
Split multiple teachers into array for external report

### DIFF
--- a/rails/app/controllers/api/v1/report_learners_es_controller.rb
+++ b/rails/app/controllers/api/v1/report_learners_es_controller.rb
@@ -350,6 +350,16 @@ class API::V1::ReportLearnersEsController < API::APIController
   end
 
   def self.detailed_learner_info(learner)
+    teacherIds = learner.teachers_id.split(', ')
+    teachers = teacherIds.each_with_index.map do |id, i|
+      {
+        user_id: id,
+        name: learner.teachers_name.split(', ')[i],
+        district: learner.teachers_district.split(', ')[i],
+        state: learner.teachers_state.split(', ')[i],
+        email: learner.teachers_email.split(', ')[i],
+      }
+    end
     {
       student_id: learner.student_id,
       learner_id: learner.learner_id,
@@ -363,15 +373,7 @@ class API::V1::ReportLearnersEsController < API::APIController
       last_run: learner.last_run,
       run_remote_endpoint: learner.learner ? learner.learner.remote_endpoint_url : nil,
       runnable_url: learner.runnable && learner.runnable.respond_to?(:url) ? learner.runnable.url : nil,
-      teachers: [
-        {
-          user_id: learner.teachers_id,
-          name: learner.teachers_name,
-          district: learner.teachers_district,
-          state: learner.teachers_state,
-          email: learner.teachers_email
-        }
-      ]
+      teachers: teachers
     }
   end
 end


### PR DESCRIPTION
If a class has multiple teachers, the `teachers_` properties will be a comma-separated list. This splits the teachers into an array of multiple teachers if so.

I tried breaking the splitting by adding a comma to the school district and to one of the teacher's names, and it handled it fine, substituting the commas with spaces. (From Kibana I can see that the values are being saved in ES without the commas.)