### PR TITLE
Simplify Codespaces setup

### DIFF
--- a/.env-gh-codespaces-sample
+++ b/.env-gh-codespaces-sample
@@ -5,23 +5,18 @@
 # docker-compose-publish-capybara-port.yml: expose the capybara port so a chrome driver
 #   running on the host machine can talk to the capaybara server and you can see the UI
 #   while the test are running.
-#
-# docker/dev/docker-compose-graphql.yml: start a graphql back-end server and
-#   a react-admin interface for managing administrative tasks
-COMPOSE_FILE=docker-compose.yml:docker/dev/docker-compose-gh-codespaces.yml:docker/dev/docker-compose-publish-capybara-port.yml:docker/dev/docker-compose-graphql.yml:docker/dev/docker-compose-lara-proxy.yml
+COMPOSE_FILE=docker-compose.yml:docker/dev/docker-compose-gh-codespaces.yml:docker/dev/docker-compose-publish-capybara-port.yml:docker/dev/docker-compose-lara-proxy.yml
 
-# The URL for ourselves. This is used when resources are published to the portal.
-# SITE_URL in docker-compose will be constructed from PORTAL_HOST and PORTAL_PROTOCOL.
-# The PORTAL_HOST variable is also used to set VIRTUAL_HOST variable. GitHub Codespaces will assign a random
-# host name that can be obtained after the port is made public in the Visual Studio Code "Ports" tab.
-#
-# For automation PORTAL_HOST should be learn.dev.docker and PORTAL_PROTOCOL should be https.
-PORTAL_HOST=[PORTAL-RANDOM-GH-CODESPACES-HOST]].githubpreview.dev
+# Run `echo ${CODESPACE_NAME}` in LARA GitHub Codespace container and copy returned value here. It'll be used
+# to automatically set LARA_HOST, LARA_DOMAIN, and LARA_TOOL_ID variables.
+LARA_CODESPACE_NAME=
+
+LARA_HOST=${LARA_CODESPACE_NAME}-3000.githubpreview.dev
+LARA_DOMAIN=${LARA_CODESPACE_NAME}-3000.githubpreview.dev
+
+# CODESPACE_NAME is available in GitHub Codespace container.
+PORTAL_HOST=${CODESPACE_NAME}-3000.githubpreview.dev
 PORTAL_PROTOCOL=https
-
-# GitHub Codespaces will assign a random host name that can be obtained after the port is made public
-# in the Visual Studio Code "Ports" tab.
-LARA_HOST=[LARA-RANDOM-GH-CODESPACES-HOST].githubpreview.dev
 
 # Run the portal in researcher report mode this is used by the researcher portal
 # RESEARCHER_REPORT_ONLY=true

--- a/README.md
+++ b/README.md
@@ -238,41 +238,37 @@ install a Codespaces extension.
 
 Once machine is up and running, most of the steps described for local development are still valid for GH Codespaces.
 The main difference is that you should copy `.env-gh-codespaces-sample` to `.env` (instead of `.env-osx-sample`),
-there's no need for Dinghy setup, and LARA and Portal host will be significantly different (impossible to guess
-until you make their ports visible in Visual Studio Code).
+there's no need for Dinghy setup, and LARA and Portal hosts will be significantly different. However, everything
+you need to do in practice is described below.
 
-Run:
-```
-  cp .env-gh-codespaces-sample .env
-  docker login
-  docker-compose up
-```
+1. Run:
+    ```
+      cp .env-gh-codespaces-sample .env
+    ```
 
-Once the app has started, open "Ports" tab in Visual Studio Code. Find a process that uses port 3000 and change its
+2. Open LARA GitHub Codespace, run `echo ${CODESPACE_NAME}` in terminal, and set `LARA_CODESPACE_NAME` variable
+in Portal's `.env` file.
+
+3. Run
+    ```
+      docker login
+      docker-compose up
+    ```
+
+4.  Once the app has started, open "Ports" tab in Visual Studio Code. Find a process that uses port 3000 and change its
 visibility to public (right click on "Private" -> Port Visibility -> Public). You should see an updated address in
-"Local Address" column. You can open this URL in the web browser and LARA should load. It seems it's necessary to do it
+"Local Address" column. You can open this URL in the web browser and Portal should load. It seems it's necessary to do it
 each time you run `docker-compose up`.
 
-Copy this randomly generated host and open `.env` file. Find `[PORTAL-RANDOM-GH-CODESPACES-HOST]` and replace it with the
-copied value. Note that you have to do it only once, as this host will stay the same in the future, even if you
-shut down and restart your Codespaces machine.
+5. Open Portal, login as `admin` (password: `password`), and go to Admin tab.
 
-Once you setup LARA and make its port public, you should open `.env` file again, find `[LARA-RANDOM-GH-CODESPACES-HOST]`,
-and replace it with the randomly generated host for LARA.
-
-Each time `.env` file is updated, you need stop docker-compose and start it again using `docker-compose up`.
-
-#### Setting up Auth Clients and Firebase Apps
-
-Open Portal, login as `admin` (password: `password`), and go to Admin tab.
-
-1. Go to Auth Clients and edit "authoring". Change Site URL to `https://[LARA-RANDOM-GH-CODESPACES-HOST].githubpreview.dev/`,
-and Allowed redirect URIs to `https://[LARA-RANDOM-GH-CODESPACES-HOST].githubpreview.dev/users/auth/cc_portal_localhost/callback`.
-2. Go to Firebase Apps and create two new apps:
-  - report-service-dev
-  - token-service
+    Go to Firebase Apps and create two new apps:
+      - report-service-dev
+      - token-service
 
     Client emails and private keys can be copied from learn.staging.concord.org.
+
+Now, your Portal instance should work with LARA, Activity Player and basic reports.
 
 ### Theme support & Rolling your own theme:
 


### PR DESCRIPTION
[#182524012]

I've updated Readme and .env file to take advantage of `CODESPACE_NAME` env variable available in Codespace container. That way we don't have to start the server and make host public to guess the domain. Apparently, it's always `${CODESPACE_NAME}-{port}.githubpreview.dev`. So, the only manual part of the setup here is to go to LARA container and copy its Codespace name, and then paste into .env.

I removed `docker-compose-graphql.yml` as suggested in the previous PR.

Also, I'm setting `LARA_DOMAIN` in `.env` file so `LARA_TOOL_ID` is set correctly. This ensures that Auth Client and default reports are all defined 100% correct (correct source key), and there's no never-ending spinner of death in the report (I tested all the variants: student, student from activity page, teacher).

I also thought about re-defining `LARA_TOOL_ID` in docker-compose-gh-codespaces.yml, so it doesn't use `USER` variable.

In practice, the report tool id / source key will look like: `${CODESPACE_NAME}-3000.githubpreview.dev.codespace`, as the username is always `codespace`. If there's no advantage of having 100% real hostname as tool id / source key, I guess this is fine. It makes this custom gh-codespaces config simpler.

Related LARA PR: https://github.com/concord-consortium/lara/pull/968

UPDATE: 
> If there's no advantage of having 100% real hostname as tool id / source key, I guess this is fine. It makes this custom gh-codespaces config simpler.

Heh, I've just noticed that when Activity Player generates student report (summary), it just uses LARA host. I guess it has no better way to do it. So, apparently there's an advantage is using host / domain as report service tool ID and I guess I should change it again. I'll do it a bit later.