### PR TITLE
fix: Escape special search characters [RIGSE-105]

### DIFF
--- a/rails/app/models/search.rb
+++ b/rails/app/models/search.rb
@@ -72,9 +72,11 @@ class Search
 
   def self.clean_search_terms (term)
     return NoSearchTerm if (term.nil? || term.blank?)
-    # http://rubular.com/r/ML9V9EMCKh (include apostrophe)
-    not_valid_chars = /[-+]+/
-    term.gsub(not_valid_chars,' ').strip
+    # escape all special solr characters with a slash so they are treated as literals
+    # see: https://solr.apache.org/guide/7_5/the-standard-query-parser.html#escaping-special-characters
+    # note: \\\\ escapes the backslash itself (\\ in Ruby string to \ in output) where
+    #       \1 refers to the matched character from the capturing group.
+    term.gsub(/([+\-\&\|\!\(\)\{\}\[\]\^"~\*\?:\/])/, '\\\\\1').strip
   end
 
   def user

--- a/rails/spec/models/search_spec.rb
+++ b/rails/spec/models/search_spec.rb
@@ -19,14 +19,11 @@ describe Search do
 
   describe "parameter cleaning" do
     describe "clean_search_terms" do
-      it "should remove normal dashes" do
-        expect(Search.clean_search_terms("balrgs-bonk")).to eq("balrgs bonk")
+      it "should escape normal dashes" do
+        expect(Search.clean_search_terms("balrgs-bonk")).to eq("balrgs\\-bonk")
       end
-      it "should remove pluses" do
-        expect(Search.clean_search_terms("balrgs+bonk")).to eq("balrgs bonk")
-      end
-      it "should remove pluses" do
-        expect(Search.clean_search_terms("balrgs+bonk")).to eq("balrgs bonk")
+      it "should escape pluses" do
+        expect(Search.clean_search_terms("balrgs+bonk")).to eq("balrgs\\+bonk")
       end
       it "should leave white spaces in the middle" do
         expect(Search.clean_search_terms("balrgs bonk")).to eq("balrgs bonk")
@@ -35,7 +32,7 @@ describe Search do
         expect(Search.clean_search_terms(" balrgs bonk")).to eq("balrgs bonk")
       end
 
-      it "should not remove single quote strings" do
+      it "should not escape single quote strings" do
         expect(Search.clean_search_terms("This is Sarah's test sequence")).to eq("This is Sarah's test sequence")
       end
 
@@ -157,8 +154,8 @@ describe Search do
               expect(subject.results[:all]).to include funny_activity
             end
           end
-          describe "searching for 'Noah'" do
-            let(:search_term)      { "Noah*" }
+          describe "searching for \"Noah's\"" do
+            let(:search_term)      { "Noah's" }
             it "should be found" do
               expect(subject.results[:all]).to include funny_activity
             end


### PR DESCRIPTION
This updates the search.rb#clean_search_terms method to escape all Solr special query characters with a slash so they are searchable.

Previously we just removed the plus and minus character breaking searches for content with things like ? in them (the reason for this bug fix).