### PR TITLE
Fix Collection Lightbox

### DIFF
--- a/rails/react-components/src/library/components/collection-lightbox.tsx
+++ b/rails/react-components/src/library/components/collection-lightbox.tsx
@@ -11,7 +11,6 @@ const CollectionLightbox = Component({
       collectionName: "",
       collectionViews: this.props.collectionViews,
       handleNav: this.props.handleNav,
-      isLoaded: false,
       landingPageSlug: null,
       returnPath: null,
       returnLinkText: null
@@ -26,7 +25,6 @@ const CollectionLightbox = Component({
       success: function (data: any) {
         this.setState({
           collectionName: data.name,
-          isLoaded: true,
           landingPageSlug: data.landing_page_slug
         });
         jQuery("html, body").css("overflow", "hidden");
@@ -104,10 +102,7 @@ const CollectionLightbox = Component({
   },
 
   render () {
-    const { collectionName, collectionViews, isLoaded, landingPageSlug, returnPath } = this.state;
-    if (!isLoaded) {
-      return (null);
-    }
+    const { collectionName, collectionViews, landingPageSlug, returnPath } = this.state;
     return (
       <div>
         <div className={css.portalPagesCollectionLightboxBackground} />


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187707117

The `componentDidMount` method of this component relied on elements rendered by the React component, using `document.querySelector` to access them. I suspect it broke because React 18 might render things in a slightly different order or with a delay. I could use refs, but there's a lot of DOM manipulation in this component already. Genrally, there's significant technical debt in everything related to search, assignment modals, material collections, and project pages. 😉
