### PR TITLE
Add Researcher Classes landing page

### DIFF
--- a/rails/app/controllers/admin/projects_controller.rb
+++ b/rails/app/controllers/admin/projects_controller.rb
@@ -69,6 +69,13 @@ class Admin::ProjectsController < ApplicationController
     # renders edit.html.haml
   end
 
+  # GET /admin/projects/1/classes
+  def classes
+    @project = Admin::Project.find(params[:id])
+    authorize @project
+    # renders classes.html.haml
+  end
+
   # POST /admin/projects
   def create
     authorize Admin::Project

--- a/rails/app/helpers/navigation_helper.rb
+++ b/rails/app/helpers/navigation_helper.rb
@@ -263,7 +263,7 @@ module NavigationHelper
       links << {
         id: "/researcher_projects/#{project.id}",
         label: project.name,
-        url: url_for(project),
+        url: url_for([:classes, project]),
       }
     end
 

--- a/rails/app/policies/admin/project_policy.rb
+++ b/rails/app/policies/admin/project_policy.rb
@@ -81,4 +81,8 @@ class Admin::ProjectPolicy < ApplicationPolicy
   def api_show?
     teacher? || admin?
   end
+
+  def classes?
+    update_or_edit? || user.is_project_researcher?(record)
+  end
 end

--- a/rails/app/views/admin/projects/classes.haml
+++ b/rails/app/views/admin/projects/classes.haml
@@ -1,0 +1,2 @@
+%div
+  %h1 Research Classes: #{@project.name}

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -224,6 +224,9 @@ RailsPortal::Application.routes.draw do
       resources :projects do
         resources :cohorts
         resources :project_links
+        member do
+          get :classes
+        end
       end
       resources :cohorts
       resources :project_links

--- a/rails/spec/policies/admin/project_policy_spec.rb
+++ b/rails/spec/policies/admin/project_policy_spec.rb
@@ -191,8 +191,39 @@ RSpec.describe Admin::ProjectPolicy do
       end
     end
 
+    describe 'classes' do
+      describe 'a regular user' do
+        it 'should not permit access to classes page' do
+          expect(policy.classes?).to be false
+        end
+      end
 
+      describe 'as site admin' do
+        before(:each) do
+          allow(user).to receive(:has_role?).with('admin').and_return(true)
+        end
+        it 'should permit access to classses page' do
+          expect(policy.classes?).to be true
+        end
+      end
+
+      describe 'as a project admin' do
+        before(:each) do
+          allow(user).to receive(:is_project_admin?).with(project).and_return(true)
+        end
+        it 'should permit access to classses page' do
+          expect(policy.classes?).to be true
+        end
+      end
+
+      describe 'as a project researcher' do
+        before(:each) do
+          allow(user).to receive(:is_project_researcher?).with(project).and_return(true)
+        end
+        it 'should permit access to classses page' do
+          expect(policy.classes?).to be true
+        end
+      end
+    end
   end
-
-
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187185134

This PR adds the Researcher Classes landing page. There's no real functionality there yet, but controller, routes, policy and policy specs are already updated, and interaction with the Researcher Project menu feels less broken.