### PR TITLE
Add GH Codespaces docs

### DIFF
--- a/.env-gh-codespaces-sample
+++ b/.env-gh-codespaces-sample
@@ -1,0 +1,38 @@
+# This configuration adds the following overlays:
+#
+# docker-compose-sync: setup to speed up OSX using unison under the hood
+#
+# docker-compose-random-ports: export random exported ports, so it doesn't conflict with
+#   the portal or other apps running on port 3000
+#
+# docker-compose-publish-capybara-port.yml: expose the capybara port so a chrome driver
+#   running on the host machine can talk to the capaybara server and you can see the UI
+#   while the test are running.
+#
+# docker/dev/docker-compose-graphql.yml: start a graphql back-end server and
+#   a react-admin interface for managing administrative tasks
+#
+COMPOSE_FILE=docker-compose.yml:docker/dev/docker-compose-gh-codespaces.yml:docker/dev/docker-compose-publish-capybara-port.yml:docker/dev/docker-compose-graphql.yml:docker/dev/docker-compose-lara-proxy.yml
+
+# The URL for ourselves. This is used when resources are published to the portal.
+# SITE_URL in docker-compose will be constructed from PORTAL_HOST and PORTAL_PROTOCOL.
+# The PORTAL_HOST variable is also used to set VIRTUAL_HOST variable. This variable is
+# used by the digny proxy to override the default `[service-name].[folder-name].docker`
+#
+# For automation PORTAL_HOST should be learn.dev.docker and PORTAL_PROTOCOL should be https.
+PORTAL_HOST=[PORTAL-RANDOM-GH-CODESPACES-HOST]].githubpreview.dev
+PORTAL_PROTOCOL=https
+
+LARA_HOST=[LARA-RANDOM-GH-CODESPACES-HOST].githubpreview.dev
+
+# Run the portal in researcher report mode this is used by the researcher portal
+# RESEARCHER_REPORT_ONLY=true
+MYSQL_ROOT_PASSWORD=xyzzy
+
+# Sets the secret used to generate the portal JWT tokens in lib/signed_jwt.rb
+JWT_HMAC_SECRET=XXXX
+
+# Configure rails logging levels:
+#     DEBUG | INFO | WARN | ERROR | FATAL | UNKNOWN
+TEST_LOG_LEVEL=WARN
+DEV_LOG_LEVEL=DEBUG

--- a/.env-gh-codespaces-sample
+++ b/.env-gh-codespaces-sample
@@ -1,9 +1,6 @@
 # This configuration adds the following overlays:
 #
-# docker-compose-sync: setup to speed up OSX using unison under the hood
-#
-# docker-compose-random-ports: export random exported ports, so it doesn't conflict with
-#   the portal or other apps running on port 3000
+# docker-gh-codespaces: GitHub Codespaces settings (eg port 3000 exposed)
 #
 # docker-compose-publish-capybara-port.yml: expose the capybara port so a chrome driver
 #   running on the host machine can talk to the capaybara server and you can see the UI
@@ -11,18 +8,19 @@
 #
 # docker/dev/docker-compose-graphql.yml: start a graphql back-end server and
 #   a react-admin interface for managing administrative tasks
-#
 COMPOSE_FILE=docker-compose.yml:docker/dev/docker-compose-gh-codespaces.yml:docker/dev/docker-compose-publish-capybara-port.yml:docker/dev/docker-compose-graphql.yml:docker/dev/docker-compose-lara-proxy.yml
 
 # The URL for ourselves. This is used when resources are published to the portal.
 # SITE_URL in docker-compose will be constructed from PORTAL_HOST and PORTAL_PROTOCOL.
-# The PORTAL_HOST variable is also used to set VIRTUAL_HOST variable. This variable is
-# used by the digny proxy to override the default `[service-name].[folder-name].docker`
+# The PORTAL_HOST variable is also used to set VIRTUAL_HOST variable. GitHub Codespaces will assign a random
+# host name that can be obtained after the port is made public in the Visual Studio Code "Ports" tab.
 #
 # For automation PORTAL_HOST should be learn.dev.docker and PORTAL_PROTOCOL should be https.
 PORTAL_HOST=[PORTAL-RANDOM-GH-CODESPACES-HOST]].githubpreview.dev
 PORTAL_PROTOCOL=https
 
+# GitHub Codespaces will assign a random host name that can be obtained after the port is made public
+# in the Visual Studio Code "Ports" tab.
 LARA_HOST=[LARA-RANDOM-GH-CODESPACES-HOST].githubpreview.dev
 
 # Run the portal in researcher report mode this is used by the researcher portal

--- a/README.md
+++ b/README.md
@@ -208,10 +208,71 @@ If you want to change the portal url from "app.portal.docker" to "learn.dev.dock
 1. In the Portal, edit '.env' file and update PORTAL_HOST as learn.dev.docker
 2. In the Portal, edit '.env' file and update PORTAL_PROTOCOL as https for automation
 3. In the Portal, as an administrator, edit the Auth Client settings:
-```   
+```
     Site Url: 'https://learn.dev.docker'
     Allowed URL Redirects: 'https://learn.dev.docker/users/auth/cc_portal_localhost/callback'
 ```
+
+#### GitHub Codespaces
+
+Github Codespaces is a cloud-based development environment. We are currently using it to do development work on LARA and
+Portal since it’s proven difficult to do local development on those codebases on M1 MacBooks.
+
+Github’s documentation for Codespaces can be found at [here](docs.github.com/en/codespaces).
+
+You will need to set up separate codespaces for LARA and the Portal.
+
+Use of Codespaces incurs an hourly cost. The amount is not a lot, but it should be kept in mind. Codespaces will shut themselves down
+automatically after a period of inactivity, but it would be best to manually shut them down when you’re done working in order to
+minimize cost.
+
+You can use Codespaces in web browser or you can connect to selected machine from desktop Visual Studio Code if you
+install a Codespaces extension.
+
+##### Basic setup
+
+- Your GitHub account needs to have Codespaces activated by the organization admin.
+- Go to the github.com page for the repository you will be working on.
+- Click on the Code button, then click the Codespaces tab, and then click the “Create codespace on master” button.
+- Portal requires 4-core machine because of memory (MySQL server tends to fail randomly on 2-core variant)
+
+Once machine is up and running, most of the steps described for local development are still valid for GH Codespaces.
+The main difference is that you should copy `.env-gh-codespaces-sample` to `.env` (instead of `.env-osx-sample`),
+there's no need for Dinghy setup, and LARA and Portal host will be significantly different (impossible to guess
+until you make their ports visible in Visual Studio Code).
+
+Run:
+```
+  cp .env-gh-codespaces-sample .env
+  docker login
+  docker-compose up
+```
+
+Once the app has started, open "Ports" tab in Visual Studio Code. Find a process that uses port 3000 and change its
+visibility to public (right click on "Private" -> Port Visibility -> Public). You should see an updated address in
+"Local Address" column. You can open this URL in the web browser and LARA should load. It seems it's necessary to do it
+each time you run `docker-compose up`.
+
+Copy this randomly generated host and open `.env` file. Find `[PORTAL-RANDOM-GH-CODESPACES-HOST]` and replace it with the
+copied value. Note that you have to do it only once, as this host will stay the same in the future, even if you
+shut down and restart your Codespaces machine.
+
+Once you setup LARA and make its port public, you should open `.env` file again, find `[LARA-RANDOM-GH-CODESPACES-HOST]`,
+and replace it with the randomly generated host for LARA.
+
+Each time `.env` file is updated, you need stop docker-compose and start it again using `docker-compose up`.
+
+#### Setting up Auth Clients and Firebase Apps
+
+Open Portal, login as `admin` (password: `password`), and go to Admin tab.
+
+1. Go to Auth Clients and edit "authoring". Change Site URL to `https://[LARA-RANDOM-GH-CODESPACES-HOST].githubpreview.dev/`,
+and Allowed redirect URIs to `https://[LARA-RANDOM-GH-CODESPACES-HOST].githubpreview.dev/users/auth/cc_portal_localhost/callback`.
+2. Go to Firebase Apps and create two new apps:
+  - report-service-dev
+  - token-service
+
+    Client emails and private keys can be copied from learn.staging.concord.org.
 
 ### Theme support & Rolling your own theme:
 

--- a/docker/dev/docker-compose-gh-codespaces.yml
+++ b/docker/dev/docker-compose-gh-codespaces.yml
@@ -1,0 +1,15 @@
+# This is a docker-compose overlay with changes necessary to support GitHub Codespaces.
+# As of June 21, 2022, it only publishes the app port. More changes might be necessary in the future.
+
+# A convient way to overlay this file is to add a `.env` file with the contents:
+#  COMPOSE_FILE=docker-compose.yml:docker/dev/docker-compose-gh-codespaces.yml
+# You can also do it manually when you run docker-compose each time with
+# docker-compose -f docker-compose.yml -f docker/dev/docker-compose-random-ports.yml
+# if you are making changes to docker-compose.yml or this file it is useful to
+# run `docker-compose config` which shows how the two files get merged together
+
+version: '3'
+services:
+  app:
+    ports:
+      - "3000:3000"


### PR DESCRIPTION
[#182524012]

I've got `.env `and a modified `docker-compose.yml` files from @emcelroy. 
I've extracted docker-compose changes to a new overlay, and created `.env-gh-codespaces-sample`. I've also updated readme  (Ethan's doc: https://docs.google.com/document/d/1O8CQaoIBAnZLrHnrQmxY_ywKE6EUv-7scIK1Dr6-AiY/edit# has been helpful too)

I'm not sure where is the balance between having a complete guide and not repeating steps from other Readme sections (many steps are the same). But the current GH Codespaces readme provides a complete setup that enables LARA-Portal SSO, activity publications, etc., and it seems not to be too long.

Also, I could use `docker-compose.override.yml` as it also exposes Ports, but it didn't seem that clean. Do we need this file at all? I'd think it's a file for local overrides, but it's versioned in git.

Related LARA PR: https://github.com/concord-consortium/lara/pull/963