### PR TITLE
Update LICENSE file extension and copyright date

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Concord Consortium
+Copyright (c) 2015-2022 Concord Consortium
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Since we keep the copyright year in the portal footer up to date I thought we might as well do the same for the source license.