### PR TITLE
use the learner created at for the sort

### DIFF
--- a/rails/app/controllers/api/v1/report_learners_es_controller.rb
+++ b/rails/app/controllers/api/v1/report_learners_es_controller.rb
@@ -339,7 +339,7 @@ class API::V1::ReportLearnersEsController < API::APIController
         }
       },
       :sort => {
-        :created_at => {
+        :created_at_and_id => {
           :order => "asc"
         }
       }

--- a/rails/app/controllers/api/v1/report_learners_es_controller.rb
+++ b/rails/app/controllers/api/v1/report_learners_es_controller.rb
@@ -382,7 +382,8 @@ class API::V1::ReportLearnersEsController < API::APIController
       last_run: learner.last_run,
       run_remote_endpoint: learner.learner ? learner.learner.remote_endpoint_url : nil,
       runnable_url: learner.runnable && learner.runnable.respond_to?(:url) ? learner.runnable.url : nil,
-      teachers: teachers
+      teachers: teachers,
+      created_at: learner.created_at
     }
   end
 end

--- a/rails/app/controllers/api/v1/report_learners_es_controller.rb
+++ b/rails/app/controllers/api/v1/report_learners_es_controller.rb
@@ -338,11 +338,18 @@ class API::V1::ReportLearnersEsController < API::APIController
           :filter => filters
         }
       },
-      :sort => {
-        :created_at_and_id => {
-          :order => "asc"
+      :sort => [
+        {
+          :created_at => {
+            :order => "asc"
+          }
+        },
+        {
+          :learner_id => {
+            :order => "asc"
+          }
         }
-      }
+      ]
     }
 
     if options[:search_after]

--- a/rails/app/models/portal/learner.rb
+++ b/rails/app/models/portal/learner.rb
@@ -234,6 +234,14 @@ class Portal::Learner < ActiveRecord::Base
       user_id:  self.student.user.id,
       remote_endpoint_url: self.remote_endpoint_url,
       created_at: self.created_at,
+      # The created_at_and_id field is used for sorting the restuls in ES
+      # The created_at is used so new learners are at the end of the results, this way
+      # when the results are loaded via paging. The last page should include the newest
+      # learners. So if loading the results takes a long time new learners will be less
+      # likely to be lost.
+      # The id is added to the end to keep the field unique since it is possible two learners
+      # get created at the same time.
+      created_at_and_id: "#{self.created_at.iso8601(3)}_ID#{self.id}",
       offering_id: self.offering.id,
       offering_name: self.offering.name,
       class_id: self.offering.clazz.id,

--- a/rails/app/models/portal/learner.rb
+++ b/rails/app/models/portal/learner.rb
@@ -251,7 +251,7 @@ class Portal::Learner < ActiveRecord::Base
         learner_id: self.id,
         student_id: self.student.id,
         user_id:  self.student.user.id,
-        created_at: self.student.user.created_at,
+        created_at: self.created_at,
         offering_id: self.offering.id,
         offering_name: self.offering.name,
         class_id: self.offering.clazz.id,

--- a/rails/app/models/portal/learner.rb
+++ b/rails/app/models/portal/learner.rb
@@ -234,14 +234,6 @@ class Portal::Learner < ActiveRecord::Base
       user_id:  self.student.user.id,
       remote_endpoint_url: self.remote_endpoint_url,
       created_at: self.created_at,
-      # The created_at_and_id field is used for sorting the restuls in ES
-      # The created_at is used so new learners are at the end of the results, this way
-      # when the results are loaded via paging. The last page should include the newest
-      # learners. So if loading the results takes a long time new learners will be less
-      # likely to be lost.
-      # The id is added to the end to keep the field unique since it is possible two learners
-      # get created at the same time.
-      created_at_and_id: "#{self.created_at.iso8601(3)}_ID#{self.id}",
       offering_id: self.offering.id,
       offering_name: self.offering.name,
       class_id: self.offering.clazz.id,

--- a/rails/spec/controllers/api/v1/report_learners_es_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/report_learners_es_controller_spec.rb
@@ -84,7 +84,7 @@ describe API::V1::ReportLearnersEsController do
         }
       },
       "sort" => {
-        "created_at" => {
+        "created_at_and_id" => {
           "order" => "asc"
         }
       }
@@ -101,7 +101,7 @@ describe API::V1::ReportLearnersEsController do
         }
       },
       "sort" => {
-        "created_at" => {
+        "created_at_and_id" => {
           "order" => "asc"
         }
       }

--- a/rails/spec/controllers/api/v1/report_learners_es_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/report_learners_es_controller_spec.rb
@@ -114,22 +114,16 @@ describe API::V1::ReportLearnersEsController do
       hits: {
         hits: [
           {
-            _id: learner1.report_learner.id,
-            _source: {
-              runnable_type_and_id: 'externalactivity_1',
-            }
+            _id: learner1.id,
+            _source: learner1.elastic_search_learner_model
           },
           {
-            _id: learner2.report_learner.id,
-            _source: {
-              runnable_type_and_id: 'externalactivity_2',
-            }
+            _id: learner2.id,
+            _source: learner2.elastic_search_learner_model
           },
           {
-            _id: learner3.report_learner.id,
-            _source: {
-              runnable_type_and_id: 'externalactivity_2',
-            }
+            _id: learner3.id,
+            _source: learner3.elastic_search_learner_model
           }
         ]
       }
@@ -138,6 +132,9 @@ describe API::V1::ReportLearnersEsController do
 
 
   before (:each) do
+    # This silences warnings in the console when running
+    generate_default_settings_and_jnlps_with_mocks
+
     WebMock.stub_request(:post, /report_learners\/_search$/).
       to_return(:status => 200, :body => fake_response, :headers => { "Content-Type" => "application/json" })
   end

--- a/rails/spec/controllers/api/v1/report_learners_es_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/report_learners_es_controller_spec.rb
@@ -83,11 +83,18 @@ describe API::V1::ReportLearnersEsController do
           "filter" => []
         }
       },
-      "sort" => {
-        "created_at_and_id" => {
-          "order" => "asc"
+      "sort" => [
+        {
+          "created_at" => {
+            "order" => "asc"
+          }
+        },
+        {
+          "learner_id" => {
+            "order" => "asc"
+          }
         }
-      }
+      ]
     }
   end
 
@@ -100,11 +107,18 @@ describe API::V1::ReportLearnersEsController do
           "filter" => []
         }
       },
-      "sort" => {
-        "created_at_and_id" => {
-          "order" => "asc"
+      "sort" => [
+        {
+          "created_at" => {
+            "order" => "asc"
+          }
+        },
+        {
+          "learner_id" => {
+            "order" => "asc"
+          }
         }
-      }
+      ]
     }
   end
 

--- a/rails/spec/models/report/learner/selector_spec.rb
+++ b/rails/spec/models/report/learner/selector_spec.rb
@@ -15,26 +15,25 @@ describe Report::Learner::Selector do
   let(:permission_form_a)   { FactoryBot.create(:permission_form, permission_params_a) }
   let(:permission_params_b) { { name: "b" } }
   let(:permission_form_b)   { FactoryBot.create(:permission_form, permission_params_b) }
-  let(:learner)             { FactoryBot.create(:full_portal_learner) }
-  let(:report_learner)      { learner.report_learner                   }
-  let(:selector)            { Report::Learner::Selector.new(selector_opts, current_user )   }
-  let(:selector_opts)       { {} }
-  let(:students_p_forms)    { [] }
   let(:runnable)            { FactoryBot.create(:external_activity, {
                               :name      => "Some Activity",
                               :url       => "http://example.com",
                               :save_path => "/path/to/save",
                             } )  }
+  let(:offering)            { FactoryBot.create(:portal_offering, runnable: runnable) }
+  let(:learner)             { FactoryBot.create(:full_portal_learner, offering: offering) }
+  let(:report_learner)      { learner.report_learner                   }
+  let(:selector)            { Report::Learner::Selector.new(selector_opts, current_user )   }
+  let(:selector_opts)       { {} }
+  let(:students_p_forms)    { [] }
 
   before(:each) do
     es_response = {
           "hits" => {
             "hits" => [
               {
-                "_id" => report_learner.id,
-                "_source" => {
-                  "runnable_type_and_id" => "externalactivity_#{runnable.id}"
-                }
+                "_id" => learner.id,
+                "_source" => learner.elastic_search_learner_model
               }
             ]
           }


### PR DESCRIPTION
The code is now sorting by a new created_at and id field in the ES document. 

Previously it was sorting by a created_at field. This created_at was the student's user.created_at which would then be duplicated if the report is for multiple runnables, or the student ran the report in multiple classes.  And if the student runs a new assignment during the middle of the paged learner request this new learner would likely get lost.

If the sort key is not unique and it is used for paging results it can result in missing learners. If a set of 6 documents have sort keys of `A,B,C,C,D,E` and the Page size is 3. The first page of docs will be `A,B,C` and the second page of docs will be `D,E`.  This is because the sort value of the last doc in the first page will be `[C]`.  And when requesting the second page we say "search after [C]`, so then 2nd C will be skipped.

I don't think this PR will completely fix the issue of missing learners, but it does improve several issues.

So this PR:
- updates the created_at to be the `Portal::Learner#created_at` instead of `Portal::Student#created_at`
- adds the created_at to the info returned in the learner structure, this created_at might be useful to include for researchers in the future
- uses `[created_at, learner_id]` as the sort field
- adds `report_learner_id` field to ES Doc. The `Report::Learner#id` used to be the id of the ES Doc, and this id was used to look up a report learner in some parts of the code. Now that the ES Doc id is `Portal::Learner#id`, the report_learner_id field is used in those places that are looking up `Report::Learner`
- removed the use of `Report::Learner` from `report_learners_es_controller.rb`, it now uses the fields in the ES Doc directly.
  - This required adding 2 fields to the ES Doc: `remote_endpoint_url` and `runnable_url`.
  - This also required updating `Report::Learner::Selector` to return the ES Docs and only optionally load the `Report::Learner` objects.
- extract `elastic_search_learner_model` into its own method so the tests can more accurately mock a response from ES.

The timestamps added to ES go into millisecond resolution. The way this works seems to be kind of magical to me. The timestamp value is being added to a hash. At this point it is some kind of Rails timestamp object. It is then converted into some JSON compatible form. I haven't verfied this, but the JSON standard for datetime is ISO 8601. This standard optionally allow milliseconds. Then when it arrives at ES, ES seems to automatically identify it as a datetime field even though it is just a string with a specific format. Internally ES seems to store it as a number, because this number is what is used returned as the `sort` value in ES search results. 

[#178544757]