### PR TITLE
Update report model cache when class name changes [#178863014]

### DIFF
--- a/rails/app/models/portal/clazz.rb
+++ b/rails/app/models/portal/clazz.rb
@@ -297,4 +297,11 @@ class Portal::Clazz < ApplicationRecord
       .sort{ |r1, r2| r1.launch_text <=> r2.launch_text }
   end
 
+  def update_report_model_cache
+    self.offerings.each do |offering|
+      offering.learners.each do |learner|
+        learner.update_report_model_cache()
+      end
+    end
+  end
 end


### PR DESCRIPTION
This ensures the reports reflect the updated class name.

NOTE: this is a refactor of two update callsites that also use a lambda into a single helper method.