### PR TITLE
fix: Misspellings in en.yml [PT-186819266]

### DIFF
--- a/rails/config/locales/en.yml
+++ b/rails/config/locales/en.yml
@@ -69,8 +69,8 @@ en:
     report_client: Report Auth Client
     rubric_url_label: Rubric JSON (URL)
     rubric_doc_url_label: Rubric Document (URL)
-    short_description_description: Shown in search results, student listings, and used as a fallback for long descrption. It is recommended that every activity has this value provided.
-    long_description_description: Shown in places where activity details are vible (e.g. STEM Resource finder lightbox). Uses Short Description as a fallback.
+    short_description_description: Shown in search results, student listings, and used as a fallback for long description. It is recommended that every activity has this value provided.
+    long_description_description: Shown in places where activity details are visible (e.g. STEM Resource finder lightbox). Uses Short Description as a fallback.
     long_description_for_teachers_description: Variant of Long Description visible only for teachers. Uses Long Description as a fallback.
     keywords: Enter a list of keywords this resource should be associated with in the search engine. Only include words that do not already appear in the short and long descriptions above.
   matedit:
@@ -80,8 +80,8 @@ en:
     unarchive: Unarchive
     archive_confirm: "Are you sure you want to archive this activity?"
     unarchive_confirm: "Are you sure you want to un-archive this activity?"
-    archive_success: "'%{name}' was successfuly archived."
-    unarchive_success: "'%{name}' was successfuly restored."
+    archive_success: "'%{name}' was successfully archived."
+    unarchive_success: "'%{name}' was successfully restored."
   material_collection:
     is_archived: (archived)
     remove: "Remove %{name} from the collection '%{collection_name}'"


### PR DESCRIPTION
Fixed the following words (old → new):

- descrption → description
- vible → visible
- successfuly → successfully