### PR TITLE
feat: Add teacher feedback notice to student offerings [PT-188732128]

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,8 @@ With the following settings you can:
 4. Add a Firebase App for report-service-dev with `docker-compose exec app bundle exec app:setup:add_report_service_firebase_app`, it will ask for the "private_key", paste in the private key from report-service-dev firebase app in learn.staging.concord.org
 5. in LARA: `cp .env-osx-sample .env`
 6. in LARA `.env`:
-    1. set `REPORT_SERVICE_TOKEN` (see the comment in the .env-osx-sample file)
-    2. set `LARA_PROTOCOL=https`
-    3. set `PORTAL_PROTOCOL=https`
+    1. set `LARA_PROTOCOL=https`
+    2. set `PORTAL_PROTOCOL=https`
 7. start up LARA: `docker-compose up`
 8. Setup admin access to LARA using a portal SSO login:
     1. Go to https://app.lara.docker
@@ -151,7 +150,7 @@ Notes:
     2. Set `PORTAL_HOST` to `app.portal.docker` or whatever domain your local portal is
     3. Set `PORTAL_PROTOCOL=https`
     4. set `LARA_PROTOCOL=https`
-    5. Set `REPORT_SERVICE_TOKEN` (see the comment in the .env file)
+    5. Set `REPORT_SERVICE_BEARER_TOKEN` (see the comment in the .env file)
     6. set `REPORT_SERVICE_URL` (see the value in the .env-osx-sample file)
 5. Stop your Lara services if they are running, and update them with `docker-compose up`
 6. If you want admin access to Lara when signing in with a portal user, you will need to first login to LARA
@@ -189,7 +188,7 @@ When you run the portal-report if you just see a spinner. Here are some steps to
     1. Go to the firebase console and open the report-service-dev firestore.
     2. Look in the sources collection
     3. You should see a `app.lara.docker.{$USER}` collection (USER is your local username)
-    4. If you don't see this collection then your LARA is not properly publishing the report structure to the report-service. In LARA check the values of `REPORT_SERVICE_TOKEN` and `REPORT_SERVICE_URL` (see above). A less common error would be a misconfigured `LARA_HOST` and `TOOL_ID` setup.
+    4. If you don't see this collection then your LARA is not properly publishing the report structure to the report-service. In LARA check the values of `REPORT_SERVICE_BEARER_TOKEN` and `REPORT_SERVICE_URL` (see above). A less common error would be a misconfigured `LARA_HOST` and `TOOL_ID` setup.
     5. After fixing these values update your lara app so it picks up the variables with `docker-compose up`. And make a change to your activity so it republishes the structure to Firestore. Check that the `app.lara.docker.{$USER}` collection is there now.
 2. Verify the resource structure added to firestore has the right URL:
     1. Go to the firebase console and open the report-service-dev firestore.

--- a/configs/cloudformation/stack_template.yml
+++ b/configs/cloudformation/stack_template.yml
@@ -260,6 +260,20 @@ Parameters:
     Default: https://report-server.concord.org/reports
     Description: URL of the root report page report server. This is used in the sidebar link for report server.
 
+  ReportServiceURL:
+    Type: String
+    Default: https://us-central1-report-service-pro.cloudfunctions.net/api
+    Description: URL of the API endpoint in the report-service Firebase Functions API (use https://us-central1-report-service-dev.cloudfunctions.net/api for staging)
+
+  ReportServiceBearerToken:
+    Type: String
+    Description: Server-to-server bearer token for report-service API (see report-service project)
+
+  ReportServiceSource:
+    Type: String
+    Default: authoring.concord.org
+    Description: Source collection for report service data (use authoring.lara.staging.concord.org for staging)
+
 Conditions:
   PortalPagesLibraryDefined: !Not [!Equals [!Ref PortalPagesLibraryVersion, ""]]
   CreateLoadBalancerHTTPRedirectCond:
@@ -561,6 +575,12 @@ Resources:
               Value: !Ref LoggerUri
             - Name: REPORT_SERVER_REPORTS_URL
               Value: !Ref ReportServerReportsUrl
+            - Name: REPORT_SERVICE_URL
+              Value: !Ref ReportServiceURL
+            - Name: REPORT_SERVICE_BEARER_TOKEN
+              Value: !Ref ReportServiceBearerToken
+            - Name: REPORT_SERVICE_SOURCE
+              Value: !Ref ReportServiceSource
 
   # Notes from 2017-11-14:
   # Values where changed to match the changed made to the CPU reservation value for the
@@ -1073,6 +1093,12 @@ Resources:
               Value: !Ref LoggerUri
             - Name: REPORT_SERVER_REPORTS_URL
               Value: !Ref ReportServerReportsUrl
+            - Name: REPORT_SERVICE_URL
+              Value: !Ref ReportServiceURL
+            - Name: REPORT_SERVICE_BEARER_TOKEN
+              Value: !Ref ReportServiceBearerToken
+            - Name: REPORT_SERVICE_SOURCE
+              Value: !Ref ReportServiceSource
 
   WorkerService:
     Type: AWS::ECS::Service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,6 +146,10 @@ services:
 
       REPORT_SERVER_REPORTS_URL: "${REPORT_SERVER_REPORTS_URL:-https://report-server.concordqa.org/reports}"
 
+      FEEDBACK_METADATA_URL: "${FEEDBACK_METADATA_URL:-https://us-central1-report-service-dev.cloudfunctions.net/api/student_feedback_metadata}"
+      FEEDBACK_METADATA_SOURCE: "${FEEDBACK_METADATA_SOURCE:-authoring.lara.staging.concord.org}"
+      FEEDBACK_METADATA_BEARER_TOKEN:
+
     # open standard in and turn on tty so we can attach to the container and debug it
     stdin_open: true
     tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,11 +117,6 @@ services:
       TEST_LOG_LEVEL: "${TEST_LOG_LEVEL:-WARN}"
       DEV_LOG_LEVEL: "${DEV_LOG_LEVEL:-DEBUG}"
 
-      #
-      # Source for report service lookups
-      #
-      REPORT_SERVICE_SOURCE: "app_lara_docker"
-
       # Used by imagemagick to add attribution to the images in the image library
       # the DejaVu-Sans font is provided by the docker image this one is built on
       WATERMARK_FONT: "${WATERMARK_FONT:-DejaVu-Sans}"
@@ -146,9 +141,12 @@ services:
 
       REPORT_SERVER_REPORTS_URL: "${REPORT_SERVER_REPORTS_URL:-https://report-server.concordqa.org/reports}"
 
-      FEEDBACK_METADATA_URL: "${FEEDBACK_METADATA_URL:-https://us-central1-report-service-dev.cloudfunctions.net/api/student_feedback_metadata}"
-      FEEDBACK_METADATA_SOURCE: "${FEEDBACK_METADATA_SOURCE:-authoring.lara.staging.concord.org}"
-      FEEDBACK_METADATA_BEARER_TOKEN:
+      #
+      # Report Service settings (used for feedback lookup)
+      #
+      REPORT_SERVICE_URL: "${REPORT_SERVICE_URL:-https://us-central1-report-service-dev.cloudfunctions.net/api}"
+      REPORT_SERVICE_SOURCE: "${REPORT_SERVICE_SOURCE:-authoring.lara.staging.concord.org}"
+      REPORT_SERVICE_BEARER_TOKEN:
 
     # open standard in and turn on tty so we can attach to the container and debug it
     stdin_open: true

--- a/docs/external-services.md
+++ b/docs/external-services.md
@@ -102,7 +102,6 @@ Also the learner (student, offering) is added to the access grant of the token.
 
 ## Launching
 The offering_controller provides the following actions for reports:
-- student_report
 - report
 - external_report
 

--- a/rails/app/assets/images/teacher-feedback-icon.svg
+++ b/rails/app/assets/images/teacher-feedback-icon.svg
@@ -1,0 +1,9 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none" fill-rule="evenodd">
+        <path d="M0 0h24v24H0z"/>
+        <g fill-rule="nonzero">
+            <path d="M3 1a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2h15l5 5V3a2 2 0 0 0-2-2H3zm2 11h9v2H5v-2zm0-4h14v2H5V8zm0-4h14v2H5V4z" fill="#4EA15A"/>
+            <path d="M3 1.5c-.414 0-.79.168-1.06.44-.272.27-.44.646-.44 1.06v13c0 .414.168.79.44 1.06.27.272.646.44 1.06.44h15.207l4.293 4.293V3c0-.414-.168-.79-.44-1.06A1.495 1.495 0 0 0 21 1.5z" stroke="#378142"/>
+        </g>
+    </g>
+</svg>

--- a/rails/app/assets/stylesheets/web/app.scss
+++ b/rails/app/assets/stylesheets/web/app.scss
@@ -1485,10 +1485,19 @@ ul.quiet_list {
     color: gray;
   }
   .run_buttons {
+    display: flex;
+    align-items: center;
+    margin-top: 1em;
+
     .button {
-      margin-top: 1em;
       margin-left: 0px;
       margin-right: 1em;
+    }
+
+    .feedback_metadata {
+      display: flex;
+      gap: 7px;
+      align-items: center;
     }
   }
   .not_run {

--- a/rails/app/controllers/api/v1/students_controller.rb
+++ b/rails/app/controllers/api/v1/students_controller.rb
@@ -216,13 +216,6 @@ class API::V1::StudentsController < API::APIController
   end
 
   def get_feedback_metadata
-    if !current_user || !current_user.portal_student
-      return error("You must be a student to use this endpoint")
-    end
-
-    platform_id = APP_CONFIG[:site_url]
-    platform_student_id = current_user.id
-
     url = ENV['FEEDBACK_METADATA_URL']
     source = ENV['FEEDBACK_METADATA_SOURCE']
     token = ENV['FEEDBACK_METADATA_BEARER_TOKEN']
@@ -233,9 +226,16 @@ class API::V1::StudentsController < API::APIController
     if !source
       return error("Feedback metadata source not configured")
     end
-    if !source
+    if !token
       return error("Feedback metadata bearer token not configured")
     end
+
+    if !current_user || !current_visitor.portal_student
+      return error("You must be a student to use this endpoint")
+    end
+
+    platform_id = APP_CONFIG[:site_url]
+    platform_student_id = current_user.id
 
     uri = URI.parse(url)
     uri.query = URI.encode_www_form({ source: source, platform_id: platform_id, platform_student_id: platform_student_id })

--- a/rails/app/controllers/api/v1/students_controller.rb
+++ b/rails/app/controllers/api/v1/students_controller.rb
@@ -216,9 +216,9 @@ class API::V1::StudentsController < API::APIController
   end
 
   def get_feedback_metadata
-    url = ENV['FEEDBACK_METADATA_URL']
-    source = ENV['FEEDBACK_METADATA_SOURCE']
-    token = ENV['FEEDBACK_METADATA_BEARER_TOKEN']
+    url = ENV['REPORT_SERVICE_URL']
+    source = ENV['REPORT_SERVICE_SOURCE']
+    token = ENV['REPORT_SERVICE_BEARER_TOKEN']
 
     if !url
       return error("Feedback metadata URL not configured")
@@ -238,6 +238,7 @@ class API::V1::StudentsController < API::APIController
     platform_student_id = current_user.id
 
     uri = URI.parse(url)
+    uri.path = uri.path.gsub(/\/?$/, '/student_feedback_metadata')
     uri.query = URI.encode_www_form({ source: source, platform_id: platform_id, platform_student_id: platform_student_id })
 
     response = HTTParty.get(uri, headers: { "Authorization" => "Bearer #{token}" })

--- a/rails/app/controllers/api/v1/students_controller.rb
+++ b/rails/app/controllers/api/v1/students_controller.rb
@@ -215,6 +215,35 @@ class API::V1::StudentsController < API::APIController
     render_ok
   end
 
+  def get_feedback_metadata
+    if !current_user || !current_user.portal_student
+      return error("You must be a student to use this endpoint")
+    end
+
+    platform_id = APP_CONFIG[:site_url]
+    platform_student_id = current_user.id
+
+    url = ENV['FEEDBACK_METADATA_URL']
+    source = ENV['FEEDBACK_METADATA_SOURCE']
+    token = ENV['FEEDBACK_METADATA_BEARER_TOKEN']
+
+    if !url
+      return error("Feedback metadata URL not configured")
+    end
+    if !source
+      return error("Feedback metadata source not configured")
+    end
+    if !source
+      return error("Feedback metadata bearer token not configured")
+    end
+
+    uri = URI.parse(url)
+    uri.query = URI.encode_www_form({ source: source, platform_id: platform_id, platform_student_id: platform_student_id })
+
+    response = HTTParty.get(uri, headers: { "Authorization" => "Bearer #{token}" })
+    render json: response.body
+  end
+
   private
 
   def render_ok

--- a/rails/app/controllers/portal/offerings_controller.rb
+++ b/rails/app/controllers/portal/offerings_controller.rb
@@ -143,18 +143,6 @@ class Portal::OfferingsController < ApplicationController
 
   end
 
-  # report shown to students
-  def student_report
-    offering_id = params[:id]
-    offering = Portal::Offering.find(offering_id)
-    authorize offering
-    student_id = current_visitor.portal_student.id
-    report = DefaultReportService::default_report_for_offering(offering)
-    raise ActionController::RoutingError.new('Default Report Not Found') unless report
-    next_url = report.url_for_offering(offering, current_visitor, request.protocol, request.host_with_port, { student_id: student_id })
-    redirect_to next_url
-  end
-
   # This is in fact a default external report.
   def report
     offering_id = params[:id]

--- a/rails/app/controllers/portal/offerings_controller.rb
+++ b/rails/app/controllers/portal/offerings_controller.rb
@@ -70,7 +70,15 @@ class Portal::OfferingsController < ApplicationController
           }.to_query
           redirect_to(uri.to_s)
         else
-          redirect_to(@offering.runnable.url(learner, root_url))
+          redirect_url = @offering.runnable.url(learner, root_url)
+          if params[:show_feedback].present?
+            uri = URI.parse(redirect_url)
+            query_params = URI.decode_www_form(uri.query || "")
+            query_params << ["showFeedback", "true"]
+            uri.query = URI.encode_www_form(query_params)
+            redirect_url = uri.to_s
+          end
+          redirect_to(redirect_url)
         end
        }
     end

--- a/rails/app/models/api/v1/offering.rb
+++ b/rails/app/models/api/v1/offering.rb
@@ -65,6 +65,7 @@ class API::V1::Offering
   attribute :reportable, Boolean
   attribute :reportable_activities, Array
   attribute :students, Array[OfferingStudent]
+  attribute :locked, Boolean
 
   def report_attributes(report, offering, protocol, host_with_port)
     {
@@ -112,5 +113,6 @@ class API::V1::Offering
     end
 
     self.students = offering.clazz.students.map { |s| OfferingStudent.new(s, offering, protocol, host_with_port, anonymize_students) }
+    self.locked = offering.locked
   end
 end

--- a/rails/app/policies/portal/offering_policy.rb
+++ b/rails/app/policies/portal/offering_policy.rb
@@ -60,10 +60,6 @@ class Portal::OfferingPolicy < ApplicationPolicy
     class_teacher_or_admin? || class_student?
   end
 
-  def student_report?
-    class_student?
-  end
-
   def report?
     class_teacher_or_admin? || class_researcher?
   end

--- a/rails/app/views/dynamic_scripts/_api_paths.html.haml
+++ b/rails/app/views/dynamic_scripts/_api_paths.html.haml
@@ -128,7 +128,10 @@
     // Logging
     getLogManagerUrl: function () {
       return "#{ENV['LOGGER_URI']}" || "https://logger.concord.org/logs"
-    }
+    },
+
+    // feedback
+    GET_FEEDBACK_METADATA: "#{get_feedback_metadata_api_v1_students_path}"
   };
 - if current_user.present?
   - if current_user.portal_teacher

--- a/rails/app/views/shared/_offering_for_student.html.haml
+++ b/rails/app/views/shared/_offering_for_student.html.haml
@@ -15,9 +15,9 @@
             =student_run_buttons(offering)
             %div
               %span.last_run= student_status.last_run_string
-              %div.feedback_metadata{style: "display: none"}
+              %div.feedback_metadata{style: "display: none", :data => {:link => run_url_for(offering)}}
                 =image_tag("teacher-feedback-icon.svg")
-                %span.feedback_metadata_text
+                %a.feedback_metadata_text{:href => run_url_for(offering, {:show_feedback => true}), :target => "_blank"}
           / displayed when the student is already running the activity.
           .run_in_progress{:style => "display: none;"}
             .status

--- a/rails/app/views/shared/_offering_for_student.html.haml
+++ b/rails/app/views/shared/_offering_for_student.html.haml
@@ -31,14 +31,6 @@
               You haven't started this yet.
             - percentage = student_status.complete_percent
             .run_graph{style: "display: #{student_status.never_run ? 'none' : 'block'}"}
-              - if student_status.display_report_link?
-                %span.lightbox_report_link
-                  - if percentage > 99
-                    =link_to t("StudentProgress.GenerateReport.Done"), student_report_portal_offering_url(offering), target: "_blank"
-                  - else
-                    =link_to t("StudentProgress.GenerateReport.NotDone"), student_report_portal_offering_url(offering)
-                %br
-
               - external_reports = offering.runnable.external_reports.where(allowed_for_students: true)
               - if params[:add_external_report]
                 - additional_report = ExternalReport.find_by_id(params[:add_external_report])

--- a/rails/app/views/shared/_offering_for_student.html.haml
+++ b/rails/app/views/shared/_offering_for_student.html.haml
@@ -15,7 +15,7 @@
             =student_run_buttons(offering)
             %div
               %span.last_run= student_status.last_run_string
-              %div.feedback_metadata{style: "display: none", :data => {:link => run_url_for(offering)}}
+              %div.feedback_metadata{style: "display: none"}
                 =image_tag("teacher-feedback-icon.svg")
                 %a.feedback_metadata_text{:href => run_url_for(offering, {:show_feedback => true}), :target => "_blank"}
           / displayed when the student is already running the activity.

--- a/rails/app/views/shared/_offering_for_student.html.haml
+++ b/rails/app/views/shared/_offering_for_student.html.haml
@@ -13,7 +13,11 @@
             %span.name= offering.name
           .run_buttons
             =student_run_buttons(offering)
-            %span.last_run= student_status.last_run_string
+            %div
+              %span.last_run= student_status.last_run_string
+              %div.feedback_metadata{style: "display: none"}
+                =image_tag("teacher-feedback-icon.svg")
+                %span.feedback_metadata_text
           / displayed when the student is already running the activity.
           .run_in_progress{:style => "display: none;"}
             .status

--- a/rails/app/views/shared/_offerings_for_student.html.haml
+++ b/rails/app/views/shared/_offerings_for_student.html.haml
@@ -11,3 +11,37 @@
     %ul.quiet_list
       %li
         .tiny= "No offerings available."
+
+:javascript
+  // get the feedback metadata for the student and update the offerings
+  jQuery(document).ready(function () {
+    jQuery.ajax({
+      url: Portal.API_V1.GET_FEEDBACK_METADATA,
+      success: function(result) {
+        if (result && result.success && result.result) {
+          var feedbackMap = result.result;
+          Object.keys(feedbackMap).forEach((offeringId) => {
+            const metadata = feedbackMap[offeringId]
+            if (metadata && metadata.updatedAt) {
+              const updatedAt = new Date(feedbackMap[offeringId].updatedAt * 1000);
+              const time = new Intl.DateTimeFormat(undefined, {
+                year: 'numeric',
+                month: 'short',
+                day: '2-digit',
+                hour: 'numeric',
+                minute: '2-digit',
+                hour12: undefined
+              }).format(updatedAt);
+
+              // feedback_metadata_text is within feedback_metadata and feedback_metadata
+              // also includes an image which is why we don't just set the .html() on feedback_metadata
+              jQuery("[data-offering-id=" + offeringId + "] .feedback_metadata_text")
+                .html("Teacher Feedback, updated " + time)
+              jQuery("[data-offering-id=" + offeringId + "] .feedback_metadata")
+                .show();
+            }
+          });
+        }
+      },
+    });
+  });

--- a/rails/config/locales/en.yml
+++ b/rails/config/locales/en.yml
@@ -87,10 +87,6 @@ en:
     remove: "Remove %{name} from the collection '%{collection_name}'"
   "Requires download": Requires download
   "Runs in browser": Runs in browser
-  "StudentProgress":
-    "GenerateReport":
-      "NotDone": Generate a report of your work.
-      "Done": Generate a report of your work.
   "StudentReport":
     "Waiting": Please wait. Your report will display soon.
   StudentHasntRun: Not run yet

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -120,8 +120,6 @@ RailsPortal::Application.routes.draw do
           post :answers
           post :offering_collapsed_status
           get :activity_report
-          get :student_report
-          post :student_report
         end
       end
 

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -340,6 +340,7 @@ RailsPortal::Application.routes.draw do
             post :register
             # post :add_to_class
             post :remove_from_class
+            get :get_feedback_metadata
           end
           member do
             post :check_password

--- a/rails/features/step_definitions/student_steps.rb
+++ b/rails/features/step_definitions/student_steps.rb
@@ -88,11 +88,6 @@ Then /^I should not see the run link for "([^"]*)"$/ do | runnable_name |
   expect(page).not_to have_content(runnable_name)
 end
 
-Then /^I should see a link to generate a report of my work$/ do
-  text = I18n.t("StudentProgress.GenerateReport.NotDone")
-  expect(page).to have_selector("div.run_graph", text: /#{text}/i, visible: true)
-end
-
 Then /^I should not see a link to generate a report of my work$/ do
   expect(page).not_to have_selector("div.run_graph", text: /generate a report of my work/i, visible: true)
 end

--- a/rails/features/student_views_report.feature
+++ b/rails/features/student_views_report.feature
@@ -26,7 +26,6 @@ Feature: Student views report
     Then the browser should send a GET to "http://fake-lara.com/mock_html/test-external-activity25.html"
     When I visit my classes page
     Then I should see "Last run"
-    When I should see a link to generate a report of my work
 
   @mechanize
   Scenario: Student does not see report link if student report is disabled

--- a/rails/spec/controllers/api/v1/offerings_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/offerings_controller_spec.rb
@@ -12,7 +12,8 @@ describe API::V1::OfferingsController do
   let(:clazz)             { FactoryBot.create(:portal_clazz, name: 'test class', teachers: [teacher], students:[student_a, student_b]) }
   let(:student_a)         { FactoryBot.create(:full_portal_student) }
   let(:student_b)         { FactoryBot.create(:full_portal_student) }
-  let(:offering)          { FactoryBot.create(:portal_offering, {clazz: clazz, runnable: runnable}) }
+  let(:locked)            { false }
+  let(:offering)          { FactoryBot.create(:portal_offering, {clazz: clazz, runnable: runnable, locked: locked}) }
 
   before(:each) {
     # This silences warnings in the console when running
@@ -101,6 +102,7 @@ describe API::V1::OfferingsController do
         expect(json["clazz_id"]).to eq clazz.id
         expect(json["clazz_info_url"]).to eq "http://test.host/api/v1/classes/#{clazz.id}"
         expect(json["activity"]).to eq runnable.name
+        expect(json["locked"]).to eq false
         expect(json["report_url"]).to eql report_portal_offering_url(id: offering.id, host: 'test.host')
 
         expect(json["preview_url"]).to eql external_activity_url(runnable, {logging: true, format: runnable.run_format})
@@ -121,6 +123,17 @@ describe API::V1::OfferingsController do
         expect(student2["last_run"]).to eq nil
         expect(student2["total_progress"]).to eq 0
         expect(student2["detailed_progress"]).to eq nil
+      end
+
+      describe "when offering is locked" do
+        let(:locked) { true }
+
+        it "returns locked:true" do
+          get :show, params: { id: offering.id }
+          expect(response.status).to eq 200
+          json = JSON.parse(response.body)
+          expect(json["locked"]).to eq true
+        end
       end
     end
 

--- a/rails/spec/controllers/api/v1/students_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/students_controller_spec.rb
@@ -279,9 +279,9 @@ RSpec.describe API::V1::StudentsController, type: :controller do
       student_user.portal_student = student
 
       stub_const("ENV", ENV.to_h.merge(
-        "FEEDBACK_METADATA_URL" => "http://example.com",
-        "FEEDBACK_METADATA_SOURCE" => "authoring.example.org",
-        "FEEDBACK_METADATA_BEARER_TOKEN" => bearer_token
+        "REPORT_SERVICE_URL" => "http://example.com",
+        "REPORT_SERVICE_SOURCE" => "authoring.example.org",
+        "REPORT_SERVICE_BEARER_TOKEN" => bearer_token
       ))
     end
 
@@ -298,24 +298,24 @@ RSpec.describe API::V1::StudentsController, type: :controller do
       expect(response.body).to eq('{"success":false,"response_type":"ERROR","message":"You must be a student to use this endpoint"}')
     end
 
-    it 'should fail when the feedback metadata URL is not configured' do
-      stub_const("ENV", ENV.to_h.merge("FEEDBACK_METADATA_URL" => nil))
+    it 'should fail when the report service URL is not configured' do
+      stub_const("ENV", ENV.to_h.merge("REPORT_SERVICE_URL" => nil))
       sign_in student_user
       get :get_feedback_metadata
       expect(response).to have_http_status(:bad_request)
       expect(response.body).to eq('{"success":false,"response_type":"ERROR","message":"Feedback metadata URL not configured"}')
     end
 
-    it 'should fail when the feedback metadata source is not configured' do
-      stub_const("ENV", ENV.to_h.merge("FEEDBACK_METADATA_SOURCE" => nil))
+    it 'should fail when the report service source is not configured' do
+      stub_const("ENV", ENV.to_h.merge("REPORT_SERVICE_SOURCE" => nil))
       sign_in student_user
       get :get_feedback_metadata
       expect(response).to have_http_status(:bad_request)
       expect(response.body).to eq('{"success":false,"response_type":"ERROR","message":"Feedback metadata source not configured"}')
     end
 
-    it 'should fail when the feedback metadata bearer token is not configured' do
-      stub_const("ENV", ENV.to_h.merge("FEEDBACK_METADATA_BEARER_TOKEN" => nil))
+    it 'should fail when the report service bearer token is not configured' do
+      stub_const("ENV", ENV.to_h.merge("REPORT_SERVICE_BEARER_TOKEN" => nil))
       sign_in student_user
       get :get_feedback_metadata
       expect(response).to have_http_status(:bad_request)
@@ -327,11 +327,11 @@ RSpec.describe API::V1::StudentsController, type: :controller do
 
       stubbed_response = { "success": true, "result": { "foo": "bar" } }.to_json
       expected_query = URI.encode_www_form(
-        source: ENV['FEEDBACK_METADATA_SOURCE'],
+        source: ENV['REPORT_SERVICE_SOURCE'],
         platform_id: APP_CONFIG[:site_url] || "http://learn.concord.org",
         platform_student_id: student_user.id
       )
-      stub_request(:get, ENV['FEEDBACK_METADATA_URL'])
+      stub_request(:get, "#{ENV['REPORT_SERVICE_URL']}/student_feedback_metadata")
         .with(query: expected_query, headers: {"Authorization"=>"Bearer #{bearer_token}"})
         .to_return(status: 200, body: stubbed_response, headers: { "Content-Type" => "application/json" })
 

--- a/rails/spec/controllers/api/v1/students_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/students_controller_spec.rb
@@ -271,4 +271,32 @@ RSpec.describe API::V1::StudentsController, type: :controller do
     end
   end
 
+  # describe '#get_feedback_metadata' do
+    # it 'should fail without a user' do
+      # get :get_feedback_metadata
+    # end
+
+    # failures:
+    # no user
+    # user not student
+    # missing
+    # url = ENV['FEEDBACK_METADATA_URL']
+    # source = ENV['FEEDBACK_METADATA_SOURCE']
+    # token = ENV['FEEDBACK_METADATA_BEARER_TOKEN']
+
+    # it 'returns the full Firebase function result' do
+      # stub_const("ENV", ENV.to_h.merge("FEEDBACK_METADATA_URL" => "http://example.com"))
+#
+      # stub = WebMock.stub_request(:get, ENV['FEEDBACK_METADATA_URL'])
+          # .with{ |request|
+            # doc = JSON.parse(request.body)["doc"]
+            # doc["learner_id"] == learner.id && doc["permission_forms_id"] == [permission_form.id] }
+          # .to_return(status: 200, body: "", headers: {})
+#
+      # get :get_feedback_metadata
+#
+      # expect(response).to have_http_status(:bad_request)
+    # end
+  # end
+
 end

--- a/rails/spec/controllers/portal/offerings_controller_spec.rb
+++ b/rails/spec/controllers/portal/offerings_controller_spec.rb
@@ -272,44 +272,6 @@ describe Portal::OfferingsController do
     end
   end
 
-  describe '#student_report' do
-    let(:external_activity) { FactoryBot.create(:external_activity) }
-    let(:clazz)       { FactoryBot.create(:portal_clazz) }
-    let(:offering)    { FactoryBot.create(:portal_offering, runnable: external_activity, clazz: clazz)}
-    let(:post_params) { { id: offering.id } }
-    let(:student)     { FactoryBot.create(:full_portal_student) }
-
-    before(:each) do
-      sign_in student.user
-      student.clazzes << clazz
-    end
-
-    describe "When the student requests the default report" do
-      let(:report_url)  { "https://concord-consortium.github.io/portal-report/" }
-
-      describe "when offering report is used" do
-        before(:each) do
-          # Ensure that default report is available.
-          FactoryBot.create(:default_lara_report, { url: report_url })
-        end
-
-        it "should redirect to the default reporting service" do
-          get :student_report, params: post_params
-          expect(response.location).to match(/#{report_url}/)
-        end
-        it "should provide studentId" do
-          get :student_report, params: post_params
-          expect(response.location).to include("studentId=#{student.user.id}")
-        end
-        it "should not include researcher=true parameter" do
-          get :report, params: post_params
-          expect(response.location).not_to include("researcher=")
-        end
-      end
-    end
-  end
-
-
   # TODO: auto-generated
   describe '#update' do
     it 'PATCH update' do
@@ -352,15 +314,6 @@ describe Portal::OfferingsController do
       admin = FactoryBot.generate :admin_user
       sign_in admin
       get :deactivate, params: { id: FactoryBot.create(:portal_offering).to_param }
-
-      expect(response).to have_http_status(:redirect)
-    end
-  end
-
-  # TODO: auto-generated
-  describe '#student_report' do
-    it 'GET student_report' do
-      get :student_report, params: { id: FactoryBot.create(:portal_offering).to_param }
 
       expect(response).to have_http_status(:redirect)
     end

--- a/rails/spec/policies/portal/offering_policy_spec.rb
+++ b/rails/spec/policies/portal/offering_policy_spec.rb
@@ -182,16 +182,6 @@ RSpec.describe Portal::OfferingPolicy do
   end
 
   # TODO: auto-generated
-  describe '#student_report?' do
-    it 'student_report?' do
-      offering_policy = described_class.new(nil, nil)
-      result = offering_policy.student_report?
-
-      expect(result).to be_nil
-    end
-  end
-
-  # TODO: auto-generated
   describe '#report?' do
     it 'report?' do
       offering_policy = described_class.new(nil, nil)


### PR DESCRIPTION
This adds a new api endpoint that calls a Firebase function using an url provided in the environment variables, along with a source key and bearer authentication token.  That Firebase function returns a map of offering ids to feedback metadata, that for now, includes the last time feedback was created/updated for the offering by a teacher.