### PR TITLE
fix: Allow project admins of any project to toggle hide names control [PT-187796954]

### DIFF
--- a/rails/app/controllers/api/v1/report_learners_es_controller.rb
+++ b/rails/app/controllers/api/v1/report_learners_es_controller.rb
@@ -94,8 +94,11 @@ class API::V1::ReportLearnersEsController < API::APIController
   def external_report_query_jwt
     authorize Portal::PermissionForm
 
-    # only admins and managers can see names
-    force_hide_names = !current_user || !current_user.has_role?(%w{admin manager})
+    # only site admins, project admins (of any project) and managers can see names
+    is_admin_or_manager = current_user && current_user.has_role?(%w{admin manager})
+    is_admin_of_any_project = current_user && current_user.is_project_admin?
+    current_user_can_see_names = is_admin_or_manager || is_admin_of_any_project
+    force_hide_names = !current_user || !current_user_can_see_names
     if force_hide_names
       params["hide_names"] = "true"
     end

--- a/rails/app/views/dynamic_scripts/_current_user.html.haml
+++ b/rails/app/views/dynamic_scripts/_current_user.html.haml
@@ -9,6 +9,9 @@
     get isAdmin() {
       return "#{current_visitor.has_role?('admin')}" === "true";
     },
+    get isAdminForAnyProject() {
+      return "#{current_visitor.is_project_admin?}" === "true";
+    },
     get isManager() {
       return "#{current_visitor.has_role?('manager')}" === "true";
     },

--- a/rails/react-components/src/library/components/learner-report-form/index.tsx
+++ b/rails/react-components/src/library/components/learner-report-form/index.tsx
@@ -371,8 +371,8 @@ export default class LearnerReportForm extends React.Component<any, any> {
       });
     };
 
-    // only admins and managers can see names
-    const showHideNames = Portal.currentUser.isAdmin || Portal.currentUser.isManager;
+    // only site admins, project admins (of any project) and managers can see names
+    const showHideNames = Portal.currentUser.isAdmin || Portal.currentUser.isAdminForAnyProject || Portal.currentUser.isManager;
 
     return (
       <form method="get">


### PR DESCRIPTION
Previously only site admins and managers could toggle the hide names control in the learner reports.  This expands this ability for project admins of any project to also toggle this control.

The original reason that only site admins and managers had access is the user could use the learner report page to select teachers or resources both in and out of a project they admined so there was not enough fine grained control.  It was decided to open this toggle up to any project admin as those roles have blanket coverage in the IRBs.