### PR TITLE
"Remove Concord Consortium Teachers" should remove classes owned by CC teachers from the results table on the Research Class page

### DIFF
--- a/rails/app/models/portal/clazz.rb
+++ b/rails/app/models/portal/clazz.rb
@@ -152,6 +152,13 @@ class Portal::Clazz < ApplicationRecord
     return nil
   end
 
+  def teacher_school
+    if teacher
+      return teacher.school
+    end
+    return nil
+  end
+
   # HACK: to support transitioning to multiple teachers.
   def teacher
     self.teachers.first

--- a/rails/spec/controllers/api/v1/research_classes_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/research_classes_controller_spec.rb
@@ -8,7 +8,10 @@ describe API::V1::ResearchClassesController do
   }
 
   before (:each) do
-    @teacher1 = FactoryBot.create(:portal_teacher)
+    @cc_school = FactoryBot.create(:portal_school, {name: 'concord consortium'})
+
+    @teacher1 = FactoryBot.create(:portal_teacher, schools: [@cc_school])
+
     @teacher2 = FactoryBot.create(:portal_teacher)
 
     @project1 = FactoryBot.create(:project, name: 'Project 1')
@@ -146,6 +149,21 @@ describe API::V1::ResearchClassesController do
         json = JSON.parse(response.body)
         expect(response.status).to eql(200)
         expect(json["hits"]["runnables"].length).to eql(0)
+      end
+      it "filters out CC teachers from teachers results (when requested)" do
+        params[:load_only] = "teachers"
+        params[:remove_cc_teachers] = "true"
+        get :index, params: params
+        json = JSON.parse(response.body)
+        expect(response.status).to eql(200)
+        expect(json["hits"]["teachers"].length).to eql(0)
+      end
+      it "filters out CC teachers from classes results (when requested)" do
+        params[:remove_cc_teachers] = "true"
+        get :index, params: params
+        json = JSON.parse(response.body)
+        expect(response.status).to eql(200)
+        expect(json["hits"]["classes"].length).to eql(0)
       end
     end
   end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187421739

I've also added the "teacher_school" method to a class to get the school name via teacher instead of `course`. I'm not really familiar with the course concept, and I get that, especially in the Research Classes scenario, we want to get this name via teacher.