### PR TITLE
Fix logic related to can_manage_permission_forms

### DIFF
--- a/rails/app/controllers/api/v1/permission_forms_controller.rb
+++ b/rails/app/controllers/api/v1/permission_forms_controller.rb
@@ -184,7 +184,7 @@ class API::V1::PermissionFormsController < API::APIController
   private
 
   # Default scope is too wide, we need extra filtering for project researchers.
-  # Pundint doesn't seem to be flexible enough to handle this, so we need to do it manually.
+  # Pundit doesn't seem to be flexible enough to handle this, so we need to do it manually.
   def management_policy_scope(scope)
     if current_user.has_role?('admin')
       # Admin users have access to all projects

--- a/rails/app/controllers/api/v1/permission_forms_controller.rb
+++ b/rails/app/controllers/api/v1/permission_forms_controller.rb
@@ -3,7 +3,7 @@ class API::V1::PermissionFormsController < API::APIController
   # GET /api/v1/permission_forms/index
   def index
     authorize Portal::PermissionForm, :permission_forms_v2_index?
-    permission_forms = managment_policy_scope(Portal::PermissionForm)
+    permission_forms = management_policy_scope(Portal::PermissionForm)
 
     permission_forms_with_permissions = permission_forms.map do |permission_form|
       {
@@ -113,7 +113,7 @@ class API::V1::PermissionFormsController < API::APIController
         id: student.id,
         name: student.user.name,
         login: student.user.login,
-        permission_forms: managment_policy_scope(student.permission_forms).select(:id, :name, :is_archived).map do |form|
+        permission_forms: management_policy_scope(student.permission_forms).select(:id, :name, :is_archived).map do |form|
           {
             id: form.id,
             name: form.name,
@@ -185,13 +185,22 @@ class API::V1::PermissionFormsController < API::APIController
 
   # Default scope is too wide, we need extra filtering for project researchers.
   # Pundint doesn't seem to be flexible enough to handle this, so we need to do it manually.
-  def managment_policy_scope(scope)
-    scope = policy_scope(scope)
-    if current_user.is_project_researcher?
-      researcher_project_ids = current_user._project_user_researchers.where(can_manage_permission_forms: true).pluck(:project_id)
-      scope.where(project_id: researcher_project_ids)
+  def management_policy_scope(scope)
+    if current_user.has_role?('admin')
+      # Admin users have access to all projects
+      scope.all
+    elsif current_user.is_project_admin? || current_user.is_project_researcher?
+      admin_project_ids = current_user.admin_for_projects.pluck(:id)
+      manageable_project_ids = current_user._project_user_researchers.where(can_manage_permission_forms: true).pluck(:project_id)
+
+      # Combine these two sets of project ids to determine the final scope
+      final_project_ids = (admin_project_ids + manageable_project_ids).uniq
+
+      # Filter the scope to include only the relevant project IDs
+      scope.where(project_id: final_project_ids)
     else
-      scope
+      # No access for users without the relevant roles
+      scope.none
     end
   end
 

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -435,10 +435,10 @@ class User < ApplicationRecord
     project_user&.expiration_date
   end
 
-  def can_manage_permission_forms?(project = nil, allow_expired: false)
+  def can_manage_permission_forms?(project = nil)
     return true if has_role?('admin')
     return true if is_project_admin?(project)
-    return true if is_project_researcher?(project, allow_expired: allow_expired, check_can_manage_permission_forms: true)
+    return true if is_project_researcher?(project, check_can_manage_permission_forms: true)
     return false
   end
 

--- a/rails/app/policies/portal/permission_form_policy.rb
+++ b/rails/app/policies/portal/permission_form_policy.rb
@@ -5,12 +5,9 @@ class Portal::PermissionFormPolicy < ApplicationPolicy
       if user.has_role?('admin')
         scope.all
       elsif user.is_project_admin? || user.is_project_researcher?
-        admin_project_ids = user.admin_for_projects.pluck(:id)
-        researcher_project_ids = user.researcher_for_projects.pluck(:id)
-
-        final_project_ids = (admin_project_ids + researcher_project_ids).uniq
-
-        scope.where(project_id: final_project_ids)
+        admin_project_ids = user.admin_for_projects.select(:id)
+        researcher_project_ids = user.researcher_for_projects.select(:id)
+        scope.where("project_id IN (?) OR project_id IN (?)", admin_project_ids, researcher_project_ids)
       else
         scope.none
       end

--- a/rails/app/policies/portal/permission_form_policy.rb
+++ b/rails/app/policies/portal/permission_form_policy.rb
@@ -3,21 +3,16 @@ class Portal::PermissionFormPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
       if user.has_role?('admin')
-        all
+        scope.all
       elsif user.is_project_admin? || user.is_project_researcher?
-        where = []
-        params = {}
-        if user.is_project_admin?
-          where << "(project_id in (:admin_project_ids))"
-          params[:admin_project_ids] = user.admin_for_projects.map { |p| p.id }
-        end
-        if user.is_project_researcher?
-          where << "(project_id in (:researcher_project_ids))"
-          params[:researcher_project_ids] = user.researcher_for_projects.map { |p| p.id }
-        end
-        scope.where([where.join(" OR "), params])
+        admin_project_ids = user.admin_for_projects.pluck(:id)
+        researcher_project_ids = user.researcher_for_projects.pluck(:id)
+
+        final_project_ids = (admin_project_ids + researcher_project_ids).uniq
+
+        scope.where(project_id: final_project_ids)
       else
-        none
+        scope.none
       end
     end
   end

--- a/rails/app/views/users/_researcher_for_projects.html.haml
+++ b/rails/app/views/users/_researcher_for_projects.html.haml
@@ -7,7 +7,7 @@
     - projects.each_with_index do |project, i|
       - checkbox_id = "project-#{i}-researcher"
       - expiration_date = @user.expiration_date_for_project(project)
-      - can_manage_permission_forms = @user.can_manage_permission_forms?(project, allow_expired: true)
+      - can_manage_permission_forms = @user.is_project_researcher?(project, allow_expired: true, check_can_manage_permission_forms: true)
       - is_researcher = @user.researcher_for_projects_inc_expired.include?(project)
       %li
         .inline-fields


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187860708

This PR fixes two issues I found while testing recent updates to the researcher role.

First, the `management_policy_scope` was incorrect if the user was both an admin or project admin and a researcher. The scope was too limited. I ended up almost copying the basic Pundit scope. Pundit doesn't offer any reasonable flexibility to provide arguments to a single scope and customize its behavior. I also refactored the original scope a bit, so both variants are similar.

The second issue was related to how the value of `can_manage_permission_forms` was calculated. If the user was an admin but the `can_manage_permission_forms` value was false, it would still show as checked.
