### PR TITLE
Let admin set expiration date for a researcher on their project 

### DIFF
--- a/rails/app/assets/stylesheets/web/app.scss
+++ b/rails/app/assets/stylesheets/web/app.scss
@@ -778,6 +778,20 @@ form {
         margin-bottom: 5px;
         min-height: 20px;
 
+        .inline-fields {
+          display: flex;
+          align-items: center;
+          justify-self: flex-start;
+
+          input[type="date"] {
+            margin-left: 20px;
+          }
+
+          label {
+            width: auto;
+          }
+        }
+
         input[type="checkbox"] {
           clear: left;
           display: inline-block;

--- a/rails/app/controllers/api/v1/jwt_controller.rb
+++ b/rails/app/controllers/api/v1/jwt_controller.rb
@@ -61,7 +61,7 @@ class API::V1::JwtController < API::APIController
     # In practice project_users (admin_project_users table) is only used for project admins and researchers
     # But to be safe we make sure the project_user is one of these two types
     only_admin_or_researcher_projects =
-      user_permission_form_students.where("admin_project_users.is_admin = true OR admin_project_users.is_researcher = true")
+      user_permission_form_students.where("admin_project_users.is_admin = true OR (admin_project_users.is_researcher = true AND (expiration_date IS NULL OR expiration_date > ?))", Date.today)
 
     # Finally check if there is a portal_student with the target_user_id
     return only_admin_or_researcher_projects.where(portal_students: {user_id: target_user_id}).exists?

--- a/rails/app/controllers/users_controller.rb
+++ b/rails/app/controllers/users_controller.rb
@@ -159,12 +159,14 @@ class UsersController < ApplicationController
             end
             if params[:user][:has_projects_in_form]
               all_projects = Admin::Project.all
-              @user.set_role_for_projects('admin', all_projects, params[:user][:admin_project_ids] || [])
-              @user.set_role_for_projects('researcher', all_projects, params[:user][:researcher_project_ids] || [])
+              expiration_dates = params[:user][:project_expiration_dates] || {}
+              @user.set_role_for_projects('admin', all_projects, params[:user][:admin_project_ids] || [], expiration_dates)
+              @user.set_role_for_projects('researcher', all_projects, params[:user][:researcher_project_ids] || [], expiration_dates)
             end
           elsif current_visitor.is_project_admin?
             if params[:user][:has_projects_in_form]
-              @user.set_role_for_projects('researcher', current_visitor.admin_for_projects, params[:user][:researcher_project_ids] || [])
+              expiration_dates = params[:user][:project_expiration_dates] || {}
+              @user.set_role_for_projects('researcher', current_visitor.admin_for_projects, params[:user][:researcher_project_ids] || [], expiration_dates)
             end
           end
 

--- a/rails/app/policies/admin/cohort_policy.rb
+++ b/rails/app/policies/admin/cohort_policy.rb
@@ -8,7 +8,7 @@ class Admin::CohortPolicy < ApplicationPolicy
         # prevents a bunch of unnecessary model loads by not using the user#admin_for_project_cohorts method
         scope
           .joins("INNER JOIN admin_project_users __apu_scope ON __apu_scope.project_id = admin_cohorts.project_id")
-          .where("__apu_scope.user_id = ? AND (__apu_scope.is_admin = 1 OR __apu_scope.is_researcher = 1)", user.id)
+          .where("__apu_scope.user_id = ? AND (__apu_scope.is_admin = 1 OR (__apu_scope.is_researcher = 1 AND (expiration_date IS NULL OR expiration_date > ?)))", user.id, Date.today)
       else
         none
       end

--- a/rails/app/policies/portal/teacher_policy.rb
+++ b/rails/app/policies/portal/teacher_policy.rb
@@ -14,7 +14,7 @@ class Portal::TeacherPolicy < ApplicationPolicy
       AND
           __apu_scope.user_id = #{user.id}
       AND
-          (__apu_scope.is_admin = 1 OR __apu_scope.is_researcher = 1)
+          (__apu_scope.is_admin = 1 OR (__apu_scope.is_researcher = 1 AND (__apu_scope.expiration_date IS NULL OR expiration_date > '#{Date.today.to_s(:db)}')))
       UNION
         SELECT id
         FROM portal_teachers

--- a/rails/app/views/users/_researcher_for_projects.html.haml
+++ b/rails/app/views/users/_researcher_for_projects.html.haml
@@ -4,9 +4,29 @@
     Researcher for Projects
   %ul.options-list
     - projects = projects.sort_by &:name
-    - projects.each_with_index do |p, i|
-      - checkbox_id = "project-" + i.to_s + "-researcher"
+    - projects.each_with_index do |project, i|
+      - checkbox_id = "project-#{i}-researcher"
+      - expiration_date = @user.expiration_date_for_project(project)
+      - is_researcher = @user.researcher_for_projects_inc_expired.include?(project)
       %li
-        = check_box_tag "user[researcher_project_ids][]", p.id, @user.researcher_for_projects.include?(p), id: checkbox_id
-        = label_tag checkbox_id do
-          = p.name
+        .inline-fields
+          = check_box_tag "user[researcher_project_ids][]", project.id, is_researcher, id: checkbox_id, class: 'project-checkbox'
+          = label_tag checkbox_id do
+            = project.name
+          = date_field_tag "user[project_expiration_dates][#{project.id}]", expiration_date, placeholder: 'Expiration Date', class: 'date-input', style: ('display:none;' unless is_researcher)
+
+:javascript
+  document.addEventListener("DOMContentLoaded", function() {
+    document.querySelectorAll('.project-checkbox').forEach(function(checkbox) {
+      checkbox.addEventListener('change', function() {
+        // Find the date input related to this checkbox. Assuming it's always the following sibling after the next (after the label).
+        var dateInput = this.parentNode.querySelector('.date-input');
+        if (this.checked) {
+          dateInput.style.display = 'inline-block'; // Use inline-block or block depending on your layout needs
+        } else {
+          dateInput.style.display = 'none';
+        }
+      });
+    });
+  });
+

--- a/rails/db/migrate/20240403132757_add_expiration_date_to_admin_project_users.rb
+++ b/rails/db/migrate/20240403132757_add_expiration_date_to_admin_project_users.rb
@@ -1,0 +1,6 @@
+class AddExpirationDateToAdminProjectUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :admin_project_users, :expiration_date, :date, null: true
+    add_index :admin_project_users, [:is_researcher, :expiration_date], name: 'index_project_users_on_researcher_and_expiration'
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_03_13_184118) do
+ActiveRecord::Schema.define(version: 2024_04_03_132757) do
 
   create_table "access_grants", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "code"
@@ -84,6 +84,8 @@ ActiveRecord::Schema.define(version: 2024_03_13_184118) do
     t.integer "user_id"
     t.boolean "is_admin", default: false
     t.boolean "is_researcher", default: false
+    t.date "expiration_date"
+    t.index ["is_researcher", "expiration_date"], name: "index_project_users_on_researcher_and_expiration"
     t.index ["project_id", "user_id"], name: "admin_proj_user_uniq_idx", unique: true
     t.index ["project_id"], name: "index_admin_project_users_on_project_id"
     t.index ["user_id"], name: "index_admin_project_users_on_user_id"

--- a/rails/spec/models/user_spec.rb
+++ b/rails/spec/models/user_spec.rb
@@ -318,6 +318,26 @@ describe User do
         expect(user.admin_for_projects.size).to eq(1)
       end
     end
+
+    describe "when expriation date for researcher role is set and it's not expired" do
+      before(:each) do
+        user.add_role_for_project('researcher', project, Time.now + 1.day)
+      end
+      it "should be a project researcher for the project now " do
+        expect(user.is_project_researcher?(project)).to eq true
+        expect(user.is_project_researcher?(project, true)).to eq true # allow_expired=true
+      end
+    end
+
+    describe "when expriation date for researcher role is set and it's expired" do
+      before(:each) do
+        user.add_role_for_project('researcher', project, Time.now - 1.day)
+      end
+      it "should not be a project researcher for the project now " do
+        expect(user.is_project_researcher?(project)).to eq false
+        expect(user.is_project_researcher?(project, true)).to eq true # allow_expired=true
+      end
+    end
   end
 
   describe "remove_role_for_project" do

--- a/rails/spec/models/user_spec.rb
+++ b/rails/spec/models/user_spec.rb
@@ -319,7 +319,7 @@ describe User do
       end
     end
 
-    describe "when expriation date for researcher role is set and it's not expired" do
+    describe "when expiration date for researcher role is set and it's not expired" do
       before(:each) do
         user.add_role_for_project('researcher', project, Time.now + 1.day)
       end
@@ -329,7 +329,7 @@ describe User do
       end
     end
 
-    describe "when expriation date for researcher role is set and it's expired" do
+    describe "when expiration date for researcher role is set and it's expired" do
       before(:each) do
         user.add_role_for_project('researcher', project, Time.now - 1.day)
       end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187153676

This PR introduces an `expiration_date` to the `Admin::ProjectUser` model. Rather than updating every instance where `User.where researcher_for_projects` was used, I've adjusted this relation to exclude expired projects. This automatically addresses most scenarios. However, custom SQL queries can sometimes be tricky to identify. If you're aware of additional spots that may need adjustments, please let me know.