### PR TITLE
update Elastic Search permission forms

### DIFF
--- a/rails/app/models/portal/student.rb
+++ b/rails/app/models/portal/student.rb
@@ -105,8 +105,8 @@ class Portal::Student < ActiveRecord::Base
   end
 
   def update_report_permissions(permission_form)
-    report_learners = Report::Learner.where(:student_id => self.id)
     report_learners.each { |l| l.update_permission_forms; l.save }
+    learners.each { |l| l.update_report_model_cache(true) }
   end
 
   ## TODO: fix with has_many finderSQL


### PR DESCRIPTION
this updates the permission forms when the student object is updated
it uses the pre-existing report_learners and learners fields on Student.

It also updates the spec test to cover this case, and switches
the spec tests to using 'let' instead of a instance variables.