### PR TITLE
Re add username and student_name to learners

### DIFF
--- a/rails/app/controllers/api/v1/report_learners_es_controller.rb
+++ b/rails/app/controllers/api/v1/report_learners_es_controller.rb
@@ -54,7 +54,7 @@ class API::V1::ReportLearnersEsController < API::APIController
 
     # Note that Report::Learner::Selector is a little helper that actually calls
     # API::V1::ReportLearnersEsController.query_es.
-    learner_selector = Report::Learner::Selector.new(params, current_user, { skip_report_learners: true})
+    learner_selector = Report::Learner::Selector.new(params, current_user, { learner_type: :elasticsearch })
     # In the future, we might want to extend this query format and add other filters, e.g. dates.
     response = {
       type: "learners",
@@ -142,7 +142,7 @@ class API::V1::ReportLearnersEsController < API::APIController
     query[:size_limit] = page_size
 
     learner_selector = Report::Learner::Selector.new(query, current_user, {
-      skip_report_learners: true,
+      learner_type: :elasticsearch,
       search_after: search_after
     })
 
@@ -407,8 +407,11 @@ class API::V1::ReportLearnersEsController < API::APIController
       school: learner.school_name,
       user_id: learner.user_id,
       permission_forms: learner.permission_forms,
-      username: learner.username,
-      student_name: learner.student_name,
+
+      # These two fields are not stored in ES, the Selector class looked up the user
+      username: learner.user.login,
+      student_name: learner.user.name,
+
       last_run: learner.last_run,
       run_remote_endpoint: learner.remote_endpoint_url,
       runnable_url: learner.runnable_url,

--- a/rails/spec/controllers/api/v1/report_learners_es_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/report_learners_es_controller_spec.rb
@@ -441,6 +441,8 @@ describe API::V1::ReportLearnersEsController do
           expect(filter["learners"].length).to eq 3
           expect(filter["learners"][0]["student_id"].to_i).to be_an_instance_of(Fixnum)
           expect(filter["learners"][0]["learner_id"].to_i).to eq learner1.id
+          expect(filter["learners"][0]["student_name"]).to eq learner1.user.name
+          expect(filter["learners"][0]["username"]).to eq learner1.user.login
           expect(filter["learners"][0]["class_id"].to_i).to eq clazz1.id
           expect(filter["learners"][0]["teachers"]).to be_an_instance_of(Array)
           expect(filter["learners"][0]["teachers"].length).to eq 1

--- a/rails/spec/models/report/learner/selector_spec.rb
+++ b/rails/spec/models/report/learner/selector_spec.rb
@@ -23,7 +23,8 @@ describe Report::Learner::Selector do
   let(:offering)            { FactoryBot.create(:portal_offering, runnable: runnable) }
   let(:learner)             { FactoryBot.create(:full_portal_learner, offering: offering) }
   let(:report_learner)      { learner.report_learner                   }
-  let(:selector)            { Report::Learner::Selector.new(selector_opts, current_user )   }
+  let(:selector)            { Report::Learner::Selector.new(selector_params, current_user, selector_opts )   }
+  let(:selector_params)       { {} }
   let(:selector_opts)       { {} }
   let(:students_p_forms)    { [] }
 
@@ -52,6 +53,22 @@ describe Report::Learner::Selector do
     end
     it "should return the runnable when it finds a runnable type and id" do
       expect(selector.runnables_to_report_on).to include runnable
+    end
+    it "should not return es_leaners" do
+      expect(selector.es_learners).to be_empty
+    end
+    describe "when learner type is elasticsearch" do
+      let(:selector_opts) { {learner_type: :elasticsearch} }
+
+      it "should not report learners when it finds a learner id" do
+        expect(selector.learners).to be_empty
+      end
+
+      it "should return es_learners when it finds a learner id" do
+        expect(selector.es_learners.length).to eq(1)
+        expect(selector.es_learners[0].user_id).to eq(learner.user.id)
+        expect(selector.es_learners[0].user.id).to eq(learner.user.id)
+      end
     end
   end
 

--- a/rails/spec/models/report/learner/selector_spec.rb
+++ b/rails/spec/models/report/learner/selector_spec.rb
@@ -24,7 +24,7 @@ describe Report::Learner::Selector do
   let(:learner)             { FactoryBot.create(:full_portal_learner, offering: offering) }
   let(:report_learner)      { learner.report_learner                   }
   let(:selector)            { Report::Learner::Selector.new(selector_params, current_user, selector_opts )   }
-  let(:selector_params)       { {} }
+  let(:selector_params)     { {} }
   let(:selector_opts)       { {} }
   let(:students_p_forms)    { [] }
 
@@ -54,7 +54,7 @@ describe Report::Learner::Selector do
     it "should return the runnable when it finds a runnable type and id" do
       expect(selector.runnables_to_report_on).to include runnable
     end
-    it "should not return es_leaners" do
+    it "should not return es_learners" do
       expect(selector.es_learners).to be_empty
     end
     describe "when learner type is elasticsearch" do


### PR DESCRIPTION
These two fields were lost when the code was converted to use the ES document instead of the report learner
Rather than add the fields to the ES document, they are pulled from the portal database this way
Elastic search doesn't contain the most sensitive student names.

The skip_report_learners option was replaced with a learner_type option which seemed more clear.
We are planning to completely remove the Report::Learner model in the future.

[#178897764]