### PR TITLE
Added user and portal_url to external report queries [#180951212]

### DIFF
--- a/rails/app/controllers/api/v1/report_learners_es_controller.rb
+++ b/rails/app/controllers/api/v1/report_learners_es_controller.rb
@@ -104,6 +104,7 @@ class API::V1::ReportLearnersEsController < API::APIController
           id: url_for(current_user),
           email: current_user.email
         },
+        portal_url: root_url,
         learnersApiUrl: external_report_learners_from_jwt_api_v1_report_learners_es_url
       }
     }

--- a/rails/app/controllers/api/v1/report_users_controller.rb
+++ b/rails/app/controllers/api/v1/report_users_controller.rb
@@ -50,6 +50,11 @@ class API::V1::ReportUsersController < API::APIController
       type: "users",
       version: "1.0",
       domain: URI.parse(APP_CONFIG[:site_url]).host,
+      user: {
+        id: url_for(current_user),
+        email: current_user.email
+      },
+      portal_url: root_url,
       users: users,
       runnables: runnables,
       start_date: params[:start_date],

--- a/rails/spec/controllers/api/v1/report_users_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/report_users_controller_spec.rb
@@ -117,6 +117,8 @@ describe API::V1::ReportUsersController do
       end
     end
     describe "GET external_report_query" do
+      let(:url_for_user) { "http://test.host/users/#{admin_user.id}" } # can't use url_for(user) helper in specs
+
       before(:each) do
         @old_configuration = APP_CONFIG[:site_url]
         APP_CONFIG[:site_url] = 'http://example.com'
@@ -137,6 +139,9 @@ describe API::V1::ReportUsersController do
         expect(filter["type"]).to eq "users"
         expect(filter["version"]).to eq "1.0"
         expect(filter["domain"]).to eq "example.com"
+        expect(filter["user"]["id"]).to eq url_for_user
+        expect(filter["user"]["email"]).to eq admin_user.email
+        expect(filter["portal_url"]).to eq "http://test.host/"
         expect(filter["users"].length).to eq 5
         expect(filter["runnables"].length).to eq 3
         expect(filter["start_date"]).to eq "01/02/19"


### PR DESCRIPTION
Previously the info of the user making the request was only available in the learner query.  This makes the user info available in both the learner and user external report queries as it is needed to create the AWS workgroup.

This also adds a new portal_url attribute to both the learners and user queries.  The current query creator code infers this url from another url attribute (learnersApiUrl) and since it is also needed in the user report handling it has been pulled out into its own attribute.