### PR TITLE
Improve error handling, logging, and handling no matches

### DIFF
--- a/external-report-demo/README.md
+++ b/external-report-demo/README.md
@@ -40,6 +40,12 @@ You can launch the service on a local server with
 sam local start-api
 ```
 
+Because of an [issue with sam local](https://github.com/aws/aws-lambda-runtime-interface-emulator/issues/15#issuecomment-792448261), it can be better to run this command instead:
+```bash
+sam local start-api 2>&1 | tr "\r" "\n"
+```
+Otherwise multiline message get squashed together. 
+
 ## Running tests
 
 Start the server running on port 3001: `sam local start-lambda`

--- a/external-report-demo/report-demo/app.js
+++ b/external-report-demo/report-demo/app.js
@@ -79,10 +79,11 @@ exports.lambdaHandler = async (event, context) => {
         }
       }
     } catch (err) {
-      console.log(err);
+      console.log("Error occured:");
+      console.log(err.stack);
       response = {
         statusCode: 500,
-        body: `${err.toString()}\n\n${err.stack}`
+        body: err.stack
       }
     }
 
@@ -147,6 +148,9 @@ async function fetchLearnerData(jwt, query, learnersApiUrl, pageSize) {
   while (!foundAllLearners) {
     const res = await getLearnerDataWithJwt(learnersApiUrl, queryParams, jwt);
     if (res.json.learners) {
+      console.log(`Recieved ${res.json.learners.length} learners`);
+      console.log(`  lastHitSortValue: ${res.json.lastHitSortValue}`);
+
       allLearners.push(res.json.learners);
 
       if (res.json.learners.length < pageSize && res.json.lastHitSortValue) {
@@ -162,15 +166,43 @@ async function fetchLearnerData(jwt, query, learnersApiUrl, pageSize) {
 }
 
 async function getLearnerDataWithJwt(learnersApiUrl, queryParams, jwt) {
-  return axios.post(learnersApiUrl, queryParams,
-    {
-      headers: {
-        "Authorization": `Bearer/JWT ${jwt}`
+  try {
+    const res = await axios.post(learnersApiUrl, queryParams,
+      {
+        headers: {
+          "Authorization": `Bearer/JWT ${jwt}`
+        }
       }
-    }
-  ).then((res) => {
+    );
     return res.data;
-  }, (error) => {
-    throw error;
-  });
+  } catch (error) {
+    if (error.response) {
+      // The request was made and the server responded with a status code
+      // that falls out of the range of 2xx
+      const details = JSON.stringify({
+        url: error.config.url,
+        method: error.config.method,
+        requestData: queryParams,
+        requestHeaders: error.config.headers,
+        responseStatus: error.response.status,
+        responseData: error.response.data
+      }, null, 2);
+      throw new Error(`Request failed, details: ${details}`);
+    } else if (error.request) {
+      // The request was made but no response was received
+      // `error.request` is an instance of http.ClientRequest in node.js
+      const details = JSON.stringify({
+        url: error.config.url,
+        method: error.config.method,
+        requestData: queryParams,
+        requestHeaders: error.config.headers,
+        clientRequest: error.request
+      }, null, 2);
+      throw new Error(`No response received, details: ${details}`);
+    } else {
+      // Something happened in setting up the request that triggered an Error
+      throw new Error(`Request setup error ${error.message}
+        config: ${JSON.stringify(error.config, null, 2)}`);
+    }
+  }
 }

--- a/rails/app/controllers/api/api_controller.rb
+++ b/rails/app/controllers/api/api_controller.rb
@@ -100,14 +100,14 @@ class API::APIController < ApplicationController
   # NOTE: this approach requires you to return from the
   # method to prevent a double render problem. An easy way to do this:
   #  return error(...)
-  def error(message, status = 400)
-    render :json =>
-      {
-        :success => false,
-        :response_type => "ERROR",
-        :message => message
-      },
-      :status => status
+  def error(message, status = 400, details = nil)
+    error_body = {
+      :success => false,
+      :response_type => "ERROR",
+      :message => message,
+    }
+    error_body[:details] = details if details
+    render :json => error_body, :status => status
   end
 
   def pundit_user_not_authorized(exception)

--- a/rails/app/models/report/learner/selector.rb
+++ b/rails/app/models/report/learner/selector.rb
@@ -9,6 +9,7 @@ class Report::Learner::Selector
 
 
   def initialize(params, current_visitor, options={})
+    @es_learners = []
     @learners = []
     @runnable_names = []
     @last_hit_sort_value = nil
@@ -26,18 +27,14 @@ class Report::Learner::Selector
 
     hits = esResponse['hits']['hits']
 
-    if hits
+    if hits && hits.size > 0
       ids = hits.map { |h| h['_source']['report_learner_id'] }
-      if hits.size > 0
-        @learners = Report::Learner.find(ids) unless skip_report_learners
-        # every returned document will have a unique 'sort' value. This returns the last one.
-        @last_hit_sort_value = hits.last['sort']
-      else
-        @learners = []
-      end
+      @learners = Report::Learner.find(ids) unless skip_report_learners
       @es_learners = hits.map { |h| OpenStruct.new(h['_source']) }
       @runnable_names = hits.map { |h| h['_source']['runnable_type_and_id'] }
       @runnable_names = @runnable_names.uniq
+      # every returned document will have a unique 'sort' value. This returns the last one.
+      @last_hit_sort_value = hits.last['sort']
     end
   end
 


### PR DESCRIPTION
report-demo:
- logs requests to get learners
- if there is an error while requesting learners, print out the request info as well as the response from the portal
- removes redundant logging of the error message when an exception is thrown. The error message is included in the err.stack

report_learner_es:
- general api controller error function now supports optional details json response
- new ESError class is used to raise errors with a string message and json details
- if the ES query results in no hits, the response is now an empty list of learners instead of an error
  the empty results can happen in a few ways with the current design
- added tests for this new error handling, and empty query results

cases that cause empty query results:
- if the sort key is duplicated and there are multiple learners at the end of the last page of results, a new page of results will be requested with learners starting after that last value. No learners match, so the results are empty
- if the number of learners is exactly divisible by the page size, the logic used by the external reports is to compare the results size with the page size and if it matches then a new request will be made. So when the total is divisible by the page size, on the last page of results the number of results will equal the page size. Then the external report will make an additional request which will have no results.