### PR TITLE
Removed "rememberable" Devise mapping

### DIFF
--- a/rails/app/assets/stylesheets/web/app.scss
+++ b/rails/app/assets/stylesheets/web/app.scss
@@ -1080,11 +1080,6 @@ h2, h3 {
 
 .graphic-input li.remember {
   background: transparent;
-  input#remember_me {
-    background-image: none !important;
-    display: inline;
-    float: left;
-    width: 25px; }
   label {
     font-size: 0.9em;
     font-weight: normal; } }

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
   has_many :favorites
 
   devise :database_authenticatable, :registerable, :token_authenticatable, :confirmable, :bearer_token_authenticatable, :jwt_bearer_token_authenticatable,
-         :recoverable,:timeoutable, :rememberable, :trackable, :validatable,:encryptable, :encryptor => :restful_authentication_sha1
+         :recoverable, :timeoutable, :trackable, :validatable,:encryptable, :encryptor => :restful_authentication_sha1
   devise :omniauthable, :omniauth_providers => Devise.omniauth_providers
 
   def apply_omniauth(omniauth)
@@ -517,20 +517,6 @@ class User < ApplicationRecord
 
   def only_a_student?
     portal_student and !has_role?('admin', 'manager', 'researcher', 'author') and portal_teacher.nil?
-  end
-
-  def remember_me_for(time)
-    self.remember_me_until time.from_now.utc
-  end
-
-  def remember_me_until(time)
-    self.remember_created_at = time
-    self.remember_token = self.class.remember_token
-    save(:validate => false)
-  end
-
-  def forget_me
-    self.forget_me!
   end
 
   def set_passive_users_as_pending

--- a/rails/app/views/devise/sessions/new.html.erb
+++ b/rails/app/views/devise/sessions/new.html.erb
@@ -7,10 +7,6 @@
   <div><%= f.label :password %><br />
   <%= f.password_field :password %></div>
 
-  <% if devise_mapping.rememberable? -%>
-    <div><%= f.check_box :remember_me %> <%= f.label :remember_me %></div>
-  <% end -%>
-
   <div><%= f.submit "Sign in" %></div>
 <% end %>
 

--- a/rails/config/initializers/devise.rb
+++ b/rails/config/initializers/devise.rb
@@ -116,7 +116,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
-  config.remember_for = 2.weeks
+  # config.remember_for = 2.weeks
 
   # If true, extends the user's remember period when remembered via cookie.
   # config.extend_remember_period = false

--- a/rails/lib/tasks/create_spec_test_fixtures.rake
+++ b/rails/lib/tasks/create_spec_test_fixtures.rake
@@ -10,8 +10,8 @@ namespace :app do
       result << "\n"
     end
 
-    desc "Saves users.yaml to spec/fixtures" 
-    task :create_fixtures => :environment do 
+    desc "Saves users.yaml to spec/fixtures"
+    task :create_fixtures => :environment do
       dir = File.join(::Rails.root.to_s, 'spec/fixtures')
       FileUtils.mkdir_p(dir)
       FileUtils.chdir(dir) do
@@ -30,9 +30,7 @@ quentin:
   salt:                      #{quentin.salt}
   crypted_password:          #{quentin.crypted_password}
   created_at:                <%= 5.days.ago.to_s :db  %>
-  remember_token_expires_at: <%= 1.days.from_now.to_s %>
-  remember_token:            77de68daecd823babbb58edb1c8e14d7106e83bb
-  activation_code:           
+  activation_code:
   activated_at:              <%= 5.days.ago.to_s :db %>
   state:                     active
 
@@ -44,10 +42,8 @@ aaron:
   salt:                      #{aaron.salt}
   crypted_password:          #{aaron.crypted_password}
   created_at:                <%= 1.days.ago.to_s :db %>
-  remember_token_expires_at: 
-  remember_token:            
   activation_code:           1b6453892473a467d07372d45eb05abc2031647a
-  activated_at:              
+  activated_at:
   state:                     pending
 
 
@@ -59,7 +55,7 @@ old_password_holder:
   salt:                      7e3041ebc2fc05a40c60028e2c4901a81035d3cd
   crypted_password:          00742970dc9e6319f8019fd54864d3ea740f04b1 # test
   created_at:                <%= 1.days.ago.to_s :db %>
-  activation_code:           
+  activation_code:
   activated_at:              <%= 5.days.ago.to_s :db %>
   state:                     active
 

--- a/rails/spec/fixtures/users.yml
+++ b/rails/spec/fixtures/users.yml
@@ -16,8 +16,6 @@ quentin:
   password_salt:             w7TnCtPqEjEzGAQtyvZs
   encrypted_password:        36aabfd5891e9e6e3981f3ebcee6d270a7e00a1d # monkey
   created_at:                <%= ActiveRecord::Base.connection.quote(5.days.ago) %>
-  remember_created_at:       <%= ActiveRecord::Base.connection.quote(1.days.from_now) %>
-  remember_token:            77de68daecd823babbb58edb1c8e14d7106e83bb
   confirmation_token:
   confirmed_at:              <%= ActiveRecord::Base.connection.quote(5.days.ago) %>
   state:                     active
@@ -32,8 +30,6 @@ aaron:
   password_salt:             qp3wVvnW2xszu4QECpaV
   encrypted_password:        4501ec62797702f8daec5d46132c7ea19785f34e # monkey
   created_at:                <%= ActiveRecord::Base.connection.quote(1.days.ago) %>
-  remember_created_at:
-  remember_token:
   confirmation_token:        1b6453892473a467d07372d45eb05abc2031647a
   confirmed_at:
   state:                     pending

--- a/rails/spec/models/user_spec.rb
+++ b/rails/spec/models/user_spec.rb
@@ -172,45 +172,6 @@ describe User do
   # Authentication
   #
 
-  it 'sets remember token' do
-    users(:quentin).remember_me!
-    expect(users(:quentin).remember_token).not_to be_nil
-    expect(users(:quentin).remember_created_at).not_to be_nil
-  end
-
-  it 'unsets remember token' do
-    users(:quentin).remember_me!
-    expect(users(:quentin).remember_token).not_to be_nil
-    users(:quentin).forget_me
-    expect(users(:quentin).remember_token).to be_nil
-  end
-
-  it 'remembers me for one week' do
-    before = 1.week.ago.utc
-    users(:quentin).remember_me_for 1.week
-    after = 1.week.from_now.utc
-    expect(users(:quentin).remember_token).not_to be_nil
-    expect(users(:quentin).remember_created_at).not_to be_nil
-    expect(users(:quentin).remember_created_at.between?(before, after)).to be_truthy
-  end
-
-  it 'remembers me until one week' do
-    time = 1.week.from_now.utc
-    users(:quentin).remember_me_until time
-    expect(users(:quentin).remember_token).not_to be_nil
-    expect(users(:quentin).remember_created_at).not_to be_nil
-    expect(users(:quentin).remember_created_at.utc.to_s(:db)).to eq(time.to_s(:db))
-  end
-
-  it 'remembers me default two weeks' do
-    before = 2.weeks.ago.utc
-    users(:quentin).remember_me!
-    after = 2.weeks.from_now.utc
-    expect(users(:quentin).remember_token).not_to be_nil
-    expect(users(:quentin).remember_created_at).not_to be_nil
-    expect(users(:quentin).remember_created_at.between?(before, after)).to be_truthy
-  end
-
   it 'registers passive user' do
     user = create_user(:password => nil, :password_confirmation => nil)
     expect(user.state).to eq('passive')
@@ -1195,38 +1156,6 @@ protected
     it 'only_a_student?' do
       user = described_class.new
       result = user.only_a_student?
-
-      expect(result).to be_nil
-    end
-  end
-
-  # TODO: auto-generated
-  describe '#remember_me_for' do
-    it 'remember_me_for' do
-      user = described_class.new
-      time = 2.days
-      result = user.remember_me_for(time)
-
-      expect(result).not_to be_nil
-    end
-  end
-
-  # TODO: auto-generated
-  describe '#remember_me_until' do
-    it 'remember_me_until' do
-      user = described_class.new
-      time = Time.now
-      result = user.remember_me_until(time)
-
-      expect(result).not_to be_nil
-    end
-  end
-
-  # TODO: auto-generated
-  describe '#forget_me' do
-    it 'forget_me' do
-      user = described_class.new
-      result = user.forget_me
 
       expect(result).to be_nil
     end


### PR DESCRIPTION
This no longer can be used at the same time as the "timeoutable" Devise mapping.  Since the "remember me" checkbox is not present in the default React sign in UI this should have no change in the UX of the portal.

**NOTE**: this does **not** include a migration to remove the `remember_token` and `remember_created_at` columns in the user model.