### PR TITLE
fix error during error reporting, and log exception

### DIFF
--- a/rails/app/controllers/authentications_controller.rb
+++ b/rails/app/controllers/authentications_controller.rb
@@ -78,7 +78,12 @@ class AuthenticationsController < Devise::OmniauthCallbacksController
       @user.require_portal_user_type = !current_visitor.has_portal_user_type?
       sign_in_and_redirect @user, :event => :authentication
     rescue => e
-      set_flash_message :alert, :failure, kind: OmniAuth::Utils.camelize(env["omniauth.strategy"].name), reason: "a user with that email from that provider already exists. #{e.message}"
+      # Record this exception so we can figure out what is going wrong
+      ExceptionNotifier.notify_exception(
+        e,
+        env: request.env
+      )
+      set_flash_message :alert, :failure, kind: OmniAuth::Utils.camelize(request.env["omniauth.strategy"].name), reason: "a user with that email from that provider already exists. #{e.message}"
       redirect_to after_omniauth_failure_path_for(resource_name)
     end
   end


### PR DESCRIPTION
For some reason we are getting students that are not being able log in.
Our exception notifier is providing an error with:

```
A NameError occurred in authentications#google:

  undefined local variable or method `env' for #<AuthenticationsController:0x00000000d87200>
Did you mean?  end
               END
  app/controllers/authentications_controller.rb:81:in `rescue in generic_oauth'
```

Which I think means the env needs to be changed to `request.env`.
However fixing this also means that we wouldn't see these exceptions anymore.
So I added the ExceptionNotifier call to record the actual exception.

The existing recorded exceptions include email addresses that don't exist in the database.

I suspect it could be one of 2 things:
- the authentication with google is taking a while, so the student gets impatient and reloads the page, this causes some error.
- the student names or emails have some kind of invalid characters in them and this causes an exception while trying to create
the user object