### PR TITLE
Fix duplicate HTML ids for District and State in school creation page.

### DIFF
--- a/rails/app/views/portal/schools/_form.html.haml
+++ b/rails/app/views/portal/schools/_form.html.haml
@@ -25,6 +25,6 @@
 
         %li
           District:
-          = f.select(:state, @districts, {:prompt => "Select a district ..."})
+          = f.select(:district_id, @districts, {:prompt => "Select a district ..."})
 
       = submit_tag


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/178598808

[#178598808]