### PR TITLE
fix: Remove assigning material collections to students UI [RIGSE-12]

### DIFF
--- a/rails/react-components/src/library/components/browse-page/browse-page.tsx
+++ b/rails/react-components/src/library/components/browse-page/browse-page.tsx
@@ -197,12 +197,24 @@ const BrowsePage = Component({
   renderAssignableLinks () {
     const resource = this.state.resource;
     const links = resource.links;
+    const isCollection = resource.material_type === "Collection";
 
     const editLink = resource.lara_activity_or_sequence && links.external_lara_edit
       ? links.external_lara_edit.url
       : links.external_edit
         ? links.external_edit.url
         : null;
+
+    // only allow admin links for collections
+    if (isCollection) {
+      return (
+        <>
+          { links.external_copy ? <a className="portal-pages-secondary-button" href={links.external_copy.url}>Copy</a> : null }
+          { editLink ? <a className="portal-pages-secondary-button" href={editLink}>Edit</a> : null }
+          { links.edit ? <a className="portal-pages-secondary-button" href={links.edit.url}>Settings</a> : null }
+        </>
+      );
+    }
 
     return (
       <>

--- a/rails/react-components/src/library/components/resource-lightbox.tsx
+++ b/rails/react-components/src/library/components/resource-lightbox.tsx
@@ -389,6 +389,13 @@ const ResourceLightbox = Component({
     const resource = this.state.resource;
     const showTeacherResourcesButton = this.props.showTeacherResourcesButton;
     const links = resource.links;
+    const isCollection = resource.material_type === "Collection";
+
+    // no assignable links for collections
+    if (isCollection) {
+      return null;
+    }
+
     return (
       <span>
         { Portal.currentUser.isTeacher && resource.has_teacher_edition ? <a className="teacherEditionLink portal-pages-secondary-button" href={MakeTeacherEditionLink(resource.external_url)} target="_blank" onClick={this.handleTeacherEditionClick} rel="noreferrer">Teacher Edition</a> : null }

--- a/rails/react-components/src/library/components/stem-finder-result.tsx
+++ b/rails/react-components/src/library/components/stem-finder-result.tsx
@@ -380,7 +380,10 @@ const StemFinderResult = Component({
         </div>
         <div className={css.finderResultText}>
           <div className={css.finderResultTextName}>
-            <a href={resourceLink} target="_blank" title={resourceName} rel="noreferrer">{ resourceName }</a>
+            {resource.material_type !== "Collection"
+              ? <a href={resourceLink} target="_blank" title={resourceName} rel="noreferrer">{ resourceName }</a>
+              : <a href={resource.links.preview.url} target="_blank" title={resourceName} rel="noreferrer" onClick={this.handleViewCollectionClick}>{ resourceName }</a>
+            }
           </div>
           <div className={css.metaTags}>
             <GradeLevels resource={resource} />


### PR DESCRIPTION
This removes the assignable links for students so that material collections can't be assigned (as that makes no sense).

This fixes a bug that was introduced when we made material collections searchable.