### PR TITLE
fix: Update sign_up_path limit in users table to 1024 [RIGSE-217]

### DIFF
--- a/rails/db/migrate/20250516145846_expand_sign_up_path.rb
+++ b/rails/db/migrate/20250516145846_expand_sign_up_path.rb
@@ -1,0 +1,11 @@
+class ExpandSignUpPath < ActiveRecord::Migration[8.0]
+  def up
+    execute "ALTER TABLE users MODIFY COLUMN sign_up_path VARCHAR(1024), ALGORITHM=INPLACE, LOCK=NONE;"
+  end
+
+  def down
+    # this can't be done using the inplace algorithm unfortunately
+    execute "ALTER TABLE users MODIFY COLUMN sign_up_path VARCHAR(255);"
+  end
+end
+

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_09_115230) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_16_145846) do
   create_table "access_grants", id: :integer, charset: "utf8", force: :cascade do |t|
     t.string "code"
     t.string "access_token"
@@ -1616,7 +1616,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_09_115230) do
     t.string "unconfirmed_email"
     t.datetime "confirmation_sent_at", precision: nil
     t.boolean "require_portal_user_type", default: false
-    t.string "sign_up_path"
+    t.string "sign_up_path", limit: 1024
     t.boolean "email_subscribed", default: false
     t.boolean "can_add_teachers_to_cohorts", default: false
     t.datetime "reset_password_sent_at", precision: nil


### PR DESCRIPTION
The existing default 255 character limit was not allowing us to store the return path to CLUE standalone.