### PR TITLE
fix: Allow blanks in bookmark links [RIGSE-255]

### DIFF
--- a/rails/react-components/src/library/components/bookmarks/bookmark-row.tsx
+++ b/rails/react-components/src/library/components/bookmarks/bookmark-row.tsx
@@ -42,12 +42,19 @@ class BookmarkRow extends React.Component<any, any> {
       }
     };
 
+     // prevents @dnd-kit/sortable KeyboardSensor starting a drag when the space key is pressed
+    const stopSpaceFromStartingDrag = (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.code === "Space" || e.key === " ") {
+        e.stopPropagation();
+      }
+    };
+
     if (editing) {
       return (
         <div className={css.editBookmarkRow}>
           <span className={css.editBookmarkName}>
-            <input type="text" ref={this.nameRef} defaultValue={bookmark.name} placeholder="Name" />
-            <input type="text" ref={this.urlRef} defaultValue={bookmark.url} placeholder="URL" />
+            <input type="text" ref={this.nameRef} defaultValue={bookmark.name} placeholder="Name" autoFocus onKeyDown={stopSpaceFromStartingDrag} />
+            <input type="text" ref={this.urlRef} defaultValue={bookmark.url} placeholder="URL" onKeyDown={stopSpaceFromStartingDrag} />
           </span>
           <span className={css.editBookmarkButtons}>
             <button onClick={handleSave}>Save</button>


### PR DESCRIPTION
This fixes an issue where spaces could not be added to bookmark names or URLs in the bookmark form.

The SortableContainer surrounding the bookmark form was intercepting space key presses and starting a drag operation, preventing the user from typing spaces into the form fields.

This change adds event handlers to the input fields to stop propagation of space key presses, allowing spaces to be entered.

As a usability improvement, this also adds autoFocus to the name input field, so that it is focused automatically when the user starts editing a bookmark.