### PR TITLE
Add Projects API # index_with_permissions, use it in Project Forms, sort projects

### DIFF
--- a/rails/app/controllers/api/v1/projects_controller.rb
+++ b/rails/app/controllers/api/v1/projects_controller.rb
@@ -1,15 +1,16 @@
 class API::V1::ProjectsController < API::APIController
 
   def index
-    projects = Admin::Project.select {|p| policy(p).visible?}
-    result = projects.map{ |p| {
-      name: p.name,
-      id: p.id,
-      landing_page_slug: p.landing_page_slug,
-      project_card_image_url: p.project_card_image_url,
-      project_card_description: p.project_card_description,
-      public: p.public} }
-    render :json => result
+    projects = Admin::Project.select { |p| policy(p).visible? }
+    result = projects.map { |p| project_to_hash(p) }
+    render json: result
+  end
+
+  # Returns all the projects that user has a full access to.
+  def index_with_permissions
+    projects = policy_scope(Admin::Project)
+    result = projects.map { |p| project_to_hash(p) }
+    render json: result
   end
 
   def show
@@ -22,6 +23,19 @@ class API::V1::ProjectsController < API::APIController
     render status: 400, json: {
       success: false,
       message: exception.message
+    }
+  end
+
+  private
+
+  def project_to_hash(project)
+    {
+      name: project.name,
+      id: project.id,
+      landing_page_slug: project.landing_page_slug,
+      project_card_image_url: project.project_card_image_url,
+      project_card_description: project.project_card_description,
+      public: project.public
     }
   end
 

--- a/rails/app/views/dynamic_scripts/_api_paths.html.haml
+++ b/rails/app/views/dynamic_scripts/_api_paths.html.haml
@@ -96,11 +96,11 @@
     //
     PERMISSION_FORMS: "#{api_v1_permission_forms_path}",
 
-
     //
     // Projects
     //
     PROJECTS: "#{api_v1_projects_path}",
+    PROJECTS_WITH_PERMISSIONS: "#{index_with_permissions_api_v1_projects_path}",
 
     // Navigation
     // NavigationHelper#get_navigation_json  see app/helpers/navigation_helper.rb

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -322,7 +322,11 @@ RailsPortal::Application.routes.draw do
       namespace :v1 do
         devise_for :users
         resources :countries
-        resources :projects
+        resources :projects, only: [:index, :show] do
+          collection do
+            get :index_with_permissions
+          end
+        end
         resources :teachers do
           collection do
             get :email_available

--- a/rails/react-components/src/library/components/permission-forms-v2/create-edit-permission-form.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/create-edit-permission-form.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { ProjectSelect } from "./project-select";
 import { IProject, IPermissionFormFormData, CurrentSelectedProject, IPermissionForm } from "./permission-form-types";
 
 import css from "./style.scss";
@@ -42,11 +43,7 @@ export const CreateEditPermissionForm = ({ projects, currentSelectedProject, exi
       </div>
 
       <div className={css.formRow}>
-        <label>Project:</label>
-        <select value={formData.project_id} name="project_id" onChange={handleFormProjectSelectChange}>
-          <option value="">Select a project...</option>
-          { projects?.map((p: IProject) => <option key={p.id} value={p.id}>{ p.name }</option>) }
-        </select>
+        <ProjectSelect projects={projects} value={formData.project_id} onChange={handleFormProjectSelectChange} />
       </div>
 
       <div className={css.formRow}>

--- a/rails/react-components/src/library/components/permission-forms-v2/index.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/index.tsx
@@ -3,6 +3,7 @@ import { useFetch } from "../../hooks/use-fetch";
 import { CreateEditPermissionForm } from "./create-edit-permission-form";
 import { IPermissionForm, IPermissionFormFormData, IProject, CurrentSelectedProject, PermissionsTab } from "./permission-form-types";
 import PermissionFormRow from "./permission-form-row";
+import { ProjectSelect } from "./project-select";
 import ModalDialog from "../shared/modal-dialog";
 
 import css from "./style.scss";
@@ -59,10 +60,12 @@ const deletePermissionForm = async (permissionFormId: string) =>
 const getFilteredForms = (forms: IPermissionForm[], projectId: string | number) =>
   projectId === "" ? forms : forms.filter((form: IPermissionForm) => form.project_id === Number(projectId));
 
+const sortByName = (a: { name: string }, b: { name: string }) => a.name.localeCompare(b.name);
+
 // Sort forms by is_archived first and then by name
 const sortForms = (forms: IPermissionForm[]) => forms.sort((a, b) => {
   if (a.is_archived === b.is_archived) {
-    return a.name.localeCompare(b.name);
+    return sortByName(a, b);
   }
   return a.is_archived ? 1 : -1;
 });
@@ -70,7 +73,7 @@ const sortForms = (forms: IPermissionForm[]) => forms.sort((a, b) => {
 export default function PermissionFormsV2() {
   // Fetch projects and permission forms (with refetch function) on initial load
   const { data: permissionsData, refetch: refetchPermissions } = useFetch<IPermissionForm[]>(Portal.API_V1.PERMISSION_FORMS, []);
-  const { data: projectsData } = useFetch<IProject[]>(Portal.API_V1.PROJECTS, []);
+  const { data: projectsData } = useFetch<IProject[]>(Portal.API_V1.PROJECTS_WITH_PERMISSIONS, []);
 
   // State for UI
   const [openTab, setOpenTab] = useState<PermissionsTab>("projectsTab");
@@ -148,11 +151,7 @@ export default function PermissionFormsV2() {
           <h3>Create/Manage Project Permission Forms</h3>
           <div className={css.controlsArea}>
             <div className={css.leftSide}>
-              <div>Project:</div>
-              <select data-testid="top-project-select" value={currentSelectedProject} onChange={handleProjectSelectChange}>
-                <option value="">Select project..</option>
-                { projectsData?.map((p: IProject) => <option key={p.id} value={p.id}>{ p.name }</option>) }
-              </select>
+              <ProjectSelect projects={projectsData} value={currentSelectedProject} onChange={handleProjectSelectChange} />
             </div>
             <div className={css.rightSide}>
               <button onClick={handleCreateFormClick}>Create New Permission Form</button>

--- a/rails/react-components/src/library/components/permission-forms-v2/permission-form-row.scss
+++ b/rails/react-components/src/library/components/permission-forms-v2/permission-form-row.scss
@@ -9,12 +9,14 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     padding-left: 5px;
+    max-width: 300px;
   }
 
   .urlColumn {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    max-width: 250px;
     a {
       color: $col-link;
       text-decoration: none;

--- a/rails/react-components/src/library/components/permission-forms-v2/project-select.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/project-select.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { IProject } from "./permission-form-types";
+
+interface IProjectSelectProps {
+  projects: IProject[];
+  onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  value?: string | number;
+}
+
+export const ProjectSelect = ({ projects, value, onChange }: IProjectSelectProps) => {
+  const sortedProjects = projects.sort((a, b) => a.name.localeCompare(b.name));
+  return (
+    <>
+      <label>Project:</label>
+      <select data-testid="project-select" value={value} name="project_id" onChange={onChange}>
+        <option value="">Select a project...</option>
+        { sortedProjects?.map((p: IProject) => <option key={p.id} value={p.id}>{ p.name }</option>) }
+      </select>
+    </>
+  );
+};

--- a/rails/react-components/src/library/components/permission-forms-v2/style.scss
+++ b/rails/react-components/src/library/components/permission-forms-v2/style.scss
@@ -38,6 +38,14 @@
       justify-content: space-between;
       margin-bottom: 20px;
 
+      label {
+        text-transform: none;
+        font-weight: 300;
+        margin-right: 10px;
+        display: flex;
+        align-items: center;
+      }
+
       div {
         display: flex;
       }
@@ -76,6 +84,8 @@
   }
 
   .newPermissionForm {
+    width: 420px;
+
     .formTop {
       display: flex;
       align-content: center;

--- a/rails/react-components/tests/library/components/permission-forms/permission-forms.test.tsx
+++ b/rails/react-components/tests/library/components/permission-forms/permission-forms.test.tsx
@@ -7,7 +7,7 @@ jest.mock("../../../../src/library/hooks/use-fetch");
 
 window.Portal = {
   API_V1: {
-    PROJECTS: "/api/v1/projects",
+    PROJECTS_WITH_PERMISSIONS: "/api/v1/projects/index_with_permissions",
     PERMISSION_FORMS: "/api/v1/permission_forms",
   }
 };
@@ -30,7 +30,7 @@ describe("PermissionFormsV2", () => {
           data: mockPermissions,
           refetch: jest.fn().mockResolvedValue({ data: mockPermissions }),
         };
-      } else if (url === window.Portal.API_V1.PROJECTS) {
+      } else if (url === window.Portal.API_V1.PROJECTS_WITH_PERMISSIONS) {
         return {
           data: mockProjects,
           refetch: jest.fn().mockResolvedValue({ data: mockProjects }),

--- a/rails/react-components/tests/library/components/permission-forms/permission-forms.test.tsx
+++ b/rails/react-components/tests/library/components/permission-forms/permission-forms.test.tsx
@@ -48,7 +48,7 @@ describe("PermissionFormsV2", () => {
     expect(screen.getByText("Form 3")).toBeInTheDocument();
 
     // filter by project 1
-    const projectSelect = screen.getByTestId("top-project-select");
+    const projectSelect = screen.getByTestId("project-select");
     fireEvent.change(projectSelect, { target: { value: 1 } });
 
     expect(screen.getByText("Form 1")).toBeInTheDocument();


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187790662
https://www.pivotaltracker.com/story/show/187790676

This PR adds a new API endpoint that filters Projects to those that the user has full access to. I didn't modify the existing index action, as its logic also makes sense; it's just different.

Also, I extracted Projects Select into a new component so that sorting and other styles/logic can be shared.