### PR TITLE
Add provider and uid

### DIFF
--- a/rails/app/controllers/authentications_controller.rb
+++ b/rails/app/controllers/authentications_controller.rb
@@ -87,12 +87,14 @@ class AuthenticationsController < Devise::OmniauthCallbacksController
         e,
         env: request.env,
         data: {
-          extra_first_name: extra_first_name, 
+          extra_first_name: extra_first_name,
           info_first_name: info_first_name,
           extra_last_name: extra_last_name,
           info_last_name: info_last_name,
           first_name_64: Base64.encode64(extra_first_name  || info_first_name || ''),
-          last_name_64: Base64.encode64(extra_last_name || info_last_name || '')
+          last_name_64: Base64.encode64(extra_last_name || info_last_name || ''),
+          provider: auth&.provider,
+          uid: auth&.uid
         }
       )
       set_flash_message :alert, :failure, kind: OmniAuth::Utils.camelize(request.env["omniauth.strategy"].name), reason: "a user with that email from that provider already exists. #{e.message}"


### PR DESCRIPTION
the recent error messages are reporting non-unique email and login fields
when creating the User. These fields are based on the provider and uid.
Including them here will let us track down the existing user to figure out how it
is broken.

In theory any user with an email and login that matches should have an
Authentication object too.
If that Authentication exists then User#find_for_omniauth should find it
first and return the associated user.
But for some reason this isn't working.