### PR TITLE
chore: Add AWS_REGION to report task definition (RIGSE-83)

### DIFF
--- a/configs/cloudformation/stack_template.yml
+++ b/configs/cloudformation/stack_template.yml
@@ -789,6 +789,8 @@ Resources:
               Value: portal-report.concord.org concord-consortium.github.io
             - Name: REPORT_VIEW_URL
               Value: !Sub "https://portal-report.concord.org/${PortalReportVersion}/"
+            - Name: AWS_REGION
+              Value: us-east-1
             - Name: S3_ACCESS_KEY_ID
               Value: !Ref S3AccessKeyId
             - Name: S3_BUCKET


### PR DESCRIPTION
[RIGSE-83](https://concord-consortium.atlassian.net/browse/RIGSE-83)

Turns out we need this in the Report task definition as well.

[RIGSE-83]: https://concord-consortium.atlassian.net/browse/RIGSE-83?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ