### PR TITLE
Remove Rush and Sextant gems

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -73,7 +73,6 @@ gem 'RedCloth',             '~> 4.2.8'
 gem 'responders'
 gem 'rollbar'
 gem 'rubyzip',              '~> 1.2.2'
-gem 'rush',                 git: 'https://github.com/concord-consortium/rush.git'
 gem 'sanitize'
 gem 'sass',                 '~> 3.4.0'
 gem 'sass-rails' # if running rails 3.1 or greater
@@ -136,7 +135,6 @@ group :development do
   gem 'rb-inotify', require: false
   gem 'ruby-debug', platforms: [:mri_18, :mingw_18]
   gem 'ruby-prof'
-  gem 'sextant' # adds http://localhost:9000/rails/routes in dev mode
   gem 'spring', '~> 1.7.2'
   gem 'what_methods'
   gem 'wirble'

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -5,13 +5,6 @@ GIT
     in_place_editing (1.2.0)
 
 GIT
-  remote: https://github.com/concord-consortium/rush.git
-  revision: 10d9715697d7cc5ce069c32093289b809dea8bd3
-  specs:
-    rush (0.6.8)
-      session
-
-GIT
   remote: https://github.com/concord-consortium/secure-samesite-cookies.git
   revision: da3078b1f2d1ac9c4c62b5cd7cd4c1fce1eb6dd1
   tag: v1.0.2
@@ -1110,9 +1103,6 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    session (3.2.0)
-    sextant (0.2.4)
-      rails (>= 3.2)
     shellany (0.0.1)
     simplecov (0.16.1)
       docile (~> 1.1)
@@ -1294,12 +1284,10 @@ DEPENDENCIES
   ruby-debug
   ruby-prof
   rubyzip (~> 1.2.2)
-  rush!
   sanitize
   sass (~> 3.4.0)
   sass-rails
   selenium-webdriver
-  sextant
   simplecov
   spring (~> 1.7.2)
   spring-commands-cucumber

--- a/rails/config/initializers/delayed_job_config.rb
+++ b/rails/config/initializers/delayed_job_config.rb
@@ -9,7 +9,9 @@ Delayed::Worker.delay_jobs = !(Rails.env.test? || Rails.env.cucumber?)
 
 if Rails.env.development?
   # use a scaler that dynamically starts the worker process so
-  # devs don't need to remember to start it
+  # devs don't need to remember to start it.
+  # 2021-06-14 NP:  We could set `delay_jobs` to false like we did for tests above
+  # see: https://github.com/collectiveidea/delayed_job#gory-details
   Delayed::Backend::ActiveRecord::Job.send(:include, Delayed::Worker::Scaler)
 end
 

--- a/rails/lib/delayed/worker/scaler.rb
+++ b/rails/lib/delayed/worker/scaler.rb
@@ -1,15 +1,7 @@
 class JobManager
-  def self.instance
-    @@instance = self.new if @@instance.nil?
-    return @@instance
-  end
 
   def ps_tag
     Digest::MD5.hexdigest(Rails.root.to_s)[0..8]
-  end
-
-  def initialize
-    @jobs = []
   end
 
   def exec_env
@@ -18,39 +10,33 @@ class JobManager
 
   def workers
     # Synchronous read for jobs
-    running = `ps`.split("\n").select do |line|
-      line =~ /delayed_job start -i #{ps_tag}/ &&
-      line =~ /#{ps_tag}/
+    all_jobs = `ps aux`.split("\n")
+    running = all_jobs.select do |line|
+      line =~ /delayed_job/ && line =~ /#{ps_tag}/
     end
     running.size
   end
 
   def start
     cmd_args = "script/delayed_job start -i #{ps_tag}".split
-    @jobs << IO.popen([exec_env] + cmd_args)
+    IO.popen([exec_env] + cmd_args)
   end
 
   def stop
     cmd_args = "script/delayed_job stop -i #{ps_tag}".split
-    @jobs << IO.popen([exec_env] + cmd_args)
+    IO.popen([exec_env] + cmd_args)
   end
-
 end
 
 # Controls for spawning a background processor if one doesn't already exist
 # whenever delayed jobs are created.
-# 2021-06-14 NP: If you have any failed jobs, the worker will continue running.
+# 2021-06-14 NP: This worker will continue running. When we switch to
+# ActiveJob, we can use the built-in in-memory job queuing implementation
 
 module Delayed::Worker::Scaler
   def self.included(base)
     base.send :extend, ClassMethods
     base.class_eval do
-      after_commit(on: :update, if: proc { |r| !r.failed_at.nil? }) do
-        self.class.down
-      end
-      after_commit(on: :destroy, if: proc { |r| r.destroyed? || !r.failed_at.nil? }) do
-        self.class.down
-      end
       after_commit(on: :create) do
         self.class.up
       end
@@ -65,13 +51,6 @@ module Delayed::Worker::Scaler
       if workers == 0 && ((Time.now - @@last_start) > 30)
         @@last_start = Time.now
         @@job_manager.start
-      end
-      true
-    end
-
-    def down
-      if jobs.count == 0 and workers > 0
-        @@job_manager.stop
       end
       true
     end

--- a/rails/lib/delayed/worker/scaler.rb
+++ b/rails/lib/delayed/worker/scaler.rb
@@ -1,16 +1,51 @@
-require 'rush'
+class JobManager
+  def self.instance
+    @@instance = self.new if @@instance.nil?
+    return @@instance
+  end
+
+  def ps_tag
+    Digest::MD5.hexdigest(Rails.root.to_s)[0..8]
+  end
+
+  def initialize
+    @jobs = []
+  end
+
+  def exec_env
+    { "RAILS_ENV" => Rails.env }
+  end
+
+  def workers
+    # Synchronous read for jobs
+    running = `ps`.split("\n").select do |line|
+      line =~ /delayed_job start -i #{ps_tag}/ &&
+      line =~ /#{ps_tag}/
+    end
+    running.size
+  end
+
+  def start
+    cmd_args = "script/delayed_job start -i #{ps_tag}".split
+    @jobs << IO.popen([exec_env] + cmd_args)
+  end
+
+  def stop
+    cmd_args = "script/delayed_job stop -i #{ps_tag}".split
+    @jobs << IO.popen([exec_env] + cmd_args)
+  end
+
+end
 
 # Controls for spawning a background processor if one doesn't already exist
-# whenever delayed jobs are created. It will also tear the processor down
-# after all the jobs in the queue have been taken care of.
-
-# Based off the 'workless' gem: https://github.com/lostboy/workless
+# whenever delayed jobs are created.
+# 2021-06-14 NP: If you have any failed jobs, the worker will continue running.
 
 module Delayed::Worker::Scaler
   def self.included(base)
     base.send :extend, ClassMethods
     base.class_eval do
-      after_commit(on: :update, if: proc { |r| !r.failed_at.nil? }) do 
+      after_commit(on: :update, if: proc { |r| !r.failed_at.nil? }) do
         self.class.down
       end
       after_commit(on: :destroy, if: proc { |r| r.destroyed? || !r.failed_at.nil? }) do
@@ -23,36 +58,31 @@ module Delayed::Worker::Scaler
   end
 
   module ClassMethods
+    @@job_manager = JobManager.new
     @@ps_tag = nil
     @@last_start = 1.day.ago
     def up
       if workers == 0 && ((Time.now - @@last_start) > 30)
         @@last_start = Time.now
-        Rush::Box.new[Rails.root].bash("script/delayed_job start -i #{process_tag}", :background => true, :env => {:RAILS_ENV => Rails.env})
+        @@job_manager.start
       end
       true
     end
 
     def down
       if jobs.count == 0 and workers > 0
-        Rush::Box.new[Rails.root].bash("script/delayed_job stop -i #{process_tag}", :background => true, :env => {:RAILS_ENV => Rails.env})
+        @@job_manager.stop
       end
       true
     end
 
     def workers
-      Rush::Box.new.processes.filter(:cmdline => /delayed_job start -i #{process_tag}|delayed_job.#{process_tag}/).size
+      @@job_manager.workers
     end
 
     def jobs
       Delayed::Job.where(failed_at: nil)
     end
 
-    def process_tag
-      unless @@ps_tag
-        @@ps_tag = Digest::MD5.hexdigest(Rails.root.to_s)[0..8]
-      end
-      @@ps_tag
-    end
   end
 end


### PR DESCRIPTION
Sextant is no longer needed because `/rails/routes` works out of the box now.

Remove some Fixnum deprecations
Remove unused sextant

#178186921
https://www.pivotaltracker.com/story/show/178186921