### PR TITLE
187773575 expand permissions

### DIFF
--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.scss
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.scss
@@ -19,6 +19,14 @@ table.studentsTable {
     overflow: visible;
   }
 
+  &.expandedPermissions {
+    td.permissionFormsColumn {
+      overflow: visible;
+      white-space: normal;
+      text-overflow: none;
+    }
+  }
+
   .permissionFormSelectOption {
     overflow: hidden;
     text-overflow: ellipsis;

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.tsx
@@ -44,6 +44,7 @@ export const StudentsTable = ({ classId }: IProps) => {
   const [permissionFormsToRemove, setPermissionFormsToRemove] = useState<readonly PermissionFormOption[]>([]);
   const [editStudent, setEditStudent] = useState<IStudent | null>(null);
   const [requestInProgress, setRequestInProgress] = useState(false);
+  const [permissionsExpanded, setPermissionsExpanded] = useState(false);
 
   const nonArchivedPermissionForms = nonArchived(permissionForms);
   const permissionFormToAddOptions = Object.freeze(
@@ -129,19 +130,29 @@ export const StudentsTable = ({ classId }: IProps) => {
     refetchStudentsData();
   }
 
+  const handleClickPermissionExpandToggle = () => {
+    setPermissionsExpanded(!permissionsExpanded);
+  };
+
   const selectedStudentsCount = Object.keys(isStudentSelected).length;
   const allStudentsSelected = Object.keys(isStudentSelected).length === studentsData.length;
 
   return (
     <>
-      <table className={css.studentsTable}>
+      <table className={`${css.studentsTable} ${permissionsExpanded ? css.expandedPermissions : ''}`}>
         <thead>
           <tr>
             <th className={css.checkboxColumn}><input type="checkbox" checked={allStudentsSelected} onChange={handleSelectAllChange} /></th>
             <th>Student Name</th>
             <th>Username</th>
-            <th className={css.permissionFormsColumn}>Permission Forms</th>
-            <th className={css.expandButtonColumn}></th>
+            <th className={css.permissionFormsColumn} colSpan={2}>
+            <div role="button" onClick={handleClickPermissionExpandToggle}>
+                Permission Forms
+                <span className={`${css.expandIcon}`}>
+                  {permissionsExpanded ? "▼" : "▲"}
+                </span>
+              </div>
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -154,7 +165,16 @@ export const StudentsTable = ({ classId }: IProps) => {
                   </td>
                   <td>{ studentInfo.name }</td>
                   <td>{ studentInfo.login }</td>
-                  <td className={css.permissionFormsColumn}>{ nonArchived(studentInfo.permission_forms).map(pf => pf.name).join(", ") }</td>
+                  <td className={css.permissionFormsColumn}>
+                    {
+                      nonArchived(studentInfo.permission_forms).map((pf, i, forms) => (
+                        <React.Fragment key={pf.id}>
+                          {pf.name}
+                          {i < forms.length - 1 && (permissionsExpanded ? <br /> : ", ")}
+                        </React.Fragment>
+                      ))
+                    }
+                  </td>
                   <td className={css.expandButtonColumn}>
                     <button className={css.basicButton} onClick={() => handleEditClick(studentInfo.id)}>Edit</button>
                   </td>

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.tsx
@@ -149,8 +149,8 @@ export const StudentsTable = ({ classId }: IProps) => {
             <div role="button" onClick={handleClickPermissionExpandToggle}>
                 Permission Forms
                 { permissionsExpanded
-                  ? <i className="icon icon-caret-down"></i>
-                  : <i className="icon icon-caret-up"></i>
+                  ? <i className="icon icon-caret-up"></i>
+                  : <i className="icon icon-caret-down"></i>
                 }
               </div>
             </th>

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.tsx
@@ -146,7 +146,7 @@ export const StudentsTable = ({ classId }: IProps) => {
             <th>Student Name</th>
             <th>Username</th>
             <th className={css.permissionFormsColumn} colSpan={2}>
-            <div role="button" onClick={handleClickPermissionExpandToggle}>
+              <div role="button" onClick={handleClickPermissionExpandToggle}>
                 Permission Forms
                 { permissionsExpanded
                   ? <i className="icon icon-caret-up"></i>

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.tsx
@@ -148,9 +148,10 @@ export const StudentsTable = ({ classId }: IProps) => {
             <th className={css.permissionFormsColumn} colSpan={2}>
             <div role="button" onClick={handleClickPermissionExpandToggle}>
                 Permission Forms
-                <span className={`${css.expandIcon}`}>
-                  {permissionsExpanded ? "▼" : "▲"}
-                </span>
+                { permissionsExpanded
+                  ? <i className="icon icon-caret-down"></i>
+                  : <i className="icon icon-caret-up"></i>
+                }
               </div>
             </th>
           </tr>

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.tsx
@@ -131,7 +131,7 @@ export const StudentsTable = ({ classId }: IProps) => {
   };
 
   const handleClickPermissionExpandToggle = () => {
-    setPermissionsExpanded(!permissionsExpanded);
+    setPermissionsExpanded(prevPermissionsExpanded => !prevPermissionsExpanded);
   };
 
   const selectedStudentsCount = Object.keys(isStudentSelected).length;

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.tsx
@@ -128,7 +128,7 @@ export const StudentsTable = ({ classId }: IProps) => {
   const handleSaveStudentPermissionsSuccess = async () => {
     setEditStudent(null);
     refetchStudentsData();
-  }
+  };
 
   const handleClickPermissionExpandToggle = () => {
     setPermissionsExpanded(!permissionsExpanded);
@@ -139,7 +139,7 @@ export const StudentsTable = ({ classId }: IProps) => {
 
   return (
     <>
-      <table className={`${css.studentsTable} ${permissionsExpanded ? css.expandedPermissions : ''}`}>
+      <table className={`${css.studentsTable} ${permissionsExpanded ? css.expandedPermissions : ""}`}>
         <thead>
           <tr>
             <th className={css.checkboxColumn}><input type="checkbox" checked={allStudentsSelected} onChange={handleSelectAllChange} /></th>


### PR DESCRIPTION
PT-187773575

Clicking on the Permission Forms header will toggle the state of the list of student permissions forms  listed in the cell. 
- The default is a  comma-separated list with text truncated to column width
- The expanded state puts each form name on it's own line within the cell (text wrapping if needed)
