### PR TITLE
178900989 -- Guard  nils in ExternalReport#show

### DIFF
--- a/rails/app/views/admin/external_reports/_show.html.haml
+++ b/rails/app/views/admin/external_reports/_show.html.haml
@@ -23,7 +23,7 @@
             = report.launch_text
           %li
             Client:
-            = report.client.name
+            = report.client && report.client.name
           %li
             Report Type:
             = report.report_type


### PR DESCRIPTION
 `views/admin/external_reports/_show.html.haml`   attempts to print the name of the client, which is now sometimes 'nil' and we get a standard ` (undefined method `name' for nil:NilClass)` error.

[#178900989]
https://www.pivotaltracker.com/story/show/178900989