### PR TITLE
Add indexes migration

### DIFF
--- a/rails/db/migrate/20241209134710_add_portal_grade_indexes.rb
+++ b/rails/db/migrate/20241209134710_add_portal_grade_indexes.rb
@@ -1,0 +1,8 @@
+class AddPortalGradeIndexes < ActiveRecord::Migration[6.1]
+  def change
+    add_index :portal_grade_levels, [:has_grade_levels_id, :has_grade_levels_type],
+      :name => 'by_grade_levels_id_and_type'
+    add_index :portal_grade_levels, [:grade_id],
+      :name => 'by_grade_id'
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_06_27_133234) do
+ActiveRecord::Schema.define(version: 2024_12_09_134710) do
 
   create_table "access_grants", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "code"
@@ -544,6 +544,8 @@ ActiveRecord::Schema.define(version: 2024_06_27_133234) do
     t.integer "has_grade_levels_id"
     t.string "has_grade_levels_type"
     t.integer "grade_id"
+    t.index ["grade_id"], name: "by_grade_id"
+    t.index ["has_grade_levels_id", "has_grade_levels_type"], name: "by_grade_levels_id_and_type"
   end
 
   create_table "portal_grade_levels_teachers", id: false, charset: "utf8", force: :cascade do |t|


### PR DESCRIPTION
I am hopeful that adding these indexes would allow the `resource-metrics-details` report to show grade levels for classes without timing out.