### PR TITLE
Add guard for report learner search model teacher info [#181176739]

### DIFF
--- a/rails/app/controllers/api/v1/report_learners_es_controller.rb
+++ b/rails/app/controllers/api/v1/report_learners_es_controller.rb
@@ -416,10 +416,10 @@ class API::V1::ReportLearnersEsController < API::APIController
     teachers = teacherIds.each_with_index.map do |id, i|
       {
         user_id: id,
-        name: learner.teachers_name[i],
-        district: learner.teachers_district[i],
-        state: learner.teachers_state[i],
-        email: learner.teachers_email[i],
+        name: learner.teachers_name.present? ? learner.teachers_name[i] : "",
+        district: learner.teachers_district.present? ? learner.teachers_district[i] : "",
+        state: learner.teachers_state.present? ? learner.teachers_state[i] : "",
+        email: learner.teachers_email.present? ? learner.teachers_email[i] : "",
       }
     end
     {


### PR DESCRIPTION
If a learner's teacher had incomplete information (missing district, state, etc) the report learners es api controller would fail when it rendered the result.