### PR TITLE
Permission Forms: don't show Delete button for researchers, improve handling of the failed API requests

### DIFF
--- a/rails/app/controllers/api/v1/permission_forms_controller.rb
+++ b/rails/app/controllers/api/v1/permission_forms_controller.rb
@@ -4,7 +4,19 @@ class API::V1::PermissionFormsController < API::APIController
   def index
     authorize Portal::PermissionForm, :permission_forms_v2_index?
     permission_forms = managment_policy_scope(Portal::PermissionForm)
-    render :json => permission_forms
+
+    permission_forms_with_permissions = permission_forms.map do |permission_form|
+      {
+        id: permission_form.id,
+        name: permission_form.name,
+        project_id: permission_form.project_id,
+        url: permission_form.url,
+        is_archived: permission_form.is_archived,
+        can_delete: Pundit.policy(current_user, permission_form).destroy?
+      }
+    end
+
+    render json: permission_forms_with_permissions
   end
 
   def create

--- a/rails/react-components/src/library/components/permission-forms-v2/common/types.ts
+++ b/rails/react-components/src/library/components/permission-forms-v2/common/types.ts
@@ -2,6 +2,7 @@ export interface IPermissionForm {
   id: string;
   name: string;
   is_archived: boolean;
+  can_delete: boolean;
   project_id?: number | string; // need to fix this
   url?: string;
 }

--- a/rails/react-components/src/library/components/permission-forms-v2/manage-forms-tab/manage-forms-tab.scss
+++ b/rails/react-components/src/library/components/permission-forms-v2/manage-forms-tab/manage-forms-tab.scss
@@ -51,4 +51,8 @@
   .deleteColumn {
     width: $deleteColumnWidth;
   }
+  .hiddenColumn {
+    width: 0;
+    padding: 0;
+  }
 }

--- a/rails/react-components/src/library/components/permission-forms-v2/manage-forms-tab/manage-forms-tab.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/manage-forms-tab/manage-forms-tab.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { clsx } from "clsx";
 import { useFetch } from "../../../hooks/use-fetch";
 import { CreateEditPermissionForm } from "./create-edit-permission-form";
 import { IPermissionForm, IPermissionFormFormData, IProject, CurrentSelectedProject } from "./types";
@@ -95,6 +96,7 @@ export default function ManageFormsTab() {
   };
 
   const processedForms = sortForms(getFilteredForms(permissionsData, currentSelectedProject));
+  const cantDeleteAnyForm = processedForms.every((form: IPermissionForm) => form.can_delete === false);
 
   return (
     <div className={css.manageFormsTabContent}>
@@ -109,7 +111,12 @@ export default function ManageFormsTab() {
 
       <table className={css.permissionFormsTable}>
         <thead>
-          <tr><th>Name</th><th>URL</th><th className={css.editColumn} /><th className={css.archiveColumn} /><th className={css.deleteColumn} /></tr>
+          <tr>
+            <th>Name</th><th>URL</th>
+            <th className={css.editColumn} />
+            <th className={css.archiveColumn} />
+            <th className={clsx(css.deleteColumn, { [css.hiddenColumn]: cantDeleteAnyForm })} />
+          </tr>
         </thead>
         <tbody>
           {

--- a/rails/react-components/src/library/components/permission-forms-v2/manage-forms-tab/permission-form-row.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/manage-forms-tab/permission-form-row.tsx
@@ -64,7 +64,7 @@ const PermissionFormRow: React.FC<PermissionFormRowProps> = ({ permissionForm, o
         </button>
       </td>
       <td className={css.deleteColumn}>
-        <button className={css.basicButton} onClick={handleDelete}>Delete</button>
+        { permissionForm.can_delete && <button className={css.basicButton} onClick={handleDelete}>Delete</button> }
       </td>
     </tr>
   );

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/edit-student-permissions-form.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/edit-student-permissions-form.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from "react";
+import React, { useEffect, useState } from "react";
 import { IPermissionForm, IStudent } from "./types";
 import { bulkUpdatePermissionForms } from "./students-table";
 
@@ -68,7 +68,7 @@ export const EditStudentPermissionsForm = ({ student, permissionForms, onFormCan
         { `EDIT: ${student.name}` }
       </div>
 
-      {permissionForms.map((p, i) => {
+      { permissionForms.map((p, i) => {
         const isChecked = localPermissions.some(lp => lp.id === p.id);
 
         return (
@@ -78,10 +78,10 @@ export const EditStudentPermissionsForm = ({ student, permissionForms, onFormCan
               checked={isChecked}
               onChange={() => handlePermissionChange(p.id)}
             />
-            {p.name}
+            { p.name }
           </div>
         );
-      })}
+      }) }
 
       <div className={css.formButtonArea}>
         <button className={css.cancelButton} onClick={onFormCancel}>

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.tsx
@@ -170,8 +170,8 @@ export const StudentsTable = ({ classId }: IProps) => {
                     {
                       nonArchived(studentInfo.permission_forms).map((pf, i, forms) => (
                         <React.Fragment key={pf.id}>
-                          {pf.name}
-                          {i < forms.length - 1 && (permissionsExpanded ? <br /> : ", ")}
+                          { pf.name }
+                          { i < forms.length - 1 && (permissionsExpanded ? <br /> : ", ") }
                         </React.Fragment>
                       ))
                     }

--- a/rails/react-components/src/library/helpers/api/request.ts
+++ b/rails/react-components/src/library/helpers/api/request.ts
@@ -6,7 +6,14 @@ export const getAuthToken = () => {
   return authToken;
 };
 
-export const request = async ({ url, method, body }: { url: string, method: string, body?: string }) => {
+interface IOptions {
+  url: string;
+  method: string;
+  body?: string;
+  onError?: (error: Error) => void;
+}
+
+export const request = async ({ url, method, body, onError }: IOptions) => {
   try {
     const response = await fetch(url, {
       method,
@@ -16,20 +23,24 @@ export const request = async ({ url, method, body }: { url: string, method: stri
       },
       body
     });
-    const data = await response.json();
     if (!response.ok) {
+      const info = `${method} ${url}`;
       switch (response.status) {
         case 404:
-          throw new Error('Resource not found.');
+          throw new Error(`${info}: Resource not found.`);
         case 403:
-          throw new Error('You are not authorized to perform this action.');
+          throw new Error(`${info}: You are not authorized to perform this action.`);
         default:
-          throw new Error(`Request failed: ${response.status} ${response.statusText}`);
+          throw new Error(`${info}: Request failed with HTTP error ${response.status} ${response.statusText}`);
       }
     }
-    return data;
+    return await response.json();
   } catch (e: any) {
-    window.alert(e.message);
+    if (onError) {
+      onError(e);
+    } else {
+      window.alert(e.message);
+    }
   }
   return null;
 };

--- a/rails/react-components/src/library/helpers/api/request.ts
+++ b/rails/react-components/src/library/helpers/api/request.ts
@@ -18,11 +18,18 @@ export const request = async ({ url, method, body }: { url: string, method: stri
     });
     const data = await response.json();
     if (!response.ok) {
-      throw new Error(`HTTP error: ${response.status}`);
+      switch (response.status) {
+        case 404:
+          throw new Error('Resource not found.');
+        case 403:
+          throw new Error('You are not authorized to perform this action.');
+        default:
+          throw new Error(`Request failed: ${response.status} ${response.statusText}`);
+      }
     }
     return data;
-  } catch (e) {
-    console.error(`${method} ${url} failed.`, e);
+  } catch (e: any) {
+    window.alert(e.message);
   }
   return null;
 };

--- a/rails/react-components/src/library/hooks/use-fetch.ts
+++ b/rails/react-components/src/library/hooks/use-fetch.ts
@@ -1,24 +1,19 @@
 import { useState, useEffect, useCallback } from "react";
+import { request } from "../helpers/api/request";
 
 export const useFetch = <T>(url: string, initialData: T) => {
   const [data, setData] = useState<T>(initialData);
   const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<Error | null>(null);
 
   // We store fetchData function once with useCallback
   // so it is not recreated on every render of enclosing component
   const fetchData = useCallback(async () => {
     setIsLoading(true);
-    try {
-      const response = await fetch(url);
-      if (!response.ok) throw new Error(`HTTP error: ${response.status}`);
-      const responseData = await response.json();
+    const responseData = await request({ url, method: "GET" });
+    if (responseData) {
       setData(responseData);
-    } catch (e: any) {
-      setError(e);
-    } finally {
-      setIsLoading(false);
     }
+    setIsLoading(false);
   }, [url]);
 
   useEffect(() => {
@@ -26,6 +21,6 @@ export const useFetch = <T>(url: string, initialData: T) => {
   }, [fetchData]);
 
   // we return fetchData as `refetch` so that the component can refetch the data if needed
-  return { data, isLoading, error, refetch: fetchData };
+  return { data, isLoading, refetch: fetchData };
 };
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187638044/comments/241759710

Previously failed API requests (e.g. 403 error for researchers trying to delete a form) were only logged to console, but nothing would happen in the UI. Now, we'll show an alert.

I've also extended API to include `can_delete` attribute for each form so we can actually hide Delete button when it's not gonna work anyway.

@bacalj, I've also updated `useFetch` to reuse the more generic `request` helper and rely on its error handling. While `useFetch` was nicely exposing `error` as a state, we never used this in any component, and errors were completely silent. So, I think it's better to have an ugly but informative alert than nothing at all. If we need a place where errors should be handled more gracefully, we can easily extend the options to export the error to the state again.