### PR TITLE
Seeing failures in ECS for worker: Bad file descriptor

### DIFF
--- a/rails/config/initializers/delayed_job_config.rb
+++ b/rails/config/initializers/delayed_job_config.rb
@@ -15,6 +15,9 @@ if Rails.env.development?
   Delayed::Backend::ActiveRecord::Job.send(:include, Delayed::Worker::Scaler)
 end
 
-Delayed::Worker.logger = Logger.new(
-    File.join(Rails.root, 'log', 'delayed_job.log') )
-
+if BoolENV['RAILS_STDOUT_LOGGING']
+  Delayed::Worker.logger = Logger.new(STDOUT)
+else
+  path = File.join(Rails.root, 'log', 'delayed_job.log')
+  Delayed::Worker.logger = Logger.new(path)
+end


### PR DESCRIPTION
The worker service should honor RAILS_STDOUT_LOGGING.

We are seeing the following error in AWS:

`log writing failed. Bad file descriptor @ io_write - /rigse/log/delayed_job.log`