### PR TITLE
Permission Forms: implement bulk_update API and update UI to use it 

### DIFF
--- a/rails/app/views/dynamic_scripts/_api_paths.html.haml
+++ b/rails/app/views/dynamic_scripts/_api_paths.html.haml
@@ -111,6 +111,7 @@
     permissionFormsClassPermissionForms(classId) {
       return this.PERMISSION_FORMS_CLASS_PERMISSION_FORMS + "?class_id=" + classId;
     },
+    PERMISSION_FORMS_BULK_UPDATE: "#{bulk_update_api_v1_permission_forms_path}",
 
     //
     // Projects

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -494,6 +494,7 @@ RailsPortal::Application.routes.draw do
           collection do
             get :search_teachers
             get :class_permission_forms
+            post :bulk_update
           end
         end
       end

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.scss
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.scss
@@ -93,11 +93,21 @@ table.studentsTable {
       margin-top: 10px;
       background-color: $col-blue;
       border-color: $col-blue;
+      display: inline-block;
 
       &:hover {
         background-color: $col-lightblue;
         border-color: $col-lightblue;
       }
+
+      &:disabled {
+        pointer-events: none;
+        filter: grayscale(1);
+      }
+    }
+
+    .updateInProgress {
+      margin-left: 10px;
     }
   }
 }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187613422

This PR adds the bulk_update API used by the bulk update UI. 
I believe the main challenge is to correctly check authorization (for each student and permission form) and ensure that a project admin or researcher cannot access permission forms from another project, as one student can theoretically have multiple permission forms. I'll add tests in a subsequent PR but am opening this earlier so that @bacalj can merge it into his branch.

@bacalj, this applies to your single-student edit modal as well. That's why I think it's worth reusing this API. You cannot simply overwrite a student's permission forms with whatever selection the user made in the edit modal, as the user might have limited access and might not even see many other permission forms. So, checked and unchecked forms should act as lists of forms to add and remove.

@dougmartin, now that Joe is back, I'm not sure if I should keep tagging you for reviews. Maybe there's some value in staying up-to-date with this work since you started (or had to start) reviewing it, but I can probably save you from this.