### PR TITLE
Fix researcher classes runnables query 

### DIFF
--- a/rails/app/controllers/api/v1/research_classes_controller.rb
+++ b/rails/app/controllers/api/v1/research_classes_controller.rb
@@ -101,7 +101,7 @@ class API::V1::ResearchClassesController < API::APIController
   def runnables_query(options, user, scope, clazz_ids_subquery, count_only = false)
     scope = scope
       .joins("INNER JOIN portal_teacher_clazzes ptc2 ON portal_offerings.clazz_id = ptc2.clazz_id")
-      .where(portal_teacher_clazzes: { clazz_id: clazz_ids_subquery })
+      .where("ptc2.clazz_id": clazz_ids_subquery)
       .distinct
 
     if count_only


### PR DESCRIPTION
This PR fixes a bug described in this story:
https://www.pivotaltracker.com/story/show/187373382

The previous version of the query worked fine when the user was not an admin, but it failed if the user also had an admin role. When I removed the alias, the opposite happened. I have no idea why, but I simply changed the form to 'where' with an explicit alias, which seems to make sense anyway and fixed the problem.

