### PR TITLE
Update some failing migrations in Rails6

### DIFF
--- a/rails/db/migrate/20100210214257_add_more_indexes.rb
+++ b/rails/db/migrate/20100210214257_add_more_indexes.rb
@@ -1,6 +1,6 @@
 class AddMoreIndexes < ActiveRecord::Migration[5.1]
   def self.up
-    add_index :embeddable_multiple_choice_choices, :multiple_choice_id
+    # add_index :embeddable_multiple_choice_choices, :multiple_choice_id
     add_index :saveable_open_response_answers, [:open_response_id, :position], :name => 'o_r_id_and_position_index'
     add_index :saveable_multiple_choice_answers, [:multiple_choice_id, :position], :name => 'm_c_id_and_position_index'
     add_index :pages, [:section_id, :position]

--- a/rails/db/migrate/20130212203033_create_commons_license.rb
+++ b/rails/db/migrate/20130212203033_create_commons_license.rb
@@ -9,7 +9,7 @@ class CreateCommonsLicense < ActiveRecord::Migration[5.1]
       t.string   :image
       t.timestamps
     end
-    execute "ALTER TABLE commons_licenses ADD PRIMARY KEY (code);"
+    # execute "ALTER TABLE commons_licenses ADD PRIMARY KEY (code);"
   end
 
   def down

--- a/rails/db/migrate/20131108201323_create_portal_student_permission_forms.rb
+++ b/rails/db/migrate/20131108201323_create_portal_student_permission_forms.rb
@@ -2,11 +2,11 @@ class CreatePortalStudentPermissionForms < ActiveRecord::Migration[5.1]
   def change
     create_table :portal_student_permission_forms do |t|
       t.boolean :signed
-      t.references :portal_student
-      t.references :portal_permission_form
+      t.references :portal_student, index: false
+      t.references :portal_permission_form, index: false
       t.timestamps
     end
-    add_index :portal_student_permission_forms, :portal_student_id
+    add_index :portal_student_permission_forms, :portal_student_id, :name => "p_s_p_student_id"
     add_index :portal_student_permission_forms, :portal_permission_form_id, :name => "p_s_p_form_id"
   end
 end

--- a/rails/db/migrate/20160120211203_create_external_reports.rb
+++ b/rails/db/migrate/20160120211203_create_external_reports.rb
@@ -7,6 +7,5 @@ class CreateExternalReports < ActiveRecord::Migration[5.1]
       t.references :client
       t.timestamps
     end
-    add_index :external_reports, :client_id
   end
 end

--- a/rails/db/migrate/20160212173953_create_learner_processing_events.rb
+++ b/rails/db/migrate/20160212173953_create_learner_processing_events.rb
@@ -14,7 +14,6 @@ class CreateLearnerProcessingEvents < ActiveRecord::Migration[5.1]
 
       t.timestamps
     end
-    add_index :learner_processing_events, :learner_id
     add_index :learner_processing_events, :url
   end
 end

--- a/rails/db/migrate/20171010220806_create_portal_learner_activity_feedbacks.rb
+++ b/rails/db/migrate/20171010220806_create_portal_learner_activity_feedbacks.rb
@@ -9,7 +9,6 @@ class CreatePortalLearnerActivityFeedbacks < ActiveRecord::Migration[5.1]
 
       t.timestamps
     end
-    add_index :portal_learner_activity_feedbacks, :portal_learner_id
-    add_index :portal_learner_activity_feedbacks, :activity_feedback_id
+
   end
 end

--- a/rails/db/migrate/20191122221036_teacher_project_view.rb
+++ b/rails/db/migrate/20191122221036_teacher_project_view.rb
@@ -1,11 +1,9 @@
 class TeacherProjectView < ActiveRecord::Migration[5.1]
   def change
     create_table :teacher_project_views do |t|
-      t.string :limit  => 36
       t.belongs_to :viewed_project, null: false
       t.belongs_to :teacher, null: false
       t.timestamps
     end
-    add_index :teacher_project_views, :teacher_id
   end
 end


### PR DESCRIPTION
@dougmartin  @scytacki  and I were merging master into rails6 and decided to run all the migrations.

We encountered some errors, this PR fixes them.

A mixture of changes introduce in Rails 5+ and some
changes to how/when indexes are automatically added for
relational columns.