### PR TITLE
Cleanup authorization in Classes and Offering API

### DIFF
--- a/rails/app/controllers/api/api_controller.rb
+++ b/rails/app/controllers/api/api_controller.rb
@@ -157,32 +157,4 @@ class API::APIController < ApplicationController
 
     return auth
   end
-
-  def auth_student_or_teacher(params)
-    auth = auth_not_anonymous(params)
-    return auth if auth[:error]
-    user = auth[:user]
-
-    if !user.portal_student && !user.portal_teacher
-      auth[:error] = 'You must be logged in as a student or teacher to use this endpoint'
-    end
-
-    return auth
-  end
-
-  def auth_student_or_teacher_or_researcher(params)
-    auth = auth_not_anonymous(params)
-    return auth if auth[:error]
-    user = auth[:user]
-
-    # Check if the user is a researcher of ANY project - the controller will check for a specific resource
-    auth[:role] ||= {}
-    auth[:role][:is_project_researcher] = user && user.is_project_researcher?
-
-    if !user.portal_student && !user.portal_teacher && !auth[:role][:is_project_researcher]
-      auth[:error] = 'You must be logged in as a student or teacher or researcher to use this endpoint'
-    end
-
-    return auth
-  end
 end

--- a/rails/app/controllers/api/v1/offerings_controller.rb
+++ b/rails/app/controllers/api/v1/offerings_controller.rb
@@ -5,10 +5,6 @@
 class API::V1::OfferingsController < API::APIController
 
   def show
-    auth = auth_student_or_teacher_or_researcher(params)
-    return error(auth[:error]) if auth[:error]
-    user = auth[:user]
-
     offering = Portal::Offering
                    .where(id: params[:id])
                    .includes(API::V1::Offering::INCLUDES_DEF)
@@ -17,13 +13,10 @@ class API::V1::OfferingsController < API::APIController
       return error('offering not found', 404)
     end
 
-    role_in_clazz = user.role_in_clazz(offering.clazz)
+    authorize offering, :api_show?
 
-    if (!role_in_clazz[:student] && !role_in_clazz[:teacher] && !role_in_clazz[:researcher])
-      return error('You are not a student or teacher or researcher of the requested offerings class')
-    end
+    anonymize_students = !current_user.has_full_access_to_student_data?(offering.clazz)
 
-    anonymize_students = role_in_clazz[:researcher]
     offering_api = API::V1::Offering.new(offering, request.protocol, request.host_with_port, current_user, params[:add_external_report], anonymize_students)
     render :json => offering_api.to_json, :callback => params[:callback]
   end

--- a/rails/app/policies/portal/clazz_policy.rb
+++ b/rails/app/policies/portal/clazz_policy.rb
@@ -20,14 +20,40 @@ class Portal::ClazzPolicy < ApplicationPolicy
     end
   end
 
+  # Used by API::V1::ClassesController:
+  def api_show?
+    class_teacher_or_admin? || class_student? || class_researcher?
+  end
+
+  def mine?
+    teacher? || student?
+  end
+
+  def log_links?
+    admin?
+  end
+
+  def set_is_archived?
+    class_teacher_or_admin?
+  end
+
+  # Used by Portal::ClazzesController:
   def materials?
     class_teacher? || class_researcher? || admin?
   end
 
   private
 
+  def class_student?
+    user && record && record.is_student?(user)
+  end
+
   def class_teacher?
     user && record && record.is_teacher?(user)
+  end
+
+  def class_teacher_or_admin?
+    class_teacher? || admin?
   end
 
   def class_researcher?

--- a/rails/spec/controllers/api/v1/classes_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/classes_controller_spec.rb
@@ -44,8 +44,8 @@ describe API::V1::ClassesController do
 
     it "should fail when id is a class that the teacher doesn't own" do
       post :set_is_archived, params: { id: other_clazz.id }
-      expect(response).to have_http_status(:bad_request)
-      expect(JSON.parse(response.body)["message"]).to eq "You are not a teacher of the requested class"
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["message"]).to eq "Not authorized"
     end
 
     it "should succeed when the id is a class the teacher owns" do
@@ -66,7 +66,7 @@ describe API::V1::ClassesController do
     it 'GET mine' do
       get :mine
 
-      expect(response).to have_http_status(:bad_request)
+      expect(response).to have_http_status(:forbidden)
     end
   end
 


### PR DESCRIPTION
This PR cleanups authorization in Classes and Offerings API methods. Now, authorization is done purely by Pundit as I believe that's the main way we do it. 

Anonymization is handled by a new method `User#has_full_access_to_student_data?(clazz)` - this is similar logic to the previous ones, but it also handles admins and project admins. Note that it lacks explicit check whether user is a class researcher, as it's not necessary - researchers simply don't have full access. But the "basic" access is granted via Pundit authorization. 

