### PR TITLE
feat: Add auto external activity rule model [RIGSE-206]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,12 +147,6 @@ services:
       REPORT_SERVICE_SOURCE: "${REPORT_SERVICE_SOURCE:-authoring.lara.staging.concord.org}"
       REPORT_SERVICE_BEARER_TOKEN:
 
-      # Temporary setting for the new automatic external activity creator to test on staging
-      # This will be replaced with a new model that has a CRUD UI to manage the user id to use
-      # when automatically creating external activities.
-      # THIS SHOULD BE REMOVED BEFORE THE FINAL RELEASE AND NOT BE USED IN PRODUCTION
-      AUTOMATIC_EXTERNAL_ACTIVITY_CREATOR_USER_ID:
-
     # open standard in and turn on tty so we can attach to the container and debug it
     stdin_open: true
     tty: true

--- a/rails/app/controllers/admin/auto_external_activity_rules_controller.rb
+++ b/rails/app/controllers/admin/auto_external_activity_rules_controller.rb
@@ -1,0 +1,73 @@
+class Admin::AutoExternalActivityRulesController < ApplicationController
+  before_action :set_auto_external_activity_rule, only: %i[ show edit update destroy ]
+  before_action :set_authors
+
+  # GET /auto_external_activity_rules
+  def index
+    @auto_external_activity_rules = Admin::AutoExternalActivityRule.all
+  end
+
+  # GET /auto_external_activity_rules/1
+  def show
+  end
+
+  # GET /auto_external_activity_rules/new
+  def new
+    @auto_external_activity_rule = Admin::AutoExternalActivityRule.new
+  end
+
+  # GET /auto_external_activity_rules/1/edit
+  def edit
+  end
+
+  # POST /auto_external_activity_rules
+  def create
+    @auto_external_activity_rule = Admin::AutoExternalActivityRule.new(auto_external_activity_rule_params)
+
+    if params[:update_external_reports]
+      @auto_external_activity_rule.external_report_ids= (params[:external_reports] || [])
+    end
+
+    if @auto_external_activity_rule.save
+      redirect_to @auto_external_activity_rule, notice: "Auto external activity rule was successfully created."
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH/PUT /auto_external_activity_rules/1
+  def update
+    if @auto_external_activity_rule.update(auto_external_activity_rule_params)
+      if params[:update_external_reports]
+        @auto_external_activity_rule.external_report_ids= (params[:external_reports] || [])
+        @auto_external_activity_rule.save
+      end
+
+      redirect_to @auto_external_activity_rule, notice: "Auto external activity rule was successfully updated.", status: :see_other
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /auto_external_activity_rules/1
+  def destroy
+    @auto_external_activity_rule.destroy!
+    redirect_to admin_auto_external_activity_rules_path, notice: "Auto external activity rule was successfully destroyed.", status: :see_other
+  end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_auto_external_activity_rule
+    @auto_external_activity_rule = Admin::AutoExternalActivityRule.find(params.expect(:id))
+  end
+
+  def set_authors
+    @authors = User.with_role("author").order([:first_name, :last_name])
+  end
+
+  # Only allow a list of trusted parameters through.
+  def auto_external_activity_rule_params
+    params.expect(admin_auto_external_activity_rule: [ :name, :slug, :description, :allow_patterns, :user_id, :external_reports ])
+  end
+end

--- a/rails/app/controllers/api/v1/offerings_controller.rb
+++ b/rails/app/controllers/api/v1/offerings_controller.rb
@@ -107,6 +107,7 @@ class API::V1::OfferingsController < API::APIController
     return error("A class_id is required") unless params[:class_id].present?
     return error("A name is required") unless params[:name].present?
     return error("An url is required") unless params[:url].present?
+    return error("A rule is required") unless params[:rule].present?
 
     begin
       validated_url = URI.parse(params[:url])
@@ -130,11 +131,10 @@ class API::V1::OfferingsController < API::APIController
       # find the existing external activity
       external_activity = ExternalActivity.where(url: params[:url]).first
       if !external_activity
-        # FIXME: add a new CRUD model for automatically creating external activities
-        # that includes a user_id and an allowed list of url prefixes/patterns
-        # FOR NOW: we will use a temporary ENV variable to set the USER_ID
-        automatic_creator_user_id = ENV["AUTOMATIC_EXTERNAL_ACTIVITY_CREATOR_USER_ID"]
-        return error("Unable to find AUTOMATIC_EXTERNAL_ACTIVITY_CREATOR_USER_ID env var") unless automatic_creator_user_id
+        # check if the rule allows the url
+        rule = Admin::AutoExternalActivityRule.find_by(slug: params[:rule])
+        return error("Unable to find #{params[:rule]} rule") unless rule
+        return error("The URL is not allowed by the rule") unless rule.matches_pattern?(params[:url])
 
         # create a new external activity
         external_activity = ExternalActivity.create(
@@ -142,7 +142,7 @@ class API::V1::OfferingsController < API::APIController
           :url                    => params[:url],
           :material_type          => "Activity",
           :publication_status     => params[:publication_status] || "published",
-          :user_id                => automatic_creator_user_id, # FIXME: use the user_id in the TBD CRUD model
+          :user_id                => rule.user_id,
           :append_auth_token      => params[:append_auth_token] || false,
           :author_url             => params[:author_url],
           :print_url              => params[:print_url],

--- a/rails/app/controllers/api/v1/offerings_controller.rb
+++ b/rails/app/controllers/api/v1/offerings_controller.rb
@@ -155,16 +155,14 @@ class API::V1::OfferingsController < API::APIController
           :rubric_doc_url         => params[:rubric_doc_url]
         )
 
-        if params[:external_report_url]
-          external_report = ExternalReport.find_by_url(params[:external_report_url])
-          if external_report
-            external_activity.external_reports=[external_report]
-            external_activity.save
-          end
-        end
-
         if !external_activity.valid?
           return error("Unable to create external activity", 422)
+        end
+
+        # add all the external reports setup in the rule
+        if rule.external_reports.any?
+          external_activity.external_reports += rule.external_reports
+          external_activity.save
         end
       end
 

--- a/rails/app/models/admin/auto_external_activity_rule.rb
+++ b/rails/app/models/admin/auto_external_activity_rule.rb
@@ -1,0 +1,28 @@
+class Admin::AutoExternalActivityRule < ApplicationRecord
+  belongs_to :user, foreign_key: :user_id
+  has_and_belongs_to_many :external_reports, join_table: :auto_external_activity_rules_external_reports
+
+  validates :name, :slug, :description, :allow_patterns, presence: true
+  validates :slug, uniqueness: true
+  validates :slug, format: { with: /\A[\w-]+\z/, message: "can only contain letters, numbers, underscores, and dashes" }
+
+  validate :user_must_be_author
+
+  def matches_pattern?(url)
+    # Split allow_patterns on newlines and check if any pattern matches the URL
+    allow_patterns.split("\n").any? do |pattern|
+      regex = Regexp.new(pattern)
+      regex.match?(url)
+    end
+  end
+
+  private
+
+  def user_must_be_author
+    if !user
+      errors.add(:user_id, "must be present")
+    elsif !user.has_role?("author")
+      errors.add(:user_id, "must be a user with the 'author' role")
+    end
+  end
+end

--- a/rails/app/views/admin/auto_external_activity_rules/_auto_external_activity_rule.html.erb
+++ b/rails/app/views/admin/auto_external_activity_rules/_auto_external_activity_rule.html.erb
@@ -1,0 +1,31 @@
+<div id="<%= dom_id auto_external_activity_rule %>">
+  <p>
+    <strong>Name:</strong>
+    <%= auto_external_activity_rule.name %>
+  </p>
+
+  <p>
+    <strong>User:</strong>
+    <%= auto_external_activity_rule.user.name %>
+  </p>
+
+  <p>
+    <strong>Slug:</strong>
+    <%= auto_external_activity_rule.slug %>
+  </p>
+
+  <p>
+    <strong>Description:</strong>
+    <%= auto_external_activity_rule.description %>
+  </p>
+
+  <p>
+    <strong>Allow patterns:</strong>
+    <%= auto_external_activity_rule.allow_patterns.split("\n").join(", ") %>
+  </p>
+
+  <p>
+    <strong>External Reports:</strong>
+    <%= auto_external_activity_rule.external_reports.map(&:name).join(", ") %>
+  </p>
+</div>

--- a/rails/app/views/admin/auto_external_activity_rules/_form.html.erb
+++ b/rails/app/views/admin/auto_external_activity_rules/_form.html.erb
@@ -1,0 +1,67 @@
+<%= form_with(model: auto_external_activity_rule) do |form| %>
+  <div style="display: flex; flex-direction: column; gap: 15px; width: 90%">
+    <% if auto_external_activity_rule.errors.any? %>
+      <div style="color: red">
+        <h2><%= pluralize(auto_external_activity_rule.errors.count, "error") %> prohibited this from being saved:</h2>
+
+        <ul>
+          <% auto_external_activity_rule.errors.each do |error| %>
+            <li><%= error.full_message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <div>
+      <%= form.label :name, style: "display: block" %>
+      <%= form.text_field :name, style: "width: 100%" %>
+      <div>This is what is displayed in the admin interface.</div>
+    </div>
+
+    <div>
+      <%= form.label :user_id, "User", style: "display: block" %>
+      <%= form.select :user_id, options_from_collection_for_select(@authors, :id, :name, form.object.user_id),
+                      { include_blank: "Select an author" }, style: "width: 100%" %>
+      <div>Select the user to use as the author when creating external activities with this rule.</div>
+    </div>
+
+    <div>
+      <%= form.label :slug, style: "display: block" %>
+      <%= form.text_field :slug, style: "width: 100%" %>
+      <div>
+        The slug must be unique and can only contain letters, numbers, underscores, and dashes.
+        Once set it should not be changed as it is used by API clients to reference this rule.
+      </div>
+    </div>
+
+    <div>
+      <%= form.label :description, style: "display: block" %>
+      <%= form.text_field :description, style: "width: 100%" %>
+      <div>Describe why this rule exists. Shown in the list of rules in the admin interface.</div>
+    </div>
+
+    <div>
+      <%= form.label :allow_patterns, style: "display: block" %>
+      <%= form.text_area :allow_patterns, class: "mceNoEditor", rows: 10, style: "width: 100%", placeholder: "Examples:\n\nhttps://collaborative-learning.concord.org/*\nhttp://localhost:8080/*" %>
+      <div>One or more regex patterns that will be used to determine if the activity is allowed to be automatically created.  The pattern must match the entire URL. Use newlines to separate patterns.</div>
+    </div>
+
+    <div>
+      <%= form.label :external_reports, style: "display: block" %>
+      <%= hidden_field_tag :update_external_reports, "true" %>
+      <div style="padding: 10px; background-color: #f0f0f0;">
+        <% ExternalReport.where(report_type: [ExternalReport::OfferingReport, ExternalReport::ClassReport]).each do |external_report| %>
+          <div>
+            <%= check_box_tag "external_reports[]", external_report.id, form.object.external_report_ids.include?(external_report.id), id: external_report.id %>
+            <%= label_tag external_report.name, external_report.name %>
+          </div>
+        <% end %>
+      </div>
+      <div>Select the reports that should be added to the activity when an activity is created with this rule.</div>
+    </div>
+
+    <div>
+      <%= form.submit %>
+    </div>
+  </div>
+<% end %>

--- a/rails/app/views/admin/auto_external_activity_rules/edit.html.erb
+++ b/rails/app/views/admin/auto_external_activity_rules/edit.html.erb
@@ -1,0 +1,12 @@
+<% content_for :title, "Editing Auto External Activity Rule" %>
+
+<h1>Editing Auto External Activity Rule</h1>
+
+<%= render "form", auto_external_activity_rule: @auto_external_activity_rule %>
+
+<br>
+
+<div>
+  <%= link_to "Show this Auto External Activity Rule", @auto_external_activity_rule %> |
+  <%= link_to "Back to Auto External Activity Rules", admin_auto_external_activity_rules_path %>
+</div>

--- a/rails/app/views/admin/auto_external_activity_rules/index.html.erb
+++ b/rails/app/views/admin/auto_external_activity_rules/index.html.erb
@@ -1,0 +1,50 @@
+<p style="color: green"><%= notice %></p>
+
+<% content_for :title, "Auto External Activity Rules" %>
+
+<h1>Auto External Activity Rules</h1>
+
+<div id="auto_external_activity_rules">
+  <% if @auto_external_activity_rules.length > 0 %>
+    <table cellpadding="5" border="0">
+      <tr>
+        <th style="text-align: left;">Name</th>
+        <th style="text-align: left;">User</th>
+        <th style="text-align: left;">Slug</th>
+        <th style="text-align: left;">Description</th>
+      </tr>
+    <% @auto_external_activity_rules.each do |auto_external_activity_rule| %>
+      <tr>
+        <td>
+          <%= link_to auto_external_activity_rule.name, auto_external_activity_rule %>
+        </td>
+        <td>
+          <%= auto_external_activity_rule.user.name %>
+        </td>
+        <td>
+          <%= auto_external_activity_rule.slug %>
+        </td>
+        <td>
+          <%= auto_external_activity_rule.description %>
+        </td>
+      </tr>
+    <% end %>
+    </table>
+  <% else %>
+    <div style="margin: 10px 0">
+      You have no auto external activity rules.
+      <br/>
+      To create one click the "Create Auto External Activity Rule" button.
+    </div>
+  <% end %>
+</div>
+
+<%= link_to "Create Auto External Activity Rule", new_admin_auto_external_activity_rule_path, {:class => 'button'} %>
+
+<div style="margin-top: 20px; padding: 10px; background: #f1f1f1;">
+  Auto external activity rules are used to automatically create external activities in the API offerings controller
+  when the external activity for the offering does not exist.  The "slug" for the rule is passed to the api endpoint
+  which then uses it to look up the rule and ensure the external activity
+  url matches the allow patterns regex.  If it does the associated user for the rule is used as the author of the
+  external activity.
+</div>

--- a/rails/app/views/admin/auto_external_activity_rules/new.html.erb
+++ b/rails/app/views/admin/auto_external_activity_rules/new.html.erb
@@ -1,0 +1,11 @@
+<% content_for :title, "New Auto External Activity Rule" %>
+
+<h1>New Auto External Activity Rule</h1>
+
+<%= render "form", auto_external_activity_rule: @auto_external_activity_rule %>
+
+<br>
+
+<div>
+  <%= link_to "Back to Auto External Activity Rules", admin_auto_external_activity_rules_path %>
+</div>

--- a/rails/app/views/admin/auto_external_activity_rules/show.html.erb
+++ b/rails/app/views/admin/auto_external_activity_rules/show.html.erb
@@ -1,0 +1,9 @@
+<h1>Auto External Activity Rule</h1>
+
+<%= render @auto_external_activity_rule %>
+
+<div style="display: flex; gap: 10px">
+  <%= link_to "Edit", edit_admin_auto_external_activity_rule_path(@auto_external_activity_rule), class: "button" %>
+  <%= link_to "Back", admin_auto_external_activity_rules_path, class: "button" %>
+</div>
+<%= button_to "Delete", @auto_external_activity_rule, method: :delete %>

--- a/rails/app/views/home/admin.html.haml
+++ b/rails/app/views/home/admin.html.haml
@@ -15,6 +15,7 @@
       %ul
         %li= link_to 'Auth Clients', admin_clients_path
         %li= link_to 'Authoring Sites', admin_authoring_sites_path
+        %li= link_to 'Auto External Activity Rules', admin_auto_external_activity_rules_path
         %li= link_to 'Classes', portal_clazzes_path
         %li= link_to 'Cohorts', admin_cohorts_path
         %li= link_to 'Districts', portal_districts_path

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -1,5 +1,4 @@
 RailsPortal::Application.routes.draw do
-
   devise_for :users, :controllers => {
     :registrations => 'registrations',
     :confirmations => 'confirmations',
@@ -250,6 +249,7 @@ RailsPortal::Application.routes.draw do
 
       resources :authoring_sites
       resources :firebase_apps
+      resources :auto_external_activity_rules
     end
 
     resources :materials_collections

--- a/rails/db/migrate/20250509115230_create_auto_external_activity_rules.rb
+++ b/rails/db/migrate/20250509115230_create_auto_external_activity_rules.rb
@@ -1,0 +1,24 @@
+class CreateAutoExternalActivityRules < ActiveRecord::Migration[8.0]
+  def change
+    create_table :auto_external_activity_rules do |t|
+      t.string :name
+      t.string :slug
+      t.string :description
+      t.text :allow_patterns
+      t.references :user
+
+      t.timestamps
+    end
+
+    add_index :auto_external_activity_rules, :slug, unique: true, name: 'auto_external_activity_rules_uniq_idx'
+
+    create_table :auto_external_activity_rules_external_reports, id: false do |t|
+      t.references :auto_external_activity_rule
+      t.references :external_report
+    end
+
+    add_index :auto_external_activity_rules_external_reports,
+      [:auto_external_activity_rule_id, :external_report_id],
+      name: "auto_external_activity_rules_reports"
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_01_146000) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_09_115230) do
   create_table "access_grants", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "code"
     t.string "access_token"
@@ -206,6 +206,26 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_01_146000) do
     t.string "url"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+  end
+
+  create_table "auto_external_activity_rules", charset: "utf8", force: :cascade do |t|
+    t.string "name"
+    t.string "slug"
+    t.string "description"
+    t.text "allow_patterns"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["slug"], name: "auto_external_activity_rules_uniq_idx", unique: true
+    t.index ["user_id"], name: "index_auto_external_activity_rules_on_user_id"
+  end
+
+  create_table "auto_external_activity_rules_external_reports", id: false, charset: "utf8", force: :cascade do |t|
+    t.bigint "auto_external_activity_rule_id"
+    t.bigint "external_report_id"
+    t.index ["auto_external_activity_rule_id", "external_report_id"], name: "auto_external_activity_rules_reports"
+    t.index ["auto_external_activity_rule_id"], name: "idx_on_auto_external_activity_rule_id_02af4cd4b9"
+    t.index ["external_report_id"], name: "idx_on_external_report_id_50ce69adab"
   end
 
   create_table "clients", id: :integer, charset: "utf8", force: :cascade do |t|

--- a/rails/factories/auto_external_activity_rules.rb
+++ b/rails/factories/auto_external_activity_rules.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :admin_auto_external_activity_rule, class: Admin::AutoExternalActivityRule do
+    name { "Test Rule" }
+    slug { "test" }
+    description { "This is the test rule" }
+    allow_patterns { ".*" }
+  end
+end

--- a/rails/spec/controllers/api/v1/offerings_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/offerings_controller_spec.rb
@@ -5,6 +5,7 @@ describe API::V1::OfferingsController do
 
   let(:admin_user)        { FactoryBot.generate(:admin_user) }
   let(:manager_user)      { FactoryBot.generate(:manager_user) }
+  let(:author_user)       { FactoryBot.generate(:author_user) }
   let(:teacher)           { FactoryBot.create(:portal_teacher) }
   let(:activity_1)        { FactoryBot.create(:external_activity, name: 'Activity 1') }
   let(:activity_2)        { FactoryBot.create(:external_activity, name: 'Activity 2') }
@@ -14,6 +15,9 @@ describe API::V1::OfferingsController do
   let(:student_b)         { FactoryBot.create(:full_portal_student) }
   let(:locked)            { false }
   let(:offering)          { FactoryBot.create(:portal_offering, {clazz: clazz, runnable: runnable, locked: locked}) }
+  let(:slug)              { "test" }
+  let(:allow_patterns)    { ".*" }
+  let(:rule)              { FactoryBot.create(:admin_auto_external_activity_rule, slug: slug, allow_patterns: allow_patterns, user: author_user) }
 
   before(:each) {
     # This silences warnings in the console when running
@@ -467,36 +471,68 @@ describe API::V1::OfferingsController do
       end
 
       it "should fail when class_id is not provided" do
-        post :create_for_external_activity, params: { name: 'Test', url: 'http://test.com' }
+        post :create_for_external_activity, params: { name: 'Test', url: 'http://test.com', rule: 'test' }
         expect(JSON.parse(response.body)["message"]).to eq "A class_id is required"
         expect(response.status).to eql(400)
       end
 
       it "should fail when name is not provided" do
-        post :create_for_external_activity, params: { class_id: clazz.id, url: 'http://test.com' }
+        post :create_for_external_activity, params: { class_id: clazz.id, url: 'http://test.com', rule: 'test' }
         expect(JSON.parse(response.body)["message"]).to eq "A name is required"
         expect(response.status).to eql(400)
       end
 
       it "should fail when url is not provided" do
-        post :create_for_external_activity, params: { class_id: clazz.id, name: 'Test' }
+        post :create_for_external_activity, params: { class_id: clazz.id, name: 'Test', rule: 'test' }
         expect(JSON.parse(response.body)["message"]).to eq "An url is required"
         expect(response.status).to eql(400)
+      end
+
+      it "should fail when rule is not provided" do
+        post :create_for_external_activity, params: { class_id: clazz.id, name: 'Test', url: 'http://test.com' }
+        expect(JSON.parse(response.body)["message"]).to eq "A rule is required"
+        expect(response.status).to eql(400)
+      end
+
+      it "should fail when rule doesn't exist" do
+        post :create_for_external_activity, params: { class_id: clazz.id, name: 'Test', url: 'http://test.com', rule: 'invalid-rule' }
+        expect(JSON.parse(response.body)["message"]).to eq "Unable to find invalid-rule rule"
+        expect(response.status).to eql(400)
+      end
+
+      describe "when rule is provided" do
+        let (:allow_patterns) { "https://example.com/*\nhttp://foo.com/*" }
+
+        it "should fail when url doesn't match rule allowed_patterns" do
+          rule
+          post :create_for_external_activity, params: { class_id: clazz.id, name: 'Test', url: 'http://test.com', rule: 'test' }
+          expect(JSON.parse(response.body)["message"]).to eq "The URL is not allowed by the rule"
+          expect(response.status).to eql(400)
+        end
+
+        it "should succeed when url does match rule allowed_patterns" do
+          rule
+          post :create_for_external_activity, params: { class_id: clazz.id, name: 'Test', url: 'http://foo.com/bar', rule: 'test' }
+          expect(response.status).to eql(200)
+          json = JSON.parse(response.body)
+          expect(json["id"]).not_to eq nil
+          expect(json["id"]).not_to eq offering.id
+          expect(Portal::Offering.find(json["id"]).runnable.url).to eq 'http://foo.com/bar'
+        end
       end
 
       it "should fail when user is not a teacher for the class" do
         other_teacher = FactoryBot.create(:portal_teacher)
         sign_in other_teacher.user
-        post :create_for_external_activity, params: { class_id: clazz.id, name: 'Test', url: 'http://test.com' }
+        post :create_for_external_activity, params: { class_id: clazz.id, name: 'Test', url: 'http://test.com', rule: 'test' }
         expect(JSON.parse(response.body)["message"]).to eq "You are not a teacher of the specified class"
         expect(response.status).to eql(403)
       end
 
       it "should create a new offering and external activity if one does not exist" do
-        # FIXME: remove when new CRUD table is added for automatically creating external activities
-        ENV["AUTOMATIC_EXTERNAL_ACTIVITY_CREATOR_USER_ID"] = teacher.user.id.to_s
+        rule
         offering # Make sure that the offering is created.
-        post :create_for_external_activity, params: { class_id: clazz.id, name: 'Test', url: 'http://test.com' }
+        post :create_for_external_activity, params: { class_id: clazz.id, name: 'Test', url: 'http://test.com', rule: 'test' }
         expect(response.status).to eql(200)
         json = JSON.parse(response.body)
         expect(json["id"]).not_to eq nil
@@ -508,7 +544,7 @@ describe API::V1::OfferingsController do
         offering # Make sure that the offering is created.
         external_activity = ExternalActivity.create!(name: "Existing activity", url: "http://test.com/existing")
 
-        post :create_for_external_activity, params: { class_id: clazz.id, name: 'Test', url: external_activity.url }
+        post :create_for_external_activity, params: { class_id: clazz.id, name: 'Test', url: external_activity.url, rule: 'test' }
         expect(response.status).to eql(200)
         json = JSON.parse(response.body)
         expect(json["id"]).not_to eq nil
@@ -519,7 +555,7 @@ describe API::V1::OfferingsController do
 
       it "should not create a new offering if one already exists" do
         offering # Make sure that the offering is created.
-        post :create_for_external_activity, params: { class_id: clazz.id, name: 'Test', url: offering.runnable.url }
+        post :create_for_external_activity, params: { class_id: clazz.id, name: 'Test', url: offering.runnable.url, rule: 'test' }
         expect(response.status).to eql(200)
         json = JSON.parse(response.body)
         expect(json["id"]).not_to eq nil

--- a/rails/spec/controllers/api/v1/offerings_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/offerings_controller_spec.rb
@@ -503,14 +503,14 @@ describe API::V1::OfferingsController do
       describe "when rule is provided" do
         let (:allow_patterns) { "https://example.com/*\nhttp://foo.com/*" }
 
-        it "should fail when url doesn't match rule allowed_patterns" do
+        it "should fail when url doesn't match rule allow_patterns" do
           rule
           post :create_for_external_activity, params: { class_id: clazz.id, name: 'Test', url: 'http://test.com', rule: 'test' }
           expect(JSON.parse(response.body)["message"]).to eq "The URL is not allowed by the rule"
           expect(response.status).to eql(400)
         end
 
-        it "should succeed when url does match rule allowed_patterns" do
+        it "should succeed when url does match rule allow_patterns" do
           rule
           post :create_for_external_activity, params: { class_id: clazz.id, name: 'Test', url: 'http://foo.com/bar', rule: 'test' }
           expect(response.status).to eql(200)

--- a/rails/spec/models/admin/auto_external_activity_rule_spec.rb
+++ b/rails/spec/models/admin/auto_external_activity_rule_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+
+describe Admin::AutoExternalActivityRule do
+  let(:non_author_user)  { FactoryBot.create(:confirmed_user) }
+  let(:author_user)      { FactoryBot.generate(:author_user) }
+  let(:slug)             { "test" }
+  let(:allow_patterns)   { ".*" }
+  let(:rule)             { FactoryBot.create(:admin_auto_external_activity_rule, slug: slug, allow_patterns: allow_patterns, user: author_user) }
+  let(:valid_attributes) {
+    { name: "Test", slug: "test", description: "This is a test rule", allow_patterns: allow_patterns, user: author_user }
+  }
+
+  it "should create a new instance given valid attributes" do
+    Admin::AutoExternalActivityRule.create!(valid_attributes)
+  end
+
+  describe "#name" do
+    it "should be required" do
+      expect(Admin::AutoExternalActivityRule.new(valid_attributes.merge(name: '')).valid?).to be_falsey
+    end
+  end
+
+  describe "#slug" do
+    it "should be required" do
+      expect(Admin::AutoExternalActivityRule.new(valid_attributes.merge(slug: '')).valid?).to be_falsey
+    end
+
+    it "should be unique" do
+      expect(Admin::AutoExternalActivityRule.create(valid_attributes).valid?).to be_truthy
+      expect(Admin::AutoExternalActivityRule.create(valid_attributes).valid?).to be_falsey
+    end
+
+    it "should be limited to only contain letters, numbers, underscores, and dashes" do
+      expect(Admin::AutoExternalActivityRule.new(valid_attributes.merge(slug: 'valid-slug')).valid?).to be_truthy
+      expect(Admin::AutoExternalActivityRule.new(valid_attributes.merge(slug: 'valid-slug-2')).valid?).to be_truthy
+      expect(Admin::AutoExternalActivityRule.new(valid_attributes.merge(slug: '3-valid_slug')).valid?).to be_truthy
+      expect(Admin::AutoExternalActivityRule.new(valid_attributes.merge(slug: 'invalid/slug')).valid?).to be_falsey
+      expect(Admin::AutoExternalActivityRule.new(valid_attributes.merge(slug: 'invalid.slug')).valid?).to be_falsey
+    end
+  end
+
+  describe "#description" do
+    it "should be required" do
+      expect(Admin::AutoExternalActivityRule.new(valid_attributes.merge(description: '')).valid?).to be_falsey
+    end
+  end
+
+  describe "#allow_patterns" do
+    it "should be required" do
+      expect(Admin::AutoExternalActivityRule.new(valid_attributes.merge(allow_patterns: '')).valid?).to be_falsey
+    end
+  end
+
+  describe "#user" do
+    it "should be required" do
+      expect(Admin::AutoExternalActivityRule.new(valid_attributes.merge(user: nil)).valid?).to be_falsey
+    end
+
+    it "should be an author" do
+      expect(Admin::AutoExternalActivityRule.new(valid_attributes.merge(user: non_author_user)).valid?).to be_falsey
+    end
+
+    it "should be valid with an author" do
+      expect(Admin::AutoExternalActivityRule.new(valid_attributes).valid?).to be_truthy
+    end
+  end
+
+  describe "#matches_pattern?" do
+    let(:allow_patterns) { "https?://example.com/*\nhttp://foo.com/*" }
+
+    it "should return false if the URL does not match any pattern" do
+      expect(rule.matches_pattern?("http://notmatching.com")).to be_falsey
+    end
+
+    it "should return true if the URL matches a pattern" do
+      expect(rule.matches_pattern?("http://example.com/test")).to be_truthy
+    end
+
+    it "should return true if the URL matches another pattern" do
+      expect(rule.matches_pattern?("http://foo.com/test")).to be_truthy
+    end
+  end
+end

--- a/rails/spec/models/admin/auto_external_activity_rule_spec.rb
+++ b/rails/spec/models/admin/auto_external_activity_rule_spec.rb
@@ -49,6 +49,16 @@ describe Admin::AutoExternalActivityRule do
     it "should be required" do
       expect(Admin::AutoExternalActivityRule.new(valid_attributes.merge(allow_patterns: '')).valid?).to be_falsey
     end
+
+    it "should be valid regex" do
+      expect(Admin::AutoExternalActivityRule.new(valid_attributes.merge(allow_patterns: 'invalid[')).valid?).to be_falsey
+      expect(Admin::AutoExternalActivityRule.new(valid_attributes.merge(allow_patterns: 'vali?d*')).valid?).to be_truthy
+    end
+
+    it "should be valid regex with multiple patterns" do
+      expect(Admin::AutoExternalActivityRule.new(valid_attributes.merge(allow_patterns: 'valid\ninvalid[')).valid?).to be_falsey
+      expect(Admin::AutoExternalActivityRule.new(valid_attributes.merge(allow_patterns: 'val?id*\nvalid2.*')).valid?).to be_truthy
+    end
   end
 
   describe "#user" do


### PR DESCRIPTION
This adds a new model to be used in the API offerings controller to validate the passed external activity.