### PR TITLE
Portal resource URL migration script sets "short-lived token" option.

### DIFF
--- a/rails/lib/tasks/lara2.rake
+++ b/rails/lib/tasks/lara2.rake
@@ -45,6 +45,7 @@ namespace :lara2 do
             ea.legacy_lara_url = ea.url
             ea.url = ap_uri.to_s
             ea.tool_id = ap_tool.id
+            ea.append_auth_token = true
             ea.save!
 
             migrate_count = migrate_count + 1


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/182846106

[#182846106]

Set the "Append a short-lived authentication token" option to `true` when migrating external activities to Activity Player URLs so Activity Player will recognize logged-in students as being logged in.