### PR TITLE
Fix production error related to delayed_job start

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - "2.5.9"
+  - "2.7.3"
 
 dist: trusty
 

--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -19,6 +19,7 @@ gem 'bootsnap'
 gem 'coffee-rails'
 # was sub-dependency of react-rails, needed in test setup code
 gem 'connection_pool'
+gem 'daemons'
 gem 'default_value_for'
 gem 'delayed_job', '~> 4.1.1'
 gem 'delayed_job_active_record', '~> 4.1.0'

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -150,7 +150,6 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    columnize (0.9.0)
     concurrent-ruby (1.1.8)
     connection_pool (2.2.2)
     crack (0.4.3)
@@ -178,6 +177,7 @@ GEM
       railties (>= 4.2, < 7)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
+    daemons (1.1.9)
     database_cleaner (2.0.1)
       database_cleaner-active_record (~> 2.0.0)
     database_cleaner-active_record (2.0.1)
@@ -280,8 +280,6 @@ GEM
     kgio (2.10.0)
     launchy (2.4.3)
       addressable (~> 2.3)
-    linecache (0.46)
-      rbx-require-relative (> 0.0.4)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -414,7 +412,6 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rbx-require-relative (0.0.9)
     redcarpet (2.1.1)
     regexp_parser (2.1.1)
     remarkable (3.1.13)
@@ -456,11 +453,6 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.10.2)
-    ruby-debug (0.10.4)
-      columnize (>= 0.1)
-      ruby-debug-base (~> 0.10.4.0)
-    ruby-debug-base (0.10.4)
-      linecache (>= 0.3)
     ruby_dep (1.5.0)
     rubyzip (1.2.3)
     safe_yaml (1.0.4)
@@ -583,6 +575,7 @@ DEPENDENCIES
   connection_pool
   cucumber
   cucumber-rails
+  daemons
   database_cleaner
   default_value_for
   delayed-web
@@ -660,4 +653,4 @@ DEPENDENCIES
   yui-compressor
 
 BUNDLED WITH
-   1.17.3
+   2.2.17

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -80,8 +80,8 @@ GEM
       activerecord (>= 5.0, < 6.2)
     acts_as_list (1.0.4)
       activerecord (>= 4.2)
-    addressable (2.5.2)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     appsignal (2.11.0)
       rack
     arrayfields (4.7.4)
@@ -150,10 +150,11 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
+    columnize (0.9.0)
     concurrent-ruby (1.1.8)
     connection_pool (2.2.2)
-    crack (0.4.3)
-      safe_yaml (~> 1.0.0)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     cucumber (3.1.2)
       builder (>= 2.1.2)
@@ -255,7 +256,7 @@ GEM
     haml (5.2.1)
       temple (>= 0.8.0)
       tilt
-    hashdiff (0.3.7)
+    hashdiff (1.0.1)
     hashie (2.0.3)
     highline (1.6.15)
     htmlentities (4.3.4)
@@ -280,6 +281,7 @@ GEM
     kgio (2.10.0)
     launchy (2.4.3)
       addressable (~> 2.3)
+    linecache (1.3.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -367,7 +369,7 @@ GEM
     pry-byebug (3.6.0)
       byebug (~> 10.0)
       pry (~> 0.10)
-    public_suffix (3.0.3)
+    public_suffix (4.0.6)
     pundit (1.1.0)
       activesupport (>= 3.0.0)
     racc (1.5.2)
@@ -422,6 +424,7 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rexml (3.2.5)
     rollbar (3.1.2)
     rsolr (2.3.0)
       builder (>= 2.1.2)
@@ -453,9 +456,13 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.10.2)
+    ruby-debug (0.10.4)
+      columnize (>= 0.1)
+      ruby-debug-base (~> 0.10.4.0)
+    ruby-debug-base (0.10.4)
+      linecache (>= 0.3)
     ruby_dep (1.5.0)
     rubyzip (1.2.3)
-    safe_yaml (1.0.4)
     sanitize (5.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.8.0)
@@ -534,10 +541,10 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (~> 1.0)
       selenium-webdriver (~> 3.0)
-    webmock (3.4.2)
+    webmock (3.13.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
-      hashdiff
+      hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
     webrobots (0.1.2)
     websocket-driver (0.7.3)
@@ -653,4 +660,4 @@ DEPENDENCIES
   yui-compressor
 
 BUNDLED WITH
-   2.2.17
+   2.2.20

--- a/rails/spec/libs/school_importer_spec.rb
+++ b/rails/spec/libs/school_importer_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe SchoolImporter do
       line = ''
       result = school_importer.add_csv_row(line)
 
-      expect(result).to be_nil
+      expect(result).to be 0
     end
   end
 


### PR DESCRIPTION
add gem 'daemons' at the request of delayed_job:

`You need to add gem 'daemons' to your Gemfile`

This also cleans up removed gems from gemfile lock, after running `bundle clean`

Not sure why we have a change in `BUNDLED WITH`.