### PR TITLE
Fix Dockerfile-dev, update Codespaces readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,6 @@ in Portal's `.env` file.
 
 3. Run
     ```
-      docker login
       docker-compose up
     ```
 

--- a/rails/Dockerfile-dev
+++ b/rails/Dockerfile-dev
@@ -1,28 +1,46 @@
-FROM concordconsortium/docker-rails-base-private:ruby-2.7-rails-6.1.3.2
+ARG RUBY_VERSION=2.7
+# Stick to Alpine <= 3.13 to avoid issues with ECS Docker
+# See: https://github.com/docker-library/ruby/issues/351#issue-940462153
+FROM docker.io/ruby:${RUBY_VERSION}-alpine3.12
 
-RUN apt-get -o Acquire::Check-Valid-Until=false update
+RUN true
 
-#
-# Install some basic dev tools
-#
-RUN apt-get install -y vim
+RUN apk add \
+  # The Ruby Gem "delayed-web" has a transitive depdency for "racc" which builds
+  # native extensions and requires a C toolchain (it attempts to use gcc):
+  # "Gem::Ext::BuildError: ERROR: Failed to build gem native extension."
+  # "The compiler failed to generate an executable file. (RuntimeError)"
+  # "You have to install development tools first."
+  build-base \
+  # The Ruby Gem "mimemagic" requires Freedesktop.org Shared MIME Info to be installed:
+  # "Could not find MIME type database in the following locations:"
+  # "Ensure you have either installed the shared-mime-info package for your distribution..."
+  shared-mime-info \
+  # The Ruby Gem "mysql2" requires a MySQL client library to link against
+  # See: https://github.com/brianmario/mysql2#general-instructions
+  mariadb-dev \
+  # The "execjs" requires a supported JavaScript runtime to be installed
+  # "/usr/local/bundle/gems/execjs-2.8.1/lib/execjs/runtimes.rb:58:in `autodetect':
+  # Could not find a JavaScript runtime. See https://github.com/rails/execjs for a list of available runtimes.
+  # (ExecJS::RuntimeUnavailable)"
+  # See: https://github.com/rails/execjs#execjs
+  nodejs \
+  # "/usr/local/bundle/gems/tzinfo-2.0.4/lib/tzinfo/data_source.rb:159:in
+  # `rescue in create_default_data_source': tzinfo-data is not present. Please add gem 'tzinfo-data'
+  # to your Gemfile and run bundle install (TZInfo::DataSourceNotFound)"
+  tzdata \
+  # See: https://github.com/sstephenson/ruby-yui-compressor#label-Installing+and+loading+Ruby-YUI+Compressor
+  openjdk8-jre \
+  # Alpine Linux doesn't include bash by default
+  bash
 
-#
-# Install java runtime needed by yuicompressor step in rake assets:precompile task
-#
-RUN apt-get install -qq -y default-jre-headless
-
-#
+# This is currently commented out, as installing Chrome on Alpine Linux needs to be done in a different way,
+# and this linux distribution is missing multiple dependencies required for installing Chrome.
 # Install Google Chrome for Selenium
 #
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-  && echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list \
-  && apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y google-chrome-stable
-
-#
-# Install shared mime info for mimemagic gem
-#
-RUN apt-get install -qq -y shared-mime-info
+# RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+# && echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list \
+# && apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y google-chrome-stable
 
 #
 # Install wait-for-it to support docker-volume-sync


### PR DESCRIPTION
The `Dockerfile-dev` was no longer working, so I've made it more similar to the recently updated `Dockerfile`. The most significant change is switching to Alpine Linux. Essentially, I'm installing the same dependencies as in `Dockerfile`, plus `bash` (since Alpine doesn't include it by default, and its absence crashes some dev startup scripts).

I commented out the Google Chrome installation, as it would require some time to learn how to do it on Alpine Linux. However, I did manage to successfully run both `docker/dev/run-spec.sh` and `docker/dev/run-cucumber.sh` (although it appears that most of them are skipped). So, I'm wondering if we actually need Chrome at all?

Also, I've removed `docker login` command from GH Codespaces readme as it's no longer necessary.
