### PR TITLE
fix: Offering visibility check when rendering list for student [RIGSE-253]

### DIFF
--- a/rails/app/models/portal/offering.rb
+++ b/rails/app/models/portal/offering.rb
@@ -49,7 +49,14 @@ class Portal::Offering < ApplicationRecord
 
   end
 
-  def active?
+  def active?(current_user = nil)
+    active = self.active
+    if current_user
+      metadata = UserOfferingMetadata.find_by(user_id: current_user.id, offering_id: self.id)
+      if metadata.present?
+        active = metadata.active
+      end
+    end
     active
   end
 
@@ -75,8 +82,8 @@ class Portal::Offering < ApplicationRecord
     runnable.archived?
   end
 
-  def should_show?
-    active? && (!archived?)
+  def should_show?(current_user = nil)
+    active?(current_user) && (!archived?)
   end
 
   def can_be_deleted?

--- a/rails/app/views/shared/_offerings_for_student.html.haml
+++ b/rails/app/views/shared/_offerings_for_student.html.haml
@@ -1,7 +1,7 @@
 %div
   - active_offerings = []
   - offerings.each do |offering|
-    - if offering.runnable and offering.should_show? then
+    - if offering.runnable and offering.should_show?(current_user) then
       - active_offerings << offering
 
   = render :partial => 'shared/offering_for_student', :collection => active_offerings, :as => :offering


### PR DESCRIPTION
This updates the offerings_for_student partial to pass in the current user to the Portal::Offering#should_show? method so that it can check if the students user offering metadata active flag overrides the offering active flag.