### PR TITLE
fix(MaterialsController): rm reference to removed :template prop

### DIFF
--- a/rails/app/controllers/api/v1/materials_controller.rb
+++ b/rails/app/controllers/api/v1/materials_controller.rb
@@ -756,10 +756,6 @@ class API::V1::MaterialsController < API::APIController
                     :subject_areas,
                     :grade_levels   ]
 
-      if rubyclass == ExternalActivity
-        includes.push :template
-      end
-
       item = rubyclass.includes(includes).find(id)
 
       if item


### PR DESCRIPTION
This PR fixes an error observed by Leslie and Aden (via emails with error reports).
I could also find the issue in logs:

<img width="1668" alt="Screenshot 2023-04-14 at 19 24 59" src="https://user-images.githubusercontent.com/767857/232114619-5bd3384b-8546-4623-842c-5fa8a91c8163.png">

 I could replace the issue using Rails console on the production instance. Apparently, a reference to `:template` was causing it. If I skip `:template` the query works fine.

I guess we could also fully remove templates from ExternalActivities, both model and database, right?
I'm not doing it here not to break something new while applying this fix.