### PR TITLE
feat: Add researcher portal JWTs [PT-188754102]

### DIFF
--- a/rails/app/controllers/api/v1/jwt_controller.rb
+++ b/rails/app/controllers/api/v1/jwt_controller.rb
@@ -149,7 +149,20 @@ class API::V1::JwtController < API::APIController
     user, learner, teacher = handle_initial_auth
 
     claims = {}
-    if learner
+    if params[:researcher] == "true"
+      # Note: no check is done to see if the user is a researcher for any projects.
+      # The researcher user_type is used only by clients to know what type of JWT they have
+      # and all requests to the portal using the JWT are checked for permissions using the user_id
+      # which will check if the user has permissions to access the data.
+      # These JWTs are used currently only by generated links in reports and those links may
+      # be used by people who are not researchers but have access to the data as project admins
+      # or site admins.
+      claims = {
+        :domain => root_url,
+        :user_type => "researcher",
+        :user_id => url_for(user)
+      }
+    elsif learner
       offering = learner.offering
       claims = {
         :domain => root_url,

--- a/rails/app/controllers/api/v1/jwt_controller.rb
+++ b/rails/app/controllers/api/v1/jwt_controller.rb
@@ -160,7 +160,9 @@ class API::V1::JwtController < API::APIController
       claims = {
         :domain => root_url,
         :user_type => "researcher",
-        :user_id => url_for(user)
+        :user_id => url_for(user),
+        :first_name => user.first_name,
+        :last_name => user.last_name
       }
     elsif learner
       offering = learner.offering

--- a/rails/spec/controllers/api/v1/jwt_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/jwt_controller_spec.rb
@@ -650,6 +650,8 @@ SHlL1Ceaqm35aMguGMBcTs6T5jRJ36K2OPEXU2ZOiRygxcZhFw==
             expect(decoded_token[:data]["domain"]).to eql root_url
             expect(decoded_token[:data]["user_type"]).to eq "researcher"
             expect(decoded_token[:data]["user_id"]).not_to be_nil
+            expect(decoded_token[:data]["first_name"]).to eql user.first_name
+            expect(decoded_token[:data]["last_name"]).to eql user.last_name
           end
         end
       end

--- a/rails/spec/controllers/api/v1/jwt_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/jwt_controller_spec.rb
@@ -636,6 +636,22 @@ SHlL1Ceaqm35aMguGMBcTs6T5jRJ36K2OPEXU2ZOiRygxcZhFw==
             end
           end
         end
+
+        context "and the jwt is requested as a researcher" do
+          it "returns a valid JWT with researcher params" do
+            post :portal, params: { :researcher => "true" }, session: { :format => :json }
+            expect(response.status).to eq(201)
+
+            body = JSON.parse(response.body)
+            token = body["token"]
+            decoded_token = SignedJWT::decode_portal_token(token)
+
+            expect(decoded_token[:data]["uid"]).to eql user.id
+            expect(decoded_token[:data]["domain"]).to eql root_url
+            expect(decoded_token[:data]["user_type"]).to eq "researcher"
+            expect(decoded_token[:data]["user_id"]).not_to be_nil
+          end
+        end
       end
 
       context "and the token has a learner" do


### PR DESCRIPTION
This adds a new user_type of "researcher" to the portal JWTs.  Like the Firebase JWT code the requester needs to add "researcher=true" to the request to ask for a researcher JWT.

Unlike the Firebase JWT no checks are made to see if the user is actually a researcher.  This is because, unlike the Firebase JWT, no claim is being made for a specific class and the researcher user_type is used only by clients to know what type of JWT they have and all requests to the portal using the JWT are checked for permissions using the user_id which will check if the user has permissions to access the data.

These JWTs are used currently only by generated links in reports and those links may be used by people who are not researchers but have access to the data as project admins.