### PR TITLE
Fix date inputs on Learner and User Report pages

### DIFF
--- a/rails/react-components/src/library/components/learner-report-form/index.tsx
+++ b/rails/react-components/src/library/components/learner-report-form/index.tsx
@@ -295,11 +295,12 @@ export default class LearnerReportForm extends React.Component<any, any> {
     );
   }
 
-  renderDatePicker (name: any) {
+  renderDatePicker (name: "start_date" | "end_date") {
     const label = name === "start_date" ? "Earliest date of last run" : "Latest date of last run";
 
-    const handleChange = (value: any) => {
-      // allow clearing of the date
+    const handleChange = (event: any) => {
+      const { value } = event.target;
+
       this.setState({ [name]: value || "" }, () => {
         this.updateFilters();
         this.updateQueryParams();

--- a/rails/react-components/src/library/components/user-report-form/index.tsx
+++ b/rails/react-components/src/library/components/user-report-form/index.tsx
@@ -196,16 +196,13 @@ export default class UserReportForm extends React.Component<any, any> {
     );
   }
 
-  renderDatePicker (name: any) {
+  renderDatePicker (name: "start_date" | "end_date") {
     const label = name === "start_date" ? "Earliest date" : "Latest date";
 
     const handleChange = (event: any) => {
       const { value } = event.target;
-      if (!value) {
-        // Incorrect date.
-        return;
-      }
-      this.setState({ [name]: value }, () => {
+
+      this.setState({ [name]: value || "" }, () => {
         this.updateQueryParams();
       });
     };


### PR DESCRIPTION
[PT-187707073] [PT-187707087] [PT-187707067]

I probably broke the Learner Report page while manually merging recent changes (the value argument was replaced with event when the new native input was used). I also fixed the User Report in a similar manner to the Learner Report, as Saravanan noticed the issue.