### PR TITLE
Support string-based search of runnables on Learner Report page

### DIFF
--- a/rails/app/controllers/api/v1/report_learners_es_controller.rb
+++ b/rails/app/controllers/api/v1/report_learners_es_controller.rb
@@ -233,12 +233,22 @@ class API::V1::ReportLearnersEsController < API::APIController
       end
     end
     if options[:runnables] && !options[:runnables].empty?
-      runnables = options[:runnables].split(',')
-      filters << {
-        :terms => {
-          "runnable_type_and_id.keyword" => runnables
+      # Look specifically for externalactivity_1,externalactivity_2,etc., as ExternalActivity is currently
+      # the only type supported by Portal. More generic regexp could conflict with string-based search.
+      if /\A(externalactivity_\d+,*)+\z/.match(options[:runnables])
+        runnables = options[:runnables].split(',')
+        filters << {
+          :terms => {
+            "runnable_type_and_id.keyword" => runnables
+          }
         }
-      }
+      else
+        filters << {
+          :prefix => {
+            :runnable_type_id_name => options[:runnables].downcase
+          }
+        }
+      end
     end
 
     # If we don't have all_access privilages:


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187402079

When you open /report/learner, an initial query preloads all dropdowns (Schools, Teachers, Resources, Permission Forms) with a maximum of 500 or 1000 options, depending on the field. If you simply open one of the dropdowns and try to pick an option, you're limited to these 500/1000 most popular options. However, you can also type in the dropdown using your keyboard, which triggers two different behaviors:
1. When you type between 1 and 3 characters, the JS code performs client-side filtering of the dropdown options, using the currently available 500/1000 options.
2. When you type a fourth character, the JS code issues a new request to the Portal server to query Elasticsearch specifically for Schools, Teachers, Resources, or Permission Forms that start with these four characters. This may result in new options appearing in the dropdown that were not part of the initial 500/1000 set.

However, the second functionality is broken for Resources, which is the main reason why Trudi (and possibly other users) couldn't find their resources if they were not part of the initially downloaded set of 1000 most popular resources. Trudi's "Changing climate, changing forests: What is the future of boreal forests?" activity wasn't part of the 1000 most popular resources, so client-side filtering didn't work.

Only after Trudi selected a teacher, a new Elasticsearch query got issued, downloading a new, much smaller set of resources. This time, the requested resource was already in the dropdown and Trudi could find it using client-side filtering.
So, I think an obvious step is to fix this for Resources filtering and handle the second functionality (server-side filtering) in a way similar to what we do for Schools and Teachers.

More context:
https://concord-consortium.slack.com/archives/C0M5CM1RA/p1714665002925099
