### PR TITLE
187782786 filter permission forms, fix student modal text wrap and scroll

### DIFF
--- a/rails/react-components/src/library/components/permission-forms-v2/common/permission-utils.ts
+++ b/rails/react-components/src/library/components/permission-forms-v2/common/permission-utils.ts
@@ -5,7 +5,7 @@ export const filteredByProject = (forms: IPermissionForm[], projectId: CurrentSe
   return projectId === null
     ? forms
     : forms.filter((form: IPermissionForm) => form.project_id === projectId);
-}
+};
 
 export const nonArchived = (forms: IPermissionForm[]) => {
   return forms.filter(form => !form.is_archived);
@@ -21,4 +21,4 @@ export const sortedByArchiveAndName = (forms: IPermissionForm[]) => forms.sort((
 export const formsOfStudent = (forms: IPermissionForm[], studentInfo: IStudent) => {
   const ids = studentInfo.permission_forms.map(form => form.id);
   return forms.filter(form => ids.includes(form.id));
-}
+};

--- a/rails/react-components/src/library/components/permission-forms-v2/common/permission-utils.ts
+++ b/rails/react-components/src/library/components/permission-forms-v2/common/permission-utils.ts
@@ -1,0 +1,24 @@
+import { IStudent } from "../students-tab/types";
+import { CurrentSelectedProject, IPermissionForm } from "./types";
+
+export const filteredByProject = (forms: IPermissionForm[], projectId: CurrentSelectedProject) => {
+  return projectId === null
+    ? forms
+    : forms.filter((form: IPermissionForm) => form.project_id === projectId);
+}
+
+export const nonArchived = (forms: IPermissionForm[]) => {
+  return forms.filter(form => !form.is_archived);
+};
+
+export const sortedByArchiveAndName = (forms: IPermissionForm[]) => forms.sort((a, b) => {
+  if (a.is_archived === b.is_archived) {
+    return a.name.localeCompare(b.name);
+  }
+  return a.is_archived ? 1 : -1;
+});
+
+export const formsOfStudent = (forms: IPermissionForm[], studentInfo: IStudent) => {
+  const ids = studentInfo.permission_forms.map(form => form.id);
+  return forms.filter(form => ids.includes(form.id));
+}

--- a/rails/react-components/src/library/components/permission-forms-v2/common/project-select.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/common/project-select.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { IProject } from "./types";
+import { CurrentSelectedProject, IProject } from "./types";
 
 interface IProjectSelectProps {
   projects: IProject[];
   onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
-  value?: string | number;
+  value?: CurrentSelectedProject;
 }
 
 export const ProjectSelect = ({ projects, value, onChange }: IProjectSelectProps) => {
@@ -12,7 +12,7 @@ export const ProjectSelect = ({ projects, value, onChange }: IProjectSelectProps
   return (
     <>
       <label>Project:</label>
-      <select data-testid="project-select" value={value} name="project_id" onChange={onChange}>
+      <select data-testid="project-select" value={value ?? undefined} name="project_id" onChange={onChange}>
         <option value="">Select a project...</option>
         { sortedProjects?.map((p: IProject) => <option key={p.id} value={p.id}>{ p.name }</option>) }
       </select>

--- a/rails/react-components/src/library/components/permission-forms-v2/common/types.ts
+++ b/rails/react-components/src/library/components/permission-forms-v2/common/types.ts
@@ -1,9 +1,10 @@
+export type CurrentSelectedProject = number | null;
 export interface IPermissionForm {
   id: string;
   name: string;
   is_archived: boolean;
   can_delete: boolean;
-  project_id?: number | string; // need to fix this
+  project_id: CurrentSelectedProject;
   url?: string;
 }
 
@@ -12,4 +13,3 @@ export interface IProject {
   name: string;
 }
 
-export type CurrentSelectedProject = number | "";

--- a/rails/react-components/src/library/components/permission-forms-v2/manage-forms-tab/create-edit-permission-form.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/manage-forms-tab/create-edit-permission-form.tsx
@@ -16,7 +16,7 @@ export const CreateEditPermissionForm = ({ projects, currentSelectedProject, exi
   const [formData, setFormData] = useState<IPermissionFormFormData>({
     id: existingFormData?.id || undefined,
     name: existingFormData?.name || "",
-    project_id: existingFormData?.project_id || (currentSelectedProject ? Number(currentSelectedProject) : ""),
+    project_id: existingFormData?.project_id || (currentSelectedProject ? currentSelectedProject : null),
     url: existingFormData?.url || ""
   });
 

--- a/rails/react-components/src/library/components/permission-forms-v2/manage-forms-tab/manage-forms-tab.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/manage-forms-tab/manage-forms-tab.tsx
@@ -42,7 +42,7 @@ export default function ManageFormsTab() {
   const [currentSelectedProject, setCurrentSelectedProject] = useState<CurrentSelectedProject>(null);
 
   const handleProjectSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    setCurrentSelectedProject(e.target.value === '' ? null : Number(e.target.value));
+    setCurrentSelectedProject(e.target.value === "" ? null : Number(e.target.value));
   };
 
   const handleCreateFormClick = () => {

--- a/rails/react-components/src/library/components/permission-forms-v2/manage-forms-tab/manage-forms-tab.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/manage-forms-tab/manage-forms-tab.tsx
@@ -30,8 +30,14 @@ const deletePermissionForm = async (permissionFormId: string) =>
     method: "DELETE"
   });
 
-const getFilteredForms = (forms: IPermissionForm[], projectId: string | number) =>
-  projectId === "" ? forms : forms.filter((form: IPermissionForm) => form.project_id === Number(projectId));
+const getFormsByProject = (forms: IPermissionForm[], projectId: CurrentSelectedProject) => {
+  if (projectId === null) {
+    return forms;
+  } else {
+    return forms.filter((form: IPermissionForm) => form.project_id === projectId);
+  }
+}
+  // projectId === "" ? forms : forms.filter((form: IPermissionForm) => form.project_id === Number(projectId));
 
 const sortByName = (a: { name: string }, b: { name: string }) => a.name.localeCompare(b.name);
 
@@ -51,10 +57,10 @@ export default function ManageFormsTab() {
   // State for UI
   const [showCreateNewFormModal, setShowCreateNewFormModal] = useState(false);
   const [editForm, setEditForm] = useState<IPermissionForm | false>(false);
-  const [currentSelectedProject, setCurrentSelectedProject] = useState<number | "">("");
+  const [currentSelectedProject, setCurrentSelectedProject] = useState<CurrentSelectedProject>(null);
 
   const handleProjectSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    setCurrentSelectedProject(e.target.value as CurrentSelectedProject);
+    setCurrentSelectedProject(e.target.value === '' ? null : Number(e.target.value));
   };
 
   const handleCreateFormClick = () => {
@@ -95,7 +101,7 @@ export default function ManageFormsTab() {
     refetchPermissions();
   };
 
-  const processedForms = sortForms(getFilteredForms(permissionsData, currentSelectedProject));
+  const processedForms = sortForms(getFormsByProject(permissionsData, currentSelectedProject));
   const cantDeleteAnyForm = processedForms.every((form: IPermissionForm) => form.can_delete === false);
 
   return (

--- a/rails/react-components/src/library/components/permission-forms-v2/manage-forms-tab/manage-forms-tab.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/manage-forms-tab/manage-forms-tab.tsx
@@ -3,10 +3,11 @@ import { clsx } from "clsx";
 import { useFetch } from "../../../hooks/use-fetch";
 import { CreateEditPermissionForm } from "./create-edit-permission-form";
 import { IPermissionForm, IPermissionFormFormData, IProject, CurrentSelectedProject } from "./types";
-import PermissionFormRow from "./permission-form-row";
 import { ProjectSelect } from "../common/project-select";
-import ModalDialog from "../../shared/modal-dialog";
 import { request } from "../../../helpers/api/request";
+import { filteredByProject, sortedByArchiveAndName } from "../common/permission-utils";
+import PermissionFormRow from "./permission-form-row";
+import ModalDialog from "../../shared/modal-dialog";
 
 import css from "./manage-forms-tab.scss";
 
@@ -29,25 +30,6 @@ const deletePermissionForm = async (permissionFormId: string) =>
     url: `${Portal.API_V1.PERMISSION_FORMS}/${permissionFormId}`,
     method: "DELETE"
   });
-
-const getFormsByProject = (forms: IPermissionForm[], projectId: CurrentSelectedProject) => {
-  if (projectId === null) {
-    return forms;
-  } else {
-    return forms.filter((form: IPermissionForm) => form.project_id === projectId);
-  }
-}
-  // projectId === "" ? forms : forms.filter((form: IPermissionForm) => form.project_id === Number(projectId));
-
-const sortByName = (a: { name: string }, b: { name: string }) => a.name.localeCompare(b.name);
-
-// Sort forms by is_archived first and then by name
-const sortForms = (forms: IPermissionForm[]) => forms.sort((a, b) => {
-  if (a.is_archived === b.is_archived) {
-    return sortByName(a, b);
-  }
-  return a.is_archived ? 1 : -1;
-});
 
 export default function ManageFormsTab() {
   // Fetch projects and permission forms (with refetch function) on initial load
@@ -101,7 +83,7 @@ export default function ManageFormsTab() {
     refetchPermissions();
   };
 
-  const processedForms = sortForms(getFormsByProject(permissionsData, currentSelectedProject));
+  const processedForms = sortedByArchiveAndName(filteredByProject(permissionsData, currentSelectedProject));
   const cantDeleteAnyForm = processedForms.every((form: IPermissionForm) => form.can_delete === false);
 
   return (

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/edit-student-permissions-form.scss
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/edit-student-permissions-form.scss
@@ -13,9 +13,11 @@
   }
 
   .formRow {
-    display: flex;
     align-items: center;
     padding: 10px 5px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 
     label {
       width: 80px;

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/edit-student-permissions-form.scss
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/edit-student-permissions-form.scss
@@ -12,6 +12,11 @@
     padding: 10px;
   }
 
+  .scrollableWrapper {
+    max-height: 300px;
+    overflow-y: scroll;
+  }
+
   .formRow {
     align-items: center;
     padding: 10px 5px;

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/edit-student-permissions-form.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/edit-student-permissions-form.tsx
@@ -67,21 +67,22 @@ export const EditStudentPermissionsForm = ({ student, permissionForms, onFormCan
       <div className={css.formTop}>
         { `EDIT: ${student.name}` }
       </div>
+      <div className={css.scrollableWrapper}>
+        { permissionForms.map((p, i) => {
+          const isChecked = localPermissions.some(lp => lp.id === p.id);
 
-      { permissionForms.map((p, i) => {
-        const isChecked = localPermissions.some(lp => lp.id === p.id);
-
-        return (
-          <div key={i} className={css.formRow}>
-            <input
-              type="checkbox"
-              checked={isChecked}
-              onChange={() => handlePermissionChange(p.id)}
-            />
-            { p.name }
-          </div>
-        );
-      }) }
+          return (
+            <div key={i} className={css.formRow}>
+              <input
+                type="checkbox"
+                checked={isChecked}
+                onChange={() => handlePermissionChange(p.id)}
+              />
+              { p.name }
+            </div>
+          );
+        }) }
+      </div>
 
       <div className={css.formButtonArea}>
         <button className={css.cancelButton} onClick={onFormCancel}>

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-tab.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-tab.tsx
@@ -35,7 +35,7 @@ export default function StudentsTab() {
   const [currentSelectedProject, setCurrentSelectedProject] = useState<CurrentSelectedProject>(null);
 
   const handleProjectSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    setCurrentSelectedProject(e.target.value === '' ? null : Number(e.target.value));
+    setCurrentSelectedProject(e.target.value === "" ? null : Number(e.target.value));
   };
 
   const handleTeacherNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-tab.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-tab.tsx
@@ -32,10 +32,10 @@ export default function StudentsTab() {
   const[teacherName, setTeacherName] = useState<string>("");
 
   // State for UI
-  const [currentSelectedProject, setCurrentSelectedProject] = useState<number | "">("");
+  const [currentSelectedProject, setCurrentSelectedProject] = useState<CurrentSelectedProject>(null);
 
   const handleProjectSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    setCurrentSelectedProject(e.target.value as CurrentSelectedProject);
+    setCurrentSelectedProject(e.target.value === '' ? null : Number(e.target.value));
   };
 
   const handleTeacherNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.tsx
@@ -18,7 +18,13 @@ type PermissionFormOption = {
   label: string;
 };
 
-const nonArchived = (forms: IPermissionForm[]) => forms.filter(form => !form.is_archived);
+const nonArchived = (forms: IPermissionForm[]) => {
+  return forms.filter(form => !form.is_archived);
+};
+
+const inProject = (forms: IPermissionForm[], projectId: CurrentSelectedProject) => {
+  return forms.filter(form => form.project_id === projectId);
+};
 
 export const bulkUpdatePermissionForms = async (
   { classId, selectedStudentIds, addFormIds, removeFormIds }:
@@ -35,7 +41,7 @@ export const bulkUpdatePermissionForms = async (
     })
   });
 
-export const StudentsTable = ({ classId }: IProps) => {
+export const StudentsTable = ({ classId, currentSelectedProject }: IProps) => {
   const { data: studentsData, isLoading: studentsLoading, refetch: refetchStudentsData } =
     useFetch<IStudent[]>(Portal.API_V1.permissionFormsClassPermissionForms(classId), []);
   const { data: permissionForms, isLoading: permissionFormsLoading } = useFetch<IPermissionForm[]>(Portal.API_V1.PERMISSION_FORMS, []);
@@ -47,6 +53,8 @@ export const StudentsTable = ({ classId }: IProps) => {
   const [permissionsExpanded, setPermissionsExpanded] = useState(false);
 
   const nonArchivedPermissionForms = nonArchived(permissionForms);
+  const inProjectPermissionForms = inProject(permissionForms, currentSelectedProject);
+
   const permissionFormToAddOptions = Object.freeze(
     nonArchivedPermissionForms.filter(pf => !permissionFormsToRemove.find(pfr => pfr.value === pf.id)).map(pf => ({ value: pf.id, label: pf.name }))
   );
@@ -143,7 +151,7 @@ export const StudentsTable = ({ classId }: IProps) => {
         <thead>
           <tr>
             <th className={css.checkboxColumn}><input type="checkbox" checked={allStudentsSelected} onChange={handleSelectAllChange} /></th>
-            <th>Student Name</th>
+            <th>Student Name NOICE</th>
             <th>Username</th>
             <th className={css.permissionFormsColumn} colSpan={2}>
               <div role="button" onClick={handleClickPermissionExpandToggle}>

--- a/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.tsx
+++ b/rails/react-components/src/library/components/permission-forms-v2/students-tab/students-table.tsx
@@ -151,7 +151,7 @@ export const StudentsTable = ({ classId, currentSelectedProject }: IProps) => {
         <thead>
           <tr>
             <th className={css.checkboxColumn}><input type="checkbox" checked={allStudentsSelected} onChange={handleSelectAllChange} /></th>
-            <th>Student Name NOICE</th>
+            <th>Student Name</th>
             <th>Username</th>
             <th className={css.permissionFormsColumn} colSpan={2}>
               <div role="button" onClick={handleClickPermissionExpandToggle}>


### PR DESCRIPTION
PT-187782786

- Filters permission forms by selected project, if any.  
- Filters the lists of forms found in the bulk edit lists, the individual student forms edit modal, and the flat list of forms in the students table
- Moves and renames composable sort and filter functions for permission forms in a util file
- Types `CurrentSelectedProject` to `number | null` to simplify interface and streamline filtering

Additional styling fix to student permission edit modal:
- form names are truncated 
- long lists will scroll within modal window