### PR TITLE
fix: Bookmark links don't work for students [RIGSE-256]

### DIFF
--- a/rails/app/controllers/portal/bookmarks_controller.rb
+++ b/rails/app/controllers/portal/bookmarks_controller.rb
@@ -21,7 +21,7 @@ class Portal::BookmarksController < ApplicationController
   def visit
     mark = Portal::Bookmark.find(params['id'])
     mark.record_visit(current_visitor)
-    redirect_to mark.url
+    redirect_to mark.url, allow_other_host: true
   end
 
   def visits


### PR DESCRIPTION
This fix adds the `allow_other_host: true` option to the redirect in the `visit` action of the `BookmarksController`.

This allows external links to be accessed by students.