### PR TITLE
feat: Updated NGSS footer [RIGSE-258]

### DIFF
--- a/rails/app/views/themes/ngss-assessment/shared/_footer.html.haml
+++ b/rails/app/views/themes/ngss-assessment/shared/_footer.html.haml
@@ -55,11 +55,14 @@
         The Concord Consortium is a 501(c)(3) nonprofit charity registered in the U.S. under EIN 04-3254131.
         %br
         #{link_to 'Privacy Policy','https://concord.org/privacy-policy', :id=>"privacy-policy-link", :target=>"_blank", :rel=>"noopener"}
-        &middot;
+        %br
         For technical assistance, contact:
         = mail_to(APP_CONFIG[:help_email] || APP_CONFIG[:default_admin_user][:email], APP_CONFIG[:help_email] || APP_CONFIG[:default_admin_user][:email], :subject => "#{APP_CONFIG[:site_name]} question", :encode => "javascript")
-        \. For all other questions/feedback, contact: For all other questions/feedback contact:
+        \.
+        %br
+        For all other questions/feedback, contact:
         = mail_to('info@nextgenscienceassessment.org', 'info@nextgenscienceassessment.org', :subject => "#{APP_CONFIG[:site_name]} question", :encode => "javascript")
+        \.
         %br
         Version:
         = ENV['CC_PORTAL_IMAGE_VERSION'].present? ? ENV['CC_PORTAL_IMAGE_VERSION'] : ENV['CC_PORTAL_VERSION']


### PR DESCRIPTION
This removes some duplicate text in the footer and adds some line breaks to make it more readable.

Old:
<img width="1148" height="206" alt="image" src="https://github.com/user-attachments/assets/c3eed76f-6ea6-4b9d-81f2-279d7b8b9c57" />

New:
<img width="1138" height="224" alt="image" src="https://github.com/user-attachments/assets/7aa3dd05-8769-4cb0-a7c8-4bcf4139c236" />

(ignore the missing version number as that is set at release time and ignore the default help email used locally)