### PR TITLE
180559584: endpoint only report learners

### DIFF
--- a/rails/app/controllers/api/v1/report_learners_es_controller.rb
+++ b/rails/app/controllers/api/v1/report_learners_es_controller.rb
@@ -156,7 +156,7 @@ class API::V1::ReportLearnersEsController < API::APIController
       learners = learner_selector.es_learners.map do |l|
         {
           learner_id: l.learner_id,
-          run_remote_endpoint: l.remote_endpoint,
+          run_remote_endpoint: l.remote_endpoint_url,
           runnable_url: l.runnable_url
         }
       end

--- a/rails/app/models/report/learner/selector.rb
+++ b/rails/app/models/report/learner/selector.rb
@@ -39,6 +39,14 @@ class Report::Learner::Selector
           es_learner.user = users[es_learner.user_id]
           es_learner
         }
+      elsif (learner_type == :endpoint_only)
+        @es_learners = hits.map do |h|
+          OpenStruct.new({
+            learner_id: h['_source']['learner_id'],
+            remote_endpoint_url: h['_source']['remote_endpoint_url'],
+            runnable_url: h['_source']['runnable_url']
+          })
+        end
       end
       @runnable_names = hits.map { |h| h['_source']['runnable_type_and_id'] }
       @runnable_names = @runnable_names.uniq

--- a/rails/app/models/report/learner/selector.rb
+++ b/rails/app/models/report/learner/selector.rb
@@ -34,11 +34,11 @@ class Report::Learner::Selector
       elsif (learner_type == :elasticsearch)
         user_ids = hits.map { |h| h['_source']['user_id'] }.uniq
         users = User.select(:id, :login, :first_name, :last_name).find(user_ids).index_by(&:id)
-        @es_learners = hits.map { |h|
+        @es_learners = hits.map do |h|
           es_learner = OpenStruct.new(h['_source'])
           es_learner.user = users[es_learner.user_id]
           es_learner
-        }
+        end
       elsif (learner_type == :endpoint_only)
         @es_learners = hits.map do |h|
           OpenStruct.new({

--- a/rails/spec/controllers/api/v1/report_learners_es_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/report_learners_es_controller_spec.rb
@@ -467,6 +467,7 @@ describe API::V1::ReportLearnersEsController do
               expect(learner).not_to include("class_id")
               expect(learner).to include("learner_id")
               expect(learner).to include("run_remote_endpoint")
+              expect(learner).to include("runnable_url")
             end
           end
         end

--- a/rails/spec/controllers/api/v1/report_learners_es_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/report_learners_es_controller_spec.rb
@@ -468,6 +468,7 @@ describe API::V1::ReportLearnersEsController do
               expect(learner).to include("learner_id")
               expect(learner).to include("run_remote_endpoint")
               expect(learner).to include("runnable_url")
+              expect(learner["run_remote_endpoint"]).not_to eq nil
             end
           end
         end

--- a/rails/spec/controllers/api/v1/report_learners_es_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/report_learners_es_controller_spec.rb
@@ -450,6 +450,26 @@ describe API::V1::ReportLearnersEsController do
           expect(filter["learners"][1]["teachers"][0]["user_id"].to_i).to eq teacher2.id
           expect(filter["learners"][1]["teachers"][1]["user_id"].to_i).to eq teacher1.id
         end
+
+        describe "with `endpoint_only` parameter passed in" do
+          it "renders a smaller response that does not include names or teachers" do
+            get :external_report_learners_from_jwt,
+              params: {:query => {}, :page_size => 1000, :endpoint_only => true}
+            resp = JSON.parse(response.body)
+            filter = resp["json"]
+            learners = filter["learners"]
+            expect(learners.length).to eq 3
+            learners.each do |learner|
+              expect(learner["learner_id"].to_i).to be_an_instance_of(Integer)
+              expect(learner).not_to include("student_name")
+              expect(learner).not_to include("username")
+              expect(learner).not_to include("teachers")
+              expect(learner).not_to include("class_id")
+              expect(learner).to include("learner_id")
+              expect(learner).to include("run_remote_endpoint")
+            end
+          end
+        end
       end
 
       describe "GET external_report_learners_from_jwt with incorrect page_size" do


### PR DESCRIPTION
This change should result in faster responses from `app/controllers/api/v1/report_learners_es_controller.rb` when the parameter 'endpoint_only' is added to the query. It short-circuits User lookups, and sends back smaller payloads.  We would only use this option when running log queries.



Here is an example in the difference in response from just two learners.

Previous: (1232 bytes) 128ms
```
{
    "json": {
        "version": "1",
        "learners": [
            {
                "student_id": 1,
                "learner_id": 4,
                "class_id": 1,
                "class": "My Class",
                "school": "Rails Portal-school",
                "user_id": 8,
                "offering_id": 2,
                "permission_forms": [],
                "username": "apaessel",
                "student_name": "ada paessel",
                "last_run": "2021-12-08T21:06:57.000Z",
                "run_remote_endpoint": "http://app.portal.docker/dataservice/external_activity_data/3cd25cdc-29d1-4869-80af-619f2074ed43",
                "runnable_url": "https://app.lara.docker/activities/54",
                "teachers": [
                    {
                        "user_id": 1,
                        "name": "Valerie Frizzle",
                        "district": "Rails Portal-district",
                        "state": "MA",
                        "email": "teacher@concord.org"
                    }
                ],
                "created_at": "2021-08-05T18:37:07.000Z"
            },
            {
                "student_id": 1,
                "learner_id": 5,
                "class_id": 1,
                "class": "My Class",
                "school": "Rails Portal-school",
                "user_id": 8,
                "offering_id": 1,
                "permission_forms": [],
                "username": "apaessel",
                "student_name": "ada paessel",
                "last_run": "2021-12-08T21:07:14.000Z",
                "run_remote_endpoint": "http://app.portal.docker/dataservice/external_activity_data/fc2ce0f6-84d8-4eb6-84bf-10195f9a19a0",
                "runnable_url": "https://app.lara.docker/sequences/6",
                "teachers": [
                    {
                        "user_id": 1,
                        "name": "Valerie Frizzle",
                        "district": "Rails Portal-district",
                        "state": "MA",
                        "email": "teacher@concord.org"
                    }
                ],
                "created_at": "2021-12-08T21:07:07.000Z"
            }
        ],
        "lastHitSortValue": [
            1638997627000,
            5
        ]
    }
}
```
 
 Reduced payload: (458 bytes) 69ms
```
{
    "json": {
        "version": "1",
        "learners": [
            {
                "learner_id": 4,
                "run_remote_endpoint": "http://app.portal.docker/dataservice/external_activity_data/3cd25cdc-29d1-4869-80af-619f2074ed43",
                "runnable_url": "https://app.lara.docker/activities/54"
            },
            {
                "learner_id": 5,
                "run_remote_endpoint": "http://app.portal.docker/dataservice/external_activity_data/fc2ce0f6-84d8-4eb6-84bf-10195f9a19a0",
                "runnable_url": "https://app.lara.docker/sequences/6"
            }
        ],
        "lastHitSortValue": [
            1638997627000,
            5
        ]
    }
}
```
