### PR TITLE
fix: Users always redirected to learner report path on report server [PT-166155743]

### DIFF
--- a/rails/app/controllers/application_controller.rb
+++ b/rails/app/controllers/application_controller.rb
@@ -286,10 +286,7 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(resource)
     redirect_path = view_context.current_user_home_path
 
-    if BoolENV['RESEARCHER_REPORT_ONLY']
-      # force all users to try to go to the researcher page on a report only portal
-      redirect_path = learner_report_path
-    elsif params[:after_sign_in_path].present?
+    if params[:after_sign_in_path].present?
       # the check for to see if the user has permission to view the after_sigin_in_path
       # page is handled by the controller of this new page.
       # if the user doesn't have permission to see the new page they will be sent to their

--- a/rails/app/helpers/application_helper.rb
+++ b/rails/app/helpers/application_helper.rb
@@ -590,6 +590,8 @@ module ApplicationHelper
     if current_user.nil?
       # anonymous home is the '/'
       root_path
+    elsif BoolENV['RESEARCHER_REPORT_ONLY']
+      learner_report_path
     elsif current_user.portal_student
       my_classes_path
     elsif APP_CONFIG[:recent_activity_on_login] && current_user.portal_teacher


### PR DESCRIPTION
This happens both on login after clicking on a report from the main portal and when using the report portal as an oauth client.

The change here is to move the existing redirect to the learner report to the user's current homepage helper on the report server and removing the check for the report server in the application_controller.rb#after_sign_in_path_for method.