### PR TITLE
Upgrade to Ruby 2.7

### DIFF
--- a/rails/Dockerfile
+++ b/rails/Dockerfile
@@ -1,4 +1,4 @@
-FROM concordconsortium/docker-rails-base-private:2.5.9-2021-05-11-a
+FROM concordconsortium/docker-rails-base-private:ruby-2.7-rails-6.1.3.2
 
 RUN apt-get -o Acquire::Check-Valid-Until=false update
 

--- a/rails/Dockerfile-dev
+++ b/rails/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM concordconsortium/docker-rails-base-private:2.5.9-2021-05-11-a
+FROM concordconsortium/docker-rails-base-private:ruby-2.7-rails-6.1.3.2
 
 RUN apt-get -o Acquire::Check-Valid-Until=false update
 

--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -15,7 +15,7 @@ gem 'appsignal'
 gem 'arrayfields'
 gem 'aws-sdk-s3'
 gem 'axlsx',                '> 2.5'
-gem 'bootsnap',     '1.4.4' # pinned to fix upgrade to Rails 6 on Ruby 2.5
+gem 'bootsnap'
 gem 'coffee-rails'
 # was sub-dependency of react-rails, needed in test setup code
 gem 'connection_pool'
@@ -31,7 +31,7 @@ gem 'exception_notification'
 gem 'font-awesome-rails'
 gem 'haml'
 gem 'httparty'
-gem 'json', '~> 1.8.6'
+gem 'json'
 gem 'jwt'
 gem 'jquery-fileupload-rails'
 gem 'mimemagic', '0.3.10'
@@ -71,11 +71,7 @@ gem 'virtus',               '~>1.0.3'
 gem 'will_paginate'
 gem 'yui-compressor'
 
-# see above; for production asset compilation.
-# as per http://guides.rubyonrails.org/asset_pipeline.html#precompiling-assets
-# when compressing assets without a javascript runtime:
 group :production do
-  gem 'therubyracer'
   gem 'unicorn'
 end
 

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
     better_errors (1.1.0)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
-    bootsnap (1.4.4)
+    bootsnap (1.7.5)
       msgpack (~> 1.0)
     builder (3.2.4)
     bullet (6.1.4)
@@ -273,14 +273,13 @@ GEM
       actionpack (>= 3.1)
       railties (>= 3.1)
       sassc
-    json (1.8.6)
+    json (2.5.1)
     json-schema (2.8.0)
       addressable (>= 2.4)
     jwt (1.5.6)
     kgio (2.10.0)
     launchy (2.4.3)
       addressable (~> 2.3)
-    libv8 (3.16.14.19)
     linecache (0.46)
       rbx-require-relative (> 0.0.4)
     listen (3.1.5)
@@ -417,7 +416,6 @@ GEM
       ffi (~> 1.0)
     rbx-require-relative (0.0.9)
     redcarpet (2.1.1)
-    ref (2.0.0)
     regexp_parser (2.1.1)
     remarkable (3.1.13)
       rspec (>= 1.2.0)
@@ -514,9 +512,6 @@ GEM
       climate_control (>= 0.0.3, < 1.0)
     test-unit (3.0.8)
       power_assert
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -578,7 +573,7 @@ DEPENDENCIES
   aws-sdk-s3
   axlsx (> 2.5)
   better_errors (~> 1.1.0)
-  bootsnap (= 1.4.4)
+  bootsnap
   bullet
   capybara
   capybara-mechanize
@@ -609,7 +604,7 @@ DEPENDENCIES
   highline
   httparty
   jquery-fileupload-rails
-  json (~> 1.8.6)
+  json
   json-schema
   jwt
   launchy
@@ -653,7 +648,6 @@ DEPENDENCIES
   sunspot_rails
   sunspot_solr
   test-unit (~> 3.0)
-  therubyracer
   tinymce-rails (~> 3.5.6)
   uglifier
   unicorn

--- a/rails/config/environments/production.rb
+++ b/rails/config/environments/production.rb
@@ -63,7 +63,7 @@ RailsPortal::Application.configure do
   config.assets.compile = true
 
   # Minify/uglify/compress assets from the pipeline
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   config.assets.css_compressor = :yui
 
   # Generate digests for assets' URLs.

--- a/rails/spec/models/dataservice/process_external_activity_data_job_spec.rb
+++ b/rails/spec/models/dataservice/process_external_activity_data_job_spec.rb
@@ -90,7 +90,7 @@ describe Dataservice::ProcessExternalActivityDataJob do
   describe '#perform' do
     it 'perform' do
       _learner_id = 1
-      _content = '1'
+      _content = '[]'
       process_external_activity_data_job = described_class.new(_learner_id, _content)
       result = process_external_activity_data_job.perform
 


### PR DESCRIPTION
- Removed v8 and therubyracer gems.  Uglifier will use default nodejs install.
- Enabled harmony mode for Uglifier to deal with es6 syntax
- Upgraded bootsnap and json gems to work with Ruby 2.7
