### PR TITLE
add indexes to authentications and access_grants

### DIFF
--- a/rails/db/migrate/20211007180858_add_uid_provider_index_to_authentications.rb
+++ b/rails/db/migrate/20211007180858_add_uid_provider_index_to_authentications.rb
@@ -1,0 +1,6 @@
+class AddUidProviderIndexToAuthentications < ActiveRecord::Migration[6.1]
+  def change
+    add_index :authentications, [:provider, :uid]
+    add_index :access_grants, :access_token
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_07_152345) do
+ActiveRecord::Schema.define(version: 2021_10_07_180858) do
 
   create_table "access_grants", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "code"
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 2021_10_07_152345) do
     t.datetime "updated_at", null: false
     t.integer "learner_id"
     t.integer "teacher_id"
+    t.index ["access_token"], name: "index_access_grants_on_access_token"
     t.index ["client_id"], name: "index_access_grants_on_client_id"
     t.index ["learner_id"], name: "index_access_grants_on_learner_id"
     t.index ["teacher_id"], name: "index_access_grants_on_teacher_id"
@@ -187,6 +188,7 @@ ActiveRecord::Schema.define(version: 2021_10_07_152345) do
     t.string "uid"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
     t.index ["user_id"], name: "index_authentications_on_user_id"
   end
 


### PR DESCRIPTION
The SSO code looks for authentications based on the provider and uid.
The production site has 428,000 authentications, so this is a slow process

When LARA is using the portal for SSO, the portal has to look up the
access grant by the access token. This was not indexed and there are
56,000 access grants on production, so this is slow.

I'm using the AWS RDS insights to identify these slow queries.