### PR TITLE
fix: Broken pluralization in user list [RIGSE-125]

### DIFF
--- a/rails/config/locales/en.yml
+++ b/rails/config/locales/en.yml
@@ -165,6 +165,12 @@ en:
     switch_back: Switch back
     research_projects: Research Projects
     researcher_reports: Researcher Reports
+  will_paginate:
+    models:
+      user:
+        zero: users
+        one: user
+        other: users
 
 'en-HAS':
   activerecord:
@@ -180,6 +186,10 @@ en:
         zero: activities
         one: activity
         other: activities
+      user:
+        zero: users
+        one: user
+        other: users
   HomePage:
     Teacher:
       Intro: |
@@ -229,6 +239,12 @@ en:
         Instructions_html: |
           To get started, click the Activities link on the left to view all activities
           You can set up a class by clicking the “Add a New Class” link on the left
+  will_paginate:
+    models:
+      user:
+        zero: users
+        one: user
+        other: users
 
 'en-NGSS-ASSESSMENT':
   HomePage:
@@ -245,3 +261,9 @@ en:
           <p>
           For help using this portal, click the Help link on the left.
           </p>
+  will_paginate:
+    models:
+      user:
+        zero: users
+        one: user
+        other: users


### PR DESCRIPTION
This fix:

1. Sets the singular and plural labels for the User model for the will_paginate gem
2. Lowercases "User" to "user" in the output

Bugfix was for pluralization for examples like: "Displaying all 3 User"

NOTE: for completion the fix was also added to the (dead) ITSI portal configuration.