### PR TITLE
fix: Allow offering to show if show_feedback param is set [PT-188732128]

### DIFF
--- a/rails/app/policies/portal/offering_policy.rb
+++ b/rails/app/policies/portal/offering_policy.rb
@@ -37,7 +37,8 @@ class Portal::OfferingPolicy < ApplicationPolicy
 
   # Used by Portal::OfferingsController:
   def show?
-    class_teacher_or_admin? || (class_student? && !record.locked)
+    # if locked, only show if the show_feedback param is present so the student can see feedback
+    class_teacher_or_admin? || (class_student? && (!record.locked || params[:show_feedback].present?))
   end
 
   def destroy?


### PR DESCRIPTION
Without this the feedback link for a locked activity shows a dialog telling the student the offering is locked.