### PR TITLE
Update Success Message for Assigning Classes (PT-188181381)

### DIFF
--- a/rails/react-components/src/library/components/assign-to-class/assign-modal.tsx
+++ b/rails/react-components/src/library/components/assign-to-class/assign-modal.tsx
@@ -236,7 +236,7 @@ export default class AssignModal extends React.Component<any, any> {
   resourceAssigned () {
     return (
       <ReactModal ariaHideApp={false} isOpen={this.state.showModal} onRequestClose={this.props.closeFunc} className={css.confirmDialog} overlayClassName={css.confirmDialogOverlay} portalClassName={css.confirmDialogPortal}>
-        <p>The { this.props.resourceType } <strong>{ this.props.resourceTitle }</strong> is assigned to the selected class(es) successfully.</p>
+        <p>The { this.props.resourceType } <strong>{ this.props.resourceTitle }</strong> has now been successfully assigned to the selected class(es).</p>
         <button onClick={this.closeConfirmModal}>OK</button>
       </ReactModal>
     );

--- a/rails/spec/features/teacher_assigns_resource_spec.rb
+++ b/rails/spec/features/teacher_assigns_resource_spec.rb
@@ -132,7 +132,7 @@ RSpec.feature 'Teachers and anonymous users should be able to see an assign butt
           first(".unassigned_activity_class").click
           click_on "Save"
         end
-        expect(page).to have_content("is assigned to the selected class(es) successfully.")
+        expect(page).to have_content("has now been successfully assigned to the selected class(es).")
       end
     end
 


### PR DESCRIPTION
**Description:**

This PR addresses [PT-188181381](https://www.pivotaltracker.com/story/show/188181381), making a small tweak to the phrasing used when an activity is successfully assigned to a class.

**Changes:**

- Updated the success message text from:
  - "The activity **MODS problem 1.7** is assigned to the selected class(es) successfully."
  
  To:
  
  - "The activity **MODS problem 1.7** has now been successfully assigned to the selected class(es)."

This change improves clarity in the confirmation message displayed to users.