### PR TITLE
187699878 and 187595886 permission modal and tabs

### DIFF
--- a/rails/react-components/src/library/components/permission-forms-v2/create-new-permission-form.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/create-new-permission-form.tsx
@@ -48,11 +48,10 @@ export const CreateNewPermissionForm = ({ projects, currentSelectedProject, onFo
   };
 
   return (
-    <div className={css.newForm}>
+    <div className={css.newPermissionForm}>
       <div className={css.formTop}>
-        {formData.name.length > 0 ? "Edit: " + formData.name : "New form"}
+        Create New Permission Form
       </div>
-
       <div className={css.formRow}>
         <label>Name:</label>
         <div><input type="text" name="name" onChange={handleFormInputChange} autoComplete="off" /></div>

--- a/rails/react-components/src/library/components/permission-forms-v2/index.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/index.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from "react";
 import { useFetch } from "../../hooks/use-fetch";
 import { CreateNewPermissionForm } from "./create-new-permission-form";
+import { IPermissionForm, IProject, CurrentSelectedProject, PermissionsTab } from "./permission-form-types";
 import PermissionFormRow from "./permission-form-row";
-import { IPermissionForm, IProject, CurrentSelectedProject } from "./permission-form-types";
+import ModalDialog from "../shared/modal-dialog";
 
 import css from "./style.scss";
 
@@ -12,7 +13,8 @@ export default function PermissionFormsV2() {
   const { data: projectsData } = useFetch<IProject[]>(Portal.API_V1.PROJECTS, []);
 
   // State for UI
-  const [showForm, setShowForm] = useState(false);
+  const [openTab, setOpenTab] = useState<PermissionsTab>("projectsTab");
+  const [showCreateNewFormModal, setShowCreateNewFormModal] = useState(false);
   const [currentSelectedProject, setCurrentSelectedProject] = useState<number | "">("");
 
   const handleProjectSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -21,7 +23,7 @@ export default function PermissionFormsV2() {
 
   const handleFormSave = (newForm: IPermissionForm) => {
     setCurrentSelectedProject(newForm.project_id as CurrentSelectedProject);
-    setShowForm(false);
+    setShowCreateNewFormModal(false);
     refetchPermissions();
   };
 
@@ -34,45 +36,63 @@ export default function PermissionFormsV2() {
 
   return (
     <div className={css.permissionForms}>
-      <div className={css.tableAndControls}>
+
+      <div className={css.tabArea}>
         <h2>Permission Form Options</h2>
-        <p>Tabs</p>
-
-        <h3>Create / Manage Project Permission Forms</h3>
-        <div className={css.controlsArea}>
-
-          <div className={css.leftSide}>
-            <div>Project:</div>
-            <select data-testid="top-project-select" value={currentSelectedProject} onChange={handleProjectSelectChange}>
-              <option value="">Select project..</option>
-              {projectsData?.map((p: IProject) => <option key={p.id} value={p.id}>{p.name}</option>)}
-            </select>
-          </div>
-
-          <div className={css.rightSide}>
-            <button onClick={() => setShowForm(true)}>Create New Permission Form</button>
-          </div>
+        <div className={css.tabs}>
+          <button
+            className={openTab === "projectsTab" ? css.activeTab : ""}
+            onClick={() => setOpenTab("projectsTab")}
+          >
+            Create / Manage Project Permission Forms
+          </button>
+          <button
+            className={openTab === "studentsTab" ? css.activeTab : ""}
+            onClick={() => setOpenTab("studentsTab")}
+          >
+            Manage Student Permissions
+          </button>
         </div>
-
-        <table className={css.permissionFormsTable}>
-          <thead>
-            <tr><th>Name</th><th>URL</th><th></th></tr>
-          </thead>
-          <tbody>
-            {getFilteredForms()?.map((permissionForm: IPermissionForm) => (
-              <PermissionFormRow key={permissionForm.id} permissionForm={permissionForm} />
-            ))}
-          </tbody>
-        </table>
       </div>
 
-      {showForm &&
-        <CreateNewPermissionForm
-          currentSelectedProject={currentSelectedProject}
-          onFormCancel={() => setShowForm(false)}
-          onFormSave={handleFormSave}
-          projects={projectsData}
-        />
+      { openTab === "projectsTab" &&
+        <div className={css.projectPermissionsTabContent}>
+          <h3>Create/Manage Project Permission Forms</h3>
+          <div className={css.controlsArea}>
+            <div className={css.leftSide}>
+              <div>Project:</div>
+              <select data-testid="top-project-select" value={currentSelectedProject} onChange={handleProjectSelectChange}>
+                <option value="">Select project..</option>
+                {projectsData?.map((p: IProject) => <option key={p.id} value={p.id}>{p.name}</option>)}
+              </select>
+            </div>
+            <div className={css.rightSide}>
+              <button onClick={() => setShowCreateNewFormModal(true)}>Create New Permission Form</button>
+            </div>
+          </div>
+
+          <table className={css.permissionFormsTable}>
+            <thead>
+              <tr><th>Name</th><th>URL</th><th></th></tr>
+            </thead>
+            <tbody>
+              {getFilteredForms()?.map((permissionForm: IPermissionForm) => (
+                <PermissionFormRow key={permissionForm.id} permissionForm={permissionForm} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      }
+
+      {showCreateNewFormModal &&
+        <ModalDialog styles={{ padding: "0px"}}>
+          <CreateNewPermissionForm
+            currentSelectedProject={currentSelectedProject}
+            onFormCancel={() => setShowCreateNewFormModal(false)}
+            onFormSave={handleFormSave}
+            projects={projectsData}
+          />
+        </ModalDialog>
       }
     </div>
   );

--- a/rails/react-components/src/library/components/permission-forms-v2/permission-form-row.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/permission-form-row.tsx
@@ -7,11 +7,20 @@ interface PermissionFormRowProps {
   permissionForm: IPermissionForm;
 }
 
+function renderLinkOrSpan(urlValue: string): React.ReactElement | string {
+  try {
+    const urlObj = new URL(urlValue);
+    return <a href={urlObj.origin}>{urlObj.origin}</a>;
+  } catch (_) {
+    return <span className={css.invalidLink}>{urlValue}</span>;
+  }
+}
+
 const PermissionFormRow: React.FC<PermissionFormRowProps> = ({ permissionForm }) => {
   return (
     <tr className={css.permissionFormRow}>
       <td className={css.nameColumn}>{permissionForm.name}</td>
-      <td className={css.urlColumn}>{permissionForm.url}</td>
+      <td className={css.urlColumn}>{renderLinkOrSpan(permissionForm.url ?? "")}</td>
       <td className={css.buttonsColumn}>
         <button className={css.basicButton}>Edit</button>
         <button className={css.basicButton}>Archive</button>

--- a/rails/react-components/src/library/components/permission-forms-v2/permission-form-types.ts
+++ b/rails/react-components/src/library/components/permission-forms-v2/permission-form-types.ts
@@ -5,9 +5,11 @@ export interface IPermissionForm {
   name: string;
   project_id?: number | string; // need to fix this
   url?: string;
- }
+}
 
 export interface IProject {
   id: string;
   name: string;
- }
+}
+
+export type PermissionsTab = "projectsTab" | "studentsTab";

--- a/rails/react-components/src/library/components/permission-forms-v2/style.scss
+++ b/rails/react-components/src/library/components/permission-forms-v2/style.scss
@@ -14,133 +14,150 @@
     border-top: 1px solid #aaa;
   }
 
-  .controlsArea {
-    display: flex;
-    justify-content: space-between;
-    margin-bottom: 20px;
-
-    div {
+  .tabArea {
+    .tabs {
+      display:flex;
+      justify-content: left;
+      margin-bottom: 20px;
+      button {
+        background-color:white;
+        padding: 10px;
+        color: $col-link;
+        margin-right:20px;
+        border:0px;
+        font-weight: 200;
+      }
+      .activeTab {
+        color:#0592af;
+      }
+    }
+  }
+  .projectPermissionsTabContent {
+    .controlsArea {
       display: flex;
+      justify-content: space-between;
+      margin-bottom: 20px;
+
+      div {
+        display: flex;
+      }
+
+      .leftSide {
+        width: 50%;
+        justify-content: flex-start;
+        > div {
+          align-items: center;
+          margin-right:15px;
+        }
+        select {
+          width: 400px;
+        }
+      }
+
+      .rightSide {
+        justify-content: flex-end;
+      }
+    }
+    .permissionFormsTable {
+      margin-top:20px;
+      width: 100%;
+
+      tr {
+        // every other row is background #f9f9f9
+        &:nth-child(odd) {
+          background-color: #f9f9f9;
+        }
+      }
+      th {
+        text-align: left;
+        background-color: white;
+      }
+
+      .nameColumn {
+        max-width: 400px;
+        min-width: 150px;
+        padding-left:15px;
+      }
+
+      .buttonsColumn {
+        flex-grow: 1;
+        display: flex;
+        justify-content: flex-end;
+      }
+
+      .urlColumn {
+        max-width: 300px;
+        color: $col-link;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .basicButton {
+        display: inline-block;
+        color: $col-link;
+        background-color: transparent;
+        border: transparent;
+        text-transform: uppercase;
+        font-weight: 300;
+      }
+    }
+  }
+
+  .newPermissionForm {
+    .formTop {
+      display: flex;
+      align-content: center;
+      background-color: $col-link;
+      color: white;
+      font-weight: bold;
+      padding: 10px;
+      margin-bottom:10px;
     }
 
-    .leftSide {
-      width: 50%;
-      justify-content: flex-start;
-      > div {
-        align-items: center;
-        margin-right:15px;
+    .formRow {
+      display: flex;
+      align-items: center;
+      padding: 10px 20px;
+
+      label {
+        width: 80px;
+        text-align: left;
+        text-transform: capitalize;
+        font-weight: 300;
       }
+
+      input {
+        height: 40px;
+        width: 258px;
+        font-family: museo-sans, verdana, helvetica, arial, sans-serif !important;
+        padding-left: 12px;
+        font-weight: 300;
+      }
+
       select {
-        width: 400px;
+        width: 271px;
+        font-weight: 300;
+        font-family: museo-sans, verdana, helvetica, arial, sans-serif !important;
       }
     }
 
-    .rightSide {
-      justify-content: flex-end;
-    }
-  }
-  .permissionFormsTable {
-    margin-top:20px;
-    width: 100%;
-
-    tr {
-      // every other row is background #f9f9f9
-      &:nth-child(odd) {
-        background-color: #f9f9f9;
-      }
-    }
-    th {
-      text-align: left;
-      background-color: white;
-    }
-
-    .nameColumn {
-      max-width: 400px;
-      min-width: 150px;
-      padding-left:15px;
-    }
-
-    .buttonsColumn {
-      flex-grow: 1;
+    .formButtonArea {
       display: flex;
       justify-content: flex-end;
-    }
+      margin-top: 0px;
+      padding: 10px 20px;
+      margin-bottom:10px;
 
-    .urlColumn {
-      max-width: 300px;
-      color: $col-link;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
+      button:first-child {
+        margin-right: 8px;
+      }
 
-    .basicButton {
-      display: inline-block;
-      color: $col-link;
-      background-color: transparent;
-      border: transparent;
-      text-transform: uppercase;
-      font-weight: 300;
-    }
-  }
-
-  // temporary styles until modal implemented
-  .newForm {
-    width: 400px;
-    border: 3px solid $col-link;
-    box-shadow: 0 0 4px rgba(0,0,0,0.3);
-    margin-top:20px;
-    margin-bottom: 20px;
-  }
-
-  .formTop {
-    background-color: $col-link;
-    height: 40px;
-    color: white;
-    display: flex;
-    align-items: center;
-    padding-left: 10px;
-    margin-bottom:5px;
-  }
-
-  .formRow {
-    display: flex;
-    align-items: center;
-    padding: 10px;
-
-    label {
-      width: 80px;
-      margin-right: 10px;
-      text-align: left;
-      text-transform: capitalize;
-      font-weight: 300;
-      padding-left:10px;
-    }
-
-    input {
-      height: 40px;
-      width: 258px;
-      font-family: museo-sans, verdana, helvetica, arial, sans-serif !important;
-      padding-left: 10px;
-      font-weight: 300;
-    }
-  }
-
-  .formButtonArea {
-    display: flex;
-    justify-content: flex-end;
-    margin-top: 0px;
-    padding: 10px;
-    margin-right:10px;
-
-    button {
-      margin-left: 8px;
-    }
-
-    .cancelButton {
-      background-color: #ccc;
-      border-color: #ccc;
-      color:#333;
+      .cancelButton {
+        background-color: #ccc;
+        border-color: #ccc;
+        color:#333;
+      }
     }
   }
 }

--- a/rails/react-components/src/library/components/permission-forms-v2/style.scss
+++ b/rails/react-components/src/library/components/permission-forms-v2/style.scss
@@ -87,10 +87,17 @@
 
       .urlColumn {
         max-width: 300px;
-        color: $col-link;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+        color: #555;
+        a {
+          color: $col-link;
+          text-decoration: none;
+          &:hover {
+            text-decoration: underline;
+          }
+        }
       }
 
       .basicButton {

--- a/rails/react-components/src/library/components/shared/modal-dialog.tsx
+++ b/rails/react-components/src/library/components/shared/modal-dialog.tsx
@@ -6,12 +6,12 @@ import css from "./modal-dialog.scss";
 
 export default class ModalDialog extends React.Component<any, any> {
   render () {
-    const { title, children } = this.props;
+    const { title, children, styles = {} } = this.props;
 
     return (
       <Modal>
-        <div className={css.dialog}>
-          <div className={css.title}>{ title }</div>
+        <div className={css.dialog} style={styles}>
+          { title && <div className={css.title}>{ title }</div> }
           { children }
         </div>
       </Modal>


### PR DESCRIPTION
1. This puts the existing create new permission form in a modal, as described in PT-187699878
2. This sets up the project permissions section toggle, as described in PT-187595886

- add tabs to top of page
- wrap create/manage project permission components
- wrap creation form in existing modal
- modify existing modal-dialog to accept style override
- adds a render function so that only working urls render as links