### PR TITLE
Fix "Log in" link in Register modal

### DIFF
--- a/rails/react-components/src/library/components/signup/signup.tsx
+++ b/rails/react-components/src/library/components/signup/signup.tsx
@@ -127,6 +127,7 @@ export default class SignUp extends React.Component<any, any> {
       // teacherReg: this.onTeacherRegistration,
       form = <UserTypeSelector
         anonymous={anonymous}
+        oauthProviders={oauthProviders}
         onUserTypeSelect={this.onUserTypeSelect}
       />;
     } else if (basicData) {

--- a/rails/react-components/src/library/components/signup/user_type_selector.tsx
+++ b/rails/react-components/src/library/components/signup/user_type_selector.tsx
@@ -25,7 +25,7 @@ export default class UserTypeSelector extends React.Component<any, any> {
     });
 
     PortalComponents.renderLoginModal({
-      oauthProviders: this.state.oauthProviders,
+      oauthProviders: this.props.oauthProviders,
       afterSigninPath: this.props.afterSigninPath
     });
     gtag("event", "click", {


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/2441249/stories/187706984

Old code declared unused `this.state = { .. }` that I removed during maintenance. I changed that to props and provided `oauthProviders` in the parent component. So, this should also fix an existing production bug that results in no oauth options when user tries to login that way.