### PR TITLE
Update Elasticsearch pagination

### DIFF
--- a/external-report-demo/report-demo/app.js
+++ b/external-report-demo/report-demo/app.js
@@ -139,23 +139,20 @@ function validateJSON(event) {
 async function fetchLearnerData(jwt, query, learnersApiUrl, pageSize) {
   const queryParams = {
     query,
-    page_size: pageSize,
-    start_from: 0
+    page_size: pageSize
   };
   const allLearners = [];
   let foundAllLearners = false;
-  let totalLearnersFound = 0;
 
   while (!foundAllLearners) {
     const res = await getLearnerDataWithJwt(learnersApiUrl, queryParams, jwt);
     if (res.json.learners) {
       allLearners.push(res.json.learners);
 
-      if (res.json.learners.length < pageSize) {
+      if (res.json.learners.length < pageSize && res.json.lastHitSortValue) {
         foundAllLearners = true;
       } else {
-        totalLearnersFound += res.json.learners.length;
-        queryParams.start_from = totalLearnersFound;
+        queryParams.search_after = res.json.lastHitSortValue;
       }
     } else {
       throw new Error("Malformed response from the portal: " + JSON.stringify(res));

--- a/rails/app/controllers/api/v1/report_learners_es_controller.rb
+++ b/rails/app/controllers/api/v1/report_learners_es_controller.rb
@@ -108,7 +108,7 @@ class API::V1::ReportLearnersEsController < API::APIController
   # https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html
   #
   # @param query - (required) query from external_report_query_jwt
-  # @param page_size - (required) number of learners per page, hard-capped at 2000
+  # @param page_size - (required) number of learners per page, hard-capped at 5000
   # @param start_from - (optional) learner index to start from for the next page
   def external_report_learners_from_jwt
     authorize Portal::PermissionForm
@@ -119,8 +119,8 @@ class API::V1::ReportLearnersEsController < API::APIController
 
     if (page_size == nil || page_size < 1)
       return error "param page_size must be a positive number", 400
-    elsif (page_size > 2000)
-      return error "param page_size may not be larger than 2000", 400
+    elsif (page_size > 5000)
+      return error "param page_size may not be larger than 5000", 400
     end
 
     query[:size_limit] = page_size

--- a/rails/app/controllers/api/v1/report_learners_es_controller.rb
+++ b/rails/app/controllers/api/v1/report_learners_es_controller.rb
@@ -333,6 +333,11 @@ class API::V1::ReportLearnersEsController < API::APIController
         :bool => {
           :filter => filters
         }
+      },
+      :sort => {
+        :created_at => {
+          :order => "asc"
+        }
       }
     }
 

--- a/rails/app/models/report/learner/selector.rb
+++ b/rails/app/models/report/learner/selector.rb
@@ -5,20 +5,21 @@ class Report::Learner::Selector
   attr_accessor :all_schools, :all_teachers, :all_runnables, :all_perm_forms,
                 :select_schools, :select_teachers, :select_runnables, :select_perm_form,
                 :start_date, :end_date, :hide_names,
-                :learners
+                :learners, :last_hit_sort_value
 
 
   def initialize(params, current_visitor, options={})
     @learners = []
     @runnable_names = []
+    @last_hit_sort_value = nil
     include_runnable_and_learner = options.has_key?(:include_runnable_and_learner) && options[:include_runnable_and_learner]
 
     # include the learners in the results, this flag also disables the aggregrations
     # by default it includes up to 5000 learners, but this can overridden with the
     # size_limit parameter
     params['show_learners'] = params['size_limit'].present? ? params['size_limit'].to_i : 5000
-    if (options.has_key?(:start_from))
-      params['start_from'] = options[:start_from]
+    if (options.has_key?(:search_after))
+      params['search_after'] = options[:search_after]
     end
     esResponse = API::V1::ReportLearnersEsController.query_es(params, current_visitor)
     hits = esResponse['hits']['hits']
@@ -28,6 +29,8 @@ class Report::Learner::Selector
       @learners = include_runnable_and_learner ? Report::Learner.includes(:runnable, :learner).find(ids) : Report::Learner.find(ids)
       @runnable_names = hits.map { |h| h['_source']['runnable_type_and_id'] }
       @runnable_names = @runnable_names.uniq
+      # every returned document will have a unique 'sort' value. This returns the last one.
+      @last_hit_sort_value = hits.last['sort']
     end
   end
 

--- a/rails/spec/controllers/api/v1/report_learners_es_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/report_learners_es_controller_spec.rb
@@ -82,6 +82,11 @@ describe API::V1::ReportLearnersEsController do
         "bool" => {
           "filter" => []
         }
+      },
+      "sort" => {
+        "created_at" => {
+          "order" => "asc"
+        }
       }
     }
   end
@@ -93,6 +98,11 @@ describe API::V1::ReportLearnersEsController do
       "query" => {
         "bool" => {
           "filter" => []
+        }
+      },
+      "sort" => {
+        "created_at" => {
+          "order" => "asc"
         }
       }
     }


### PR DESCRIPTION
This updates the Elasticsearch pagination to use the `search_after` API, with sorted results, instead of the `from` API.

See https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html for the two methods of paginating ES results.

The `search_after` API requires including a `sort` parameter in the query, and optionally passing in the `sort` id of the last document returned in order to fetch the next page of results. By sorting on `created_at` we can be sure that we won't get omissions or duplications due to the database changing over the course of repeated requests.

With this strategy, we should be able to return > 10,000 results, which was the previous cap of the `from` API.

The external-report-demo is updated to use this new API. There will also be an equivalent PR in the Query Creator app.