### PR TITLE
Add "Researcher Projects" to sidebar

### DIFF
--- a/rails/app/helpers/navigation_helper.rb
+++ b/rails/app/helpers/navigation_helper.rb
@@ -38,6 +38,10 @@ module NavigationHelper
     current_visitor.is_project_researcher?
   end
 
+  def show_researcher_classes_links
+    current_visitor.is_project_researcher?
+  end
+
   def show_switch_user_link
     @original_user && @original_user != current_visitor
   end
@@ -241,6 +245,31 @@ module NavigationHelper
     }
   end
 
+  def researcher_class_links
+    if current_visitor.researcher_for_projects.empty?
+      return []
+    end
+
+    links = [{
+      id: '/researcher_classes',
+      label: nav_label('researcher_classes'),
+      type: NavigationService::SECTION_TYPE,
+      sort: 4
+    }]
+
+    projects = current_visitor.researcher_for_projects
+
+    projects.each do |project|
+      links << {
+        id: "/researcher_classes/#{project.id}",
+        label: project.name,
+        url: url_for(project)
+      }
+    end
+
+    links
+  end
+
   def project_links
     links = []
     if current_visitor.has_role?('admin', 'manager', 'researcher') || current_visitor.portal_teacher
@@ -290,6 +319,10 @@ module NavigationHelper
 
     if show_switch_user_link
       service.add_item switch_user_link
+    end
+
+    if show_researcher_classes_links
+      researcher_class_links.each {|clazz_link| service.add_item clazz_link}
     end
 
     clazz_links.each {|clazz_link| service.add_item clazz_link}

--- a/rails/app/helpers/navigation_helper.rb
+++ b/rails/app/helpers/navigation_helper.rb
@@ -38,7 +38,7 @@ module NavigationHelper
     current_visitor.is_project_researcher?
   end
 
-  def show_researcher_classes_links
+  def show_researcher_projects_links
     current_visitor.is_project_researcher?
   end
 
@@ -245,14 +245,14 @@ module NavigationHelper
     }
   end
 
-  def researcher_class_links
+  def researcher_project_links
     if current_visitor.researcher_for_projects.empty?
       return []
     end
 
     links = [{
-      id: '/researcher_classes',
-      label: nav_label('researcher_classes'),
+      id: '/researcher_projects',
+      label: nav_label('researcher_projects'),
       type: NavigationService::SECTION_TYPE,
       sort: 4
     }]
@@ -261,9 +261,9 @@ module NavigationHelper
 
     projects.each do |project|
       links << {
-        id: "/researcher_classes/#{project.id}",
+        id: "/researcher_projects/#{project.id}",
         label: project.name,
-        url: url_for(project)
+        url: url_for(project),
       }
     end
 
@@ -321,8 +321,8 @@ module NavigationHelper
       service.add_item switch_user_link
     end
 
-    if show_researcher_classes_links
-      researcher_class_links.each {|clazz_link| service.add_item clazz_link}
+    if show_researcher_projects_links
+      researcher_project_links.each {|clazz_link| service.add_item clazz_link}
     end
 
     clazz_links.each {|clazz_link| service.add_item clazz_link}

--- a/rails/config/locales/en.yml
+++ b/rails/config/locales/en.yml
@@ -167,7 +167,7 @@ en:
     full_status: Full Status
     links: Links
     switch_back: Switch back
-    researcher_classes: Researcher Classes
+    researcher_projects: Researcher Projects
 
 'en-HAS':
   activerecord:

--- a/rails/config/locales/en.yml
+++ b/rails/config/locales/en.yml
@@ -167,6 +167,7 @@ en:
     full_status: Full Status
     links: Links
     switch_back: Switch back
+    researcher_classes: Researcher Classes
 
 'en-HAS':
   activerecord:

--- a/rails/spec/helpers/navigation_helper_spec.rb
+++ b/rails/spec/helpers/navigation_helper_spec.rb
@@ -18,6 +18,11 @@ describe NavigationHelper, type: :helper  do
   let(:fake_clazzes) { FactoryBot.create_list(:portal_clazz, 3)}
   let(:fake_inactive_clazz) { FactoryBot.create(:portal_clazz, is_archived: true)}
   let(:fake_student) { FactoryBot.create(:full_portal_student, clazzes: fake_clazzes) }
+  let(:fake_researcher) {
+    researcher = FactoryBot.generate(:researcher_user)
+    researcher.researcher_for_projects << FactoryBot.create(:project)
+    researcher
+  }
   let(:fake_teacher) {
     teacher = FactoryBot.create(:portal_teacher, clazzes: fake_clazzes)
     teacher.teacher_clazzes.create(clazz: fake_inactive_clazz)
@@ -119,6 +124,19 @@ describe NavigationHelper, type: :helper  do
 
     it "should not include favorites links" do
       expect(subject).not_to match %r{"label": "Favorites"}
+    end
+
+    it "should not include researcher project links" do
+      expect(subject).not_to match %r{"label": "Researcher Projects"}
+    end
+  end
+
+  describe "researcher links" do
+    let(:fake_visitor) { fake_researcher }
+    subject { JSON.pretty_generate(helper.navigation_service(params).to_hash) }
+
+    it "should include researcher project links" do
+      expect(subject).to match %r{"label": "Researcher Projects"}
     end
   end
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187153689

This PR adds "Researcher Projects" to the sidebar, lists all the researcher's projects there, and keeps the selection. Apparently, Portal has the whole slightly weird utility for that, but it seems to be working. When user clicks on a selected project, it will temporarily render the basic project page (`show` route/action). It's going to be replaced by classes landing page in subsequent PRs.