### PR TITLE
fix: Remove editable rubric JSON url [PT-187946772]

### DIFF
--- a/rails/app/views/external_activities/_form.html.haml
+++ b/rails/app/views/external_activities/_form.html.haml
@@ -62,13 +62,9 @@
           = f.check_box :has_teacher_edition, :disabled => true
         This activity has a teacher edition.
     = field_set_tag t('authoring.rubric_doc_url_label') do
-      = f.text_field :rubric_doc_url, :size => 60
+      = f.text_field :rubric_doc_url, :size => 60, :title => "Rubric JSON url (for debugging): #{@external_activity.rubric_url}"
       %br
       This is the URL to the human-readable rubric document.
-    = field_set_tag t('authoring.rubric_url_label') do
-      = f.text_field :rubric_url, :size => 60
-      %br
-      This is the URL to the machine-readable rubric data.
     = field_set_tag 'Thumbnail image URL (300 x 250 px)' do
       = f.text_field :thumbnail_url, :size => 60
     = field_set_tag 'Feature On Landing Page' do


### PR DESCRIPTION
This url is now set by LARA using a system-managed authored content URL.  For debugging purposes the value is now shown as the title of the text input for the rubric document url which is still editable.