### PR TITLE
feat: Add sign in or register page [RIGSE-145]

### DIFF
--- a/rails/app/controllers/api/v1/jwt_controller.rb
+++ b/rails/app/controllers/api/v1/jwt_controller.rb
@@ -181,6 +181,16 @@ class API::V1::JwtController < API::APIController
         :user_id => url_for(user),
         :teacher_id => teacher.id
       }
+    else
+      claims = {
+        :domain => root_url,
+        :user_type => "user",
+        :user_id => url_for(user),
+        :first_name => user.first_name,
+        :last_name => user.last_name,
+        :teacher => user.portal_teacher ? true : false,
+        :student => user.portal_student ? true : false
+      }
     end
     add_admin_claims(user,claims)
 

--- a/rails/app/controllers/users_controller.rb
+++ b/rails/app/controllers/users_controller.rb
@@ -298,6 +298,22 @@ class UsersController < ApplicationController
     end
   end
 
+  def sign_in_or_register
+    # if the user is already logged in, redirect to the login_url to start the oauth flow
+    # see CLUE standalone mode for the original use case
+    if current_user && params[:login_url]
+      redirect_to params[:login_url], allow_other_host: true
+    end
+
+    @app_name = params[:app_name]
+    @login_url = params[:login_url]
+    @class_word = params[:class_word]
+
+    # the extra_options are used in the header - we hide the login and register
+    # links if the user is NOT logged in as the page itself presents login/register links
+    @extra_options = {:hideNavLinks => !current_user}
+  end
+
   def user_strong_params(params)
     params && params.permit(:first_name, :last_name, :email, :login, :password, :password_confirmation, :can_add_teachers_to_cohorts)
   end

--- a/rails/app/views/auth/login.haml
+++ b/rails/app/views/auth/login.haml
@@ -114,7 +114,7 @@
           = render_themed_partial 'shared/logo'
           %p
             Log in with your #{APP_CONFIG[:site_name]} account
-            = @app_name.present? ? " to access the #{@app_name}" : ""
+            = @app_name.present? ? " to access the #{@app_name} app" : ""
             %span>.
           %p
             %input#username{:name => "user[login]", :type => "text", :placeholder => "Enter your username."}/

--- a/rails/app/views/users/sign_in_or_register.html.haml
+++ b/rails/app/views/users/sign_in_or_register.html.haml
@@ -1,0 +1,17 @@
+-if @current_user
+  %div
+    You are already logged in!
+-else
+  #sign_in_or_register
+    <noscript>This page requires JavaScript.</noscript>
+
+  :javascript
+    jQuery(document).ready(function () {
+      var options = {
+        appName: "#{@app_name}",
+        loginUrl: "#{@login_url}",
+        classWord: "#{@class_word}",
+      }
+      PortalComponents.renderSigninOrRegister(options, 'sign_in_or_register');
+    });
+

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -33,6 +33,8 @@ RailsPortal::Application.routes.draw do
   post "home/preview_about_page"
   post "home/preview_home_page"
 
+  get "/users/sign_in_or_register" => "users#sign_in_or_register", :as => :sign_in_or_register
+
   # external_activities can have uuids for ids so this resource needs to lay outside the :id constaint
   resources :external_activities, path: 'eresources' do
     collection do

--- a/rails/react-components/src/library/components/page-header.tsx
+++ b/rails/react-components/src/library/components/page-header.tsx
@@ -20,7 +20,8 @@ const PageHeader = Component({
       theme: this.props.theme || Portal.theme || "default",
       homePath: this.props.homePath || Portal.currentUser.homePath || "/",
       isStudent: this.props.isStudent || Portal.currentUser.isStudent || false,
-      sitewideAlert: this.props.sitewideAlert
+      sitewideAlert: this.props.sitewideAlert,
+      hideNavLinks: !!this.props.hideNavLinks
     };
   },
 
@@ -207,7 +208,7 @@ const PageHeader = Component({
     let wrapperClass = "theme-" + this.state.theme;
     wrapperClass = this.state.loggedIn ? wrapperClass + " logged-in" : wrapperClass;
     let navLinks = "";
-    if (this.state.windowWidth > 950 || !this.state.nav_menu_collapsed) {
+    if (!this.state.hideNavLinks && (this.state.windowWidth > 950 || !this.state.nav_menu_collapsed)) {
       navLinks = this.renderNavLinks();
     }
     const logoClass = this.state.logo_class;

--- a/rails/react-components/src/library/components/signin-or-register/signin-or-register.scss
+++ b/rails/react-components/src/library/components/signin-or-register/signin-or-register.scss
@@ -1,0 +1,68 @@
+@import '../../../shared/styles/variables/_variables.scss';
+
+.signinOrRegister {
+  padding: 48px 0;
+  text-align: center;
+
+  .topMessage {
+    margin-bottom: 32px;
+    font-size: 14px;
+  }
+
+  .panels {
+    display: flex;
+    gap: 52px;
+    justify-content: center;
+
+    .panel {
+      border: 1px solid #777;
+      border-radius: 10px;
+      padding: 75px 60px;
+      display: flex;
+      justify-content: center;
+      gap: 20px;
+      flex-direction: column;
+
+      .top {
+        font-size: 18px;
+        max-width: 250px;
+        height: 75px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+
+      .button {
+        color: #fff;
+        border: solid 2px $col-orange;
+        background: $col-orange;
+        display: block;
+        line-height: .8;
+        padding: 14px 21px;
+        text-align: center;
+        display: block;
+        font: 700 20px / 1 museo-sans, Arial, Helvetica, sans-serif;
+
+        &:hover, &:active {
+          background: #ffc320;
+          color: #fff;
+          border: solid 2px #ffc320;
+          transition: all .2s ease-in-out;
+        }
+
+        &.reverse {
+          background: #fff;
+          border: solid 2px $col-orange;
+          color: $col-orange;
+
+          &:hover, &:active {
+            background: #ffc320;
+            color: #fff;
+            border: solid 2px #ffc320;
+            transition: all .2s ease-in-out;
+          }
+        }
+      }
+    }
+  }
+}

--- a/rails/react-components/src/library/components/signin-or-register/signin-or-register.tsx
+++ b/rails/react-components/src/library/components/signin-or-register/signin-or-register.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+
+import css from "./signin-or-register.scss";
+import clsx from "clsx";
+
+interface Props {
+  appName?: string;
+  loginUrl?: string;
+  classWord?: string;
+}
+
+const SigninOrRegister = ({appName, loginUrl, classWord}: Props) => {
+
+  const handleLogin = (e: React.MouseEvent) => {
+    // if no loginUrl is provided, show the login modal
+    if (!loginUrl) {
+      e.preventDefault();
+      PortalComponents.renderLoginModal({ oauthProviders: Portal.oauthProviders });
+    }
+  };
+
+  const handleRegister = (e: React.MouseEvent) => {
+    e.preventDefault();
+    PortalComponents.renderSignupModal({ oauthProviders: Portal.oauthProviders, loginUrl, classWord });
+  };
+
+  return (
+    <div className={css.signinOrRegister}>
+      {appName && (
+        <div className={css.topMessage}>
+          You will automatically return to the {appName} app after logging in or creating an account.
+        </div>
+      )}
+      <div className={css.panels}>
+        <div className={css.panel}>
+          <div className={css.top}>
+            Have an account with the Concord Consortium?
+          </div>
+          <div className={css.bottom}>
+            <a href={loginUrl ?? "#"} className={css.button} onClick={handleLogin}>Login</a>
+          </div>
+        </div>
+
+        <div className={css.panel}>
+          <div className={css.top}>
+            No account?
+          </div>
+          <div className={css.bottom}>
+            <a href="#" className={clsx(css.button, css.reverse)} onClick={handleRegister}>Create Account</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default SigninOrRegister;

--- a/rails/react-components/src/library/components/signup/signup.tsx
+++ b/rails/react-components/src/library/components/signup/signup.tsx
@@ -54,7 +54,8 @@ export default class SignUp extends React.Component<any, any> {
   }
 
   onBasicDataSubmit (data: any) {
-    data.sign_up_path = window.location.pathname;
+    const {pathname, search} = window.location;
+    data.sign_up_path = `${pathname}${search ? `?${search}` : ""}`;
     this.setState({
       basicData: data
     });
@@ -85,7 +86,7 @@ export default class SignUp extends React.Component<any, any> {
   }
 
   render () {
-    const { signupText, oauthProviders, anonymous, omniauthOrigin } = this.props;
+    const { signupText, oauthProviders, anonymous, omniauthOrigin, loginUrl, classWord } = this.props;
     const { userType, basicData, studentData, teacherData } = this.state;
 
     let form;
@@ -103,12 +104,12 @@ export default class SignUp extends React.Component<any, any> {
       //
       // Display completion step
       //
-      form = <StudentRegistrationComplete anonymous={anonymous} data={studentData} />;
+      form = <StudentRegistrationComplete anonymous={anonymous} data={studentData} loginUrl={loginUrl} />;
     } else if (teacherData) {
       //
       // Display completion step
       //
-      form = <TeacherRegistrationComplete anonymous={anonymous} />;
+      form = <TeacherRegistrationComplete anonymous={anonymous} loginUrl={loginUrl} />;
     } else if (omniauthOrigin != null) {
       if (omniauthOrigin.search("teacher") > -1) {
         form = <TeacherForm
@@ -120,6 +121,7 @@ export default class SignUp extends React.Component<any, any> {
         form = <StudentForm
           basicData={basicData}
           onRegistration={this.onStudentRegistration}
+          classWord={classWord}
         />;
       }
     } else if (!userType) {
@@ -129,6 +131,7 @@ export default class SignUp extends React.Component<any, any> {
         anonymous={anonymous}
         oauthProviders={oauthProviders}
         onUserTypeSelect={this.onUserTypeSelect}
+        loginUrl={loginUrl}
       />;
     } else if (basicData) {
       if (userType === "teacher") {
@@ -141,6 +144,7 @@ export default class SignUp extends React.Component<any, any> {
         form = <StudentForm
           basicData={basicData}
           onRegistration={this.onStudentRegistration}
+          classWord={classWord}
         />;
       }
     } else {

--- a/rails/react-components/src/library/components/signup/student_form.tsx
+++ b/rails/react-components/src/library/components/signup/student_form.tsx
@@ -57,6 +57,7 @@ export default class StudentForm extends React.Component<any, any> {
             <TextInput
               name="class_word"
               placeholder="Class Word (not case sensitive)"
+              value={this.props.classWord}
               required
               asyncValidation={classWordValidator}
               asyncValidationError={INVALID_CLASS_WORD}

--- a/rails/react-components/src/library/components/signup/student_registration_complete.tsx
+++ b/rails/react-components/src/library/components/signup/student_registration_complete.tsx
@@ -39,10 +39,25 @@ export default class StudentRegistrationComplete extends React.Component<any, an
   }
 
   render () {
-    const { anonymous, data } = this.props;
+    const { anonymous, data, loginUrl } = this.props;
     const { login } = data;
 
-    const successMessage = anonymous ? <div><p style={{ marginBottom: "30px" }}>Success! Your username is <span className="login">{ login }</span></p><p style={{ marginBottom: "30px" }}>Use your new account to sign in below.</p></div> : <p><a href="/">Start using the site.</a></p>;
+    const loginMessage = loginUrl ? "Click the login button below to sign in." : "Use your new account to sign in below.";
+
+    const successMessage = anonymous
+      ? <div><p style={{ marginBottom: "30px" }}>Success! Your username is <span className="login">{ login }</span></p><p style={{ marginBottom: "30px" }}>{loginMessage}</p></div>
+      : <p><a href="/">Start using the site.</a></p>;
+
+    if (loginUrl) {
+      return (
+        <div className="registration-complete student">
+          { successMessage }
+          <div className="submit-button-container">
+            <a href={loginUrl} className="submit-btn">Log In!</a>
+          </div>
+        </div>
+      );
+    }
 
     return (
       <div className="registration-complete student">

--- a/rails/react-components/src/library/components/signup/text_input.tsx
+++ b/rails/react-components/src/library/components/signup/text_input.tsx
@@ -6,7 +6,8 @@ const TIMEOUT = 350;
 
 class TextInput extends React.Component<any, any> {
   static defaultProps = {
-    type: "text"
+    type: "text",
+    value: ""
   };
 
   inputRef: any;
@@ -15,16 +16,26 @@ class TextInput extends React.Component<any, any> {
     super(props);
 
     this.state = {
-      inputVal: ""
+      inputVal: this.props.value ?? ""
     };
 
     this.onChange = this.onChange.bind(this);
     this.inputRef = React.createRef();
+
+    // if there is an initial value wait for the render and then update the input to run the validation
+    if (this.props.value) {
+      setTimeout(() => {
+        this.changeInput(this.props.value);
+      }, 0);
+    }
   }
 
   onChange (event: any) {
-    const cursor = event.target.selectionStart;
-    let newVal = event.currentTarget.value;
+    this.changeInput(event.currentTarget.value);
+  }
+
+  changeInput (newVal: any) {
+    const cursor = this.inputRef.current?.selectionStart;
     const delay = this.props.isValidValue(newVal) ? 0 : TIMEOUT;
 
     this.setState({

--- a/rails/react-components/src/library/components/signup/user_type_selector.tsx
+++ b/rails/react-components/src/library/components/signup/user_type_selector.tsx
@@ -24,6 +24,11 @@ export default class UserTypeSelector extends React.Component<any, any> {
       "label": "Step 1 Log in Link Clicked"
     });
 
+    if (this.props.loginUrl) {
+      window.location.href = this.props.loginUrl;
+      return;
+    }
+
     PortalComponents.renderLoginModal({
       oauthProviders: this.props.oauthProviders,
       afterSigninPath: this.props.afterSigninPath

--- a/rails/react-components/src/library/library.tsx
+++ b/rails/react-components/src/library/library.tsx
@@ -46,6 +46,7 @@ import BrowsePage from "./components/browse-page/browse-page";
 import ResourceRequirements from "./components/browse-page/resource-requirements";
 import ResourceLicense from "./components/browse-page/resource-license";
 import ResourceProjects from "./components/browse-page/resource-projects";
+import SigninOrRegister from "./components/signin-or-register/signin-or-register";
 import showTab from "./helpers/tabs";
 import { loadMaterialsCollections } from "./helpers/materials-collection-cache";
 import { render } from "./helpers/react-render";
@@ -346,6 +347,11 @@ window.PortalPages = window.PortalComponents = {
   ResourceProjects,
   renderResourceProjects (options: any, id: any) {
     render(createElement(ResourceProjects, options), id);
+  },
+
+  SigninOrRegister,
+  renderSigninOrRegister (options: any, id: any) {
+    render(createElement(SigninOrRegister, options), id);
   },
 
   showTab


### PR DESCRIPTION
This adds a new page that shows a login button and a create account button.

The page accepts a login_url query parameter that is used instead of calling the portal api.  CLUE uses this for standalone mode login to redirect back to itself so it can start the oauth flow.

The page also accepts a class_word parameter that is used to pre-fill the class word field in the signup form.  This is used by CLUE to pass the class word in the standalone url to the signup form.

The page is accessible at /sign-in-or-register and is not linked anywhere in the portal.  It was designed however to replace the two login and register buttons in the top right corner of the portal.

Changes in this commit:

- Added a new page at /sign-in-or-register that shows a login button and a create account button.
- Updated the routes to include the new page.
- Updated the react components to include the new page.
- Updated the react components to pass the login_url and class_word to all the needed components.
- Updated the login buttons to first check for the login_url before calling the portal api.