### PR TITLE
optimize the query to update Elasticsearch

### DIFF
--- a/rails/app/models/portal/learner.rb
+++ b/rails/app/models/portal/learner.rb
@@ -54,6 +54,9 @@ class Portal::Learner < ActiveRecord::Base
   has_one :report_learner, :dependent => :destroy, :class_name => "Report::Learner",
     :foreign_key => "learner_id", :inverse_of => :learner
 
+  has_one :report_learner_only_id, -> { select "id, learner_id" }, :class_name => "Report::Learner",
+    :foreign_key => "learner_id", :inverse_of => :learner
+
   has_many :lightweight_blobs, :dependent => :destroy, :class_name => "Dataservice::Blob"
 
   default_value_for :secure_key do
@@ -229,7 +232,7 @@ class Portal::Learner < ActiveRecord::Base
 
     {
       learner_id: self.id,
-      report_learner_id: self.report_learner.id,
+      report_learner_id: self.report_learner_only_id.id,
       student_id: self.student.id,
       user_id:  self.student.user.id,
       remote_endpoint_url: self.remote_endpoint_url,

--- a/rails/lib/tasks/report.rake
+++ b/rails/lib/tasks/report.rake
@@ -71,7 +71,8 @@ namespace :app do
 
     desc "Pushes all the Portal::Learner objects to the ElasticSearch database"
     task :update_elastic_search_learners => :environment do |t, args|
-      puts "#{Portal::Learner.count} learners to process...\n"
+      learners_count = Portal::Learner.count
+      puts "#{learners_count} learners to process...\n"
       i = 0
 
       offering_includes = [
@@ -92,10 +93,10 @@ namespace :app do
         offering.learners.includes(learner_includes).find_each do |learner|
           learner.update_report_model_cache(true)
           i += 1
-          puts "#{i} learners processed" if (i % 100 == 0)
+          puts "#{i} of #{learners_count} learners processed" if (i % 100 == 0)
         end
       end
-      puts " done."
+      puts "Done: #{i} of #{learners_count} learners processed"
     end
 
     # NP 2019-05-24: Preparing to move to reporting service.

--- a/rails/spec/models/portal/learner_spec.rb
+++ b/rails/spec/models/portal/learner_spec.rb
@@ -13,7 +13,8 @@ describe Portal::Learner do
     {
       :student        => student,
       :offering       => offering,
-      :report_learner => report_learner
+      :report_learner => report_learner,
+      :report_learner_only_id => report_learner
     }
   end
   subject           { Portal::Learner.create!(attributes) }


### PR DESCRIPTION
This query was causing an out of memory errors.
It would load in 1000 offerings and then include all of their learners and related objects.

Now it starts with 100 offerings and does not initially include the learners from the offering.
Then the learners of the offering are loaded in batches default for find_each is 1000 learners.

The includes are split up, to reduce redundant queries.

It also only loads the id of the report_learner instead of full model which can be large with large model state.

It also changes the status reporting so it prints out the number of learners processed instead of the number of offerings.
The learner processing should be linear with number of learners.

