### PR TITLE
Permission Forms: add missing features to students table and add bulk edit UI 

### DIFF
--- a/rails/react-components/src/library/components/permission-forms-v2/index.scss
+++ b/rails/react-components/src/library/components/permission-forms-v2/index.scss
@@ -1,6 +1,8 @@
 @import "../../../shared/styles/variables/variables";
 
 .permissionForms {
+  margin-bottom: 200px; // for dropdown menu
+
   .tabArea {
     .tabs {
       display:flex;

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.scss
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.scss
@@ -3,7 +3,7 @@
 table.studentsTable {
   margin-top: 0 !important;
 
-  & > thead > tr > th {
+  & > thead > tr > th, & > tfoot > tr {
     background-color: #f8ac1a;
   }
 
@@ -24,8 +24,8 @@ table.studentsTable {
   }
 
   input[type="checkbox"] {
+    margin-left: 5px;
     vertical-align: middle;
-    margin-left: 10px;
     width: 22px;
     height: 22px;
   }
@@ -40,6 +40,49 @@ table.studentsTable {
 
     &:hover {
       color: $col-gold;
+    }
+  }
+
+  .tableFooter {
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+
+    .summary {
+      font-weight: bold;
+      margin-bottom: 9px;
+    }
+
+    .permissionFormSelects {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 5px;
+
+      .selectContainer {
+        display: flex;
+        align-items: center;
+
+        .permissionFormSelect {
+          margin-left: 10px;
+          width: 340px;
+
+          input[type="text"] {
+            height: auto;
+          }
+        }
+      }
+    }
+
+    .saveChangesButton {
+      margin-top: 10px;
+      background-color: $col-blue;
+      border-color: $col-blue;
+
+      &:hover {
+        background-color: $col-lightblue;
+        border-color: $col-lightblue;
+      }
     }
   }
 }

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useState } from "react";
+import Select from "react-select";
 import { useFetch } from "../../../hooks/use-fetch";
-import { CurrentSelectedProject, IStudent } from "./types";
+import { CurrentSelectedProject, IPermissionForm, IStudent } from "./types";
 
 import css from "./students-table.scss";
 
@@ -9,27 +10,90 @@ interface IProps {
   currentSelectedProject: CurrentSelectedProject;
 }
 
-export const StudentsTable = ({ classId }: IProps) => {
-  const { data: permissionFormsData, isLoading } = useFetch<IStudent[]>(Portal.API_V1.permissionFormsClassPermissionForms(classId), []);
+type PermissionFormOption = {
+  value: string;
+  label: string;
+};
 
-  if (isLoading) {
+export const StudentsTable = ({ classId }: IProps) => {
+  const { data: studentsData, isLoading: studentsLoading } = useFetch<IStudent[]>(Portal.API_V1.permissionFormsClassPermissionForms(classId), []);
+  const { data: permissionForms, isLoading: permissionFormsLoading } = useFetch<IPermissionForm[]>(Portal.API_V1.PERMISSION_FORMS, []);
+  const [isStudentSelected, setIsStudentSelected] = useState<Record<string, boolean>>({});
+  const [permissionFormsToAdd, setPermissionFormsToAdd] = useState<readonly PermissionFormOption[]>([]);
+  const [permissionFormsToRemove, setPermissionFormsToRemove] = useState<readonly PermissionFormOption[]>([]);
+
+  // When preparing the options for the Select component, we need to filter out the permission forms that are already
+  // selected to add or remove in the opposite dropdown. Both permissionFormsToAdd and permissionFormsToRemove need
+  // to be mutually exclusive.
+  const permissionFormToAddOptions = Object.freeze(
+    permissionForms.filter(pf => !permissionFormsToRemove.find(pfr => pfr.value === pf.id)).map(pf => ({ value: pf.id, label: pf.name }))
+  );
+
+  const permissionFormToRemoveOptions = Object.freeze(
+    permissionForms.filter(pf => !permissionFormsToAdd.find(pfr => pfr.value === pf.id)).map(pf => ({ value: pf.id, label: pf.name }))
+  );
+
+  if (studentsLoading) {
     return (<div>Loading...</div>);
   }
-  if (!permissionFormsData.length) {
+  if (!studentsData.length) {
     return (<div>No students found</div>);
   }
+
+  const handleStudentSelectedToggle = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const studentId = e.target.name;
+    if (e.target.checked) {
+      setIsStudentSelected(prevIsStudentSelected => ({ ...prevIsStudentSelected, [studentId]: true }));
+    } else {
+      setIsStudentSelected(prevIsStudentSelected => {
+        const { [studentId]: _, ...rest } = prevIsStudentSelected;
+        return rest;
+      });
+    }
+  };
+
+  const handleSelectAllChange = () => {
+    setIsStudentSelected(prevIsStudentSelected => {
+      const _allStudentsSelected = Object.keys(prevIsStudentSelected).length === studentsData.length;
+      if (_allStudentsSelected) {
+        return {};
+      }
+      const result: Record<string, boolean> = {};
+      studentsData.forEach(student => {
+        result[student.id] = true;
+      });
+      return result;
+    });
+  };
+
+  const handlePermissionFormToAddSelectChange = (selectedOptions: readonly PermissionFormOption[]) => {
+    setPermissionFormsToAdd(selectedOptions);
+  };
+
+  const handlePermissionFormToRemoveSelectChange = (selectedOptions: readonly PermissionFormOption[]) => {
+    setPermissionFormsToRemove(selectedOptions);
+  };
+
+  const selectedStudentsCount = Object.keys(isStudentSelected).length;
+  const allStudentsSelected = Object.keys(isStudentSelected).length === studentsData.length;
 
   return (
     <table className={css.studentsTable}>
       <thead>
-        <tr><th><input type="checkbox" /></th><th>Student Name</th><th>Username</th><th>Permission Forms</th><th></th></tr>
+        <tr>
+          <th><input type="checkbox" checked={allStudentsSelected} onChange={handleSelectAllChange} /></th>
+          <th>Student Name</th>
+          <th>Username</th>
+          <th>Permission Forms</th>
+          <th></th>
+        </tr>
       </thead>
       <tbody>
         {
-          permissionFormsData.map((studentInfo) => {
+          studentsData.map((studentInfo) => {
             return (
               <tr key={studentInfo.id}>
-                <td><input type="checkbox" /></td>
+                <td><input type="checkbox" name={studentInfo.id} checked={isStudentSelected[studentInfo.id] ?? false} onChange={handleStudentSelectedToggle} /></td>
                 <td>{ studentInfo.name }</td>
                 <td>{ studentInfo.login }</td>
                 <td>{ studentInfo.permission_forms.map(pf => pf.name).join(", ") }</td>
@@ -39,6 +103,48 @@ export const StudentsTable = ({ classId }: IProps) => {
           })
         }
       </tbody>
+      <tfoot>
+        <tr>
+          <td colSpan={5}>
+            <div className={css.tableFooter}>
+              <div className={css.summary}>
+                { selectedStudentsCount } selected { selectedStudentsCount === 1 ? "student" : "students" }
+              </div>
+              <div className={css.permissionFormSelects}>
+                <div className={css.selectContainer}>
+                  Add:
+                  <Select<PermissionFormOption, true>
+                    className={css.permissionFormSelect}
+                    // TODO: temporarily ignoring typing issue that I cannot understand
+                    options={permissionFormToAddOptions}
+                    isMulti={true}
+                    placeholder="Select permission form(s)..."
+                    isLoading={permissionFormsLoading}
+                    value={permissionFormsToAdd}
+                    onChange={handlePermissionFormToAddSelectChange}
+                  />
+                </div>
+                <div className={css.selectContainer}>
+                  Remove:
+                  <Select<PermissionFormOption, true>
+                    className={css.permissionFormSelect}
+                    // TODO: temporarily ignoring typing issue that I cannot understand
+                    options={permissionFormToRemoveOptions}
+                    isMulti={true}
+                    placeholder="Select permission form(s)..."
+                    isLoading={permissionFormsLoading}
+                    value={permissionFormsToRemove}
+                    onChange={handlePermissionFormToRemoveSelectChange}
+                  />
+                </div>
+              </div>
+              <div>
+                <button className={css.saveChangesButton}>Save Changes</button>
+              </div>
+            </div>
+          </td>
+        </tr>
+      </tfoot>
     </table>
   );
 };

--- a/rails/react-components/src/library/components/signup/basic_data_form.tsx
+++ b/rails/react-components/src/library/components/signup/basic_data_form.tsx
@@ -26,7 +26,7 @@ export default class BasicDataForm extends React.Component<any, any> {
     this.passwordMatchValidator = this.passwordMatchValidator.bind(this);
   }
 
-  passwordMatchValidator({password, password_confirmation}: {password: string, password_confirmation: string}) {
+  passwordMatchValidator({ password, password_confirmation }: {password: string, password_confirmation: string}) {
     if ((password?.length > 0) && (password_confirmation?.length > 0) && (password !== password_confirmation)) {
       return false;
     }
@@ -99,7 +99,7 @@ export default class BasicDataForm extends React.Component<any, any> {
               <dt>Password</dt>
               <dd><TextInput name="password" placeholder="" type="password" required validations={`minLength:${MIN_PASSWORD_LENGTH}`} validationError={PASS_TOO_SHORT} /></dd>
               <dt>Confirm Password</dt>
-              <dd><TextInput name="password_confirmation" placeholder="" type="password" required validations={{passwordMatchValidator: this.passwordMatchValidator}} validationError={PASS_NOT_MATCH} /></dd>
+              <dd><TextInput name="password_confirmation" placeholder="" type="password" required validations={{ passwordMatchValidator: this.passwordMatchValidator }} validationError={PASS_NOT_MATCH} /></dd>
             </dl>
           </div>
         }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187612778
https://www.pivotaltracker.com/story/show/187613422

This PR adds missing features to the Students Table: functioning checkboxes including toggle all, summary, permission forms dropdowns (that have mutually exclusive options), Save Changes button, etc. This is also the start of the bulk edit work - UI is pretty functional I think, but API is missing.

@dougmartin, if this won't require any changes, could you click the Merge button and update Portal Staging when you have a chance? There's no rush, but probably I could cleanup status of a few PT stories before Monday standup and new Portal role planning. Thanks.