### PR TITLE
Use portable script shebangs

### DIFF
--- a/docker/dev/attach-console.sh
+++ b/docker/dev/attach-console.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # this is a simple script to attach a console to the running app container
 # it is useful for debugging the app. Another requirement for debugging is to enable

--- a/docker/dev/start-unison.sh
+++ b/docker/dev/start-unison.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # the first time you use this you probably want to bring up the unison container
 # first by doing `docker-compose up unison` then run this file to start the sync

--- a/docs/gource/generate-mp4.sh
+++ b/docs/gource/generate-mp4.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/usr/bin/env sh
+
 gource --user-image-dir .git/avatar/ --highlight-all-users --user-scale 3.0 --font-size 24 \
 --file-filter 'vendor|public\/javascripts\/.+\/.+' --file-idle-time 4 --key --highlight-dirs \
 --camera-mode track --bloom-intensity 0.2 --max-files 300 \

--- a/docs/gource/generate-webm.sh
+++ b/docs/gource/generate-webm.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 gource --user-image-dir .git/avatar/ --highlight-all-users --user-scale 3.0 --font-size 24 \
 --file-filter 'vendor|public\/javascripts\/.+\/.+' --file-idle-time 4 --key --highlight-dirs \
 --camera-mode track --bloom-intensity 0.2 --max-files 300 \

--- a/docs/gource/get_gravatar_images.pl
+++ b/docs/gource/get_gravatar_images.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #fetch Gravatars
 
 use strict;

--- a/docs/gource/interactive.sh
+++ b/docs/gource/interactive.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 gource --user-image-dir .git/avatar/ --highlight-all-users --user-scale 3.0 --font-size 24 \
 --title 'Rails Portal: http://github.com/concord-consortium/rigse' --git-branch rails3.0 \
 --file-filter 'vendor|public\/javascripts\/.+\/.+' --file-idle-time 10 --key --highlight-dirs \

--- a/rails/docker/dev/run-ci.sh
+++ b/rails/docker/dev/run-ci.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Run rspec tests in docker environment:
 #   – Execute like this: `docker-compose run --rm app ./docker/dev/run-ci.sh`

--- a/rails/docker/dev/run-cucumber-chrome.sh
+++ b/rails/docker/dev/run-cucumber-chrome.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Prepare the cucumber database:

--- a/rails/docker/dev/run-cucumber-search.sh
+++ b/rails/docker/dev/run-cucumber-search.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Prepare the cucumber database:

--- a/rails/docker/dev/run-cucumber.sh
+++ b/rails/docker/dev/run-cucumber.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-#
+#!/usr/bin/env bash
+
 # Run cucumber tests in docker environment.
 #
 

--- a/rails/docker/dev/run-spec.sh
+++ b/rails/docker/dev/run-spec.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-#
+#!/usr/bin/env bash
+
 # Run rspec tests in docker environment:
 #   – Execute like this: `docker-compose run --rm app ./docker/dev/run-spec.sh`
 #   – Or make an alias `alias dspec='docker-compose run --rm app ./docker/dev/run-spec.sh'`

--- a/rails/docker/dev/run.sh
+++ b/rails/docker/dev/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script is intended to be run inside of a development Docker container.
 # In the production environment a different script is used:

--- a/rails/docker/dev/start-solr-test.sh
+++ b/rails/docker/dev/start-solr-test.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-#
+#!/usr/bin/env bash
+
 # This should be executed from within a docker container running
 # a solr-test environment.
 #

--- a/rails/docker/prod/run.sh
+++ b/rails/docker/prod/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 APP_NAME='rigse'
 

--- a/rails/run_cucumber.sh
+++ b/rails/run_cucumber.sh
@@ -1,3 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
+
 export RAILS_ENV=cucumber
 bundle exec spring rake cucumber

--- a/rails/script/travis_after_script
+++ b/rails/script/travis_after_script
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ev
 
 RAILS_ENV=test ./bin/rake sunspot:solr:stop

--- a/rails/script/travis_before_script
+++ b/rails/script/travis_before_script
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ev
 
 cp config/database.travis.yml config/database.yml


### PR DESCRIPTION
Not all systems are [FHS compliant](https://en.wikipedia.org/w/index.php?title=Filesystem_Hierarchy_Standard&oldid=1122596983#FHS_compliance). On my machine for instance:
```console
$ file /bin/bash
/bin/bash: cannot open `/bin/bash' (No such file or directory)
$ which bash
/run/current-system/sw/bin/bash
```