### PR TITLE
Added rake task to migrate reports for AP activities [#182432397]

### DIFF
--- a/rails/lib/tasks/lara2.rake
+++ b/rails/lib/tasks/lara2.rake
@@ -124,15 +124,6 @@ namespace :lara2 do
       if STDIN.gets.chomp == "YES"
         puts "Migrating reports"
 
-        # first set the default report type for AP activities to be the "Activity Player Report"
-        ap_report.default_report_for_source_type = ap_tool.source_type
-        ap_report.save!
-
-        # and then make sure no other default report type is set for AP activities
-        ExternalReport
-          .where('id != ? AND default_report_for_source_type = ?', ap_report.id, ap_tool.source_type)
-          .update_all(default_report_for_source_type: nil)        
-
         migrated_count = 0
         total_count = 0
   
@@ -141,6 +132,12 @@ namespace :lara2 do
 
             migrated = false
 
+            # add the ap report
+            if !ea.external_reports.exists?(ap_report.id)
+              ea.external_reports << ap_report
+              migrated = true
+            end
+            
             # remove the lara dashboard report
             if ea.external_reports.exists?(lara_dashboard_report.id)
               ea.external_reports.delete(lara_dashboard_report.id)

--- a/rails/spec/libs/tasks/lara2_spec.rb
+++ b/rails/spec/libs/tasks/lara2_spec.rb
@@ -194,3 +194,145 @@ describe "lara2:reset_external_activity_urls_to_legacy_lara_url" do
     expect(ap_activity_no_legacy_url.tool).to eq(ap_tool)
   end  
 end
+
+
+describe "lara2:migrate_external_report_urls" do
+
+  let (:ap_tool)   { FactoryBot.create(:tool, {name: "ActivityPlayer"}) }
+  let (:lara_tool)   { FactoryBot.create(:tool, {name: "LARA"}) }
+
+  let (:ap_report) { FactoryBot.create(:external_report, name: "Activity Player Report")}
+  let (:lara_dashboard_report) { FactoryBot.create(:external_report, name: "Class Dashboard")}
+  let (:ap_dashboard_report) { FactoryBot.create(:external_report, name: "Activity Player Dashboard")}
+
+  let (:starting_default_ap_report) { FactoryBot.create(:external_report, name: "Starting Default Report", default_report_for_source_type: ap_tool.source_type)}
+
+  let (:lara_activity) { FactoryBot.create(:external_activity, url: "https://ap.url/123", tool: lara_tool)}
+
+  let (:ap_activity_with_no_reports) { FactoryBot.create(:external_activity, url: "https://ap.url/123", tool: ap_tool)}
+  let (:ap_activity_with_lara_report) { FactoryBot.create(:external_activity, url: "https://ap.url/456", tool: ap_tool)}
+  let (:ap_activity_with_ap_report) { FactoryBot.create(:external_activity, url: "https://ap.url/456", tool: ap_tool)}
+  let (:ap_activity_with_lara_and_ap_report) { FactoryBot.create(:external_activity, url: "https://ap.url/456", tool: ap_tool)}
+  let (:ap_activity_with_lara_and_ap_report_and_other_report) { FactoryBot.create(:external_activity, url: "https://ap.url/456", tool: ap_tool)}
+  
+  let (:invoke_task) { 
+    Rake.application.invoke_task "lara2:migrate_external_report_urls"
+  }
+
+  before do
+    Rake.application.rake_require "tasks/lara2"
+    Rake::Task.define_task(:environment)
+  end
+
+  after(:each) do
+    # the magic to allow multiple tests on the same task...
+    Rake::Task["lara2:migrate_external_report_urls"].reenable
+  end
+
+  it "fails with no ActivityPlayer tool" do
+    expect { invoke_task }.to output(/ERROR: No ActivityPlayer tool found/).to_stdout
+  end  
+
+  it "fails with no Activity Player Report" do
+    ap_tool
+    expect { invoke_task }.to output(/ERROR: No 'Activity Player Report' external report found/).to_stdout
+  end  
+
+  it "fails with no Class Dashboard Report" do
+    ap_tool
+    ap_report
+    expect { invoke_task }.to output(/ERROR: No 'Class Dashboard' external report found/).to_stdout
+  end  
+
+  it "fails with no Activity Player Dashboard Report" do
+    ap_tool
+    ap_report
+    lara_dashboard_report
+    expect { invoke_task }.to output(/ERROR: No 'Activity Player Dashboard' external report found/).to_stdout
+  end  
+
+  it "fails when the confirmation input is not correct" do
+    ap_tool
+    ap_report
+    lara_dashboard_report
+    ap_dashboard_report
+
+    allow(STDIN).to receive(:gets).and_return("NO!")
+    expect { invoke_task }.to output(/ERROR: Aborting migrating reports/).to_stdout
+  end
+
+  it "migrates the default report for AP activities" do
+    ap_tool
+    ap_report
+    lara_dashboard_report
+    ap_dashboard_report
+    starting_default_ap_report
+
+    expect(ap_report.default_report_for_source_type).to eq(nil)
+    expect(starting_default_ap_report.default_report_for_source_type).to eq(ap_tool.source_type)
+
+    allow(STDIN).to receive(:gets).and_return("YES")
+    expect { invoke_task }.to output(/Migrated external reports in 0 out of 0 AP activities found/).to_stdout
+
+    ap_report.reload
+    starting_default_ap_report.reload
+
+    expect(ap_report.default_report_for_source_type).to eq(ap_tool.source_type)
+    expect(starting_default_ap_report.default_report_for_source_type).to eq(nil)
+  end  
+
+  it "migrates the reports for the AP activities" do
+    ap_tool
+    ap_report
+
+    # add all the reports
+    lara_activity.external_reports << lara_dashboard_report
+    lara_activity.save!
+    lara_activity.reload
+
+    ap_activity_with_no_reports
+
+    ap_activity_with_lara_report.external_reports << lara_dashboard_report
+    ap_activity_with_lara_report.save!
+    ap_activity_with_lara_report.reload
+
+    ap_activity_with_ap_report.external_reports << ap_dashboard_report
+    ap_activity_with_ap_report.save!
+    ap_activity_with_ap_report.reload
+
+    ap_activity_with_lara_and_ap_report.external_reports << lara_dashboard_report
+    ap_activity_with_lara_and_ap_report.external_reports << ap_dashboard_report
+    ap_activity_with_lara_and_ap_report.save!
+    ap_activity_with_lara_and_ap_report.reload
+
+    ap_activity_with_lara_and_ap_report_and_other_report.external_reports << lara_dashboard_report
+    ap_activity_with_lara_and_ap_report_and_other_report.external_reports << ap_dashboard_report
+    ap_activity_with_lara_and_ap_report_and_other_report.external_reports << starting_default_ap_report
+    ap_activity_with_lara_and_ap_report_and_other_report.save!
+    ap_activity_with_lara_and_ap_report_and_other_report.reload
+
+    # the one AP activity that only has the ap_dashboard_report should be skipped
+    allow(STDIN).to receive(:gets).and_return("YES")
+    expect { invoke_task }.to output(/Migrated external reports in 4 out of 5 AP activities found/).to_stdout
+
+    lara_activity.reload
+    ap_activity_with_no_reports.reload
+    ap_activity_with_lara_report.reload
+    ap_activity_with_ap_report.reload
+    ap_activity_with_lara_and_ap_report.reload
+    ap_activity_with_lara_and_ap_report_and_other_report.reload
+
+    # LARA activities should not be changed
+    expect(lara_activity.external_reports).to eq([lara_dashboard_report])
+
+    # all AP activities should be changed
+    expect(ap_activity_with_no_reports.external_reports).to eq([ap_dashboard_report])
+    expect(ap_activity_with_lara_report.external_reports).to eq([ap_dashboard_report])
+    expect(ap_activity_with_ap_report.external_reports).to eq([ap_dashboard_report])
+    expect(ap_activity_with_lara_and_ap_report.external_reports).to eq([ap_dashboard_report])
+    expect(ap_activity_with_lara_and_ap_report_and_other_report.external_reports).to eq([
+      ap_dashboard_report,
+      starting_default_ap_report
+    ])
+  end    
+end


### PR DESCRIPTION
- Removes the Lara dashboard report if set on AP activities
- Sets the AP report if not set on AP activities
- Sets the AP dashboard report if not set on AP activities