### PR TITLE
fix: Change email validation regex [PT-187054507]

### DIFF
--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -116,7 +116,7 @@ class User < ApplicationRecord
 
   email_name_regex  = '[\w\.%\+\-\']+'.freeze
   domain_head_regex = '(?:[A-Z0-9\-]+\.)+'.freeze
-  domain_tld_regex  = '(?:[A-Z]{2}|com|org|net|edu|gov|mil|biz|info|mobi|name|aero|jobs|museum)'.freeze
+  domain_tld_regex  = '(?:[A-Z]{2,})'.freeze
   email_regex       = /\A#{email_name_regex}@#{domain_head_regex}#{domain_tld_regex}\z/i
   bad_email_message = "should look like an email address.".freeze
 

--- a/rails/spec/models/user_spec.rb
+++ b/rails/spec/models/user_spec.rb
@@ -91,7 +91,7 @@ describe User do
     ['foo@bar.com', 'foo@newskool-tld.museum', 'foo@twoletter-tld.de', 'foo@nonexistant-tld.qq',
      'r@a.wk', '1234567890-234567890-234567890-234567890-234567890-234567890-234567890-234567890-234567890@gmail.com',
      'hello.-_there@funnychar.com', 'uucp%addr@gmail.com', 'hello+routing-str@gmail.com',
-     'domain@can.haz.many.sub.doma.in', 'student.name@university.edu'
+     'domain@can.haz.many.sub.doma.in', 'student.name@university.edu', 'foo@anytld.xxx', 'foo@longtld.abcdefg', 'teacher@some.school'
     ].each do |email_str|
       it "'#{email_str}'" do
         expect do
@@ -103,7 +103,7 @@ describe User do
   end
 
   describe 'disallows illegitimate emails' do
-    ['!!@nobadchars.com', 'foo@no-rep-dots..com', 'foo@badtld.xxx', 'foo@toolongtld.abcdefg',
+    ['!!@nobadchars.com', 'foo@no-rep-dots..com', 'needdomain@', 'needtld@example', '@.com', '@example.com', 'oneletterltd@example.x',
      'Iñtërnâtiônàlizætiøn@hasnt.happened.to.email', 'need.domain.and.tld@de',
      'r@.wk', '1234567890-234567890-234567890-234567890-234567890-234567890-234567890-234567890-234567890@gmail2.com',
      # these are technically allowed but not seen in practice:


### PR DESCRIPTION
Removed whitelist of TLDs and replaced with a check for at least two letters.