### PR TITLE
Fix / improve ElasticSearch autocomplete search

### DIFF
--- a/rails/app/controllers/api/v1/report_learners_es_controller.rb
+++ b/rails/app/controllers/api/v1/report_learners_es_controller.rb
@@ -206,7 +206,7 @@ class API::V1::ReportLearnersEsController < API::APIController
         }
       else
         filters << {
-          :prefix => {
+          :match_phrase_prefix => {
             :school_name => options[:schools].downcase
           }
         }
@@ -226,7 +226,7 @@ class API::V1::ReportLearnersEsController < API::APIController
         }
       else
         filters << {
-          :prefix => {
+          :match_phrase_prefix => {
             :teachers_map => options[:teachers].downcase
           }
         }
@@ -244,7 +244,7 @@ class API::V1::ReportLearnersEsController < API::APIController
         }
       else
         filters << {
-          :prefix => {
+          :match_phrase_prefix => {
             :runnable_type_id_name => options[:runnables].downcase
           }
         }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187570429

The `:prefix` query could not handle a string with whitespace or any special characters. It was simply the wrong tool for this job. While reviewing the Elasticsearch documentation, I found that the `:match_phrase_prefix` query should work well in our case. There are other options too, but I doubt they are worth the added complexity.

I have tested it with whitespace, dots, multiple words, and various special characters, and it seems to work fine.