### PR TITLE
feat: Add logout_canceled hash parameter when the confirm logout is canceled [RIGSE-214]

### DIFF
--- a/rails/app/controllers/users_controller.rb
+++ b/rails/app/controllers/users_controller.rb
@@ -330,6 +330,13 @@ class UsersController < ApplicationController
       if confirm || cancel
         if confirm
           sign_out
+        else
+          # add a logout_canceled hash parameter to the URL so that it can detect that the user canceled the logout
+          if @after_url
+            uri = URI.parse(@after_url)
+            uri.fragment = [uri.fragment, "logout_canceled=true"].compact.join("&")
+            @after_url = uri.to_s
+          end
         end
         redirect_to (@after_url || home_path()), allow_other_host: true
       end


### PR DESCRIPTION
This will allow CLUE to auto login again so the user doesn't have to click the "Get Started" button.

A hash parameter is used to avoid altering any query parameters that may be present in the URL.