### PR TITLE
Add offering_id to results returned by ES Controller

### DIFF
--- a/rails/app/controllers/api/v1/report_learners_es_controller.rb
+++ b/rails/app/controllers/api/v1/report_learners_es_controller.rb
@@ -406,6 +406,7 @@ class API::V1::ReportLearnersEsController < API::APIController
       class: learner.class_name,
       school: learner.school_name,
       user_id: learner.user_id,
+      offering_id: learner.offering_id,
       permission_forms: learner.permission_forms,
 
       # These two fields are not stored in ES, the Selector class looked up the user


### PR DESCRIPTION
The offering_id is already part of the Elasticsearch learner documents, but was not being returned by the controller. This adds the offering_id so that the Athena query can use it to construct a url to the Portal Report for viewing a student's model.

This supports https://github.com/concord-consortium/report-service/pull/92