### PR TITLE
Fix AP sequence shows up as an activity in Portal search

### DIFF
--- a/rails/app/controllers/api/v1/external_activities_controller.rb
+++ b/rails/app/controllers/api/v1/external_activities_controller.rb
@@ -24,9 +24,24 @@ class API::V1::ExternalActivitiesController < API::APIController
       return error("Invalid url", 422)
     end
 
+    type = params.require(:type)
+    case type
+    when "Activity"
+      material_type = "Activity"
+    when "Investigation", "Sequence"
+      material_type = "Investigation"
+    else
+      material_type = nil
+    end
+
+    if !material_type
+      return error("Invalid material type", 422)
+    end
+
     external_activity = ExternalActivity.create(
       :name                   => name,
       :url                    => url,
+      :material_type          => material_type,
       :publication_status     => params[:publication_status] || "published",
       :user                   => user,
       :append_auth_token      => params[:append_auth_token] || false,

--- a/rails/spec/controllers/api/v1/external_activities_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/external_activities_controller_spec.rb
@@ -37,7 +37,7 @@ describe API::V1::ExternalActivitiesController do
       end
 
       it "succeeds with valid parameters" do
-        post :create, params: { :name => "test", :url => "http://example.com/" }
+        post :create, params: { :name => "test", :url => "http://example.com/", :type => "Activity" }
         expect(response.status).to eql(201)
       end
     end
@@ -48,7 +48,7 @@ describe API::V1::ExternalActivitiesController do
       end
 
       it "succeeds with valid parameters" do
-        post :create, params: { :name => "test", :url => "http://example.com/" }
+        post :create, params: { :name => "test", :url => "http://example.com/", :type => "Sequence" }
         expect(response.status).to eql(201)
       end
     end
@@ -59,7 +59,7 @@ describe API::V1::ExternalActivitiesController do
       end
 
       it "succeeds with valid minimal parameters" do
-        post :create, params: {:name => "test", :url => "http://example.com/"}
+        post :create, params: { :name => "test", :url => "http://example.com/", :type => "Activity" }
         expect(response.status).to eql(201)
       end
     end
@@ -70,22 +70,32 @@ describe API::V1::ExternalActivitiesController do
       end
 
       it "fails with a missing name parameter" do
-        post :create, params: { :url => "http://example.com/" }
+        post :create, params: { :url => "http://example.com/", :type => "Activity" }
         expect(response.status).to eql(400)
       end
 
       it "fails with a missing url parameter" do
-        post :create, params: {:name => "test"}
+        post :create, params: {:name => "test", :type => "Activity" }
         expect(response.status).to eql(400)
       end
 
       it "fails with an invalid url parameter" do
-        post :create, params: { :url => "invalid" }
+        post :create, params: { :name => "test", :url => "invalid!--http:\\!!@&][", :type => "Activity" }
+        expect(response.status).to eql(422)
+      end
+
+      it "fails with a missing type parameter" do
+        post :create, params: { :name => "test", :url => "http://example.com/" }
         expect(response.status).to eql(400)
       end
 
+      it "fails with an invalid type parameter" do
+        post :create, params: { :name => "test", :url => "http://example.com/", :type => "invalid" }
+        expect(response.status).to eql(422)
+      end
+
       it "succeeds with valid minimal parameters" do
-        post :create, params: { :name => "test", :url => "http://example.com/" }
+        post :create, params: { :name => "test", :url => "http://example.com/", :type => "Activity" }
         expect(response.status).to eql(201)
       end
     end
@@ -200,7 +210,7 @@ describe API::V1::ExternalActivitiesController do
 
       it "should update an activity they did author" do
         my_url = "http://activity.com/activity/2"
-        post :create, params: {:name => "My Cool Activity", :url => my_url}
+        post :create, params: { :name => "My Cool Activity", :url => my_url, :type => "Activity" }
         my_valid_parameters = {
           url: my_url
         }


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/178640689

These changes ensure that an external activity has its material type set when it's published via external activities API. I made type/material_type required in order to follow how the older `publish2` method in rails/lib/activity_runtime_api.rb works.