### PR TITLE
fix: Hide archived resources option from plain teachers [RIGSE-155]

### DIFF
--- a/rails/app/controllers/search_controller.rb
+++ b/rails/app/controllers/search_controller.rb
@@ -31,6 +31,9 @@ class SearchController < ApplicationController
     # PUNDIT_CHECK_SCOPE (did not find instance)
     # @searches = policy_scope(Search)
 
+    # plain teachers cannot see archived resources, only teachers that are also either admins, researchers, project admins or project researchers
+    @can_view_archived = current_user && (current_user.has_role?('admin') || current_user.has_role?('researcher') || current_user.admin_for_projects.present? || current_user.researcher_for_projects.present?)
+
     if request.query_parameters.empty?
       flash.keep
       return redirect_to action: 'index', include_official: '1'

--- a/rails/app/views/search/_filters.html.haml
+++ b/rails/app/views/search/_filters.html.haml
@@ -80,10 +80,11 @@
                 = check_box_tag 'include_mine', '1', params[:include_mine], :id => 'include_mine', :class => 'include_mine'
                 %label.tooltip{:for => "include_mine", :class => 'include_mine'}
                   = t "search.only_mine"
-              .only_show_archived
-                = check_box_tag 'show_archived', '1', params[:show_archived], :id => 'show_archived', :class => 'show_archived'
-                %label.tooltip{:for => "show archived", :class => 'show_archived'}
-                  = t "search.only_archived"
+              - if @can_view_archived
+                .only_show_archived
+                  = check_box_tag 'show_archived', '1', params[:show_archived], :id => 'show_archived', :class => 'show_archived'
+                  %label.tooltip{:for => "show archived", :class => 'show_archived'}
+                    = t "search.only_archived"
       -if @form_model.available_sensors.size > 0
         .filter-row
           #sensor-filters.filter-group

--- a/rails/spec/controllers/search_controller_spec.rb
+++ b/rails/spec/controllers/search_controller_spec.rb
@@ -9,12 +9,24 @@ describe SearchController do
 
   let(:mock_school)     { FactoryBot.create(:portal_school) }
 
-  let(:teacher_user)    { FactoryBot.create(:confirmed_user, :login => "teacher_user") }
-  let(:teacher)         { FactoryBot.create(:portal_teacher, :user => teacher_user, :schools => [mock_school]) }
-  let(:admin_user)      { FactoryBot.generate(:admin_user) }
-  let(:author_user)     { FactoryBot.generate(:author_user) }
-  let(:manager_user)    { FactoryBot.generate(:manager_user) }
-  let(:researcher_user) { FactoryBot.generate(:researcher_user) }
+  let(:teacher_user)            { FactoryBot.create(:confirmed_user, :login => "teacher_user") }
+  let(:teacher)                 { FactoryBot.create(:portal_teacher, :user => teacher_user, :schools => [mock_school]) }
+  let(:admin_user)              { FactoryBot.generate(:admin_user) }
+  let(:author_user)             { FactoryBot.generate(:author_user) }
+  let(:manager_user)            { FactoryBot.generate(:manager_user) }
+  let(:researcher_user)         { FactoryBot.generate(:researcher_user) }
+
+  let(:project)                 { FactoryBot.create(:project) }
+  let(:project_admin_user)      {
+    project_admin = FactoryBot.generate(:author_user)
+    project_admin.admin_for_projects << project
+    project_admin
+  }
+  let(:project_researcher_user) {
+    project_admin = FactoryBot.generate(:author_user)
+    project_admin.researcher_for_projects << project
+    project_admin
+  }
 
   let(:student_user)    { FactoryBot.create(:confirmed_user, :login => "authorized_student") }
   let(:student)         { FactoryBot.create(:portal_student, :user_id => student_user.id) }
@@ -80,7 +92,41 @@ describe SearchController do
         expect(response).to redirect_to action: :index, include_official: '1'
       end
     end
+
+    describe "when it is a teacher visiting" do
+      it "should not show the show archived checkbox" do
+        get :index
+        expect(assigns(:can_view_archived)).to be_falsey
+      end
+    end
+
+    describe "should show the archived resources checkbox" do
+      it "when the user is an admin" do
+        admin_user
+        allow(controller).to receive(:current_user).and_return(admin_user)
+        get :index
+        expect(assigns(:can_view_archived)).to be_truthy
+      end
+      it "when the user is a researcher" do
+        researcher_user
+        allow(controller).to receive(:current_user).and_return(researcher_user)
+        get :index
+        expect(assigns(:can_view_archived)).to be_truthy
+      end
+      it "when the user is a project admin" do
+        project
+        project_admin_user
+        allow(controller).to receive(:current_user).and_return(project_admin_user)
+        get :index
+        expect(assigns(:can_view_archived)).to be_truthy
+      end
+      it "when the user is a project researcher" do
+        project
+        project_researcher_user
+        allow(controller).to receive(:current_user).and_return(project_researcher_user)
+        get :index
+        expect(assigns(:can_view_archived)).to be_truthy
+      end
+    end
   end
-
-
 end


### PR DESCRIPTION
This change hides the "Archived resources" option in the advanced search from teachers that are not also admins, researchers, project admins or project researchers.