### PR TITLE
fix: restore student status and related controller + fix student status polling JS code

### DIFF
--- a/rails/app/assets/javascripts/poll_to_update_student_data_percentages.js
+++ b/rails/app/assets/javascripts/poll_to_update_student_data_percentages.js
@@ -24,15 +24,9 @@ window.poll_to_update_student_data_percentages = function(options) {
   const update_percentages = (status) => {
     if (status != null) {
       for (var report_learner of status.report_learners) {
-        const $offering = jQuery(`.offering_for_student[data-offering_id='${report_learner.offering_id}']`);
+        const $offering = jQuery(`.offering_for_student[data-offering-id='${report_learner.offering_id}']`);
         if ($offering && report_learner.last_run) {
           $offering.find('.last_run').html(report_learner.last_run);
-          $offering.find('.status_graphs .not_run').hide();
-          $offering.find('.status_graphs .summary .progress').css({width: `${report_learner.complete_percent}%`});
-          $offering.find('.status_graphs .details .progress').each(function(idx) {
-            jQuery(this).css({width: `${report_learner.subsection_complete_percent[idx]}%`});
-          });
-          $offering.find('.status_graphs .run_graph').show();
         }
       }
     }

--- a/rails/app/controllers/portal/students_controller.rb
+++ b/rails/app/controllers/portal/students_controller.rb
@@ -7,6 +7,21 @@ class Portal::StudentsController < ApplicationController
 
   public
 
+  def status
+    # PUNDIT_REVIEW_AUTHORIZE
+    # PUNDIT_CHOOSE_AUTHORIZE
+    # no authorization needed ...
+    # authorize Portal::Student
+    # authorize @student
+    # authorize Portal::Student, :new_or_create?
+    # authorize @student, :update_edit_or_destroy?
+    result = Portal::Student.find(params[:id]).status(params[:offerings_updated_after] || 0)
+    respond_to do |format|
+      format.xml { render :xml => result }
+      format.json { render :json => result }
+    end
+  end
+
   def index
     # PUNDIT_REVIEW_AUTHORIZE
     # PUNDIT_CHECK_AUTHORIZE

--- a/rails/app/models/portal/student.rb
+++ b/rails/app/models/portal/student.rb
@@ -67,6 +67,38 @@ class Portal::Student < ApplicationRecord
     return generated_login
   end
 
+  def status(offerings_updated_after=0)
+    # If offerings_updated_after is provided, all the offerings that haven't been updated
+    # after this timestamp will be filtered out from the results (performance optimization).
+    offerings_updated_after = Time.at(offerings_updated_after.to_i)
+    # Theoretically these queries could be merged into single one, but then
+    # ActiveRecord complains about eager loading of polymorphic association (:runnable).
+    learners_ids = Portal::Learner.joins(:report_learner)
+                                  .where('portal_learners.student_id = ?', self.id)
+                                  .where('report_learners.last_run > ?', offerings_updated_after)
+                                  .pluck(:id)
+    if learners_ids.length > 0
+      report_learners = Portal::Learner.includes(:offering, :report_learner)
+                                       .where(id: learners_ids)
+                                       .map do |learner|
+      student_status = Report::OfferingStudentStatus.new
+      student_status.student = self
+      student_status.learner = learner
+      student_status.offering = learner.offering
+      {
+        :offering_id => student_status.offering.id,
+        :last_run => student_status.last_run_string
+      }
+      end
+    else
+      report_learners = []
+    end
+    {
+      timestamp: Time.now.to_i,
+      report_learners: report_learners
+    }
+  end
+
   def update_report_permissions(permission_form)
     report_learners.each { |l| l.update_permission_forms; l.save }
     learners.each { |l| l.update_report_model_cache(true) }

--- a/rails/app/models/report/offering_student_status.rb
+++ b/rails/app/models/report/offering_student_status.rb
@@ -12,17 +12,6 @@ class Report::OfferingStudentStatus
     student_status
   end
 
-  # loosely based on offering_status.rb#student_activities
-  def sub_sections
-    runnable = offering.runnable
-
-    if runnable.is_a?(::ExternalActivity) && runnable.template
-      runnable = runnable.template
-    end
-
-    [runnable]
-  end
-
   def display_report_link?
     (offering && offering.student_report_enabled? && offering_reportable?)
   end
@@ -42,21 +31,6 @@ class Report::OfferingStudentStatus
         # Offering is not reportable, but it has been started. Return 100%.
         100
       end
-    else
-      0
-    end
-  end
-
-  # the runnable is passed because in somecases we want the progress for a sub part of the
-  # this learners runnable
-  def activity_complete_percent(activity)
-    if learner
-      # this is not efficient it has to do queries for each activity
-      learner_activity = learner.learner_activities.find{|la| la.activity_id == activity.id}
-
-      # Since there is a learner for this it actually has been started so perhaps
-      # we shouldn't return 0 here
-      learner_activity ? learner_activity.complete_percent : 0
     else
       0
     end

--- a/rails/spec/models/report/offering_student_status_spec.rb
+++ b/rails/spec/models/report/offering_student_status_spec.rb
@@ -71,16 +71,6 @@ describe Report::OfferingStudentStatus do
   end
 
   # TODO: auto-generated
-  describe '#sub_sections' do
-    xit 'sub_sections' do
-      offering_student_status = described_class.new
-      result = offering_student_status.sub_sections
-
-      expect(result).not_to be_nil
-    end
-  end
-
-  # TODO: auto-generated
   describe '#display_report_link?' do
     it 'display_report_link?' do
       offering_student_status = described_class.new


### PR DESCRIPTION
This PR restores removed student status controller and model methods.
The new `Student#status` is a simplified version of what we used to have in v2.8.0:
https://github.com/concord-consortium/rigse/blob/v2.8.0/rails/app/models/portal/student.rb#L70-L104

I've also removed pieces of JS code that tried to update non-existent progress graphs (we don't have them anymore anywhere, right?).

Also, note that I updated:
```javascript
const $offering = jQuery(`.offering_for_student[data-offering-id='${report_learner.offering_id}']`);
```
data-offering_id ===> data-offering-id

Without this change, the JS query wouldn't find the correct div. So, apparently, this whole polling and live updates were broken on production even before. Maybe when the Rails version was updated `data-offering_id` was automatically turned into `data-offering-id`? Not sure.