### PR TITLE
178633274 : mark javascript as `html_safe`

### DIFF
--- a/rails/app/helpers/runnables_helper.rb
+++ b/rails/app/helpers/runnables_helper.rb
@@ -55,7 +55,7 @@ module RunnablesHelper
         span_id = "run-with-collaborators-button-#{offering.id}"
         haml_tag :span, {:id => span_id}
         haml_tag :script do
-          haml_concat "PortalComponents.renderRunWithCollaborators(#{options.to_json}, '#{span_id}');"
+          haml_concat "PortalComponents.renderRunWithCollaborators(#{options.to_json}, '#{span_id}');".html_safe
         end
       end
     end


### PR DESCRIPTION
After Rails 6 Upgrade work, the Run With Collaborators button stopped showing up.

The javascript being sent via `haml_concat` was being escaped.

Adding `.html_safe` prevents the escape, and fixes the hidden run  with collaborators bug.

#178633274
https://www.pivotaltracker.com/story/show/178633274