### PR TITLE
Replace Uglifier with Terser

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -61,7 +61,7 @@ gem 'test-unit',            '~> 3.0'
 gem 'tinymce-rails',        '~>3.5.6'
 gem 'sprockets-rails', :require => 'sprockets/railtie'
 gem 'sprockets', '~> 3'
-gem 'uglifier'
+gem 'terser'
 # 2021-06-24 NP: We could / should probably get rid of this.
 # We currently do use 'useragent' to detect older browsers. But maybe we
 # shouldn't be doing that anymore...

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -514,6 +514,8 @@ GEM
     temple (0.8.2)
     terrapin (0.6.0)
       climate_control (>= 0.0.3, < 1.0)
+    terser (1.2.2)
+      execjs (>= 0.3.0, < 3)
     test-unit (3.0.8)
       power_assert
     thor (1.1.0)
@@ -523,8 +525,6 @@ GEM
       railties (>= 3.1.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
@@ -650,9 +650,9 @@ DEPENDENCIES
   sprockets-rails
   sunspot_rails
   sunspot_solr
+  terser
   test-unit (~> 3.0)
   tinymce-rails (~> 3.5.6)
-  uglifier
   useragent
   uuidtools (~> 2.1.2)
   virtus (~> 1.0.3)

--- a/rails/config/environments/production.rb
+++ b/rails/config/environments/production.rb
@@ -63,7 +63,7 @@ RailsPortal::Application.configure do
   config.assets.compile = true
 
   # Minify/uglify/compress assets from the pipeline
-  config.assets.js_compressor = Uglifier.new(harmony: true)
+  config.assets.js_compressor = :terser
   config.assets.css_compressor = :yui
 
   # Generate digests for assets' URLs.


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187644854

I've noticed that the Docker image step was failing because asset precompilation was failing. I suspect this is related to the fact that we might now be outputting ES6 instead of ES5. Uglifier is from 2019, and Terser seems to be recommended now.

This change will hopefully make the front-end-maintenance branch deployable to Staging (although we should not do it yet).