### PR TITLE
feat: Allow students to get a list of their own offerings

### DIFF
--- a/rails/app/policies/portal/offering_policy.rb
+++ b/rails/app/policies/portal/offering_policy.rb
@@ -5,7 +5,7 @@ class Portal::OfferingPolicy < ApplicationPolicy
   end
 
   def api_index?
-    teacher? || admin?
+    teacher? || admin? || student?
   end
 
   def api_create_for_external_activity?
@@ -28,6 +28,11 @@ class Portal::OfferingPolicy < ApplicationPolicy
 
       elsif user.portal_teacher
         scope.where(clazz_id: user.portal_teacher.clazz_ids)
+      elsif user.portal_student
+        # students can only see their own offerings
+        # in the controller the list of students in the offering is filtered
+        # to only include the student requesting the offering
+        scope.where(clazz_id: user.portal_student.clazz_ids)
       else
         none
       end

--- a/rails/spec/controllers/api/v1/offerings_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/offerings_controller_spec.rb
@@ -197,10 +197,17 @@ describe API::V1::OfferingsController do
     describe "when user is a student" do
       before (:each) do
         sign_in student_a.user
+        # Make sure that the offering is created.
+        @offering = offering
       end
-      it "returns 403 error" do
+      it "they will get a list of their own offerings with only themselves in the student list" do
         get :index
-        expect(response.status).to eql(403)
+        expect(response.status).to eql(200)
+        json = JSON.parse(response.body)
+        expect(json.length).to eq 1
+        # student only sees themselves
+        expect(json[0]["students"].length).to eq 1
+        expect(json[0]["students"][0]["user_id"]).to eq student_a.user.id
       end
     end
 
@@ -227,6 +234,10 @@ describe API::V1::OfferingsController do
         expect(response.status).to eql(200)
         json = JSON.parse(response.body)
         expect(json.length).to eq 1
+        # teacher sees both students
+        expect(json[0]["students"].length).to eq 2
+        expect(json[0]["students"][0]["user_id"]).to eq student_a.user.id
+        expect(json[0]["students"][1]["user_id"]).to eq student_b.user.id
       end
     end
 


### PR DESCRIPTION
Students can now request a list of their own offerings but the student list of each offering is filtered to only show the requesting student's info.

This is needed in CLUE to allow students to switch problems in the UI.