### PR TITLE
fix: Show archived classes in permissions UI [PT-188564811]

### DIFF
--- a/rails/app/controllers/api/v1/teachers_controller.rb
+++ b/rails/app/controllers/api/v1/teachers_controller.rb
@@ -179,9 +179,8 @@ class API::V1::TeachersController < API::APIController
 
     authorize teacher, :show?
 
-    # Fetch only non-archived classes using pluck
-    classes = teacher.clazzes.where(is_archived: false).pluck(:id, :name, :class_hash, :class_word).map do |id, name, class_hash, class_word|
-      { id: id, name: name, class_hash: class_hash, class_word: class_word }
+    classes = teacher.clazzes.pluck(:id, :name, :class_hash, :class_word, :is_archived).map do |id, name, class_hash, class_word, is_archived|
+      { id: id, name: name, class_hash: class_hash, class_word: class_word, is_archived: is_archived }
     end
 
     render json: classes

--- a/rails/react-components/src/library/components/permission-forms/students-tab/classes-table.tsx
+++ b/rails/react-components/src/library/components/permission-forms/students-tab/classes-table.tsx
@@ -30,7 +30,7 @@ export const ClassesTable = ({ teacherId, currentSelectedProject }: IProps) => {
   return (
     <table className={css.classesTable}>
       <thead>
-        <tr><th>Class Name</th><th>Class Word</th><th></th></tr>
+        <tr><th>Class Name</th><th>Class Word</th><th>Class Status</th><th></th></tr>
       </thead>
       <tbody>
         {
@@ -41,6 +41,7 @@ export const ClassesTable = ({ teacherId, currentSelectedProject }: IProps) => {
                 <tr className={clsx({ [css.activeRow]: active })}>
                   <td>{ classInfo.name }</td>
                   <td>{ classInfo.class_word }</td>
+                  <td>{ classInfo.is_archived ? "Archived" : "Active" }</td>
                   <td>
                     <LinkButton onClick={() => handleViewStudentsClick(classInfo.id)} active={active}>
                       {

--- a/rails/react-components/src/library/components/permission-forms/students-tab/types.ts
+++ b/rails/react-components/src/library/components/permission-forms/students-tab/types.ts
@@ -20,4 +20,5 @@ export interface IClassBasicInfo {
   id: number;
   name: string;
   class_word: string;
+  is_archived: boolean;
 }


### PR DESCRIPTION
This removes the server-side filtering of archived classes and adds the is_archived attribute to the returned class list.  A new column called "Class Status" has been added to the class list when a teacher in selected in the permissions UI.  This new column shows "Archived" if the class is archived and "Active" is it is not.