### PR TITLE
update documentation on integrating LARA and the Portal locally

### DIFF
--- a/.env-osx-sample
+++ b/.env-osx-sample
@@ -12,12 +12,15 @@
 # docker/dev/docker-compose-graphql.yml: start a graphql back-end server and
 #   a react-admin interface for managing administrative tasks
 #
-COMPOSE_FILE=docker-compose.yml:docker/dev/docker-compose-sync.yml:docker/dev/docker-compose-random-ports.yml:docker/dev/docker-compose-publish-capybara-port.yml:docker/dev/docker-compose-graphql.yml
+COMPOSE_FILE=docker-compose.yml:docker/dev/docker-compose-sync.yml:docker/dev/docker-compose-random-ports.yml:docker/dev/docker-compose-publish-capybara-port.yml:docker/dev/docker-compose-graphql.yml:docker/dev/docker-compose-lara-proxy.yml
 
 # The URL for ourselves. This is used when resources are published to the portal.
 # SITE_URL in docker-compose will be constructed from PORTAL_HOST and PORTAL_PROTOCOL.
+# The PORTAL_HOST variable is also used to set VIRTUAL_HOST variable. This variable is
+# used by the digny proxy to override the default `[service-name].[folder-name].docker`
+#
 # For automation PORTAL_HOST should be learn.dev.docker and PORTAL_PROTOCOL should be https.
-# PORTAL_HOST=learn.dev.docker
+# PORTAL_HOST=app.portal.docker
 # PORTAL_PROTOCOL=https
 
 # Run the portal in researcher report mode this is used by the researcher portal

--- a/README.md
+++ b/README.md
@@ -70,24 +70,62 @@ for these new features.
 #### SSO Clients and LARA (authoring) integration
 
 These instructions assume that you are setting up LARA and Portal using
-docker-compose files. It *may* also assume that you are using something like Dori or Dinghy
-as an http-proxy dns container, so that the portal is available at:`//app.portal.docker`
-and lara is available at `//app.lara.docker`
+docker-compose files. It also assumes that you are using something like Dori or Dinghy
+as an http-proxy dns container, so that the portal is available at `app.portal.docker`
+and lara is available at `app.lara.docker`
 
-If you want to provide authentication services to LARA, you need to:
-1. In the Portal, edit `.env` and append `docker/dev/docker-compose-lara-proxy.yml` to the `COMPOSE_FILE` var.
-1. In the Portal, as an administrator, setup a new "Auth Client". Use the following settings:
+##### Starting from scratch on a Mac
+
+1. in the Portal: `cp .env-osx-sample .env`
+2. start up the Portal: `docker-compose up`
+3. in LARA: `cp .env-osx-sample .env`
+4. start up LARA: `docker-compose up`
+5. in the Portal, as an administrator, setup a new "Auth Client". Use the following settings:
 ```
-Name: `localhost`
-App Id: `localhost`
+Name: 'localhost'
+App Id: 'localhost'
 App Secret: 'unsecure local secret'
-Client Type: 'confidential'
-Site Url: `https://app.lara.docker` *(use https if you are running it that way...)
+Client Type: confidential
+Site Url: 'https://app.lara.docker' *(use https if you are running it that way...)
 Allowed Domains: (leave blank)
 Allowed URL Redirects: 'https://app.lara.docker/users/auth/cc_portal_localhost/callback'
 ```
-1. In Lara, edit `.env` and append `docker/dev/docker-compose-portal-proxy.yml` to the `COMPOSE_FILE` var.
-2. You may need to use the rails console in LARA to set the `is_admin` flag to the portal admin user.
+6. If you want admin access to Lara when signing in with a portal user, you will need to first login to LARA
+with this portal user. And then either:
+    - use the rails console in LARA to set the `is_admin` flag of the newly created user.
+    - use an existing admin in LARA to make the new user an admin.
+
+##### Updating an existing setup
+
+1. In the **Portal**, edit `.env`:
+    1. Append `docker/dev/docker-compose-lara-proxy.yml` to the `COMPOSE_FILE` var.
+    2. If your portal is not running at app.portal.docker set `PORTAL_HOST`
+    3. If your portal is running on https set `PORTAL_PROTOCOL=https`
+    4. If your lara host name is not app.lara.docker, then set `LARA_HOST`
+2. Stop you portal services if they are running, and update them with `docker-compose up`
+3. In the Portal, as an administrator, setup a new "Auth Client". Use the following settings:
+```
+Name: 'localhost'
+App Id: 'localhost'
+App Secret: 'unsecure local secret'
+Client Type: confidential
+Site Url: 'https://app.lara.docker' *(use https if you are running it that way...)
+Allowed Domains: (leave blank)
+Allowed URL Redirects: 'https://app.lara.docker/users/auth/cc_portal_localhost/callback'
+```
+4. In **LARA**, edit `.env`:
+    1. Append `docker/dev/docker-compose-portal-proxy.yml` to the `COMPOSE_FILE` var.
+    2. Set `PORTAL_HOST` to `app.portal.docker` or whatever domain your local portal is
+    3. Set `PORTAL_PROTOCOL=https` if your portal is using `https`
+5. Stop you Lara services if they are running, and update them with `docker-compose up`
+6. If you want admin access to Lara when signing in with a portal user, you will need to first login to LARA
+with this portal user. And then either:
+    - use the rails console in LARA to set the `is_admin` flag of the newly created user.
+    - use an existing admin in LARA to make the new user an admin.
+
+Note: not all of these settings are necessary to just allow LARA to do SSO with the Portal.
+But they are necessary to support publishing LARA activities and sequences to the portal,
+and copying LARA activities and sequences from the portal.
 
 #### Virtual host settings (currently used for automation)
 If you want to change the portal url from "app.portal.docker" to "learn.dev.docker", please follow the below steps:

--- a/README.md
+++ b/README.md
@@ -70,9 +70,10 @@ for these new features.
 #### SSO Clients and LARA (authoring) integration
 
 These instructions assume that you are setting up LARA and Portal using
-docker-compose files. It also assumes that you are using something like Dori or Dinghy
-as an http-proxy dns container, so that the portal is available at `app.portal.docker`
-and lara is available at `app.lara.docker`
+docker-compose files. It also assumes some prerequisites:
+- You are using an http-proxy dns container: [Setup Dinghy on OSX](https://github.com/concord-consortium/lara/blob/master/README.md#setup-dinghy-on-os-x)
+- You are using https for LARA and the Portal: [Setup https for LARA and Portal](https://github.com/concord-consortium/lara/blob/master/README.md#enabling-ssl-for-dinghy-reverse-proxy-on-os-x)
+- You are logged into docker to gain access to our private images: [Logging into Docker](https://github.com/concord-consortium/lara/blob/master/README.md#getting-started)
 
 ##### Starting from scratch on a Mac
 
@@ -80,20 +81,11 @@ and lara is available at `app.lara.docker`
 2. start up the Portal: `docker-compose up`
 3. in LARA: `cp .env-osx-sample .env`
 4. start up LARA: `docker-compose up`
-5. in the Portal, as an administrator, setup a new "Auth Client". Use the following settings:
-```
-Name: 'localhost'
-App Id: 'localhost'
-App Secret: 'unsecure local secret'
-Client Type: confidential
-Site Url: 'https://app.lara.docker' *(use https if you are running it that way...)
-Allowed Domains: (leave blank)
-Allowed URL Redirects: 'https://app.lara.docker/users/auth/cc_portal_localhost/callback'
-```
-6. If you want admin access to Lara when signing in with a portal user, you will need to first login to LARA
+5. If you want admin access to Lara when signing in with a portal user, you will need to first login to LARA
 with this portal user. And then either:
     - use the rails console in LARA to set the `is_admin` flag of the newly created user.
     - use an existing admin in LARA to make the new user an admin.
+6. Additional setup is needed to view teacher and student reports of work from the LARA Runtime and AP Runtime.
 
 ##### Updating an existing setup
 
@@ -122,6 +114,7 @@ Allowed URL Redirects: 'https://app.lara.docker/users/auth/cc_portal_localhost/c
 with this portal user. And then either:
     - use the rails console in LARA to set the `is_admin` flag of the newly created user.
     - use an existing admin in LARA to make the new user an admin.
+7. Additional setup is needed to view teacher and student reports of work from the LARA Runtime and AP Runtime.
 
 Note: some of these settings are not necessary to allow LARA to do SSO with the Portal.
 But all of them are necessary to support publishing LARA activities and sequences to the portal,

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ with this portal user. And then either:
     2. If your portal is not running at app.portal.docker set `PORTAL_HOST`
     3. If your portal is running on https set `PORTAL_PROTOCOL=https`
     4. If your lara host name is not app.lara.docker, then set `LARA_HOST`
-2. Stop you portal services if they are running, and update them with `docker-compose up`
+2. Stop your portal services if they are running, and update them with `docker-compose up`
 3. In the Portal, as an administrator, setup a new "Auth Client". Use the following settings:
 ```
 Name: 'localhost'
@@ -117,14 +117,14 @@ Allowed URL Redirects: 'https://app.lara.docker/users/auth/cc_portal_localhost/c
     1. Append `docker/dev/docker-compose-portal-proxy.yml` to the `COMPOSE_FILE` var.
     2. Set `PORTAL_HOST` to `app.portal.docker` or whatever domain your local portal is
     3. Set `PORTAL_PROTOCOL=https` if your portal is using `https`
-5. Stop you Lara services if they are running, and update them with `docker-compose up`
+5. Stop your Lara services if they are running, and update them with `docker-compose up`
 6. If you want admin access to Lara when signing in with a portal user, you will need to first login to LARA
 with this portal user. And then either:
     - use the rails console in LARA to set the `is_admin` flag of the newly created user.
     - use an existing admin in LARA to make the new user an admin.
 
-Note: not all of these settings are necessary to just allow LARA to do SSO with the Portal.
-But they are necessary to support publishing LARA activities and sequences to the portal,
+Note: some of these settings are not necessary to allow LARA to do SSO with the Portal.
+But all of them are necessary to support publishing LARA activities and sequences to the portal,
 and copying LARA activities and sequences from the portal.
 
 #### Virtual host settings (currently used for automation)


### PR DESCRIPTION
This attempts to provide a simplified set of instructions if you are starting from scratch.
As well as more detailed instructions if you are not.

Besides the readme changes, it adds the lara-proxy overlay to the `.env-os-sample` so people starting from scratch have less to change.
It also sets the commented out PORTAL_HOST variable to its default value of `app.portal.docker` which I think is more clear for most developers.

I also updated LARA to remove the duplicate documentation there:
https://github.com/concord-consortium/lara/pull/732