### PR TITLE
Add a new role attribute `can_manage_permission_forms` and use it in all relevant places

### DIFF
--- a/rails/app/controllers/admin/permission_forms_v2_controller.rb
+++ b/rails/app/controllers/admin/permission_forms_v2_controller.rb
@@ -5,6 +5,6 @@ class Admin::PermissionFormsV2Controller < ApplicationController
   end
 
   def index
-    authorize Portal::PermissionForm
+    authorize Portal::PermissionForm, :permission_forms_v2_index?
   end
 end

--- a/rails/app/controllers/api/v1/permission_forms_controller.rb
+++ b/rails/app/controllers/api/v1/permission_forms_controller.rb
@@ -33,6 +33,15 @@ class API::V1::PermissionFormsController < API::APIController
     render :json => { :message => "Permission form deleted" }
   end
 
+  def projects
+    authorize Portal::PermissionForm
+    projects = policy_scope(Admin::Project)
+    filtered_projects = projects.select do |project|
+      current_user.can_manage_permission_forms?(project)
+    end
+    render json: filtered_projects
+  end
+
   def search_teachers
     authorize Portal::PermissionForm
 

--- a/rails/app/controllers/api/v1/permission_forms_controller.rb
+++ b/rails/app/controllers/api/v1/permission_forms_controller.rb
@@ -2,34 +2,35 @@ class API::V1::PermissionFormsController < API::APIController
 
   # GET /api/v1/permission_forms/index
   def index
-    @permission_forms = policy_scope(Portal::PermissionForm)
-    render :json => @permission_forms
+    authorize Portal::PermissionForm, :permission_forms_v2_index?
+    permission_forms = managment_policy_scope(Portal::PermissionForm)
+    render :json => permission_forms
   end
 
   def create
     authorize Portal::PermissionForm
-    @permission_form = Portal::PermissionForm.new(permission_form_params)
-    if @permission_form.save
-      render :json => @permission_form
+    permission_form = Portal::PermissionForm.new(permission_form_params)
+    if permission_form.save
+      render :json => permission_form
     else
-      render :json => { :errors => @permission_form.errors }, :status => 422
+      render :json => { :errors => permission_form.errors }, :status => 422
     end
   end
 
   def update
-    @permission_form = Portal::PermissionForm.find(params[:id])
-    authorize @permission_form
-    if @permission_form.update(permission_form_params)
-      render :json => @permission_form
+    permission_form = Portal::PermissionForm.find(params[:id])
+    authorize permission_form
+    if permission_form.update(permission_form_params)
+      render :json => permission_form
     else
-      render :json => { :errors => @permission_form.errors }, :status => 422
+      render :json => { :errors => permission_form.errors }, :status => 422
     end
   end
 
   def destroy
-    @permission_form = Portal::PermissionForm.find(params[:id])
-    authorize @permission_form
-    @permission_form.destroy
+    permission_form = Portal::PermissionForm.find(params[:id])
+    authorize permission_form
+    permission_form.destroy
     render :json => { :message => "Permission form deleted" }
   end
 
@@ -80,7 +81,7 @@ class API::V1::PermissionFormsController < API::APIController
         id: student.id,
         name: student.user.name,
         login: student.user.login,
-        permission_forms: policy_scope(student.permission_forms).select(:id, :name, :is_archived).map do |form|
+        permission_forms: managment_policy_scope(student.permission_forms).select(:id, :name, :is_archived).map do |form|
           {
             id: form.id,
             name: form.name,
@@ -149,6 +150,18 @@ class API::V1::PermissionFormsController < API::APIController
   end
 
   private
+
+  # Default scope is too wide, we need extra filtering for project researchers.
+  # Pundint doesn't seem to be flexible enough to handle this, so we need to do it manually.
+  def managment_policy_scope(scope)
+    scope = policy_scope(scope)
+    if current_user.is_project_researcher?
+      researcher_project_ids = current_user._project_user_researchers.where(can_manage_permission_forms: true).pluck(:project_id)
+      scope.where(project_id: researcher_project_ids)
+    else
+      scope
+    end
+  end
 
   def permission_form_params
     params.require(:permission_form).permit(:name, :project_id, :url, :is_archived)

--- a/rails/app/controllers/api/v1/projects_controller.rb
+++ b/rails/app/controllers/api/v1/projects_controller.rb
@@ -6,13 +6,6 @@ class API::V1::ProjectsController < API::APIController
     render json: result
   end
 
-  # Returns all the projects that user has a full access to.
-  def index_with_permissions
-    projects = policy_scope(Admin::Project)
-    result = projects.map { |p| project_to_hash(p) }
-    render json: result
-  end
-
   def show
     project = Admin::Project.find(params[:id])
     authorize project, :api_show?

--- a/rails/app/controllers/users_controller.rb
+++ b/rails/app/controllers/users_controller.rb
@@ -11,7 +11,7 @@ class UsersController < ApplicationController
   public
 
   def new
-    #This method is called when a user tries to register as a member
+    # This method is called when a user tries to register as a member
     @user = User.new
   end
 
@@ -63,6 +63,7 @@ class UsersController < ApplicationController
       format.xml  { render :xml => @user }
     end
   end
+
   # GET /users/1/edit
   def edit
     @user = User.find(params[:id])
@@ -134,11 +135,8 @@ class UsersController < ApplicationController
 
   def update
     if params[:commit] == "Cancel"
-
       redirect_to view_context.class_link_for_user
-
     else
-
       @user = User.find(params[:id])
       authorize @user
       respond_to do |format|
@@ -162,13 +160,15 @@ class UsersController < ApplicationController
             if params[:user][:has_projects_in_form]
               all_projects = Admin::Project.all
               expiration_dates = params[:user][:project_expiration_dates] || {}
+              can_manage_permission_forms = params[:user][:project_can_manage_permission_forms] || {}
               @user.set_role_for_projects('admin', all_projects, params[:user][:admin_project_ids] || [], expiration_dates)
-              @user.set_role_for_projects('researcher', all_projects, params[:user][:researcher_project_ids] || [], expiration_dates)
+              @user.set_role_for_projects('researcher', all_projects, params[:user][:researcher_project_ids] || [], expiration_dates, can_manage_permission_forms)
             end
           elsif current_visitor.is_project_admin?
             if params[:user][:has_projects_in_form]
               expiration_dates = params[:user][:project_expiration_dates] || {}
-              @user.set_role_for_projects('researcher', current_visitor.admin_for_projects, params[:user][:researcher_project_ids] || [], expiration_dates)
+              can_manage_permission_forms = params[:user][:project_can_manage_permission_forms] || {}
+              @user.set_role_for_projects('researcher', current_visitor.admin_for_projects, params[:user][:researcher_project_ids] || [], expiration_dates, can_manage_permission_forms)
             end
           end
 
@@ -221,7 +221,7 @@ class UsersController < ApplicationController
     render :plain => "#{params[:username]} logged in"
   end
 
-  #Used for activation of users by a manager/admin
+  # Used for activation of users by a manager/admin
   def confirm
     user = User.find(params[:id])
     authorize user
@@ -258,7 +258,8 @@ class UsersController < ApplicationController
       respond_to do |format|
         if params[:user][:has_projects_in_form]
           expiration_dates = params[:user][:project_expiration_dates] || {}
-          @user.set_role_for_projects('researcher', current_visitor.admin_for_projects, params[:user][:researcher_project_ids] || [], expiration_dates)
+          can_manage_permission_forms = params[:user][:project_can_manage_permission_forms] || {}
+          @user.set_role_for_projects('researcher', current_visitor.admin_for_projects, params[:user][:researcher_project_ids] || [], expiration_dates, can_manage_permission_forms)
         end
         if @user.portal_teacher && params[:user][:has_cohorts_in_form] && policy(@current_user).add_teachers_to_cohorts?
           @user.portal_teacher.set_cohorts_by_id(params[:user][:cohort_ids] || [])

--- a/rails/app/policies/portal/permission_form_policy.rb
+++ b/rails/app/policies/portal/permission_form_policy.rb
@@ -12,11 +12,8 @@ class Portal::PermissionFormPolicy < ApplicationPolicy
           params[:admin_project_ids] = user.admin_for_projects.map { |p| p.id }
         end
         if user.is_project_researcher?
-          researcher_project_ids = user.researcher_for_projects.select do |project|
-            user.is_project_researcher?(project, check_can_manage_permission_forms: true)
-          end.map(&:id)
           where << "(project_id in (:researcher_project_ids))"
-          params[:researcher_project_ids] = researcher_project_ids
+          params[:researcher_project_ids] = user.researcher_for_projects.map { |p| p.id }
         end
         scope.where([where.join(" OR "), params])
       else

--- a/rails/app/policies/portal/permission_form_policy.rb
+++ b/rails/app/policies/portal/permission_form_policy.rb
@@ -26,7 +26,7 @@ class Portal::PermissionFormPolicy < ApplicationPolicy
   end
 
   def index?
-    user && user.can_manage_permission_forms?
+    manager_or_researcher_or_project_researcher?
   end
 
   def external_report_query?
@@ -46,6 +46,10 @@ class Portal::PermissionFormPolicy < ApplicationPolicy
   end
 
   # API::V1::PermissionFormsController:
+
+  def permission_forms_v2_index?
+    user && user.can_manage_permission_forms?
+  end
 
   def projects?
     user && user.can_manage_permission_forms?

--- a/rails/app/views/dynamic_scripts/_api_paths.html.haml
+++ b/rails/app/views/dynamic_scripts/_api_paths.html.haml
@@ -103,6 +103,7 @@
     // Permission Forms
     //
     PERMISSION_FORMS: "#{api_v1_permission_forms_path}",
+    PERMISSION_FORMS_PROJECTS: "#{projects_api_v1_permission_forms_path}",
     PERMISSION_FORMS_SEARCH_TEACHER: "#{search_teachers_api_v1_permission_forms_path}",
     permissionFormsSearchTeacher(name) {
       return this.PERMISSION_FORMS_SEARCH_TEACHER + "?name=" + name;
@@ -117,7 +118,6 @@
     // Projects
     //
     PROJECTS: "#{api_v1_projects_path}",
-    PROJECTS_WITH_PERMISSIONS: "#{index_with_permissions_api_v1_projects_path}",
 
     // Navigation
     // NavigationHelper#get_navigation_json  see app/helpers/navigation_helper.rb

--- a/rails/app/views/home/admin.html.haml
+++ b/rails/app/views/home/admin.html.haml
@@ -33,18 +33,21 @@
         %li= link_to 'Users', users_path
 
   %div{ class: 'admin-links-cols__column' }
-    %h3
-      Project Admin & Authoring Links
-    %ul
-      - if current_visitor.has_role?('admin', 'manager', 'researcher', 'author')
-        %li.trail=link_to('Authoring', authoring_path)
-      - if is_admin_or_project_admin_or_project_researcher
-        %li= link_to 'Permission Forms', admin_permission_forms_path
-        %li= link_to 'Permission Forms V2 (DEV ONLY)', admin_permission_forms_v2_index_path
-      - if is_admin_or_project_admin
-        %li= link_to 'Projects', admin_projects_path
-        %li= link_to 'Materials Collections', materials_collections_path
-        %li= link_to 'Users', users_path
+    - # if user can't even manage permission forms, don't show the section as it'd be empty
+    - can_manage_permission_forms = current_visitor.can_manage_permission_forms?
+    - if can_manage_permission_forms
+      %h3
+        Project Admin & Authoring Links
+      %ul
+        - if current_visitor.has_role?('admin', 'manager', 'researcher', 'author')
+          %li.trail=link_to('Authoring', authoring_path)
+        - if can_manage_permission_forms
+          %li= link_to 'Permission Forms', admin_permission_forms_path
+          %li= link_to 'Permission Forms V2 (DEV ONLY)', admin_permission_forms_v2_index_path
+        - if is_admin_or_project_admin
+          %li= link_to 'Projects', admin_projects_path
+          %li= link_to 'Materials Collections', materials_collections_path
+          %li= link_to 'Users', users_path
 
     - if current_visitor.has_role?('admin', 'manager','researcher') || current_visitor.is_project_admin? || current_visitor.is_project_researcher?
       %h3 Researcher Reports

--- a/rails/app/views/users/_researcher_for_projects.html.haml
+++ b/rails/app/views/users/_researcher_for_projects.html.haml
@@ -7,6 +7,7 @@
     - projects.each_with_index do |project, i|
       - checkbox_id = "project-#{i}-researcher"
       - expiration_date = @user.expiration_date_for_project(project)
+      - can_manage_permission_forms = @user.can_manage_permission_forms?(project, allow_expired: true)
       - is_researcher = @user.researcher_for_projects_inc_expired.include?(project)
       %li
         .inline-fields
@@ -14,19 +15,27 @@
           = label_tag checkbox_id do
             = project.name
           = date_field_tag "user[project_expiration_dates][#{project.id}]", expiration_date, placeholder: 'Expiration Date', class: 'date-input', style: ('display:none;' unless is_researcher)
+          = check_box_tag "user[project_can_manage_permission_forms][#{project.id}]", "true", can_manage_permission_forms, class: 'manage-permission-forms-checkbox', style: ('display:none;' unless is_researcher)
+          = label_tag "user_project_can_manage_permission_forms_#{project.id}", "Can manage permission forms", style: ('display:none;' unless is_researcher)
 
 :javascript
   document.addEventListener("DOMContentLoaded", function() {
     document.querySelectorAll('.project-checkbox').forEach(function(checkbox) {
       checkbox.addEventListener('change', function() {
-        // Find the date input related to this checkbox. Assuming it's always the following sibling after the next (after the label).
+        // Find the date input and manage permission forms checkbox related to this checkbox.
         var dateInput = this.parentNode.querySelector('.date-input');
+        var managePermissionFormsCheckbox = this.parentNode.querySelector('.manage-permission-forms-checkbox');
+        var managePermissionFormsLabel = this.parentNode.querySelector('label[for="' + managePermissionFormsCheckbox.id + '"]');
+
         if (this.checked) {
           dateInput.style.display = 'inline-block'; // Use inline-block or block depending on your layout needs
+          managePermissionFormsCheckbox.style.display = 'inline-block';
+          managePermissionFormsLabel.style.display = 'inline-block';
         } else {
           dateInput.style.display = 'none';
+          managePermissionFormsCheckbox.style.display = 'none';
+          managePermissionFormsLabel.style.display = 'none';
         }
       });
     });
   });
-

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -323,9 +323,6 @@ RailsPortal::Application.routes.draw do
         devise_for :users
         resources :countries
         resources :projects, only: [:index, :show] do
-          collection do
-            get :index_with_permissions
-          end
         end
         resources :teachers do
           collection do
@@ -494,6 +491,7 @@ RailsPortal::Application.routes.draw do
           collection do
             get :search_teachers
             get :class_permission_forms
+            get :projects
             post :bulk_update
           end
         end

--- a/rails/db/migrate/20240627133234_add_can_manage_permission_forms_to_admin_project_users.rb
+++ b/rails/db/migrate/20240627133234_add_can_manage_permission_forms_to_admin_project_users.rb
@@ -1,0 +1,5 @@
+class AddCanManagePermissionFormsToAdminProjectUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :admin_project_users, :can_manage_permission_forms, :boolean, default: false, null: false
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_06_13_164923) do
+ActiveRecord::Schema.define(version: 2024_06_27_133234) do
 
   create_table "access_grants", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "code"
@@ -85,6 +85,7 @@ ActiveRecord::Schema.define(version: 2024_06_13_164923) do
     t.boolean "is_admin", default: false
     t.boolean "is_researcher", default: false
     t.date "expiration_date"
+    t.boolean "can_manage_permission_forms", default: false, null: false
     t.index ["is_researcher", "expiration_date"], name: "index_project_users_on_researcher_and_expiration"
     t.index ["project_id", "user_id"], name: "admin_proj_user_uniq_idx", unique: true
     t.index ["project_id"], name: "index_admin_project_users_on_project_id"

--- a/rails/react-components/src/library/components/permission-forms-v2/manage-forms-tab/manage-forms-tab.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/manage-forms-tab/manage-forms-tab.tsx
@@ -45,7 +45,7 @@ const sortForms = (forms: IPermissionForm[]) => forms.sort((a, b) => {
 export default function ManageFormsTab() {
   // Fetch projects and permission forms (with refetch function) on initial load
   const { data: permissionsData, refetch: refetchPermissions } = useFetch<IPermissionForm[]>(Portal.API_V1.PERMISSION_FORMS, []);
-  const { data: projectsData } = useFetch<IProject[]>(Portal.API_V1.PROJECTS_WITH_PERMISSIONS, []);
+  const { data: projectsData } = useFetch<IProject[]>(Portal.API_V1.PERMISSION_FORMS_PROJECTS, []);
 
   // State for UI
   const [showCreateNewFormModal, setShowCreateNewFormModal] = useState(false);

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-tab.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-tab.tsx
@@ -17,7 +17,7 @@ const searchTeachers = async (name: string) =>
 
 export default function StudentsTab() {
   // Fetch projects (with refetch function) on initial load
-  const { data: projectsData } = useFetch<IProject[]>(Portal.API_V1.PROJECTS_WITH_PERMISSIONS, []);
+  const { data: projectsData } = useFetch<IProject[]>(Portal.API_V1.PERMISSION_FORMS_PROJECTS, []);
   // `null` means no search has been done yet, while an empty array means no results were found.
   const [teachers, setTeachers] = useState<ITeacher[] | null>(null);
   const [selectedTeacherId, setSelectedTeacherId] = useState<string | null>(null);

--- a/rails/react-components/tests/library/components/permission-forms/manage-forms-tab.test.tsx
+++ b/rails/react-components/tests/library/components/permission-forms/manage-forms-tab.test.tsx
@@ -7,7 +7,7 @@ jest.mock("../../../../src/library/hooks/use-fetch");
 
 window.Portal = {
   API_V1: {
-    PROJECTS_WITH_PERMISSIONS: "/api/v1/projects/index_with_permissions",
+    PERMISSION_FORMS_PROJECTS: "/api/v1/permission_forms/projects",
     PERMISSION_FORMS: "/api/v1/permission_forms",
   }
 };
@@ -30,7 +30,7 @@ describe("ManageFormsTab", () => {
           data: mockPermissions,
           refetch: jest.fn().mockResolvedValue({ data: mockPermissions }),
         };
-      } else if (url === window.Portal.API_V1.PROJECTS_WITH_PERMISSIONS) {
+      } else if (url === window.Portal.API_V1.PERMISSION_FORMS_PROJECTS) {
         return {
           data: mockProjects,
           refetch: jest.fn().mockResolvedValue({ data: mockProjects }),

--- a/rails/spec/controllers/admin/permission_forms_controller_spec.rb
+++ b/rails/spec/controllers/admin/permission_forms_controller_spec.rb
@@ -59,7 +59,7 @@ describe Admin::PermissionFormsController do
     describe "when user is a project researcher" do
       let(:user) do
         user = FactoryBot.create(:confirmed_user)
-        user.add_role_for_project('researcher', @project2)
+        user.add_role_for_project('researcher', @project2, can_manage_permission_forms: true)
         user
       end
 

--- a/rails/spec/controllers/api/v1/permission_forms_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/permission_forms_controller_spec.rb
@@ -193,7 +193,6 @@ RSpec.describe API::V1::PermissionFormsController, type: :controller do
       Portal::PermissionForm.create!(name: 'Test Form 2', url: 'http://example2.com', project_id: another_project.id)
       get :index
       expect(response).to have_http_status(:ok)
-      puts JSON.parse(response.body)
       expect(JSON.parse(response.body).size).to eq(1)
       expect(JSON.parse(response.body)).to match([
         hash_including('name' => 'Test Form 1', 'url' => 'http://example1.com', 'project_id' => project.id)

--- a/rails/spec/controllers/api/v1/permission_forms_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/permission_forms_controller_spec.rb
@@ -141,16 +141,66 @@ RSpec.describe API::V1::PermissionFormsController, type: :controller do
     end
   end
 
-  describe 'when user is a project researcher' do
+  describe 'when user is a project researcher without access to manage permission forms' do
     let (:project) { FactoryBot.create(:project) }
     let (:project_researcher) { FactoryBot.generate(:author_user) }
 
     before do
       sign_in project_researcher
-      project_researcher.add_role_for_project('researcher', project)
+      project_researcher.add_role_for_project('researcher', project, can_manage_permission_forms: false)
     end
 
-    it 'DELETE is now allowed' do
+    it 'GET index is not allowed' do
+      Portal::PermissionForm.create!(name: 'Test Form', url: 'http://example.com', project_id: 1)
+      get :index
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'DELETE is not allowed' do
+      permission_form = Portal::PermissionForm.create!(name: 'Test Form', url: 'http://example.com', project_id: project.id)
+      expect(Portal::PermissionForm.count).to eq(1)
+      delete :destroy, params: { id: permission_form.id }
+      expect(response).to have_http_status(:forbidden)
+      expect(Portal::PermissionForm.count).to eq(1)
+    end
+
+    it 'GET search_teachers is not allowed' do
+      teacher1 = FactoryBot.create(:teacher, user: FactoryBot.create(:user, login: 'test_teacher1'))
+      cohort = FactoryBot.create(:admin_cohort, project: project)
+      teacher1.cohorts << cohort
+
+      teacher2 = FactoryBot.create(:teacher, user: FactoryBot.create(:user, login: 'test_teacher2'))
+
+      get :search_teachers, params: { name: 'test_teacher' }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'when user is a project researcher with access to manage permission forms' do
+    let (:project) { FactoryBot.create(:project) }
+    let (:another_project) { FactoryBot.create(:project) }
+    let (:project_researcher) { FactoryBot.generate(:author_user) }
+
+    before do
+      sign_in project_researcher
+      project_researcher.add_role_for_project('researcher', project, can_manage_permission_forms: true)
+      project_researcher.add_role_for_project('researcher', another_project, can_manage_permission_forms: false)
+    end
+
+    it 'GET index returns permission forms from the project' do
+      Portal::PermissionForm.create!(name: 'Test Form 1', url: 'http://example1.com', project_id: project.id)
+      Portal::PermissionForm.create!(name: 'Test Form 2', url: 'http://example2.com', project_id: another_project.id)
+      get :index
+      expect(response).to have_http_status(:ok)
+      puts JSON.parse(response.body)
+      expect(JSON.parse(response.body).size).to eq(1)
+      expect(JSON.parse(response.body)).to match([
+        hash_including('name' => 'Test Form 1', 'url' => 'http://example1.com', 'project_id' => project.id)
+      ])
+    end
+
+    it 'DELETE is not allowed' do
       permission_form = Portal::PermissionForm.create!(name: 'Test Form', url: 'http://example.com', project_id: project.id)
       expect(Portal::PermissionForm.count).to eq(1)
       delete :destroy, params: { id: permission_form.id }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187860708

<img width="857" alt="Screenshot 2024-06-27 at 17 24 01" src="https://github.com/concord-consortium/rigse/assets/767857/7d4cb3dd-6e74-4ed2-8973-3329e0b1c6d9">

This PR adds the `can_manage_permission_forms` attribute and updates all the spots where we should take it into account. @scytacki, @dougmartin, this essentially reflects what we discussed together. The changes were a bit more extensive than I had hoped for, but if we need to rename this attribute to a more generic name, all the helper methods can probably stay the same or be renamed relatively easily too.

The `can_manage_permission_forms` value will remove or grant access to the Permission Forms UI, starting with Admin links, then filtering all the projects, and permission forms. I'll probably add a bit more tests in subsequent PRs during the final cleanup.

@bacalj, when this PR gets merged into master, you'll need to run migrations again.