### PR TITLE
feat(PermissionForms): add classes and students tables, add related APIs and policies

### DIFF
--- a/rails/app/controllers/api/v1/teachers_controller.rb
+++ b/rails/app/controllers/api/v1/teachers_controller.rb
@@ -173,6 +173,20 @@ class API::V1::TeachersController < API::APIController
     return render :json => recent_collections_pages.to_json
   end
 
+  def classes
+    teacher_id = params.require(:id)
+    teacher = Portal::Teacher.find(teacher_id)
+
+    authorize teacher, :show?
+
+    # Fetch only non-archived classes using pluck
+    classes = teacher.clazzes.where(is_archived: false).pluck(:id, :name, :class_hash, :class_word).map do |id, name, class_hash, class_word|
+      { id: id, name: name, class_hash: class_hash, class_word: class_word }
+    end
+
+    render json: classes
+  end
+
   private
 
   def school_params_provided?

--- a/rails/app/policies/application_policy.rb
+++ b/rails/app/policies/application_policy.rb
@@ -89,8 +89,12 @@ class ApplicationPolicy
     user && (record.respond_to?(:changeable?) ? record.changeable?(user) : true)
   end
 
-  def project_admin?
-    user && user.is_project_admin?
+  def project_admin?(project = nil)
+    user && user.is_project_admin?(project)
+  end
+
+  def project_researcher?(project = nil)
+    user && user.is_project_researcher?(project)
   end
 
   # from old restricted_controller
@@ -119,6 +123,7 @@ class ApplicationPolicy
     user && (user.is_project_admin? || has_roles?('admin','manager'))
   end
 
+  # In fact this method should be named: admin_or_project_admin_or_project_researcher
   def manager_or_researcher_or_project_researcher?
     user && (user.is_project_researcher? || manager_or_researcher?)
   end

--- a/rails/app/policies/portal/clazz_policy.rb
+++ b/rails/app/policies/portal/clazz_policy.rb
@@ -53,7 +53,7 @@ class Portal::ClazzPolicy < ApplicationPolicy
   # Used by Portal::API::V1::PermissionFormsController:
 
   def class_permission_forms?
-    admin? || class_project_admin?
+    admin? || class_project_admin? || class_researcher?
   end
 
   private
@@ -74,7 +74,7 @@ class Portal::ClazzPolicy < ApplicationPolicy
     user && record && user.is_researcher_for_clazz?(record)
   end
 
-  def class_project_adin?
+  def class_project_admin?
     user && record && user.is_project_admin_for_clazz?(record)
   end
 end

--- a/rails/app/policies/portal/clazz_policy.rb
+++ b/rails/app/policies/portal/clazz_policy.rb
@@ -50,6 +50,12 @@ class Portal::ClazzPolicy < ApplicationPolicy
     class_teacher_or_admin? || class_researcher? || class_student?
   end
 
+  # Used by Portal::API::V1::PermissionFormsController:
+
+  def class_permission_forms?
+    admin? || class_project_admin?
+  end
+
   private
 
   def class_student?
@@ -66,5 +72,9 @@ class Portal::ClazzPolicy < ApplicationPolicy
 
   def class_researcher?
     user && record && user.is_researcher_for_clazz?(record)
+  end
+
+  def class_project_adin?
+    user && record && user.is_project_admin_for_clazz?(record)
   end
 end

--- a/rails/app/policies/portal/permission_form_policy.rb
+++ b/rails/app/policies/portal/permission_form_policy.rb
@@ -2,7 +2,7 @@ class Portal::PermissionFormPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      if user.has_role?('manager','admin','researcher')
+      if user.has_role?('admin')
         all
       elsif user.is_project_admin? || user.is_project_researcher?
         where = []
@@ -42,17 +42,21 @@ class Portal::PermissionFormPolicy < ApplicationPolicy
     manager_or_researcher_or_project_researcher?
   end
 
+  # API::V1::PermissionFormsController:
+
   def create?
-    manager_or_researcher_or_project_researcher?
+    admin_or_project_admin?
+  end
+
+  def update?
+    admin? || project_admin?(record.project)
   end
 
   def destroy?
-    admin? || (manager_or_researcher_or_project_researcher? && user.projects.include?(record.project))
+    admin? || project_admin?(record.project)
   end
 
-  # Permission Forms V2 UI:
-
   def search_teachers?
-    manager_or_researcher_or_project_researcher?
+    admin_or_project_admin?
   end
 end

--- a/rails/app/policies/portal/permission_form_policy.rb
+++ b/rails/app/policies/portal/permission_form_policy.rb
@@ -50,11 +50,11 @@ class Portal::PermissionFormPolicy < ApplicationPolicy
   end
 
   def update?
-    admin? || project_admin?(record.project) || project_researcher?(record.project)
+    admin? || record && (project_admin?(record.project) || project_researcher?(record.project))
   end
 
   def destroy?
-    admin? || project_admin?(record.project) || project_researcher?(record.project)
+    admin? || record && (project_admin?(record.project) || project_researcher?(record.project))
   end
 
   def search_teachers?

--- a/rails/app/policies/portal/permission_form_policy.rb
+++ b/rails/app/policies/portal/permission_form_policy.rb
@@ -45,18 +45,20 @@ class Portal::PermissionFormPolicy < ApplicationPolicy
   # API::V1::PermissionFormsController:
 
   def create?
-    admin_or_project_admin?
+    # In fact this method should be named: admin_or_project_admin_or_project_researcher
+    manager_or_researcher_or_project_researcher?
   end
 
   def update?
-    admin? || project_admin?(record.project)
+    admin? || project_admin?(record.project) || project_researcher?(record.project)
   end
 
   def destroy?
-    admin? || project_admin?(record.project)
+    admin? || project_admin?(record.project) || project_researcher?(record.project)
   end
 
   def search_teachers?
-    admin_or_project_admin?
+    # In fact this method should be named: admin_or_project_admin_or_project_researcher
+    manager_or_researcher_or_project_researcher??
   end
 end

--- a/rails/app/policies/portal/permission_form_policy.rb
+++ b/rails/app/policies/portal/permission_form_policy.rb
@@ -59,6 +59,6 @@ class Portal::PermissionFormPolicy < ApplicationPolicy
 
   def search_teachers?
     # In fact this method should be named: admin_or_project_admin_or_project_researcher
-    manager_or_researcher_or_project_researcher??
+    manager_or_researcher_or_project_researcher?
   end
 end

--- a/rails/app/policies/portal/teacher_policy.rb
+++ b/rails/app/policies/portal/teacher_policy.rb
@@ -44,6 +44,7 @@ class Portal::TeacherPolicy < ApplicationPolicy
   end
 
   def can_view_teacher?
+    return false if user.nil?
     return true if owner? || admin?
 
     if user.is_project_admin? || user.is_project_researcher?

--- a/rails/app/views/dynamic_scripts/_api_paths.html.haml
+++ b/rails/app/views/dynamic_scripts/_api_paths.html.haml
@@ -13,7 +13,6 @@
     studentCheckPassword: function (studentId) {
       return this.STUDENT_CHECK_PASSWORD.replace(this.FAKE_ID, studentId);
     },
-    TEACHERS: "#{api_v1_teachers_path}",
     STATES: "#{api_v1_states_path}",
     DISTRICTS: "#{api_v1_districts_path}",
     SCHOOLS: "#{api_v1_schools_path}",
@@ -51,6 +50,15 @@
       return this.OFFERING.replace(this.FAKE_ID, offeringId);
     },
     OFFERINGS: "#{api_v1_offerings_path}",
+
+    //
+    // Teachers
+    //
+    TEACHERS: "#{api_v1_teachers_path}",
+    TEACHER_CLASSES: "#{classes_api_v1_teacher_path(fake_id)}",
+    teacherClasses: function (teacherId) {
+      return this.TEACHER_CLASSES.replace(this.FAKE_ID, teacherId);
+    },
 
     //
     // Classes
@@ -96,6 +104,13 @@
     //
     PERMISSION_FORMS: "#{api_v1_permission_forms_path}",
     PERMISSION_FORMS_SEARCH_TEACHER: "#{search_teachers_api_v1_permission_forms_path}",
+    permissionFormsSearchTeacher(name) {
+      return this.PERMISSION_FORMS_SEARCH_TEACHER + "?name=" + name;
+    },
+    PERMISSION_FORMS_CLASS_PERMISSION_FORMS: "#{class_permission_forms_api_v1_permission_forms_path}",
+    permissionFormsClassPermissionForms(classId) {
+      return this.PERMISSION_FORMS_CLASS_PERMISSION_FORMS + "?class_id=" + classId;
+    },
 
     //
     // Projects

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -338,6 +338,7 @@ RailsPortal::Application.routes.draw do
             get :get_enews_subscription
             post :update_enews_subscription
             get :get_teacher_project_views
+            get :classes
           end
         end
         resources :students do
@@ -491,7 +492,8 @@ RailsPortal::Application.routes.draw do
 
         resources :permission_forms, only: [:index, :create, :update, :destroy] do
           collection do
-            post :search_teachers
+            get :search_teachers
+            get :class_permission_forms
           end
         end
       end

--- a/rails/react-components/src/library/components/permission-forms-v2/index.scss
+++ b/rails/react-components/src/library/components/permission-forms-v2/index.scss
@@ -25,7 +25,7 @@
     border-top: 1px solid #aaa;
   }
 
-  input {
+  input[type="text"] {
     height: 40px;
     font-family: $font-museo-sans !important;
     padding-left: 12px;
@@ -55,13 +55,6 @@
     td, th {
       height: 44px;
       padding: 0;
-
-      &:first-child {
-        padding-left: 5px;
-      }
-      &:last-child {
-        padding-right: 5px;
-      }
     }
   }
 }

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/classes-table.scss
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/classes-table.scss
@@ -4,7 +4,11 @@ table.classesTable {
   margin-top: 0 !important;
   border-top: 1px solid gray;
 
-  tr {
+  & > thead > tr, & > tbody > tr {
     background-color: transparent;
+  }
+
+  .activeRow {
+    font-weight: 500;
   }
 }

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/classes-table.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/classes-table.tsx
@@ -37,8 +37,8 @@ export const ClassesTable = ({ teacherId, currentSelectedProject }: IProps) => {
           classesData.map((classInfo) => {
             const active = selectedClassId === classInfo.id;
             return (
-              <>
-                <tr key={classInfo.id} className={clsx({ [css.activeRow]: active })}>
+              <React.Fragment key={classInfo.id}>
+                <tr className={clsx({ [css.activeRow]: active })}>
                   <td>{ classInfo.name }</td>
                   <td>{ classInfo.class_word }</td>
                   <td>
@@ -60,7 +60,7 @@ export const ClassesTable = ({ teacherId, currentSelectedProject }: IProps) => {
                     </td>
                   </tr>
                 }
-              </>
+              </React.Fragment>
             );
           })
         }

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/classes-table.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/classes-table.tsx
@@ -1,5 +1,9 @@
-import React from "react";
-import { CurrentSelectedProject } from "./types";
+import React, { useState } from "react";
+import clsx from "clsx";
+import { useFetch } from "../../../hooks/use-fetch";
+import { LinkButton } from "../common/link-button";
+import { StudentsTable } from "./students-table";
+import { CurrentSelectedProject, IClassBasicInfo } from "./types";
 
 import css from "./classes-table.scss";
 
@@ -8,14 +12,59 @@ interface IProps {
   currentSelectedProject: CurrentSelectedProject;
 }
 
-export const ClassesTable = ({ teacherId }: IProps) => {
+export const ClassesTable = ({ teacherId, currentSelectedProject }: IProps) => {
+  const { data: classesData, isLoading } = useFetch<IClassBasicInfo[]>(Portal.API_V1.teacherClasses(teacherId), []);
+  const [selectedClassId, setSelectedClassId] = useState<string | null>(null);
+
+  if (isLoading) {
+    return (<div>Loading...</div>);
+  }
+  if (!classesData.length) {
+    return (<div>No classes found</div>);
+  }
+
+  const handleViewStudentsClick = (classId: string) => {
+    setSelectedClassId((prevSelectedClass: string | null) => prevSelectedClass === classId ? null : classId);
+  };
+
   return (
     <table className={css.classesTable}>
       <thead>
         <tr><th>Class Name</th><th>Class Word</th><th></th></tr>
       </thead>
       <tbody>
+        {
+          classesData.map((classInfo) => {
+            const active = selectedClassId === classInfo.id;
+            return (
+              <>
+                <tr key={classInfo.id} className={clsx({ [css.activeRow]: active })}>
+                  <td>{ classInfo.name }</td>
+                  <td>{ classInfo.class_word }</td>
+                  <td>
+                    <LinkButton onClick={() => handleViewStudentsClick(classInfo.id)} active={active}>
+                      {
+                        active ? "Hide Students" : "View Students"
+                      }
+                      {
+                        active ? <i className="icon-caret-up" /> : <i className="icon-caret-down" />
+                      }
+                    </LinkButton>
+                  </td>
+                </tr>
+                {
+                  active &&
+                  <tr>
+                    <td colSpan={3}>
+                      <StudentsTable classId={classInfo.id} currentSelectedProject={currentSelectedProject} />
+                    </td>
+                  </tr>
+                }
+              </>
+            );
+          })
+        }
       </tbody>
     </table>
   );
-}
+};

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-tab.scss
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-tab.scss
@@ -53,10 +53,25 @@
     }
   }
 
-  tr.expanded:nth-child(odd) {
-    background-color: #f1f1f1;
-  }
-  tr.expanded:nth-child(even) {
-    background-color: transparent;
+  .teachersTable {
+    & > tbody > tr > td {
+      &:first-child {
+        padding-left: 5px;
+      }
+      &:last-child {
+        padding-right: 5px;
+      }
+    }
+
+    .activeRow {
+      font-weight: 500;
+    }
+
+    tr.expanded:nth-child(odd) {
+      background-color: #f1f1f1;
+    }
+    tr.expanded:nth-child(even) {
+      background-color: transparent;
+    }
   }
 }

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-tab.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-tab.tsx
@@ -72,7 +72,7 @@ export default function StudentsTab() {
               teachers.map(teacher => {
                 const active = selectedTeacherId === teacher.id;
                 return (
-                  <>
+                  <React.Fragment key={teacher.id}>
                     <tr className={clsx({ [css.activeRow]: active })}>
                       <td>{ teacher.name }</td>
                       <td>{ teacher.email }</td>
@@ -96,7 +96,7 @@ export default function StudentsTab() {
                         </td>
                       </tr>
                     }
-                  </>
+                  </React.Fragment>
                 );
               })
             }

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-tab.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-tab.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import clsx from "clsx";
 import { useFetch } from "../../../hooks/use-fetch";
 import { IProject, CurrentSelectedProject, ITeacher } from "./types";
 import { ProjectSelect } from "../common/project-select";
@@ -10,17 +11,16 @@ import css from "./students-tab.scss";
 
 const searchTeachers = async (name: string) =>
   request({
-    url: Portal.API_V1.PERMISSION_FORMS_SEARCH_TEACHER,
-    method: "POST",
-    body: JSON.stringify({ name })
+    url: Portal.API_V1.permissionFormsSearchTeacher(name),
+    method: "GET"
   });
 
 export default function StudentsTab() {
   // Fetch projects (with refetch function) on initial load
   const { data: projectsData } = useFetch<IProject[]>(Portal.API_V1.PROJECTS_WITH_PERMISSIONS, []);
-  const [ teachers, setTeachers ] = useState<ITeacher[]>([]);
-  const [ selectedTeacherId, setSelectedTeacherId ] = useState<string | null>(null);
-  const[ teacherName, setTeacherName ] = useState<string>("");
+  const [teachers, setTeachers] = useState<ITeacher[]>([]);
+  const [selectedTeacherId, setSelectedTeacherId] = useState<string | null>(null);
+  const[teacherName, setTeacherName] = useState<string>("");
 
   // State for UI
   const [currentSelectedProject, setCurrentSelectedProject] = useState<number | "">("");
@@ -69,33 +69,36 @@ export default function StudentsTab() {
           </thead>
           <tbody>
             {
-              teachers.map(teacher => (
-                <>
-                  <tr>
-                    <td>{teacher.name}</td>
-                    <td>{teacher.email}</td>
-                    <td>{teacher.login}</td>
-                    <td>
-                      <LinkButton onClick={() => handleViewClassesClick(teacher.id)} active={selectedTeacherId === teacher.id}>
-                        {
-                          selectedTeacherId === teacher.id ? "Hide Classes" : "View Classes"
-                        }
-                        {
-                          selectedTeacherId === teacher.id ? <i className="icon-caret-up" /> : <i className="icon-caret-down" />
-                        }
-                      </LinkButton>
-                    </td>
-                  </tr>
-                  {
-                    selectedTeacherId === teacher.id &&
-                    <tr className={css.expanded}>
-                      <td colSpan={4}>
-                        <ClassesTable teacherId={teacher.id} currentSelectedProject={currentSelectedProject} />
+              teachers.map(teacher => {
+                const active = selectedTeacherId === teacher.id;
+                return (
+                  <>
+                    <tr className={clsx({ [css.activeRow]: active })}>
+                      <td>{ teacher.name }</td>
+                      <td>{ teacher.email }</td>
+                      <td>{ teacher.login }</td>
+                      <td>
+                        <LinkButton onClick={() => handleViewClassesClick(teacher.id)} active={active}>
+                          {
+                            active ? "Hide Classes" : "View Classes"
+                          }
+                          {
+                            active ? <i className="icon-caret-up" /> : <i className="icon-caret-down" />
+                          }
+                        </LinkButton>
                       </td>
                     </tr>
-                  }
-                </>
-              ))
+                    {
+                      active &&
+                      <tr className={css.expanded}>
+                        <td colSpan={4}>
+                          <ClassesTable teacherId={teacher.id} currentSelectedProject={currentSelectedProject} />
+                        </td>
+                      </tr>
+                    }
+                  </>
+                );
+              })
             }
           </tbody>
         </table>

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.scss
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.scss
@@ -1,0 +1,45 @@
+@import "../../../../shared/styles/variables/variables";
+
+table.studentsTable {
+  margin-top: 0 !important;
+
+  & > thead > tr > th {
+    background-color: #f8ac1a;
+  }
+
+  & > tbody > tr {
+    background-color: white;
+    &:nth-child(even) {
+      background-color: #fbf4db;
+    }
+  }
+
+  & > tbody > tr > td, & > thead > tr > th {
+    &:first-child {
+      padding-left: 5px;
+    }
+    &:last-child {
+      padding-right: 5px;
+    }
+  }
+
+  input[type="checkbox"] {
+    vertical-align: middle;
+    margin-left: 10px;
+    width: 22px;
+    height: 22px;
+  }
+
+  .basicButton {
+    display: inline-block;
+    color: $col-link;
+    background-color: transparent;
+    border: transparent;
+    text-transform: uppercase;
+    font-weight: 300;
+
+    &:hover {
+      color: $col-gold;
+    }
+  }
+}

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { useFetch } from "../../../hooks/use-fetch";
+import { CurrentSelectedProject, IStudent } from "./types";
+
+import css from "./students-table.scss";
+
+interface IProps {
+  classId: string;
+  currentSelectedProject: CurrentSelectedProject;
+}
+
+export const StudentsTable = ({ classId }: IProps) => {
+  const { data: permissionFormsData, isLoading } = useFetch<IStudent[]>(Portal.API_V1.permissionFormsClassPermissionForms(classId), []);
+
+  if (isLoading) {
+    return (<div>Loading...</div>);
+  }
+  if (!permissionFormsData.length) {
+    return (<div>No students found</div>);
+  }
+
+  return (
+    <table className={css.studentsTable}>
+      <thead>
+        <tr><th><input type="checkbox" /></th><th>Student Name</th><th>Username</th><th>Permission Forms</th><th></th></tr>
+      </thead>
+      <tbody>
+        {
+          permissionFormsData.map((studentInfo) => {
+            return (
+              <tr key={studentInfo.id}>
+                <td><input type="checkbox" /></td>
+                <td>{ studentInfo.name }</td>
+                <td>{ studentInfo.login }</td>
+                <td>{ studentInfo.permission_forms.map(pf => pf.name).join(", ") }</td>
+                <td><button className={css.basicButton}>Edit</button></td>
+              </tr>
+            );
+          })
+        }
+      </tbody>
+    </table>
+  );
+};

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/types.ts
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/types.ts
@@ -1,8 +1,23 @@
+import { IPermissionForm } from "./types";
+
 export { IPermissionForm, IProject, CurrentSelectedProject } from "../common/types";
 
-export type ITeacher = {
+export interface ITeacher {
   id: string;
   name: string;
   email: string;
   login: string;
-};
+}
+
+export interface IStudent {
+  id: string;
+  name: string;
+  login: string;
+  permission_forms: IPermissionForm[];
+}
+
+export interface IClassBasicInfo {
+  id: string;
+  name: string;
+  class_word: string;
+}

--- a/rails/spec/policies/portal/teacher_policy_spec.rb
+++ b/rails/spec/policies/portal/teacher_policy_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Portal::TeacherPolicy do
       teacher_policy = described_class.new(nil, nil)
       result = teacher_policy.show?
 
-      expect(result).to be_nil
+      expect(result).to be_falsey
     end
   end
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187612778
https://www.pivotaltracker.com/story/show/187595842

This PR adds tables for classes and students, + all the related APIs and policies.

I have added a new endpoint to the Teacher API, as a simple list of classes seemed straightforward and generally useful. However, an API to obtain a list of class students along with their permission forms ended up in the Permission Forms API instead of the Class API. In fact, the Class API already has an endpoint that renders most of the necessary information, but it provides more than we need and does not actually include the list of permission forms. So, I thought it would not make sense to return permission forms in every context and that it would be better to have more page-oriented APIs that handle tasks efficiently. I believe this will also be easier to maintain in the long term.

I also updated policies related to permission forms to allow only admin and project admin, but this might change in the future: https://concord-consortium.slack.com/archives/C0M5CM1RA/p1718911188565409