### PR TITLE
Set sql-mode to avoid random SQL issues after upgrade to MySQL v5.7 (to fix local oauth)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,7 +171,8 @@ services:
     image: mysql:5.7
     environment:
       MYSQL_ROOT_PASSWORD:
-    command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci
+    # --sql-mode=NO_ENGINE_SUBSTITUTION fixes random SQL issues that showed up after upgrading MySQL to v5.7.
+    command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci --sql-mode=NO_ENGINE_SUBSTITUTION
     volumes:
       # use a named volume here so the database is preserved after a down and up
       - mysql:/var/lib/mysql


### PR DESCRIPTION
[[#184536435]](https://www.pivotaltracker.com/story/show/184536435)

This PR sets `sql-mode` in docker-compose mysql startup command. Apparently, it makes it compatible with some legacy SQL queries generated by Portal. I'm pretty sure this became a problem after upgrading to MySQL v5.7. I didn't notice it before, as I was testing Portal alone and apparently this query was not run. I saw the problem when I was trying to login to LARA using Portal. Portal was failing with the following error:

```
app_1            | -------------------------------
app_1            | Backtrace:
app_1            | -------------------------------
app_1            | 
app_1            |   app/models/user.rb:406:in `role_names'
app_1            |   app/controllers/auth_controller.rb:99:in `user'
app_1            |   lib/rack/expand_b64_gzip.rb:35:in `call'
app_1            |   lib/rack/response_logger.rb:13:in `call'
app_1            | 
app_1            | 
app_1            | 
app_1            | F, [2023-03-09T20:41:02.594405 #14] FATAL -- :   
app_1            | ActiveRecord::StatementInvalid (Mysql2::Error: Expression #1 of ORDER BY clause is not in SELECT list, references column 'portal_development.roles.position' which is not in SELECT list; this is incompatible with DISTINCT):
app_1            |   
app_1            | app/models/user.rb:406:in `role_names'
app_1            | app/controllers/auth_controller.rb:99:in `user'
app_1            | lib/rack/expand_b64_gzip.rb:35:in `call'
app_1            | lib/rack/response_logger.rb:13:in `call'
```

"Problematic" role_names method:
```ruby
  def role_names
    roles.pluck(:title)
  end
```

Not sure if we could somehow improve roles_names, or if it's deep in rails code, as the method looks extremely basic. Also, even if we fixed `role_names` method utsekf, there might other similar issues that might be difficult to debug.

Luckily, it doesn't seem we have this problem on production which is using Aurora.
