### PR TITLE
add indexes for common portal queries

### DIFF
--- a/rails/db/migrate/20211008153150_add_several_indexes.rb
+++ b/rails/db/migrate/20211008153150_add_several_indexes.rb
@@ -1,0 +1,7 @@
+class AddSeveralIndexes < ActiveRecord::Migration[6.1]
+  def change
+    add_index :saveable_interactives, :learner_id
+    add_index :access_grants, [:code, :client_id]
+    add_index :access_grants, :access_token_expires_at
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_07_180858) do
+ActiveRecord::Schema.define(version: 2021_10_08_153150) do
 
   create_table "access_grants", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "code"
@@ -25,7 +25,9 @@ ActiveRecord::Schema.define(version: 2021_10_07_180858) do
     t.integer "learner_id"
     t.integer "teacher_id"
     t.index ["access_token"], name: "index_access_grants_on_access_token"
+    t.index ["access_token_expires_at"], name: "index_access_grants_on_access_token_expires_at"
     t.index ["client_id"], name: "index_access_grants_on_client_id"
+    t.index ["code", "client_id"], name: "index_access_grants_on_code_and_client_id"
     t.index ["learner_id"], name: "index_access_grants_on_learner_id"
     t.index ["teacher_id"], name: "index_access_grants_on_teacher_id"
     t.index ["user_id"], name: "index_access_grants_on_user_id"
@@ -1748,6 +1750,7 @@ ActiveRecord::Schema.define(version: 2021_10_07_180858) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "iframe_id"
+    t.index ["learner_id"], name: "index_saveable_interactives_on_learner_id"
   end
 
   create_table "saveable_multiple_choice_answers", id: :integer, charset: "utf8", force: :cascade do |t|


### PR DESCRIPTION
In production:
- saveable_interactives table is queried often by learner_id and has 148,000 rows.
- access_grants are looked up by code and client_id and hover around 55,000 rows.
- access_grants are deleted often based on access_token_expires_at field.