### PR TITLE
fix: Reversed Run button lock logic [RIGSE-227]

### DIFF
--- a/rails/app/helpers/runnables_helper.rb
+++ b/rails/app/helpers/runnables_helper.rb
@@ -34,7 +34,7 @@ module RunnablesHelper
     end
 
     options         = popup_options_for(offering)
-    options[:href]  = locked ? run_url_for(offering) : "javascript:void(0)"
+    options[:href]  = locked ? "javascript:void(0)" : run_url_for(offering)
     options[:class] = student_run_button_css(offering, locked, ["solo"])
     # Disable button for 10 seconds after click, to prevent accidental double-clicks
     options[:onclick] = "if (this.classList.contains('disabled')) { event.preventDefault(); } else { this.classList.add('disabled'); setTimeout(() => { this.classList.remove('disabled'); }, 10000); }"

--- a/rails/spec/system/external_activities_can_be_run_as_offerings_spec.rb
+++ b/rails/spec/system/external_activities_can_be_run_as_offerings_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'External Activities can be run as offerings', type: :system do
     first(:link, 'Class_with_no_assignment').click
     expect(page).to have_content('MY ACTIVITY')
     expect(page).to have_content('Run')
-
+    expect(page).to have_link('Run', href: /portal\/offerings\/\d+\.run_resource_html/)
   end
 
 end


### PR DESCRIPTION
This reverses a logic bug for the run button href introduced in the per student locking story.