### PR TITLE
feat: Login/Registration form improvements [RIGSE-184]

### DIFF
--- a/rails/react-components/src/library/components/signup/already_have_account.tsx
+++ b/rails/react-components/src/library/components/signup/already_have_account.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+export default class AlreadyHaveAccount extends React.Component<any, any> {
+  constructor (props: any) {
+    super(props);
+    this.handleLoginClick = this.handleLoginClick.bind(this);
+  }
+
+  handleLoginClick (event: any) {
+    event.preventDefault();
+    gtag("event", "click", {
+      "category": "User Registration",
+      "label": "Already Have Account Log in Link Clicked"
+    });
+
+    if (this.props.loginUrl) {
+      window.location.href = this.props.loginUrl;
+      return;
+    }
+
+    PortalComponents.renderLoginModal({
+      oauthProviders: this.props.oauthProviders,
+      afterSigninPath: this.props.afterSigninPath
+    });
+    gtag("event", "click", {
+      "category": "Login",
+      "label": "Login form opened"
+    });
+  }
+
+  render () {
+    return (
+      <div className={"signup-form-login-option"}>Already have an account? <a href="/users/sign_in" onClick={this.handleLoginClick}>Log in &raquo;</a></div>
+    );
+  }
+}

--- a/rails/react-components/src/library/components/signup/basic_data_form.tsx
+++ b/rails/react-components/src/library/components/signup/basic_data_form.tsx
@@ -93,7 +93,7 @@ export default class BasicDataForm extends React.Component<any, any> {
           <div>
             <dl>
               <dt className="two-col">First Name</dt>
-              <dd className="name_wrapper first-name-wrapper two-col"><TextInput name="first_name" placeholder="" required asyncValidation={nameValidator} asyncValidationError={INVALID_FIRST_NAME} /></dd>
+              <dd className="name_wrapper first-name-wrapper two-col"><TextInput name="first_name" placeholder="" required autoFocus={true} asyncValidation={nameValidator} asyncValidationError={INVALID_FIRST_NAME} /></dd>
               <dt className="two-col">Last Name</dt>
               <dd className="name_wrapper last-name-wrapper two-col"><TextInput name="last_name" placeholder="" required asyncValidation={nameValidator} asyncValidationError={INVALID_LAST_NAME} /></dd>
               <dt>Password</dt>

--- a/rails/react-components/src/library/components/signup/forgot_password_modal.tsx
+++ b/rails/react-components/src/library/components/signup/forgot_password_modal.tsx
@@ -60,7 +60,7 @@ export default class ForgotPasswordModal extends React.Component<any, any> {
           <dl>
             <dt>Username or Email Address</dt>
             <dd>
-              <TextInput name="user[login]" placeholder="" required />
+              <TextInput name="user[login]" placeholder="" required autoFocus={true} />
             </dd>
           </dl>
           <div className="submit-button-container">

--- a/rails/react-components/src/library/components/signup/login_modal.tsx
+++ b/rails/react-components/src/library/components/signup/login_modal.tsx
@@ -78,9 +78,9 @@ export default class LoginModal extends React.Component<any, any> {
         <Formsy className={"signup-form"} onValidSubmit={this.submit}>
           <h2>
             <strong>
-              Log in
+              Log In
             </strong>
-            { " " }
+            <br />
             to the { this.props.siteName }
           </h2>
           <div className={"third-party-login-options"}>
@@ -99,7 +99,7 @@ export default class LoginModal extends React.Component<any, any> {
               Username
             </dt>
             <dd>
-              <TextInput name={"user[login]"} placeholder={""} required />
+              <TextInput name={"user[login]"} placeholder={""} autoFocus={true} required />
             </dd>
             <dt>
               Password

--- a/rails/react-components/src/library/components/signup/signup.tsx
+++ b/rails/react-components/src/library/components/signup/signup.tsx
@@ -8,6 +8,7 @@ import TeacherRegistrationComplete from "./teacher_registration_complete";
 import UserTypeSelector from "./user_type_selector";
 
 import ParseQueryString from "../../helpers/parse-query-string";
+import AlreadyHaveAccount from "./already_have_account";
 
 export default class SignUp extends React.Component<any, any> {
   static defaultProps = {
@@ -157,21 +158,22 @@ export default class SignUp extends React.Component<any, any> {
       />;
     }
 
-    let formTitleIntro = "Register";
+    let formTitleIntro = "Create an Account";
     if (this.state.userType != null) {
-      formTitleIntro = "Register as a " + userType.charAt(0).toUpperCase() + userType.slice(1);
+      formTitleIntro = `Create a ${userType.charAt(0).toUpperCase() + userType.slice(1)} Account`;
     }
 
-    const formTitle = anonymous ? <h2><strong>{ formTitleIntro }</strong> for the { this.props.siteName }</h2> : <h2><strong>Finish</strong> Signing Up</h2>;
+    const formTitle = anonymous ? <h2><strong>{ formTitleIntro }</strong><br/> for the { this.props.siteName }</h2> : <h2><strong>Finish</strong> Signing Up</h2>;
 
     return (
       <div>
         { formTitle }
         <div className="signup-form">
           { form }
+          <AlreadyHaveAccount />
         </div>
         <footer className="reg-footer">
-          <p><strong>Why sign up?</strong> It's free and you get access to several key features, like creating classes for your students, assigning activities, saving work, tracking student progress, and more!</p>
+          <p><strong>Why sign up?</strong> It’s free and you get access to bonus features! <strong>Students</strong> can save their work and get feedback from their teachers. <strong>Teachers</strong> can create classes, assign activities, track student progress, and more!</p>
         </footer>
       </div>
     );

--- a/rails/react-components/src/library/components/signup/student_form.tsx
+++ b/rails/react-components/src/library/components/signup/student_form.tsx
@@ -56,6 +56,7 @@ export default class StudentForm extends React.Component<any, any> {
           <dd>
             <TextInput
               name="class_word"
+              autoFocus={true}
               placeholder="Class Word (not case sensitive)"
               value={this.props.classWord}
               required

--- a/rails/react-components/src/library/components/signup/teacher_form.tsx
+++ b/rails/react-components/src/library/components/signup/teacher_form.tsx
@@ -146,6 +146,7 @@ export default class TeacherForm extends React.Component<any, any> {
               name="login"
               placeholder=""
               required={true}
+              autoFocus={true}
               validations={{
                 minLength: 3
               }}

--- a/rails/react-components/src/library/components/signup/text_input.tsx
+++ b/rails/react-components/src/library/components/signup/text_input.tsx
@@ -65,7 +65,7 @@ class TextInput extends React.Component<any, any> {
   }
 
   render () {
-    const { type, placeholder, disabled, name } = this.props;
+    const { type, placeholder, disabled, name, autoFocus } = this.props;
 
     let className = "text-input " + this.props.name;
     if (this.props.showRequired && !this.props.isPristine) {
@@ -90,6 +90,7 @@ class TextInput extends React.Component<any, any> {
           onChange={this.onChange}
           value={this.state.inputVal}
           placeholder={placeholder}
+          autoFocus={autoFocus}
           disabled={disabled}
         />
         <div className="input-error">

--- a/rails/react-components/src/library/components/signup/user_type_selector.tsx
+++ b/rails/react-components/src/library/components/signup/user_type_selector.tsx
@@ -4,7 +4,6 @@ export default class UserTypeSelector extends React.Component<any, any> {
   constructor (props: any) {
     super(props);
     this.handleClick = this.handleClick.bind(this);
-    this.handleLoginClick = this.handleLoginClick.bind(this);
   }
 
   handleClick (event: any) {
@@ -17,28 +16,6 @@ export default class UserTypeSelector extends React.Component<any, any> {
     this.props.onUserTypeSelect(value);
   }
 
-  handleLoginClick (event: any) {
-    event.preventDefault();
-    gtag("event", "click", {
-      "category": "User Registration",
-      "label": "Step 1 Log in Link Clicked"
-    });
-
-    if (this.props.loginUrl) {
-      window.location.href = this.props.loginUrl;
-      return;
-    }
-
-    PortalComponents.renderLoginModal({
-      oauthProviders: this.props.oauthProviders,
-      afterSigninPath: this.props.afterSigninPath
-    });
-    gtag("event", "click", {
-      "category": "Login",
-      "label": "Login form opened"
-    });
-  }
-
   render () {
     return (
       <div className="user-type-select">
@@ -48,7 +25,6 @@ export default class UserTypeSelector extends React.Component<any, any> {
         <button onClick={this.handleClick} name="type" value="student">
           I am a <strong>Student</strong>
         </button>
-        <p className={"signup-form-login-option"}>Already have an account? <a href="/users/sign_in" onClick={this.handleLoginClick}>Log in &raquo;</a></p>
       </div>
     );
   }

--- a/rails/react-components/src/library/library.scss
+++ b/rails/react-components/src/library/library.scss
@@ -809,7 +809,7 @@ $materials-collection-item-icon-width: 300px;
   .submit-button-container {
     color: $col-darkgray-25;
     font: 700 15px $font-museo-sans;
-    margin: 30px 0 60px;
+    margin: 30px 0 0 0;
     text-align: right;
     .step {
       color: inherit;
@@ -861,7 +861,8 @@ $materials-collection-item-icon-width: 300px;
 }
 #signup-default-modal {
   .signup-form-login-option {
-    margin-top: 20px;
+    margin: 20px 0;
+    text-align: center;
   }
   .signup-form-school-select {
     margin-bottom: 0;

--- a/rails/react-components/tests/library/components/signup/login_modal.test.tsx
+++ b/rails/react-components/tests/library/components/signup/login_modal.test.tsx
@@ -7,7 +7,7 @@ describe("When I try to render signup user type selector", () => {
     render(<LoginModal />);
 
     // Check for the presence of various elements in the modal
-    expect(screen.getByRole("heading", { name: "Log in to the Portal" })).toBeInTheDocument();
+    expect(screen.getByText("Log In")).toBeInTheDocument();
     expect(screen.getByText("Sign in with:")).toBeInTheDocument();
     expect(screen.getByText("Or")).toBeInTheDocument();
     expect(screen.getByText("Username")).toBeInTheDocument();

--- a/rails/react-components/tests/library/components/signup/signup.test.tsx
+++ b/rails/react-components/tests/library/components/signup/signup.test.tsx
@@ -11,7 +11,6 @@ describe("When I try to render signup student form", () => {
     expect(screen.getByRole("button", { name: "I am a Student" })).toBeInTheDocument();
     expect(screen.getByText("Already have an account?")).toBeInTheDocument();
     expect(screen.getByText("Why sign up?")).toBeInTheDocument();
-    expect(screen.getByText("It's free and you get access to several key features, like creating classes for your students, assigning activities, saving work, tracking student progress, and more!")).toBeInTheDocument();
   });
 
   it("should render with anonymous prop", () => {
@@ -22,7 +21,6 @@ describe("When I try to render signup student form", () => {
     expect(screen.getByRole("button", { name: "I am a Student" })).toBeInTheDocument();
     expect(screen.getByText("Already have an account?")).toBeInTheDocument();
     expect(screen.getByText("Why sign up?")).toBeInTheDocument();
-    expect(screen.getByText("It's free and you get access to several key features, like creating classes for your students, assigning activities, saving work, tracking student progress, and more!")).toBeInTheDocument();
   });
 
   it("should render teacher signup", () => {
@@ -30,7 +28,7 @@ describe("When I try to render signup student form", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "I am a Teacher" }));
 
-    expect(screen.getByText("Register as a Teacher")).toBeInTheDocument();
+    expect(screen.getByText("Create a Teacher Account")).toBeInTheDocument();
     expect(screen.getByText("First Name")).toBeInTheDocument();
     expect(screen.getByText("Last Name")).toBeInTheDocument();
     expect(screen.getByText("Password")).toBeInTheDocument();
@@ -43,7 +41,7 @@ describe("When I try to render signup student form", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "I am a Student" }));
 
-    expect(screen.getByText("Register as a Student")).toBeInTheDocument();
+    expect(screen.getByText("Create a Student Account")).toBeInTheDocument();
     expect(screen.getByText("First Name")).toBeInTheDocument();
     expect(screen.getByText("Last Name")).toBeInTheDocument();
     expect(screen.getByText("Password")).toBeInTheDocument();

--- a/rails/react-components/tests/library/components/signup/signup_modal.test.tsx
+++ b/rails/react-components/tests/library/components/signup/signup_modal.test.tsx
@@ -12,6 +12,9 @@ describe("When I try to render signup modal", () => {
     expect(screen.getByText("Already have an account?", { exact: false })).toBeInTheDocument();
     expect(screen.getByText("Log in »", { exact: false })).toBeInTheDocument();
     expect(screen.getByText("Why sign up?", { exact: false })).toBeInTheDocument();
-    expect(screen.getByText("It's free and you get access to several key features, like creating classes for your students, assigning activities, saving work, tracking student progress, and more!", { exact: false })).toBeInTheDocument();
+
+    // Check if the login option paragraph with the login link is rendered
+    expect(screen.getByText("Already have an account?")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Log in »/i })).toBeInTheDocument();
   });
 });

--- a/rails/react-components/tests/library/components/signup/user_type_selector.test.tsx
+++ b/rails/react-components/tests/library/components/signup/user_type_selector.test.tsx
@@ -11,10 +11,6 @@ describe("When I try to render signup user type selector", () => {
     expect(screen.getByRole("button", { name: /I am a Teacher/i })).toBeInTheDocument();
     // Check if the student button is rendered
     expect(screen.getByRole("button", { name: /I am a Student/i })).toBeInTheDocument();
-    // Check if the login option paragraph is rendered
-    expect(screen.getByText("Already have an account?")).toBeInTheDocument();
-    // Check if the login link is rendered
-    expect(screen.getByRole("link", { name: /Log in »/i })).toBeInTheDocument();
   });
 
 });


### PR DESCRIPTION
- In the screen where you choose whether you are a teacher or a student, use "Create an Account" instead of Register in the header
- Use "Create a Student Account" or "Create a Teacher Account" in the header on each of the subsequent sign-up modals
- Auto-focus on the first input field in any form
- Update footer text on each modal to match specs (current text is teacher-focused and needs to be more generic)
- Add the "Already have an account? Log In" link below the buttons in the Create a Student/Teacher Account modals
- Make the "Already have an account? Log In" link persist on any subsequent screens when the user clicks Next button
- Updated login modal to split title into two lines and autofocus username