### PR TITLE
chore: Add AWS_REGION to app and worker task definitions (RIGSE-83)

### DIFF
--- a/configs/cloudformation/stack_template.yml
+++ b/configs/cloudformation/stack_template.yml
@@ -468,6 +468,8 @@ Resources:
               Value: portal-report.concord.org concord-consortium.github.io
             - Name: REPORT_VIEW_URL
               Value: !Sub "https://portal-report.concord.org/${PortalReportVersion}/"
+            - Name: AWS_REGION
+              Value: us-east-1
             - Name: S3_ACCESS_KEY_ID
               Value: !Ref S3AccessKeyId
             - Name: S3_BUCKET
@@ -1026,6 +1028,8 @@ Resources:
               Value: portal-report.concord.org concord-consortium.github.io
             - Name: REPORT_VIEW_URL
               Value: !Sub "https://portal-report.concord.org/${PortalReportVersion}/"
+            - Name: AWS_REGION
+              Value: us-east-1
             - Name: S3_ACCESS_KEY_ID
               Value: !Ref S3AccessKeyId
             - Name: S3_BUCKET


### PR DESCRIPTION
[RIGSE-83](https://concord-consortium.atlassian.net/browse/RIGSE-83)

Due to changes in how the Portal handles file uploads, `AWS_REGION` must be set in the Environment section of both the App and Worker task definitions in the CloudFormation stack template.

[RIGSE-83]: https://concord-consortium.atlassian.net/browse/RIGSE-83?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ