### PR TITLE
Permission Forms: final code cleanup, fixed types and small layout issues [PT-187613639]

### DIFF
--- a/rails/react-components/src/library/components/permission-forms/common/types.ts
+++ b/rails/react-components/src/library/components/permission-forms/common/types.ts
@@ -1,6 +1,7 @@
 export type CurrentSelectedProject = number | null;
+
 export interface IPermissionForm {
-  id: string;
+  id: number;
   name: string;
   is_archived: boolean;
   can_delete: boolean;
@@ -9,7 +10,7 @@ export interface IPermissionForm {
 }
 
 export interface IProject {
-  id: string;
+  id: number;
   name: string;
 }
 

--- a/rails/react-components/src/library/components/permission-forms/index.scss
+++ b/rails/react-components/src/library/components/permission-forms/index.scss
@@ -1,7 +1,7 @@
 @import "../../../shared/styles/variables/variables";
 
 .permissionForms {
-  margin-bottom: 200px; // for dropdown menu
+  margin-bottom: 180px; // for dropdown menu
 
   .tabArea {
     .tabs {

--- a/rails/react-components/src/library/components/permission-forms/manage-forms-tab/create-edit-permission-form.scss
+++ b/rails/react-components/src/library/components/permission-forms/manage-forms-tab/create-edit-permission-form.scss
@@ -4,13 +4,14 @@
   width: 600px;
 
   .formTop {
-    display: flex;
-    align-content: center;
     background-color: $col-link;
     color: white;
     font-weight: bold;
     padding: 10px;
     margin-bottom:10px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .formRow {

--- a/rails/react-components/src/library/components/permission-forms/manage-forms-tab/manage-forms-tab.tsx
+++ b/rails/react-components/src/library/components/permission-forms/manage-forms-tab/manage-forms-tab.tsx
@@ -25,7 +25,7 @@ const editPermissionForm = async (formData: IPermissionFormFormData): Promise<IP
     body: JSON.stringify({ permission_form: { ...formData } })
   });
 
-const deletePermissionForm = async (permissionFormId: string) =>
+const deletePermissionForm = async (permissionFormId: number) =>
   request({
     url: `${Portal.API_V1.PERMISSION_FORMS}/${permissionFormId}`,
     method: "DELETE"
@@ -78,7 +78,7 @@ export default function ManageFormsTab() {
     }
   };
 
-  const handleDeleteClick = async (permissionFormId: string) => {
+  const handleDeleteClick = async (permissionFormId: number) => {
     await deletePermissionForm(permissionFormId);
     refetchPermissions();
   };

--- a/rails/react-components/src/library/components/permission-forms/manage-forms-tab/permission-form-row.tsx
+++ b/rails/react-components/src/library/components/permission-forms/manage-forms-tab/permission-form-row.tsx
@@ -8,7 +8,7 @@ interface PermissionFormRowProps {
   permissionForm: IPermissionForm;
   onEditModalToggle: (permissionForm: IPermissionForm) => void;
   onEdit: (permissionForm: IPermissionForm) => void;
-  onDelete: (permissionFormId: string) => void;
+  onDelete: (permissionFormId: number) => void;
 }
 
 function ensureUrlProtocol(url: string): string {

--- a/rails/react-components/src/library/components/permission-forms/students-tab/classes-table.tsx
+++ b/rails/react-components/src/library/components/permission-forms/students-tab/classes-table.tsx
@@ -8,13 +8,13 @@ import { CurrentSelectedProject, IClassBasicInfo } from "./types";
 import css from "./classes-table.scss";
 
 interface IProps {
-  teacherId: string;
+  teacherId: number;
   currentSelectedProject: CurrentSelectedProject;
 }
 
 export const ClassesTable = ({ teacherId, currentSelectedProject }: IProps) => {
   const { data: classesData, isLoading } = useFetch<IClassBasicInfo[]>(Portal.API_V1.teacherClasses(teacherId), []);
-  const [selectedClassId, setSelectedClassId] = useState<string | null>(null);
+  const [selectedClassId, setSelectedClassId] = useState<number | null>(null);
 
   if (isLoading) {
     return (<div>Loading...</div>);
@@ -23,8 +23,8 @@ export const ClassesTable = ({ teacherId, currentSelectedProject }: IProps) => {
     return (<div>No classes found</div>);
   }
 
-  const handleViewStudentsClick = (classId: string) => {
-    setSelectedClassId((prevSelectedClass: string | null) => prevSelectedClass === classId ? null : classId);
+  const handleViewStudentsClick = (classId: number) => {
+    setSelectedClassId((prevSelectedClass: number | null) => prevSelectedClass === classId ? null : classId);
   };
 
   return (

--- a/rails/react-components/src/library/components/permission-forms/students-tab/edit-student-permissions-form.scss
+++ b/rails/react-components/src/library/components/permission-forms/students-tab/edit-student-permissions-form.scss
@@ -1,6 +1,6 @@
 @import "../../../../shared/styles/variables/variables";
 
-.editStudentPerimissionsForm {
+.editStudentPermissionsForm {
   width: 540px;
 
   .formTop {
@@ -10,7 +10,7 @@
     background-color: $blue;
     color: white;
     font-weight: bold;
-    padding: 10px;
+    padding: 8px 10px;
 
     .studentName {
       align-content: center;
@@ -22,13 +22,13 @@
     .closeButton button {
       padding: 0px;
       border: none;
-      width: 40px;
-      height: 40px;
+      width: 27px;
+      height: 27px;
       text-align: center;
       display: flex;
       align-items: center;
       justify-content: center;
-      border-radius: 50px;
+      border-radius: 50%;
       background-color: white;
       &:hover {
         background-color: darken(white, 10%);
@@ -36,14 +36,14 @@
       i {
         color: $blue;
         margin: 0 auto;
-        font-size: 16px;
+        font-size: 15px;
       }
     }
   }
 
   .scrollableWrapper {
     max-height: 300px;
-    overflow-y: scroll;
+    overflow-y: auto;
   }
 
   .formRow {

--- a/rails/react-components/src/library/components/permission-forms/students-tab/students-tab.tsx
+++ b/rails/react-components/src/library/components/permission-forms/students-tab/students-tab.tsx
@@ -28,7 +28,7 @@ export default function StudentsTab() {
   // `null` means no search has been done yet, while an empty array means no results were found.
   const [teachers, setTeachers] = useState<ITeacher[] | null>(null);
   const [teachersLimitApplied, setTeachersLimitApplied] = useState<boolean>(false);
-  const [selectedTeacherId, setSelectedTeacherId] = useState<string | null>(null);
+  const [selectedTeacherId, setSelectedTeacherId] = useState<number | null>(null);
   const[teacherName, setTeacherName] = useState<string>("");
 
   // State for UI
@@ -42,6 +42,12 @@ export default function StudentsTab() {
     setTeacherName(e.target.value);
   };
 
+  const handleEnterKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      handleSearchClick();
+    }
+  };
+
   const handleSearchClick = async () => {
     setSelectedTeacherId(null);
     const { teachers: foundTeachers, limit_applied } = await searchTeachers(teacherName);
@@ -49,8 +55,8 @@ export default function StudentsTab() {
     setTeachersLimitApplied(limit_applied);
   };
 
-  const handleViewClassesClick = (teacherId: string) => {
-    setSelectedTeacherId((prevSelectedTeacher: string | null) => prevSelectedTeacher === teacherId ? null : teacherId);
+  const handleViewClassesClick = (teacherId: number) => {
+    setSelectedTeacherId((prevSelectedTeacher: number | null) => prevSelectedTeacher === teacherId ? null : teacherId);
   };
 
   return (
@@ -58,7 +64,7 @@ export default function StudentsTab() {
       <div className={css.controlsArea}>
         <div className={css.leftSide}>
           <div className={css.leftSideFirstRow}>
-            <input type="text" value={teacherName} onChange={handleTeacherNameChange} />
+            <input type="text" value={teacherName} onChange={handleTeacherNameChange} onKeyDown={handleEnterKey} />
             <button onClick={handleSearchClick}>Search</button>
           </div>
           <div>

--- a/rails/react-components/src/library/components/permission-forms/students-tab/students-table.scss
+++ b/rails/react-components/src/library/components/permission-forms/students-tab/students-table.scss
@@ -21,9 +21,7 @@ table.studentsTable {
 
   &.expandedPermissions {
     td.permissionFormsColumn {
-      overflow: visible;
       white-space: normal;
-      text-overflow: none;
     }
   }
 
@@ -32,8 +30,19 @@ table.studentsTable {
     text-overflow: ellipsis;
   }
 
+  .permissionFormSelectMenuList {
+    max-height: 250px;
+  }
+
   .checkboxColumn {
     width: 35px;
+  }
+
+  th.permissionFormsColumn {
+    cursor: pointer;
+    &:hover {
+      background-color: lighten($permission-gold, 5%);
+    }
   }
 
   .permissionFormsColumn {

--- a/rails/react-components/src/library/components/permission-forms/students-tab/types.ts
+++ b/rails/react-components/src/library/components/permission-forms/students-tab/types.ts
@@ -3,21 +3,21 @@ import { IPermissionForm } from "./types";
 export { IPermissionForm, IProject, CurrentSelectedProject } from "../common/types";
 
 export interface ITeacher {
-  id: string;
+  id: number;
   name: string;
   email: string;
   login: string;
 }
 
 export interface IStudent {
-  id: string;
+  id: number;
   name: string;
   login: string;
   permission_forms: IPermissionForm[];
 }
 
 export interface IClassBasicInfo {
-  id: string;
+  id: number;
   name: string;
   class_word: string;
 }

--- a/rails/react-components/src/library/components/shared/modal-dialog.tsx
+++ b/rails/react-components/src/library/components/shared/modal-dialog.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import Modal from "./modal";
 import css from "./modal-dialog.scss";
 
@@ -7,20 +7,29 @@ interface IProps {
   title?: string;
   borderColor?: "orange" | "teal";
 }
-export default class ModalDialog extends React.Component<IProps> {
-  render () {
-    const { title, children, borderColor } = this.props;
-    const themeClass = borderColor || "teal";
 
-    return (
-      <Modal>
-        <div className={`${css.dialog} ${css[themeClass]}`}>
-          { title && <div className={css.dialogTitleBar}>{ title }</div> }
-          <div className={css.dialogContent}>
-            { children }
-          </div>
+const ModalDialog  = ({ title, children, borderColor }: IProps) => {
+  const themeClass = borderColor || "teal";
+
+  useEffect(() => {
+    const previousOverflowValue = document.body.style.getPropertyValue("overflow");
+    const previousOverflowPriority = document.body.style.getPropertyPriority("overflow");
+    document.body.style.setProperty("overflow", "hidden", "important");
+    return () => {
+      document.body.style.setProperty("overflow", previousOverflowValue, previousOverflowPriority);
+    };
+  }, []);
+
+  return (
+    <Modal>
+      <div className={`${css.dialog} ${css[themeClass]}`}>
+        { title && <div className={css.dialogTitleBar}>{ title }</div> }
+        <div className={css.dialogContent}>
+          { children }
         </div>
-      </Modal>
-    );
-  }
-}
+      </div>
+    </Modal>
+  );
+};
+
+export default ModalDialog;


### PR DESCRIPTION
This PR cleans up a few issues I spotted in the code or while testing:

1. Fixed all the types to use `id: number` since that's what Portal returns.
2. Made the Modal block overflow of the `body` element, as both containers were scrollable, which felt weird.
3. Fixed the students table layout a bit, restored the wider width of the permission forms column, and ensured that long names are handled correctly:
   ![Screenshot 2024-07-04 at 19 31 57](https://github.com/concord-consortium/rigse/assets/767857/ba0a68e4-a1ed-41c1-9f0a-6d32cc7d7b2d)
4. Fixed the Add/Remove dropdown scrolling issue when the list was long (the page needs to have enough padding below).
5. Updated the edit student permission forms header styles to match Zeplin more closely.
6. Moved the API call out of the Edit Permission Forms dialog as ESLint was complaining about a dependency cycle.