### PR TITLE
fix: restore Report::User and Report::User policy to make user report work again

### DIFF
--- a/rails/app/models/report/user.rb
+++ b/rails/app/models/report/user.rb
@@ -1,0 +1,2 @@
+class Report::User
+end

--- a/rails/app/policies/report/user_policy.rb
+++ b/rails/app/policies/report/user_policy.rb
@@ -1,0 +1,6 @@
+class Report::UserPolicy < ApplicationPolicy
+
+  def index?
+    manager_or_researcher_or_project_researcher?
+  end
+end


### PR DESCRIPTION
[#184372422]

The issue is described here (second bullet point):
https://www.pivotaltracker.com/story/show/184372422/comments/236141391

I've removed the `Report::User` class during the cleanup, as it looked empty and/or unnecessary. However, it's broken authorization and access to the researcher user report page.

It's being used here:
https://github.com/concord-consortium/rigse/blob/master/rails/app/controllers/report/user_controller.rb#L12