### PR TITLE
Permission Forms: fix dropdown rendering, support long permission form names

### DIFF
--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/classes-table.scss
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/classes-table.scss
@@ -11,4 +11,9 @@ table.classesTable {
   .activeRow {
     font-weight: 500;
   }
+
+  .studentsTableRow {
+    // Necessary for dropdown to work correctly.
+    overflow: visible;
+  }
 }

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/classes-table.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/classes-table.tsx
@@ -55,7 +55,7 @@ export const ClassesTable = ({ teacherId, currentSelectedProject }: IProps) => {
                 {
                   active &&
                   <tr>
-                    <td colSpan={3}>
+                    <td colSpan={3} className={css.studentsTableRow}>
                       <StudentsTable classId={classInfo.id} currentSelectedProject={currentSelectedProject} />
                     </td>
                   </tr>

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-tab.scss
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-tab.scss
@@ -70,6 +70,11 @@
       font-weight: 500;
     }
 
+    .classesTableRow {
+      // Necessary for dropdown to work correctly.
+      overflow: visible;
+    }
+
     .rowWithBackground {
       background-color: #f1f1f1;
     }

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-tab.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-tab.tsx
@@ -98,7 +98,7 @@ export default function StudentsTab() {
                     {
                       active &&
                       <tr className={clsx({ [css.rowWithBackground]: background })}>
-                        <td colSpan={4}>
+                        <td colSpan={4} className={css.classesTableRow}>
                           <ClassesTable teacherId={teacher.id} currentSelectedProject={currentSelectedProject} />
                         </td>
                       </tr>

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.scss
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.scss
@@ -14,6 +14,16 @@ table.studentsTable {
     }
   }
 
+  & > tfoot > tr > td {
+    // Necessary for dropdown to work correctly.
+    overflow: visible;
+  }
+
+  .permissionFormSelectOption {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
   .checkboxColumn {
     width: 35px;
   }

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.tsx
@@ -119,8 +119,10 @@ export const StudentsTable = ({ classId }: IProps) => {
                 <div className={css.selectContainer}>
                   Add:
                   <Select<PermissionFormOption, true>
+                    classNames={{
+                      option: () => css.permissionFormSelectOption
+                    }}
                     className={css.permissionFormSelect}
-                    // TODO: temporarily ignoring typing issue that I cannot understand
                     options={permissionFormToAddOptions}
                     isMulti={true}
                     placeholder="Select permission form(s)..."
@@ -132,8 +134,10 @@ export const StudentsTable = ({ classId }: IProps) => {
                 <div className={css.selectContainer}>
                   Remove:
                   <Select<PermissionFormOption, true>
+                    classNames={{
+                      option: () => css.permissionFormSelectOption
+                    }}
                     className={css.permissionFormSelect}
-                    // TODO: temporarily ignoring typing issue that I cannot understand
                     options={permissionFormToRemoveOptions}
                     isMulti={true}
                     placeholder="Select permission form(s)..."


### PR DESCRIPTION
Recent updates slightly broke dropdown rendering, so I had to set overflow to visible in a few rows explicitly.
Also, I've added some custom styling of the dropdown options to support long permission form names.