### PR TITLE
feat: 'New Permission Form' project dropdown should show projects for which the user is either an admin or a researcher

### DIFF
--- a/rails/app/policies/admin/project_policy.rb
+++ b/rails/app/policies/admin/project_policy.rb
@@ -26,10 +26,10 @@ class Admin::ProjectPolicy < ApplicationPolicy
     def resolve
       if user.has_role?('admin')
         all
-      elsif user.is_project_admin?
-        user.admin_for_projects
-      elsif user.is_project_researcher?
-        user.researcher_for_projects
+      elsif user.is_project_admin? || user.is_project_researcher?
+        admin_project_ids = user.admin_for_projects.select(:id)
+        researcher_project_ids = user.researcher_for_projects.select(:id)
+        scope.where(id: admin_project_ids).or(scope.where(id: researcher_project_ids))
       else
         none
       end


### PR DESCRIPTION
This PR addresses an issue identified by Saravanan and described as the first bullet point here:

https://www.pivotaltracker.com/story/show/187153676/comments/240879957
