### PR TITLE
Give researchers access to class page and anonymize student names [PT-187154175]

### DIFF
--- a/rails/app/controllers/api/api_controller.rb
+++ b/rails/app/controllers/api/api_controller.rb
@@ -157,32 +157,4 @@ class API::APIController < ApplicationController
 
     return auth
   end
-
-  def auth_student_or_teacher(params)
-    auth = auth_not_anonymous(params)
-    return auth if auth[:error]
-    user = auth[:user]
-
-    if !user.portal_student && !user.portal_teacher
-      auth[:error] = 'You must be logged in as a student or teacher to use this endpoint'
-    end
-
-    return auth
-  end
-
-  def auth_student_or_teacher_or_researcher(params)
-    auth = auth_not_anonymous(params)
-    return auth if auth[:error]
-    user = auth[:user]
-
-    # Check if the user is a researcher of ANY project - the controller will check for a specific resource
-    auth[:role] ||= {}
-    auth[:role][:is_project_researcher] = user && user.is_project_researcher?
-
-    if !user.portal_student && !user.portal_teacher && !auth[:role][:is_project_researcher]
-      auth[:error] = 'You must be logged in as a student or teacher or researcher to use this endpoint'
-    end
-
-    return auth
-  end
 end

--- a/rails/app/controllers/api/v1/offerings_controller.rb
+++ b/rails/app/controllers/api/v1/offerings_controller.rb
@@ -5,10 +5,6 @@
 class API::V1::OfferingsController < API::APIController
 
   def show
-    auth = auth_student_or_teacher_or_researcher(params)
-    return error(auth[:error]) if auth[:error]
-    user = auth[:user]
-
     offering = Portal::Offering
                    .where(id: params[:id])
                    .includes(API::V1::Offering::INCLUDES_DEF)
@@ -17,13 +13,10 @@ class API::V1::OfferingsController < API::APIController
       return error('offering not found', 404)
     end
 
-    role_in_clazz = user.role_in_clazz(offering.clazz)
+    authorize offering, :api_show?
 
-    if (!role_in_clazz[:student] && !role_in_clazz[:teacher] && !role_in_clazz[:researcher])
-      return error('You are not a student or teacher or researcher of the requested offerings class')
-    end
+    anonymize_students = !current_user.has_full_access_to_student_data?(offering.clazz)
 
-    anonymize_students = role_in_clazz[:researcher]
     offering_api = API::V1::Offering.new(offering, request.protocol, request.host_with_port, current_user, params[:add_external_report], anonymize_students)
     render :json => offering_api.to_json, :callback => params[:callback]
   end

--- a/rails/app/controllers/portal/clazzes_controller.rb
+++ b/rails/app/controllers/portal/clazzes_controller.rb
@@ -15,9 +15,7 @@ class Portal::ClazzesController < ApplicationController
   # accessing.
   #
   include RestrictedTeacherController
-  before_action :check_teacher_owns_clazz, :only => [   :roster,
-                                                        :materials,
-                                                        :fullstatus ]
+  before_action :check_teacher_owns_clazz, :only => [ :roster ]
 
   def current_clazz
     # PUNDIT_REVIEW_AUTHORIZE
@@ -303,20 +301,12 @@ class Portal::ClazzesController < ApplicationController
   end
 
   def materials
-    # PUNDIT_REVIEW_AUTHORIZE
-    # PUNDIT_CHOOSE_AUTHORIZE
-    # no authorization needed ...
-    # authorize Portal::Clazz
-    # authorize @clazz
-    # authorize Portal::Clazz, :new_or_create?
-    # authorize @clazz, :update_edit_or_destroy?
-
-
     @portal_clazz = Portal::Clazz.includes(:offerings => :learners, :students => :user).find(params[:id])
+
+    authorize @portal_clazz, :materials?
 
     # Save the left pane sub-menu item
     Portal::Teacher.save_left_pane_submenu_item(current_visitor, Portal::Teacher.LEFT_PANE_ITEM['MATERIALS'])
-
   end
 
 

--- a/rails/app/helpers/navigation_helper.rb
+++ b/rails/app/helpers/navigation_helper.rb
@@ -195,12 +195,6 @@ module NavigationHelper
         label: nav_label("class_setup"),
         url: url_for([:edit, clazz])
       }
-      # TODO: Delete this one, its not used any more:
-      # clazz_links << {
-      #   id: "#{section_id}/status",
-      #   label: nav_label("full_status"),
-      #   url: url_for([:fullstatus, clazz])
-      # }
       clazz_links << {
         id: "#{section_id}/links",
         label: nav_label("links"),

--- a/rails/app/models/api/v1/offering.rb
+++ b/rails/app/models/api/v1/offering.rb
@@ -28,10 +28,10 @@ class API::V1::Offering
     attribute :total_progress, Float
     attribute :detailed_progress, Array
 
-    def initialize(student, offering, protocol, host_with_port)
+    def initialize(student, offering, protocol, host_with_port, anonymize = false)
       self.name = student.user.name
-      self.first_name = student.user.first_name
-      self.last_name = student.user.last_name
+      self.first_name = anonymize ? student.anonymized_first_name : student.user.first_name
+      self.last_name = anonymize ? student.anonymized_last_name : student.user.last_name
       self.username = student.user.login
       self.user_id = student.user.id
       learner = offering.learners.find { |l| l.student_id === student.id }
@@ -76,7 +76,7 @@ class API::V1::Offering
     }
   end
 
-  def initialize(offering, protocol, host_with_port, current_user, additional_external_report_id)
+  def initialize(offering, protocol, host_with_port, current_user, additional_external_report_id, anonymize_students = false)
     runnable = offering.runnable
     self.id = offering.id
     self.teacher = offering.clazz.teacher.name
@@ -111,6 +111,6 @@ class API::V1::Offering
       end
     end
 
-    self.students = offering.clazz.students.map { |s| OfferingStudent.new(s, offering, protocol, host_with_port) }
+    self.students = offering.clazz.students.map { |s| OfferingStudent.new(s, offering, protocol, host_with_port, anonymize_students) }
   end
 end

--- a/rails/app/models/portal/student.rb
+++ b/rails/app/models/portal/student.rb
@@ -67,6 +67,14 @@ class Portal::Student < ApplicationRecord
     return generated_login
   end
 
+  def anonymized_first_name
+    "Student"
+  end
+
+  def anonymized_last_name
+    id.to_s
+  end
+
   def status(offerings_updated_after=0)
     # If offerings_updated_after is provided, all the offerings that haven't been updated
     # after this timestamp will be filtered out from the results (performance optimization).

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -436,6 +436,18 @@ class User < ApplicationRecord
       .count > 0
   end
 
+  def role_in_clazz(clazz)
+    # NOTE: these checks are set so only one of these can be true and teacher access is checked before researcher access
+    student_in_class = portal_student && portal_student.has_clazz?(clazz)
+    teacher_in_class = !student_in_class && (portal_teacher && portal_teacher.has_clazz?(clazz))
+    researcher_in_class = !teacher_in_class && is_researcher_for_clazz?(clazz)
+    {
+      student: student_in_class,
+      teacher: teacher_in_class,
+      researcher: researcher_in_class
+    }
+  end
+
   def add_role_for_project(role, project)
     role_attribute = "is_#{role}"
     project_user = project_users.find_by_project_id project.id

--- a/rails/app/policies/portal/clazz_policy.rb
+++ b/rails/app/policies/portal/clazz_policy.rb
@@ -19,4 +19,18 @@ class Portal::ClazzPolicy < ApplicationPolicy
       end
     end
   end
+
+  def materials?
+    class_teacher? || class_researcher? || admin?
+  end
+
+  private
+
+  def class_teacher?
+    user && record && record.is_teacher?(user)
+  end
+
+  def class_researcher?
+    user && record && user.is_researcher_for_clazz?(record)
+  end
 end

--- a/rails/app/policies/portal/clazz_policy.rb
+++ b/rails/app/policies/portal/clazz_policy.rb
@@ -20,14 +20,40 @@ class Portal::ClazzPolicy < ApplicationPolicy
     end
   end
 
+  # Used by API::V1::ClassesController:
+  def api_show?
+    class_teacher_or_admin? || class_student? || class_researcher?
+  end
+
+  def mine?
+    teacher? || student?
+  end
+
+  def log_links?
+    admin?
+  end
+
+  def set_is_archived?
+    class_teacher_or_admin?
+  end
+
+  # Used by Portal::ClazzesController:
   def materials?
     class_teacher? || class_researcher? || admin?
   end
 
   private
 
+  def class_student?
+    user && record && record.is_student?(user)
+  end
+
   def class_teacher?
     user && record && record.is_teacher?(user)
+  end
+
+  def class_teacher_or_admin?
+    class_teacher? || admin?
   end
 
   def class_researcher?

--- a/rails/spec/controllers/api/v1/classes_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/classes_controller_spec.rb
@@ -44,8 +44,8 @@ describe API::V1::ClassesController do
 
     it "should fail when id is a class that the teacher doesn't own" do
       post :set_is_archived, params: { id: other_clazz.id }
-      expect(response).to have_http_status(:bad_request)
-      expect(JSON.parse(response.body)["message"]).to eq "You are not a teacher of the requested class"
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["message"]).to eq "Not authorized"
     end
 
     it "should succeed when the id is a class the teacher owns" do
@@ -66,7 +66,7 @@ describe API::V1::ClassesController do
     it 'GET mine' do
       get :mine
 
-      expect(response).to have_http_status(:bad_request)
+      expect(response).to have_http_status(:forbidden)
     end
   end
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187154175

This PR enables project researchers to open the class page (materials, in fact) and view an anonymized list of students. There's more work to be done on this page, such as making it read-only and removing UI elements, but it's a start.

Since the class#show API authorization was similar to the offering#show API authorization pattern, I've tried to make them similar and extract the common logic to the `User#role_in_clazz` method. I've also fixed the || vs && bug that we discussed on Slack.