### PR TITLE
ci(deploy): Add AWS deployment workflow

### DIFF
--- a/.github/workflows/deploy_backend_to_aws.yml
+++ b/.github/workflows/deploy_backend_to_aws.yml
@@ -26,4 +26,5 @@ jobs:
     with:
       environment: ${{ inputs.environment }}
       version: ${{ inputs.version }}
+      docker-image-template-key-prefix: Portal
     secrets: inherit


### PR DESCRIPTION
Since the deployment patterns for LARA & Portal are identical they should be able to use the same reusable workflow with slight changes to the passed `inputs`. This PR uses the composite/reusable Action from the LARA repo (pinned to the `v2` tag). I'm unable to test it until it's merged, so it most likely won't work as expected, but once merged it can be tested until it functions correctly by making commits in a new branch off of `master`.