### PR TITLE
fix(LearnerReport): ensure that last_run value gets saved in ElasticSearch

### DIFF
--- a/rails/app/models/report/learner.rb
+++ b/rails/app/models/report/learner.rb
@@ -100,6 +100,9 @@ class Report::Learner < ApplicationRecord
 
     update_permission_forms
 
+    self.complete_percent = 100
+    self.last_run = Time.now
+
     Rails.logger.debug("Updated Report Learner: #{self.student_name}")
     self.save
   end


### PR DESCRIPTION
[#184372422]

The issue is described here (first bullet point):
https://www.pivotaltracker.com/story/show/184372422/comments/236141391

I did quite a lot of debugging and I tracked that `last_run` is obtained as metadata from Portal via `API::V1::ReportLearnersEsController`. This controller is querying ElasticSearch to get student details, including `last_run` value. So, I ran ES queries manually, both in my local Portal and on Learn Staging, and noticed that `last_run` in ES is always `nil`. It's a bit surprising, as the last run value was displayed in Portal both for students and teachers.

Then, I was tracking the code that I removed and that was related to `last_run`. Apparently, the lines that I'm restoring in this PR are fixing the issue - now I can see `last_run` values in my ElasticSearch query results.

Here you can see all the lines I removed during refactoring (from v2.8.0):
https://github.com/concord-consortium/rigse/blob/v2.8.0/rails/app/models/report/learner.rb#L173-L185

I'm restoring only two lines, as the others are not useful anyway. Also, the code under `if self.learner.offering.internal_report?` was never executed as we don't have `internal_reports` anymore, `calculate_last_run` was doing nothing, and `update_answers` also doesn't make sense now when we don't have answers.
