### PR TITLE
fix: Slow load on user admin page [PT-187797154]

### DIFF
--- a/rails/app/controllers/users_controller.rb
+++ b/rails/app/controllers/users_controller.rb
@@ -41,8 +41,10 @@ class UsersController < ApplicationController
 
     search_scope = policy_scope(User)
     search_scope = search_scope
-      .includes(:imported_user, :portal_student, :authentications, :teacher_cohorts, :student_cohorts, :roles)
-      .includes({ portal_teacher: [:schools, teacher_clazzes: [:clazz]] })
+      .includes(:imported_user, :portal_student, :authentications, :roles)
+      .includes({ teacher_cohorts: [:project] })
+      .includes({ student_cohorts: [:project] })
+      .includes({ portal_teacher: [:schools] })
     search_scope = search_scope.joins(join_string).where(user_types).distinct()
     @users = search_scope.search(params[:search], params[:page], nil)
     respond_to do |format|

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -77,6 +77,11 @@ class User < ApplicationRecord
   after_update :set_passive_users_as_pending
   after_create :set_passive_users_as_pending
 
+  def self.per_page
+    # number of results to show in admin/users (default is 30)
+    10
+  end
+
   # strip leading and trailing spaces from names, login and email
   def strip_spaces
     # these are conditionalized because it is called before the validation

--- a/rails/features/manager_updates_account_information.feature
+++ b/rails/features/manager_updates_account_information.feature
@@ -40,7 +40,6 @@ Feature: A manager updates account information for another user
 
     Examples:
       | username      | userlogin | new_password |
-      | Alfred Robert | student   | foobarbaz    |
       | John Nash     | teacher   | buzbixbez    |
 
   @javascript


### PR DESCRIPTION
This fixes two issues:

1. Updates pre-loading to add project pre-loading of teacher and student cohorts and removes unneeded pre-loading of teacher_clazzes: [:clazz] based on an eager loading errors that Rails was outputting.
2. Limits the result set to 10 from the default of 30.

There are no more eager loading errors and I've verified that the query is limited to 10 results.  The only real way to tell if this fixes production, given its large number of users, is to try it there after validating the changes on staging.