### PR TITLE
Update GH Codespaces URL host in sample env file

### DIFF
--- a/.env-gh-codespaces-sample
+++ b/.env-gh-codespaces-sample
@@ -11,11 +11,11 @@ COMPOSE_FILE=docker-compose.yml:docker/dev/docker-compose-gh-codespaces.yml:dock
 # to automatically set LARA_HOST, LARA_DOMAIN, and LARA_TOOL_ID variables.
 LARA_CODESPACE_NAME=
 
-LARA_HOST=${LARA_CODESPACE_NAME}-3000.githubpreview.dev
-LARA_DOMAIN=${LARA_CODESPACE_NAME}-3000.githubpreview.dev
+LARA_HOST=${LARA_CODESPACE_NAME}-3000.preview.app.github.dev
+LARA_DOMAIN=${LARA_CODESPACE_NAME}-3000.preview.app.github.dev
 
 # CODESPACE_NAME is available in GitHub Codespace container.
-PORTAL_HOST=${CODESPACE_NAME}-3000.githubpreview.dev
+PORTAL_HOST=${CODESPACE_NAME}-3000.preview.app.github.dev
 PORTAL_PROTOCOL=https
 
 # Run the portal in researcher report mode this is used by the researcher portal


### PR DESCRIPTION
[#184536435]

This PR updates the host to a new version used by GH Codespaces. 
There are still some problems with oauth, but this is necessary update anyway.