### PR TITLE
Permission Forms:  limit search_teachers api and show a notice in UI

### DIFF
--- a/rails/app/views/dynamic_scripts/_api_paths.html.haml
+++ b/rails/app/views/dynamic_scripts/_api_paths.html.haml
@@ -105,8 +105,8 @@
     PERMISSION_FORMS: "#{api_v1_permission_forms_path}",
     PERMISSION_FORMS_PROJECTS: "#{projects_api_v1_permission_forms_path}",
     PERMISSION_FORMS_SEARCH_TEACHER: "#{search_teachers_api_v1_permission_forms_path}",
-    permissionFormsSearchTeacher(name) {
-      return this.PERMISSION_FORMS_SEARCH_TEACHER + "?name=" + name;
+    permissionFormsSearchTeacher(name, limit = 50) {
+      return this.PERMISSION_FORMS_SEARCH_TEACHER + "?name=" + name + "&limit=" + limit;
     },
     PERMISSION_FORMS_CLASS_PERMISSION_FORMS: "#{class_permission_forms_api_v1_permission_forms_path}",
     permissionFormsClassPermissionForms(classId) {

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-tab.scss
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-tab.scss
@@ -53,7 +53,7 @@
     }
   }
 
-  .noResults {
+  .searchResultsNotice {
     font-weight: 500;
   }
 

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-tab.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-tab.tsx
@@ -44,8 +44,8 @@ export default function StudentsTab() {
 
   const handleSearchClick = async () => {
     setSelectedTeacherId(null);
-    const { teachers, limit_applied } = await searchTeachers(teacherName);
-    setTeachers(teachers);
+    const { teachers: foundTeachers, limit_applied } = await searchTeachers(teacherName);
+    setTeachers(foundTeachers);
     setTeachersLimitApplied(limit_applied);
   };
 
@@ -79,7 +79,7 @@ export default function StudentsTab() {
       {
         teachersLimitApplied &&
         <div className={css.searchResultsNotice}>
-          Search results have been limited to {getTeachersLimit()} teachers. Please refine your search.
+          Search results have been limited to { getTeachersLimit() } teachers. Please refine your search.
         </div>
       }
       {

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-tab.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-tab.tsx
@@ -9,9 +9,16 @@ import { ClassesTable } from "./classes-table";
 
 import css from "./students-tab.scss";
 
+// This param is used mostly for testing purposes. It allows to set a custom limit for the number of results,
+// so staging environments can test how the search behaves when limit is reached.
+const getTeachersLimit = () => {
+  const urlParams = new URLSearchParams(window.location.search);
+  return urlParams.get("teachersLimit") || 50;
+};
+
 const searchTeachers = async (name: string) =>
   request({
-    url: Portal.API_V1.permissionFormsSearchTeacher(name),
+    url: Portal.API_V1.permissionFormsSearchTeacher(name, getTeachersLimit()),
     method: "GET"
   });
 
@@ -20,6 +27,7 @@ export default function StudentsTab() {
   const { data: projectsData } = useFetch<IProject[]>(Portal.API_V1.PERMISSION_FORMS_PROJECTS, []);
   // `null` means no search has been done yet, while an empty array means no results were found.
   const [teachers, setTeachers] = useState<ITeacher[] | null>(null);
+  const [teachersLimitApplied, setTeachersLimitApplied] = useState<boolean>(false);
   const [selectedTeacherId, setSelectedTeacherId] = useState<string | null>(null);
   const[teacherName, setTeacherName] = useState<string>("");
 
@@ -36,7 +44,9 @@ export default function StudentsTab() {
 
   const handleSearchClick = async () => {
     setSelectedTeacherId(null);
-    setTeachers(await searchTeachers(teacherName));
+    const { teachers, limit_applied } = await searchTeachers(teacherName);
+    setTeachers(teachers);
+    setTeachersLimitApplied(limit_applied);
   };
 
   const handleViewClassesClick = (teacherId: string) => {
@@ -64,7 +74,13 @@ export default function StudentsTab() {
       </div>
       {
         teachers && teachers.length === 0 &&
-        <div className={css.noResults}>No teachers found.</div>
+        <div className={css.searchResultsNotice}>No teachers found.</div>
+      }
+      {
+        teachersLimitApplied &&
+        <div className={css.searchResultsNotice}>
+          Search results have been limited to {getTeachersLimit()} teachers. Please refine your search.
+        </div>
       }
       {
         teachers && teachers.length > 0 &&

--- a/rails/spec/controllers/api/v1/permission_forms_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/permission_forms_controller_spec.rb
@@ -49,14 +49,14 @@ RSpec.describe API::V1::PermissionFormsController, type: :controller do
     it 'returns an empty array if the name is blank' do
       get :search_teachers, params: { name: '' }
       expect(response).to have_http_status(:ok)
-      expect(JSON.parse(response.body)).to eq([])
+      expect(JSON.parse(response.body)["teachers"]).to eq([])
     end
 
     it 'returns a list of teachers with login matching the name' do
       teacher = FactoryBot.create(:teacher, user: FactoryBot.create(:user, login: 'test_teacher'))
       get :search_teachers, params: { name: 'test_teacher' }
       expect(response).to have_http_status(:ok)
-      expect(JSON.parse(response.body)).to match([
+      expect(JSON.parse(response.body)["teachers"]).to match([
         hash_including('id' => teacher.id, 'name' => teacher.user.name, 'email' => teacher.user.email, 'login' => teacher.user.login)
       ])
     end
@@ -65,7 +65,7 @@ RSpec.describe API::V1::PermissionFormsController, type: :controller do
       teacher = FactoryBot.create(:teacher, user: FactoryBot.create(:user, email: 'test_teacher@mail.com'))
       get :search_teachers, params: { name: 'test_teacher' }
       expect(response).to have_http_status(:ok)
-      expect(JSON.parse(response.body)).to match([
+      expect(JSON.parse(response.body)["teachers"]).to match([
         hash_including('id' => teacher.id, 'name' => teacher.user.name, 'email' => teacher.user.email, 'login' => teacher.user.login)
       ])
     end
@@ -74,13 +74,13 @@ RSpec.describe API::V1::PermissionFormsController, type: :controller do
       teacher = FactoryBot.create(:teacher, user: FactoryBot.create(:user, first_name: 'John', last_name: 'Doe'))
       get :search_teachers, params: { name: 'John' }
       expect(response).to have_http_status(:ok)
-      expect(JSON.parse(response.body)).to match([
+      expect(JSON.parse(response.body)["teachers"]).to match([
         hash_including('id' => teacher.id, 'name' => teacher.user.name, 'email' => teacher.user.email, 'login' => teacher.user.login)
       ])
 
       get :search_teachers, params: { name: 'Doe' }
       expect(response).to have_http_status(:ok)
-      expect(JSON.parse(response.body)).to match([
+      expect(JSON.parse(response.body)["teachers"]).to match([
         hash_including('id' => teacher.id, 'name' => teacher.user.name, 'email' => teacher.user.email, 'login' => teacher.user.login)
       ])
     end
@@ -89,11 +89,20 @@ RSpec.describe API::V1::PermissionFormsController, type: :controller do
       teacher = FactoryBot.create(:teacher, user: FactoryBot.create(:user, login: 'test_teacher'))
       get :search_teachers, params: { name: 't__t_teacher' }
       expect(response).to have_http_status(:ok)
-      expect(JSON.parse(response.body)).to eq([])
+      expect(JSON.parse(response.body)["teachers"]).to eq([])
 
       get :search_teachers, params: { name: 't%t_teacher' }
       expect(response).to have_http_status(:ok)
-      expect(JSON.parse(response.body)).to eq([])
+      expect(JSON.parse(response.body)["teachers"]).to eq([])
+    end
+
+    it 'returns a list of teachers with provided limit' do
+      FactoryBot.create_list(:teacher, 5, user: FactoryBot.create(:user, login: 'test_teacher'))
+      get :search_teachers, params: { name: 'test_teacher', limit: 3 }
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["teachers"].size).to eq(3)
+      expect(JSON.parse(response.body)["limit_applied"]).to eq(true)
+      expect(JSON.parse(response.body)["total_teachers_count"]).to eq(5)
     end
   end
 
@@ -134,8 +143,8 @@ RSpec.describe API::V1::PermissionFormsController, type: :controller do
 
       expect(response).to have_http_status(:ok)
       body = JSON.parse(response.body)
-      expect(body.size).to eq(1)
-      expect(JSON.parse(response.body)).to match([
+      expect(body["teachers"].size).to eq(1)
+      expect(body["teachers"]).to match([
         hash_including('id' => teacher1.id)
       ])
     end
@@ -218,8 +227,8 @@ RSpec.describe API::V1::PermissionFormsController, type: :controller do
 
       expect(response).to have_http_status(:ok)
       body = JSON.parse(response.body)
-      expect(body.size).to eq(1)
-      expect(JSON.parse(response.body)).to match([
+      expect(body["teachers"].size).to eq(1)
+      expect(body["teachers"]).to match([
         hash_including('id' => teacher1.id)
       ])
     end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187860683

Limit can be set in URL so we can test that on staging where number of teachers is probably low.