### PR TITLE
Streamline the initial setup of the portal with new rake tasks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ With the following settings you can:
     2. Click log in, and choose "localhost"
     3. This will take you to the portal (app.portal.docker)
     4. Log in with `admin`, `password`
-    5. You are no logged in with admin@concord.org in LARA, however this user is not actually an admin in LARA
+    5. You are now logged in with admin@concord.org in LARA, however this user is not actually an admin in LARA
     6. Run the following command in terminal in the LARA folder: `docker-compose exec app bundle exec rake lightweight:admin_last_user`
 
 Notes:

--- a/README.md
+++ b/README.md
@@ -90,52 +90,30 @@ With the following settings you can:
 1. in the Portal: `cp .env-osx-sample .env`
 2. in the Portal `.env` set `PORTAL_PROTOCOL=https`
 3. start up the Portal: `docker-compose up`
-4. in the Portal, as an administrator:
-    1. Add a Firebase App for report-service-dev, copy the values for the report-service-dev firebase app in learn.staging.concord.org
-    2. Add a new "Auth Client" for the portal-report:
-        ```
-        Name: 'Portal Report SPA'
-        App Id: 'portal-report'
-        App Secret: (leave default value, this isn't used)
-        Client Type: public
-        Site Url: 'https://portal-report.concord.org'
-        Allowed Domains: 'portal-report.concord.org'
-        Allowed URL Redirects: 'https://portal-report.concord.org/branch/master/index.html'
-        ```
-   3. Update the external report called DEFAULT_REPORT_SERVICE. It should have a URL of: https://portal-report.concord.org/branch/master/index.html?sourceKey=app.lara.docker.username **Replace `username` with the username on your local system. If you don't know your username, run `echo $USER`**.
-4. in LARA: `cp .env-osx-sample .env`
-5. in LARA `.env`:
+4. Add a Firebase App for report-service-dev with `docker-compose exec app bundle exec app:setup:add_report_service_firebase_app`, it will ask for the "private_key", paste in the private key from report-service-dev firebase app in learn.staging.concord.org
+5. in LARA: `cp .env-osx-sample .env`
+6. in LARA `.env`:
     1. set `REPORT_SERVICE_TOKEN` (see the comment in the .env-osx-sample file)
     2. set `LARA_PROTOCOL=https`
     3. set `PORTAL_PROTOCOL=https`
-6. start up LARA: `docker-compose up`
-7. If you want admin access to Lara when signing in with a portal user, you will need to first login to LARA
-with this portal user. And then either:
-    - use the rails console in LARA to set the `is_admin` flag of the newly created user.
-    - use an existing admin in LARA to make the new user an admin.
-8. Setup Activity Player support
-    1. Add a Tool to the portal with:
-        ```
-        Name: ActivityPlayer
-        Source Type: ActivityPlayer
-        Tool ID: https://activity-player.concord.org
-        ```
-    2. Make an external report. In the Url field below replace the `username` in the sourceKey parameter with your local username:
-        ```
-        Name: AP Report
-        Url: https://portal-report.concord.org/branch/master/index.html?sourceKey=app.lara.docker.username&answersSourceKey=activity-player.concord.org
-        Launch text: AP Report
-        Client: DEFAULT_REPORT_SERVICE_CLIENT
-        Report Type: offering
-        Allowed For Students: true
-        Default Report For Source Type:
-        Report available for individual students: true
-        Report available for individual activities: true
-        Use Query JWT: false
-        Move Students API URL:
-        Move Students API Token:
-        ```
-    3. Add this AP Report external report to each AP resource you publish the portal from LARA.
+7. start up LARA: `docker-compose up`
+8. Setup admin access to LARA using a portal SSO login:
+    1. Go to https://app.lara.docker
+    2. Click log in, and choose "localhost"
+    3. This will take you to the portal (app.portal.docker)
+    4. Log in with `admin`, `password`
+    5. You are no logged in with admin@concord.org in LARA, however this user is not actually an admin in LARA
+    6. Run the following command in terminal in the LARA folder: `docker-compose exec app bundle exec rake lightweight:admin_last_user`
+
+Notes:
+- LARA runtime activities published to the portal will automatically have report buttons for teachers and students
+- AP runtime activities published to the portal will not have report buttons for teachers and students. You must add
+  external reports in the "portal settings" of the portal for the newly published resource
+- The "show my work" button in the AP will not work by default when running locally like this. It will not
+  add a correct sourceKey parameter for the portal-report URL it generates. Hopefully this will be fixed soon.
+- The portal will not be configured with the same settings as learn.concord.org for the home page.
+  To see this locally you should look at the settings on learn.staging.concord.org and copy those settings
+  to your local portal settings.
 
 ##### Updating an existing setup
 
@@ -224,7 +202,7 @@ When you run the portal-report if you just see a spinner. Here are some steps to
         In this case, you need to unescape the activity parameter. Then take the value of the activity param and remove the `/api/v1` and remove the `.json` at the end. The result of that transformation snould exactly match what is in `url` field in firestore.
         - if this is a AP runtime sequence follow the directions for AP activity above except the parameter name is `sequence` instead of `activity`
     5. To fix the `http:` instead of `https:` problem make sure your `LARA_PROTOCOL` is set to `https` in your lara `.env` file. Then update your lara container with `docker-compose up`. And then make a change to the LARA activity or sequence to republish it. Verify the `url` field in firestore has been updated.
-    
+
 #### Virtual host settings (currently used for automation)
 If you want to change the portal url from "app.portal.docker" to "learn.dev.docker", please follow the below steps:
 1. In the Portal, edit '.env' file and update PORTAL_HOST as learn.dev.docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,6 +139,11 @@ services:
 
       VIRTUAL_HOST: "${PORTAL_HOST:-app.portal.docker}"
 
+      # These are used for initialization code which creates external reports, and auth clients
+      # They aren't needed at runtime
+      LARA_DOMAIN: "${LARA_DOMAIN:-app.lara.docker}"
+      LARA_TOOL_ID: "${LARA_DOMAIN:-app.lara.docker}.${USER}"
+
     # open standard in and turn on tty so we can attach to the container and debug it
     stdin_open: true
     tty: true

--- a/rails/db/seeds.rb
+++ b/rails/db/seeds.rb
@@ -146,28 +146,17 @@ def create_settings
   end
 end
 
-def create_default_lara_report
-  auth_client = Client.where(name: "DEFAULT_REPORT_SERVICE_CLIENT").first_or_create(
-    app_id: "DEFAULT_REPORT_SERVICE_CLIENT",
+
+def create_spa_report_client
+  Client.where(name: "Portal Report SPA").first_or_create(
+    name: "Portal Report SPA",
+    app_id: "portal-report",
     app_secret: SecureRandom.uuid(),
-    domain_matchers: ".*\.concord\.org localhost.*",
-    client_type: "public"
+    client_type: "public",
+    site_url: "https://portal-report.concord.org",
+    domain_matchers: "portal-report.concord.org",
+    redirect_uris: "https://portal-report.concord.org/branch/master/index.html"
   )
-
-  ExternalReport.where(name: "DEFAULT_REPORT_SERVICE").first_or_create(
-    url: "http://portal-report.concord.org/branch/master/index.html",
-    launch_text: "Report",
-    client_id: auth_client.id,
-    report_type: "offering",
-    allowed_for_students: true,
-    default_report_for_source_type: "LARA",
-    individual_student_reportable: true,
-    individual_activity_reportable: true,
-    use_query_jwt: false
-  )
-
-  # To support Activity Player publishing you need to manually add a Tool with the tool_id of https://activity-player.concord.org.
-  # The convention is the source_type is ActivityPlayer.
 end
 
 create_district_school
@@ -175,7 +164,7 @@ create_roles
 create_default_users
 create_grades
 create_settings
-create_default_lara_report
+create_spa_report_client
 
 # populate Countries table
 Portal::Country.from_csv_file

--- a/rails/db/seeds.rb
+++ b/rails/db/seeds.rb
@@ -147,24 +147,11 @@ def create_settings
 end
 
 
-def create_spa_report_client
-  Client.where(name: "Portal Report SPA").first_or_create(
-    name: "Portal Report SPA",
-    app_id: "portal-report",
-    app_secret: SecureRandom.uuid(),
-    client_type: "public",
-    site_url: "https://portal-report.concord.org",
-    domain_matchers: "portal-report.concord.org",
-    redirect_uris: "https://portal-report.concord.org/branch/master/index.html"
-  )
-end
-
 create_district_school
 create_roles
 create_default_users
 create_grades
 create_settings
-create_spa_report_client
 
 # populate Countries table
 Portal::Country.from_csv_file

--- a/rails/docker/dev/run.sh
+++ b/rails/docker/dev/run.sh
@@ -35,7 +35,7 @@ if [ ! -f $DB_CONFIG ]; then
   cp $APP_HOME/config/database.sample.yml $DB_CONFIG
   # Setup DB when this script is run for the first time.
   bundle exec rake db:setup
-  bundle exec rake sso:add_dev_client
+  bundle exec rake app:setup:local_setup
 fi
 
 if [ "$RAILS_ENV" = "production" ]; then

--- a/rails/lib/tasks/app.rake
+++ b/rails/lib/tasks/app.rake
@@ -48,8 +48,18 @@ namespace :app do
         client_type: "public"
       )
 
+      Client.where(name: "Portal Report SPA").first_or_create(
+        name: "Portal Report SPA",
+        app_id: "portal-report",
+        app_secret: SecureRandom.uuid(),
+        client_type: "public",
+        site_url: "https://portal-report.concord.org",
+        domain_matchers: "portal-report.concord.org",
+        redirect_uris: "https://portal-report.concord.org/branch/master/index.html"
+      )
+
       ExternalReport.where(name: "DEFAULT_REPORT_SERVICE").first_or_create(
-        url: "http://portal-report.concord.org/branch/master/index.html?sourceKey=#{lara_tool_id}",
+        url: "https://portal-report.concord.org/branch/master/index.html?sourceKey=#{lara_tool_id}",
         launch_text: "Report",
         client_id: auth_client.id,
         report_type: "offering",
@@ -61,7 +71,7 @@ namespace :app do
       )
 
       ExternalReport.where(name: "Class Dashboard").first_or_create(
-        url: "http://portal-report.concord.org/branch/master/index.html?portal-dashboard&sourceKey=#{lara_tool_id}",
+        url: "https://portal-report.concord.org/branch/master/index.html?portal-dashboard&sourceKey=#{lara_tool_id}",
         launch_text: "Class Dashboard",
         client_id: auth_client.id,
         report_type: "offering",
@@ -72,7 +82,7 @@ namespace :app do
       )
 
       ExternalReport.where(name: "AP Class Dashboard").first_or_create(
-        url: "http://portal-report.concord.org/branch/master/index.html?portal-dashboard&sourceKey=#{lara_tool_id}&answersSourceKey=activity-player.concord.org",
+        url: "https://portal-report.concord.org/branch/master/index.html?portal-dashboard&sourceKey=#{lara_tool_id}&answersSourceKey=activity-player.concord.org",
         launch_text: "Class Dashboard",
         client_id: auth_client.id,
         report_type: "offering",
@@ -83,7 +93,7 @@ namespace :app do
       )
 
       ExternalReport.where(name: "AP Report").first_or_create(
-        url: "http://portal-report.concord.org/branch/master/index.html?sourceKey=#{lara_tool_id}&answersSourceKey=activity-player.concord.org",
+        url: "https://portal-report.concord.org/branch/master/index.html?sourceKey=#{lara_tool_id}&answersSourceKey=activity-player.concord.org",
         launch_text: "Report",
         client_id: auth_client.id,
         report_type: "offering",
@@ -116,7 +126,7 @@ namespace :app do
       )
     end
 
-    task :local_setup => [:create_default_external_reports, :add_report_service_firebase_app, :create_default_tools, 'sso:add_dev_client']
+    task :local_setup => [:create_default_external_reports, :create_default_tools, 'sso:add_dev_client']
 
     #######################################################################
     #

--- a/rails/lib/tasks/app.rake
+++ b/rails/lib/tasks/app.rake
@@ -16,6 +16,83 @@ namespace :app do
       File.join([::Rails.root.to_s] + args)
     end
 
+    desc "add report service firebase app"
+    task :add_report_service_firebase_app => :environment do
+      # this separator stuff is so a multiline string can be pasted into
+      # the highline ask command
+      old_sep = $/
+      $/ = "-----END PRIVATE KEY-----"
+      private_key = ask("private_key: ")
+      $/ = old_sep
+      FirebaseApp.create(
+        name: 'report-service-dev',
+        client_email: 'report-service-dev@appspot.gserviceaccount.com',
+        private_key: private_key
+      )
+    end
+
+    desc "create default external reports and clients"
+    task :create_default_external_reports => :environment do
+      lara_domain = ENV['LARA_DOMAIN'].blank? ? 'app.lara.docker' : ENV['LARA_DOMAIN']
+      lara_tool_id = ENV['LARA_TOOL_ID'].blank? ? "#{lara_domain}.#{ENV['USER']}" : ENV['LARA_TOOL_ID']
+
+      auth_client = Client.where(name: "DEFAULT_REPORT_SERVICE_CLIENT").first_or_create(
+        app_id: "DEFAULT_REPORT_SERVICE_CLIENT",
+        app_secret: SecureRandom.uuid(),
+        domain_matchers: ".*\.concord\.org localhost.*",
+        client_type: "public"
+      )
+
+      ExternalReport.where(name: "DEFAULT_REPORT_SERVICE").first_or_create(
+        url: "http://portal-report.concord.org/branch/master/index.html?sourceKey=#{lara_tool_id}",
+        launch_text: "Report",
+        client_id: auth_client.id,
+        report_type: "offering",
+        allowed_for_students: true,
+        default_report_for_source_type: "LARA",
+        individual_student_reportable: true,
+        individual_activity_reportable: true,
+        use_query_jwt: false
+      )
+
+      ExternalReport.where(name: "Class Dashboard").first_or_create(
+        url: "http://portal-report.concord.org/branch/master/index.html?portal-dashboard&sourceKey=#{lara_tool_id}",
+        launch_text: "Class Dashboard",
+        client_id: auth_client.id,
+        report_type: "offering",
+        allowed_for_students: false,
+        individual_student_reportable: false,
+        individual_activity_reportable: false,
+        use_query_jwt: false
+      )
+
+      ExternalReport.where(name: "AP Class Dashboard").first_or_create(
+        url: "http://portal-report.concord.org/branch/master/index.html?portal-dashboard&sourceKey=#{lara_tool_id}&answersSourceKey=activity-player.concord.org",
+        launch_text: "Class Dashboard",
+        client_id: auth_client.id,
+        report_type: "offering",
+        allowed_for_students: false,
+        individual_student_reportable: false,
+        individual_activity_reportable: false,
+        use_query_jwt: false
+      )
+
+      ExternalReport.where(name: "AP Report").first_or_create(
+        url: "http://portal-report.concord.org/branch/master/index.html?sourceKey=#{lara_tool_id}&answersSourceKey=activity-player.concord.org",
+        launch_text: "Report",
+        client_id: auth_client.id,
+        report_type: "offering",
+        allowed_for_students: true,
+        individual_student_reportable: true,
+        individual_activity_reportable: false,
+        use_query_jwt: false
+      )
+
+      # To support Activity Player publishing you need to manually add a Tool with the tool_id of https://activity-player.concord.org.
+      # The convention is the source_type is ActivityPlayer.
+    end
+
+    task :local_setup => [:create_default_external_reports, :add_report_service_firebase_app, 'sso:add_dev_client']
 
     #######################################################################
     #

--- a/rails/lib/tasks/sso.rake
+++ b/rails/lib/tasks/sso.rake
@@ -12,9 +12,9 @@ namespace :sso do
   desc "add a new single signon dev test client"
   task :add_dev_client => :environment do
     lara_domain = ENV['LARA_DOMAIN'].blank? ? 'app.lara.docker' : ENV['LARA_DOMAIN']
-    Client.create(
-        :name       => 'localhost',
-        :app_id     => 'localhost',
+    Client.where(name: 'authoring').first_or_create(
+        :name       => 'authoring',
+        :app_id     => 'authoring',
         :app_secret => 'unsecure local secret',
         :site_url   => "https://#{lara_domain}",
         :client_type => 'confidential',

--- a/rails/lib/tasks/sso.rake
+++ b/rails/lib/tasks/sso.rake
@@ -11,13 +11,14 @@ namespace :sso do
 
   desc "add a new single signon dev test client"
   task :add_dev_client => :environment do
+    lara_domain = ENV['LARA_DOMAIN'].blank? ? 'app.lara.docker' : ENV['LARA_DOMAIN']
     Client.create(
         :name       => 'localhost',
         :app_id     => 'localhost',
         :app_secret => 'unsecure local secret',
-        :site_url   => 'https://app.lara.docker',
+        :site_url   => "https://#{lara_domain}",
         :client_type => 'confidential',
-        :redirect_uris => 'https://app.lara.docker/users/auth/cc_portal_localhost/callback'
+        :redirect_uris => "https://#{lara_domain}/users/auth/cc_portal_localhost/callback"
     )
   end
 


### PR DESCRIPTION
We've run this from scratch along with a new branch in LARA, and the updated steps in the README worked. 
Hopefully this will make the setup of the portal and lara a bit less error prone.

Here is the PR for the needed LARA change: https://github.com/concord-consortium/lara/pull/791
It is just changing the client Id used by LARA so it can be easier to use this both locally and in the cloud.

The main setup task is run automatically if the user doesn't have a database.yml file in their local checkout. That is the same way it was working before.  But now this setup task creates 3 clients, 4 reports, and 2 tools. 