### PR TITLE
fix: update Report::Learner specs

### DIFF
--- a/rails/spec/models/report/learner_spec.rb
+++ b/rails/spec/models/report/learner_spec.rb
@@ -42,14 +42,6 @@ describe Report::Learner do
       report = Report::Learner.create(:learner => @learner)
       expect(report.last_run).not_to be_nil
     end
-
-    it "the last_run time should be preserved" do
-      report = Report::Learner.create(:learner => @learner)
-      expect(report.last_run).to be_nil
-      now = DateTime.now
-      report.last_run = now
-      expect(report.last_run).to eq(now)
-    end
   end
 
   describe "with_permission_ids" do


### PR DESCRIPTION
[#184372422]

I've fixed the test above and didn't notice this one was failing too. I just removed it, as it doesn't test anything at this point (well, or it tests Ruby / Rails / ActiveRecord capabilities to store data which is not so useful I believe 😉).