### PR TITLE
RIGSE 215 add horizontal padding to ensure alert text fits comfortably

### DIFF
--- a/rails/app/assets/stylesheets/modal.scss
+++ b/rails/app/assets/stylesheets/modal.scss
@@ -24,9 +24,9 @@
   left: 50%;
   height: auto;
   margin: -12.5em 0 0 -26.6675em;
-  padding: 3.5em 0 0;
+  padding: 3.5em 2em 2em 2em;
   top: 25em;
-  width: 53.335em;
+  width: 60em;
   z-index: 110;
 
   .close {

--- a/rails/react-components/src/library/styles/helpers/_modal.scss
+++ b/rails/react-components/src/library/styles/helpers/_modal.scss
@@ -24,9 +24,9 @@
   left: 50%;
   height: auto;
   margin: 0;
-  padding: 3.5em 0 0;
+  padding: 3.5em 2em 2em 2em;
   top: 100px;
-  width: 53.335em;
+  width: 60em;
   z-index: 110;
   position: fixed;
 


### PR DESCRIPTION
[RIGSE-215](https://concord-consortium.atlassian.net/browse/RIGSE-215)

This PR increases the size and padding of the modal a bit so that alert text can fit in it without overlap.

[RIGSE-215]: https://concord-consortium.atlassian.net/browse/RIGSE-215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ