### PR TITLE
Fix permission form URL rendering

### DIFF
--- a/rails/react-components/src/library/components/permission-forms-v2/permission-form-row.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/permission-form-row.tsx
@@ -20,7 +20,7 @@ function ensureUrlProtocol(url: string): string {
 }
 
 function renderLinkOrSpan(urlValue: string): React.ReactElement | string {
-  const urlWithProtocol = ensureUrlProtocol(urlValue);
+  const urlWithProtocol = ensureUrlProtocol(urlValue.trim());
   try {
     const urlObj = new URL(urlWithProtocol);
     return <a href={urlObj.toString()} target="_blank">{urlObj.toString()}</a>;

--- a/rails/react-components/src/library/components/permission-forms-v2/permission-form-row.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/permission-form-row.tsx
@@ -2,15 +2,28 @@ import React from "react";
 import css from "./style.scss";
 import { IPermissionForm } from "./permission-form-types";
 
-
 interface PermissionFormRowProps {
   permissionForm: IPermissionForm;
 }
 
+function ensureUrlProtocol(url: string): string {
+  if (!url) {
+    return "";
+  }
+  // Regular expression to check if the URL starts with http:// or https://
+  const urlPattern = /^(http:\/\/|https:\/\/)/i;
+  // If the URL does not start with http:// or https://, prepend https://
+  if (!urlPattern.test(url)) {
+      return `https://${url}`;
+  }
+  return url;
+}
+
 function renderLinkOrSpan(urlValue: string): React.ReactElement | string {
+  const urlWithProtocol = ensureUrlProtocol(urlValue);
   try {
-    const urlObj = new URL(urlValue);
-    return <a href={urlObj.origin}>{urlObj.origin}</a>;
+    const urlObj = new URL(urlWithProtocol);
+    return <a href={urlObj.toString()} target="_blank">{urlObj.toString()}</a>;
   } catch (_) {
     return <span className={css.invalidLink}>{urlValue}</span>;
   }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187611558

This relaxes the rules for the URL and automatically appends HTTPS when necessary. Additionally, the previous code only used the `origin` part of the URL, which I believe is incorrect. URLs can point to various documents that use paths or even query parameters.