### PR TITLE
Add 'primary_account' to Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,15 +370,19 @@ introduction](http://robots.thoughtbot.com/post/159807023/waiting-for-a-factory-
 
 **Running all the rspec tests:**
 
-    bundle exec rake spec
+    bundle exec rspec
 
 **Running a single file:**
 
-    bundle exec rake spec SPEC=spec/routing/dataservice/bundle_contents_routing_spec.rb
+    bundle exec rspec spec/controllers/home_controller_spec.rb 
+
+or add a line number to run just one test in the file (this line number may change over time!)
+
+    bundle exec rspec spec/controllers/home_controller_spec.rb:62
 
 **Running a single directory:**
 
-    bundle exec rake spec SPEC=spec/routing/dataservice
+    bundle exec rspec spec/controllers
 
 **Running all the controller tests:**
 

--- a/rails/app/controllers/portal/clazzes_controller.rb
+++ b/rails/app/controllers/portal/clazzes_controller.rb
@@ -38,7 +38,7 @@ class Portal::ClazzesController < ApplicationController
     # PUNDIT_REVIEW_SCOPE
     # PUNDIT_CHECK_SCOPE (did not find instance)
     # @clazzes = policy_scope(Portal::Clazz)
-    @portal_clazzes = Portal::Clazz.all
+    @portal_clazzes = Portal::Clazz.search(params[:search], params[:page], nil)
 
     respond_to do |format|
       format.html # index.html.erb

--- a/rails/app/controllers/users_controller.rb
+++ b/rails/app/controllers/users_controller.rb
@@ -67,6 +67,8 @@ class UsersController < ApplicationController
   # GET /users/1/edit
   def edit
     @user = User.find(params[:id])
+    authorize @user
+    @can_set_primary = true
     if @user.portal_student
       # Find the list of options for the "primary account" pulldown
       student = @user.portal_student
@@ -77,7 +79,6 @@ class UsersController < ApplicationController
     else
       @classmates = []
     end
-    authorize @user
     @roles = Role.all
     @projects = Admin::Project.all_sorted
   end

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -30,6 +30,9 @@ class User < ApplicationRecord
   has_many :external_activities
   has_many :security_questions
 
+  belongs_to :primary_account, :class_name => "User", :optional => true
+  has_many :secondary_accounts, :class_name => "User", :foreign_key => "primary_account_id"
+
   has_one :portal_teacher, :dependent => :destroy, :class_name => "Portal::Teacher", :inverse_of => :user
   has_one :portal_student, :dependent => :destroy, :class_name => "Portal::Student", :inverse_of => :user
 

--- a/rails/app/views/home/admin.html.haml
+++ b/rails/app/views/home/admin.html.haml
@@ -15,6 +15,7 @@
       %ul
         %li= link_to 'Auth Clients', admin_clients_path
         %li= link_to 'Authoring Sites', admin_authoring_sites_path
+        %li= link_to 'Classes', portal_clazzes_path
         %li= link_to 'Cohorts', admin_cohorts_path
         %li= link_to 'Districts', portal_districts_path
         %li= link_to 'External Reports', admin_external_reports_path

--- a/rails/app/views/portal/clazzes/index.html.haml
+++ b/rails/app/views/portal/clazzes/index.html.haml
@@ -7,12 +7,14 @@
     %th ID
     %th Name
     %th School
+    %th Classword
     %th 
   - @portal_clazzes.each do |portal_clazz|
     %tr
       %td= portal_clazz.id
       %td= portal_clazz.name
       %td= portal_clazz.school.name
+      %td= portal_clazz.class_word
       %td= link_to 'Class list', class_list_portal_clazz_path(portal_clazz)
   
 %br

--- a/rails/app/views/portal/clazzes/index.html.haml
+++ b/rails/app/views/portal/clazzes/index.html.haml
@@ -1,13 +1,19 @@
-%h1 Listing Classes
+%h1 Classes
+= render :partial => 'shared/collection_menu', :locals => { :collection => @portal_clazzes, :collection_class => Portal::Clazz }
+
 %br
-%table{:width=>"100%"}
+%table{:width=>"100%", border: 1}
+  %tr
+    %th ID
+    %th Name
+    %th School
+    %th 
   - @portal_clazzes.each do |portal_clazz|
     %tr
       %td= portal_clazz.id
       %td= portal_clazz.name
-      %td= link_to 'Show', portal_clazz
-      %td= link_to 'Edit', portal_clazz 
-      %td= link_to 'Destroy', portal_clazz 
+      %td= portal_clazz.school.name
+      %td= link_to 'Class list', class_list_portal_clazz_path(portal_clazz)
   
 %br
 

--- a/rails/app/views/users/_form.html.haml
+++ b/rails/app/views/users/_form.html.haml
@@ -6,6 +6,15 @@
   .aligned
     %ul.quiet_list
       %li
+        = f.label :primary_account_id, 'Primary account', :class => "left"
+        %div Normally 'None'; points to another account if this user has multiple accounts and this is not considered the primary one
+        = f.collection_select :primary_account_id, @classmates, :user_id, ->(s) { "#{s.name} (id=#{s.user_id})" }, { include_blank: "None" }, { disabled: @classmates.empty? }
+      - if not @user.secondary_accounts.empty?
+        %li
+          %div 
+            %strong Secondary accounts:  
+            #{@user.secondary_accounts.map { |s|"#{s.name} (id=#{s.id})" }.join(', ')}
+      %li
         = f.label :first_name, 'First name', :class => "left"
         = f.text_field :first_name, :live => false
       %li

--- a/rails/app/views/users/_form.html.haml
+++ b/rails/app/views/users/_form.html.haml
@@ -5,15 +5,16 @@
 
   .aligned
     %ul.quiet_list
-      %li
-        = f.label :primary_account_id, 'Primary account', :class => "left"
-        %div Normally 'None'; points to another account if this user has multiple accounts and this is not considered the primary one
-        = f.collection_select :primary_account_id, @classmates, :user_id, ->(s) { "#{s.name} (id=#{s.user_id})" }, { include_blank: "None" }, { disabled: @classmates.empty? }
-      - if not @user.secondary_accounts.empty?
+      - if @can_set_primary
         %li
-          %div 
-            %strong Secondary accounts:  
-            #{@user.secondary_accounts.map { |s|"#{s.name} (id=#{s.id})" }.join(', ')}
+          = f.label :primary_account_id, 'Primary account', :class => "left"
+          %div Normally 'None'; points to another account if this user has multiple accounts and this is not considered the primary one
+          = f.collection_select :primary_account_id, @classmates, :user_id, ->(s) { "#{s.name} (id=#{s.user_id})" }, { include_blank: "None" }, { disabled: @classmates.empty? }
+        - if not @user.secondary_accounts.empty?
+          %li
+            %div 
+              %strong Secondary accounts:  
+              #{@user.secondary_accounts.map { |s|"#{s.name} (id=#{s.id})" }.join(', ')}
       %li
         = f.label :first_name, 'First name', :class => "left"
         = f.text_field :first_name, :live => false

--- a/rails/app/views/users/_user.html.haml
+++ b/rails/app/views/users/_user.html.haml
@@ -67,6 +67,9 @@
             %li
               = "#{user.portal_teacher.school_names.join(', ')}"
           %br
+      - if user.primary_account
+        %li 
+          Secondary account for: #{user.primary_account.name} (id=#{user.primary_account.id}}
       %li
         Status: #{user.state}
         - if imported_user

--- a/rails/db/migrate/20250212200518_add_primary_account_to_users.rb
+++ b/rails/db/migrate/20250212200518_add_primary_account_to_users.rb
@@ -1,0 +1,6 @@
+class AddPrimaryAccountToUsers < ActiveRecord::Migration[6.1]
+
+  def change
+    add_reference :users, :primary_account, type: "int(11)", foreign_key: { to_table: :users }, index: true
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_12_11_155304) do
+ActiveRecord::Schema.define(version: 2025_02_12_200518) do
 
   create_table "access_grants", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "code"
@@ -1577,11 +1577,14 @@ ActiveRecord::Schema.define(version: 2024_12_11_155304) do
     t.boolean "email_subscribed", default: false
     t.boolean "can_add_teachers_to_cohorts", default: false
     t.datetime "reset_password_sent_at"
+    t.integer "primary_account_id"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email"
     t.index ["id"], name: "index_users_on_id_and_type"
     t.index ["login"], name: "index_users_on_login", unique: true
+    t.index ["primary_account_id"], name: "index_users_on_primary_account_id"
   end
 
   add_foreign_key "portal_runs", "portal_learners", column: "learner_id"
+  add_foreign_key "users", "users", column: "primary_account_id"
 end


### PR DESCRIPTION
Jira issue: REPORT-3

This adds a `primary_account` field in the `User` table.
This can be used to link together multiple accounts created by a student.

Also includes a start of a way for admins to look at classes and class lists.