### PR TITLE
fix: Revert default teacher classes list to not include archived classes [PT-188564811]

### DIFF
--- a/rails/app/controllers/api/v1/teachers_controller.rb
+++ b/rails/app/controllers/api/v1/teachers_controller.rb
@@ -179,7 +179,14 @@ class API::V1::TeachersController < API::APIController
 
     authorize teacher, :show?
 
-    classes = teacher.clazzes.pluck(:id, :name, :class_hash, :class_word, :is_archived).map do |id, name, class_hash, class_word, is_archived|
+    include_archived = params[:include_archived] == "true"
+    if include_archived
+      clazzes = teacher.clazzes
+    else
+      clazzes = teacher.clazzes.where(is_archived: false)
+    end
+
+    classes = clazzes.pluck(:id, :name, :class_hash, :class_word, :is_archived).map do |id, name, class_hash, class_word, is_archived|
       { id: id, name: name, class_hash: class_hash, class_word: class_word, is_archived: is_archived }
     end
 

--- a/rails/react-components/src/library/components/permission-forms/students-tab/classes-table.tsx
+++ b/rails/react-components/src/library/components/permission-forms/students-tab/classes-table.tsx
@@ -13,7 +13,8 @@ interface IProps {
 }
 
 export const ClassesTable = ({ teacherId, currentSelectedProject }: IProps) => {
-  const { data: classesData, isLoading } = useFetch<IClassBasicInfo[]>(Portal.API_V1.teacherClasses(teacherId), []);
+  const classesUrl = `${Portal.API_V1.teacherClasses(teacherId)}?include_archived=true`;
+  const { data: classesData, isLoading } = useFetch<IClassBasicInfo[]>(classesUrl, []);
   const [selectedClassId, setSelectedClassId] = useState<number | null>(null);
 
   if (isLoading) {


### PR DESCRIPTION
In case other existing api consumers are expecting non-archived classes to not be in the list of the teacher's classes a new query parameter, include_archived, must be set to true to include the archived classes in the list.

The permission forms component has been updated to use this new parameter.