### PR TITLE
Archived classes should not be shown in student's class list

### DIFF
--- a/rails/app/views/portal/clazzes/_list_for_student.html.haml
+++ b/rails/app/views/portal/clazzes/_list_for_student.html.haml
@@ -1,2 +1,2 @@
-- portal_student.clazzes.each do |c|
+- portal_student.active_clazzes.each do |c|
   = render :partial => 'portal/clazzes/show_for_student', :locals => {:portal_clazz => c}


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/180889614

[#180889614]

This change is an addition to the updates in [this PR](https://github.com/concord-consortium/rigse/pull/1102) and ensures archived classes aren't shown in the main content area of a student's Classes and Offerings page.