### PR TITLE
Only open material edit form in an iframe for teacher users.

### DIFF
--- a/rails/app/assets/stylesheets/web/matedit.scss
+++ b/rails/app/assets/stylesheets/web/matedit.scss
@@ -1,7 +1,8 @@
 #iframe_container.matedit  {
   height: 80%;
+  max-width: 1140px;
   position: absolute;
-  width: 960px;
+  width: 100%;
   overflow: hidden;
   margin: 0px;
   padding: 0px;

--- a/rails/lib/materials/data_helpers.rb
+++ b/rails/lib/materials/data_helpers.rb
@@ -369,14 +369,15 @@ module Materials
       }
 
       if external && material.author_url.present?
+        edit_in_iframe = !current_visitor.has_role?('author') && !current_visitor.has_role?('admin')
         if policy(material).matedit?
           links[:external_edit] = {
-            url: matedit_external_activity_url(material, iFrame: false),
+            url: matedit_external_activity_url(material, iFrame: edit_in_iframe),
             text: "Edit",
             target: '_blank'
           }
           links[:external_lara_edit] = {
-            url: matedit_external_activity_url(material, iFrame: true),
+            url: matedit_external_activity_url(material, iFrame: edit_in_iframe),
             text: "Edit",
             target: '_blank'
           }


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/179197451

[#179197451]

The requirements listed in the story above are already met except for having the material edit form open in an iframe only for non-author users. These changes ensure that the iframed edit form is only shown to non-author and non-admin users. There is also a small style tweak here that allows the iframe to take up the full available width of the page. That makes it easier for teacher authors to see and access the "edit" links in the ITSI-style edit form.