### PR TITLE
RIGSE 175 Fix: Proper indent for multi-line numbered steps in onboarding

### DIFF
--- a/rails/react-components/src/library/components/recent-activity/style.scss
+++ b/rails/react-components/src/library/components/recent-activity/style.scss
@@ -38,6 +38,9 @@
 }
 
 .stepNumber {
+  position: absolute;
+  left: 0;
+  top: 0.2em;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -58,5 +61,7 @@
 }
 
 .numberedStepsList li {
+  position: relative;
   margin-bottom: 1em;
+  padding-left: 32px;
 }


### PR DESCRIPTION
### Description
Adjusts CSS so wrapped lines in the Getting Started steps align with the first line, not under the number.
Improves readability and visual consistency for onboarding instructions.

### Screenshot of current behavior:
Here we fix the indent issues observed in Step 4 of the bullet:

<img width="869" alt="Screenshot 2025-05-09 at 2 27 29 PM" src="https://github.com/user-attachments/assets/19275071-0d33-496c-803a-411eabb85f27" />
