### PR TITLE
fix: Disable hiding of the forgot password modal on the forgot password page [RIGSE-209]

### DIFF
--- a/rails/app/views/passwords/login.html.haml
+++ b/rails/app/views/passwords/login.html.haml
@@ -2,7 +2,7 @@
 
 :javascript
   if (Portal.currentUser.isAnonymous) {
-    PortalComponents.renderForgotPasswordModal({});
+    PortalComponents.renderForgotPasswordModal({notHideable: true});
   } else {
     window.location.href = "/";
   }

--- a/rails/react-components/src/library/components/signup/signup_functions.tsx
+++ b/rails/react-components/src/library/components/signup/signup_functions.tsx
@@ -58,8 +58,17 @@ const openModal = (type: any, properties: any = {}, closeFunc?: () => void) => {
     properties.closeable = true;
   }
 
+  // by default, if there is no closeFunc, we hide the modal unless the modal is not hideable
+  // (e.g. the forgot password modal on the forgot password page)
   if (!closeFunc) {
-    closeFunc = () => hideModalOfType(type);
+    const notHideable = properties.notHideable ?? false;
+    if (notHideable) {
+      closeFunc = () => {
+        // do nothing
+      };
+    } else {
+      closeFunc = () => hideModalOfType(type);
+    }
   }
 
   render(React.createElement(type, properties), modalContainer);


### PR DESCRIPTION
This ensures the user does not see a blank page if they click away from the forgot password modal.