### PR TITLE
devops: Remove report domain [RIGSE-226]

### DIFF
--- a/.env-gh-codespaces-sample
+++ b/.env-gh-codespaces-sample
@@ -18,8 +18,6 @@ LARA_DOMAIN=${LARA_CODESPACE_NAME}-3000.${GITHUB_CODESPACES_PORT_FORWARDING_DOMA
 PORTAL_HOST=${CODESPACE_NAME}-3000.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}
 PORTAL_PROTOCOL=https
 
-# Run the portal in researcher report mode this is used by the researcher portal
-# RESEARCHER_REPORT_ONLY=true
 MYSQL_ROOT_PASSWORD=xyzzy
 
 # Sets the secret used to generate the portal JWT tokens in lib/signed_jwt.rb

--- a/.env-osx-sample
+++ b/.env-osx-sample
@@ -23,8 +23,6 @@ COMPOSE_FILE=docker-compose.yml:docker/dev/docker-compose-sync.yml:docker/dev/do
 # PORTAL_HOST=app.portal.docker
 # PORTAL_PROTOCOL=https
 
-# Run the portal in researcher report mode this is used by the researcher portal
-# RESEARCHER_REPORT_ONLY=true
 MYSQL_ROOT_PASSWORD=xyzzy
 
 # Sets the secret used to generate the portal JWT tokens in lib/signed_jwt.rb

--- a/configs/cloudformation/stack_template.yml
+++ b/configs/cloudformation/stack_template.yml
@@ -33,18 +33,12 @@ Parameters:
     Description:
       The DNS name that will be created or updated to point at the load
       balancer
-  ReportDomainName:
-    Type: String
-    Description:
-      The DNS name of a secondary server that is configured to only handle reports
-      the main server will redirect users to this secondary server. This host will be accessed
-      with https so the name needs to work with the selected SSL certificate.
 
   HostedZoneId:
     Type: AWS::Route53::HostedZone::Id
     Default: Z2P4W3M7MDAUV6
     Description:
-      The Route53 hosted zone for the DNS entries for the portal and report portal.
+      The Route53 hosted zone for the DNS entries for the portal.
       This should be concord.org for the production AWS account and concordqa.org for the
       QA AWS account.
 
@@ -111,11 +105,6 @@ Parameters:
   PortalFeatures:
     Type: String
     Description: list of rails engines to load to support exstra features
-  PortalReportVersion:
-    Type: String
-    Description:
-      version of portal report used to construct the REPORT_VIEW_URL using the
-      pattern https://portal-report.concord.org/[PortalReportVersion]/ For example 'version/v1.0.0'
   S3AccessKeyId:
     Type: String
   S3SecreateAccessKey:
@@ -464,10 +453,6 @@ Resources:
               Value: !Ref PortalFeatures
             - Name: RAILS_STDOUT_LOGGING
               Value: "true"
-            - Name: REPORT_DOMAINS
-              Value: portal-report.concord.org concord-consortium.github.io
-            - Name: REPORT_VIEW_URL
-              Value: !Sub "https://portal-report.concord.org/${PortalReportVersion}/"
             - Name: AWS_REGION
               Value: us-east-1
             - Name: S3_ACCESS_KEY_ID
@@ -498,8 +483,6 @@ Resources:
               Value: !Ref Theme
             - Name: TOP_LEVEL_CONTAINER_NAME
               Value: activity
-            - Name: RESEARCHER_REPORT_HOST
-              Value: !Sub "https://${ReportDomainName}"
             - Name: JWT_HMAC_SECRET
               Value: !Ref JWTHMACSecret
             - !If
@@ -546,13 +529,6 @@ Resources:
                         ],
                       ]
                     - !Ref "AWS::NoValue"
-                  - !Join [
-                      "-",
-                      [
-                        "report",
-                        !Select [1, !Split ["/", !Ref PortalReportVersion]],
-                      ],
-                    ]
             - Name: OG_TITLE
               Value: !Ref OpenGraphTitle
             - Name: OG_DESCRIPTION
@@ -718,230 +694,6 @@ Resources:
       DesiredCount: "1"
       Cluster: { "Fn::ImportValue": !Sub "${ClusterStackName}-ClusterName" }
 
-  # 2019-04-04
-  # Most of the time the report task is just sitting around. So it doesn't need to
-  # reserve a lot of Cpu. A much better approach would be look again at the parts of the
-  # reporting that are slow and move them into worker, then we can get rid of this report
-  # task. But in the meantime we an set the Cpu low, and just let it spike up to use as
-  # much of the available CPU as it can, when someone decides to use it.
-  # So we'll move the Cpu down from 512 to 128.
-  # Looking at the memory usage of learn the report service is maxing out around 40%
-  # So I'll decrease the memory reservation to 1400 which is the same as the app task
-  ReportTaskDefinition:
-    Type: AWS::ECS::TaskDefinition
-    Properties:
-      Family: !Sub "${AWS::StackName}-Report"
-      ContainerDefinitions:
-        - Name: Report
-          Image: !Ref PortalDockerImage
-          Cpu: "128"
-          PortMappings:
-            - ContainerPort: "3000"
-          Memory: "1400"
-          Essential: "true"
-          LogConfiguration:
-            LogDriver: awslogs
-            Options:
-              awslogs-region: us-east-1
-              awslogs-group: !Ref CloudWatchLogGroup
-              awslogs-stream-prefix: portal
-          Environment:
-            - Name: ADMIN_EMAIL
-              Value: !Ref AdminEmail
-            - Name: APPSIGNAL_PUSH_API_KEY
-              Value: !Ref AppSignalPushAPIKey
-            - Name: APPSIGNAL_APP_NAME
-              Value: !Ref AppSignalAppName
-            - Name: APPSIGNAL_APP_ENV
-              Value: !Ref Environment
-            # this is to help appsignal track revisions
-            - Name: APP_REVISION
-              Value: !Select [1, !Split [":", !Ref PortalDockerImage]]
-            - Name: AUTHORING_SITE_URL
-              Value: !Ref AuthoringSiteURL
-            - Name: DB_HOST
-              Value: !Ref DbHost
-            - Name: DB_NAME
-              Value: portal
-            - Name: DB_PASSWORD
-              Value: !Ref DbPassword
-            - Name: DB_USER
-              Value: !Ref DbUserName
-            - Name: DEVISE_SECRET_KEY
-              Value: !Ref DeviseSecretKey
-            - Name: HELP_EMAIL
-              Value: !Ref HelpEmail
-            - Name: NEW_RELIC_APP_NAME
-              Value: !Ref NewRelicAppName
-            - Name: NEW_RELIC_LICENSE_KEY
-              Value: !Ref NewRelicLicenseKey
-            - Name: NUM_UNICORN_PROCESSES
-              Value: "2"
-            - Name: PADLET_PASSWORD
-              Value: !Ref PadletPassword
-            - Name: PADLET_USER
-              Value: !Ref PadletUser
-            - Name: PORTAL_FEATURES
-              Value: !Ref PortalFeatures
-            - Name: RAILS_STDOUT_LOGGING
-              Value: "true"
-            - Name: REPORT_DOMAINS
-              Value: portal-report.concord.org concord-consortium.github.io
-            - Name: REPORT_VIEW_URL
-              Value: !Sub "https://portal-report.concord.org/${PortalReportVersion}/"
-            - Name: AWS_REGION
-              Value: us-east-1
-            - Name: S3_ACCESS_KEY_ID
-              Value: !Ref S3AccessKeyId
-            - Name: S3_BUCKET
-              Value: !Ref S3Bucket
-            - Name: S3_SECRET_ACCESS_KEY
-              Value: !Ref S3SecreateAccessKey
-            - Name: SCHOOLOGY_CONSUMER_KEY
-              Value: !Ref SchoologyConsumerKey
-            - Name: SCHOOLOGY_CONSUMER_SECRET
-              Value: !Ref SchoologyConsumerSecret
-            - Name: SITE_KEY
-              Value: !Ref SiteKey
-            - Name: SITE_NAME
-              Value: !Ref SiteName
-            - Name: SITE_URL
-              Value: !Ref SiteURL
-            - Name: SMTP_PASS
-              Value: !Ref SMTPPassword
-            - Name: SMTP_USER
-              Value: !Ref SMTPUser
-            - Name: SOLR_HOST
-              Value: !GetAtt InternalLoadBalancerStack.Outputs.ELBDNSName # this should refer to the solr
-            - Name: SOLR_PORT
-              Value: "80"
-            - Name: THEME
-              Value: !Ref Theme
-            - Name: TOP_LEVEL_CONTAINER_NAME
-              Value: activity
-            - Name: JWT_HMAC_SECRET
-              Value: !Ref JWTHMACSecret
-            - !If
-              - PortalPagesLibraryDefined
-              - Name: PORTAL_PAGES_LIBRARY_URL
-                Value: !Sub "https://portal-pages.concord.org/${PortalPagesLibraryVersion}/library"
-              - !Ref "AWS::NoValue"
-            - Name: EXTERNAL_CSS_URL
-              Value: !Ref ExternalCSSURL
-            - Name: RESEARCHER_REPORT_ONLY
-              Value: "true"
-            - Name: UNICORN_TIMEOUT
-              Value: "300"
-            - Name: GOOGLE_ANALYTICS_MEASUREMENT_ID
-              Value: !Ref GoogleAnalyticsMeasurementID
-            - Name: GOOGLE_CLIENT_KEY
-              Value: !Ref GoogleClientKey
-            - Name: GOOGLE_CLIENT_SECRET
-              Value: !Ref GoogleClientSecret
-            - Name: ROLLBAR_ACCESS_TOKEN
-              Value: !Ref RollbarAccessToken
-            - Name: ROLLBAR_CLIENT_ACCESS_TOKEN
-              Value: !Ref RollbarClientAccessToken
-            - Name: RESTART_TOGGLE
-              Value: !Ref RestartToggle
-            - Name: CC_PORTAL_VERSION
-              Value: !Join
-                - ", "
-                - - !Join [
-                      "-",
-                      [
-                        "portal",
-                        !Select [1, !Split [":", !Ref PortalDockerImage]],
-                      ],
-                    ]
-                  - !If
-                    - PortalPagesLibraryDefined
-                    - !Join [
-                        "-",
-                        [
-                          "pages",
-                          !Select [
-                            1,
-                            !Split ["/", !Ref PortalPagesLibraryVersion],
-                          ],
-                        ],
-                      ]
-                    - !Ref "AWS::NoValue"
-                  - !Join [
-                      "-",
-                      [
-                        "report",
-                        !Select [1, !Split ["/", !Ref PortalReportVersion]],
-                      ],
-                    ]
-            - Name: ELASTICSEARCH_URL
-              Value: !Sub "https://${ElasticSearchStack.Outputs.DomainEndpoint}"
-            - Name: RAILS_SECRET_KEY_BASE
-              Value: !Ref RailsSecretKeyBase
-
-  # Need ECS Service definition
-  ReportTargetGroup:
-    Type: AWS::ElasticLoadBalancingV2::TargetGroup
-    Properties:
-      HealthCheckProtocol: HTTP
-      # even though this is set to 80 the actual port will
-      # be overriden by each of the containers that is added
-      # to the target group
-      Port: "80"
-      Protocol: HTTP
-      VpcId: { "Fn::ImportValue": !Sub "${ClusterStackName}-ClusterVpcId" }
-      TargetGroupAttributes:
-        # The report is only used by admins, and if their connections get killed off during
-        # an update that is OK
-        - Key: deregistration_delay.timeout_seconds
-          Value: "20"
-      # Use this name property to force the TargetGroup to be recreated whenever the load
-      # balancer is recreated. Otherwise CloudFormation tries to add the TargetGroup
-      # to the new load balancer before removing it from the old one. And that results
-      # in an error.
-      Name: !Sub "ReportTarget-${LoadBalancerStack.Outputs.LoadBalancerEndingId}"
-
-  ReportDNS:
-    Type: AWS::Route53::RecordSet
-    Properties:
-      AliasTarget:
-        DNSName: !GetAtt LoadBalancerStack.Outputs.ELBDNSName
-        HostedZoneId: !GetAtt LoadBalancerStack.Outputs.CanonicalHostedZoneID
-      # HostedZoneName: concord.org.
-      HostedZoneId: !Ref "HostedZoneId"
-      Name: !Ref ReportDomainName
-      Type: A
-
-  ReportService:
-    Type: AWS::ECS::Service
-    DependsOn:
-      - AppListener443
-    # The docs recommend adding a dependency on the load balancer listener hear
-    # but I don't see why that is necessary so were are trying without it...
-    Properties:
-      Role: ecsServiceRole
-      TaskDefinition: !Ref ReportTaskDefinition
-      DesiredCount: "1"
-      LoadBalancers:
-        - TargetGroupArn: !Ref ReportTargetGroup
-          ContainerPort: "3000"
-          ContainerName: Report
-      Cluster: { "Fn::ImportValue": !Sub "${ClusterStackName}-ClusterName" }
-
-  # Send all requests to the report domain name to the report target group
-  ReportListenerRule:
-    Type: AWS::ElasticLoadBalancingV2::ListenerRule
-    Properties:
-      ListenerArn: !Ref AppListener443
-      Actions:
-        - TargetGroupArn: !Ref ReportTargetGroup
-          Type: forward
-      Conditions:
-        - Field: host-header
-          Values:
-            - !Ref ReportDomainName
-      Priority: "1"
-
   # Notes from Nov 14, 2017
   # Reviewing data over 4 weeks of usage
   # several CPU spikes up to 768 CPU and one spike up to 1024.
@@ -1026,10 +778,6 @@ Resources:
               Value: !Ref PortalFeatures
             - Name: RAILS_STDOUT_LOGGING
               Value: "true"
-            - Name: REPORT_DOMAINS
-              Value: portal-report.concord.org concord-consortium.github.io
-            - Name: REPORT_VIEW_URL
-              Value: !Sub "https://portal-report.concord.org/${PortalReportVersion}/"
             - Name: AWS_REGION
               Value: us-east-1
             - Name: S3_ACCESS_KEY_ID
@@ -1276,4 +1024,3 @@ Metadata:
         Parameters:
           - PortalDockerImage
           - PortalPagesLibraryVersion
-          - PortalReportVersion

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,6 @@ services:
       GOOGLE_CLIENT_SECRET:
 
       SITE_URL: "${PORTAL_PROTOCOL:-http}://${PORTAL_HOST:-app.portal.docker}"
-      RESEARCHER_REPORT_ONLY:
 
       #
       # ASN API key

--- a/rails/app/controllers/application_controller.rb
+++ b/rails/app/controllers/application_controller.rb
@@ -80,29 +80,21 @@ class ApplicationController < ActionController::Base
       render :html => "<div class='flash_error'>#{error_message}</div>", :status => 403
     else
       if current_user
-        if BoolEnv['RESEARCHER_REPORT_ONLY']
-          # if we are here then current user is not authorized to access the reports.
-          # The normal code path would send them in a redirect loop
-          # instead sign them out and show them a page telling them this ia report only portal
-          sign_out :user
-          redirect_to learner_report_only_path
-        else
-          # only show the error alert if we are not redirecting after signing in
-          # An error on redirecting after signing in should only happen in two cases:
-          # 1. the user was logged out and then clicked on an restricted link, then the user
-          #    didn't actually log in, but just left the page there. Then a different user
-          #    logged in. This new user didn't have access to the page of the original user
-          #    so this exception was thrown during the automatic redirect to the original
-          # 2. A anonymous user tried to access something they shouldn't access. They should
-          #    have been shown a message and directed to the login page.  Now if the user
-          #    logs in the portal will redirect to this initial page. Since the user already
-          #    saw the message there is no need to show it again.
-          # So instead of showing the error message again, we just send the user to the
-          # default login page for that user.
-          flash['alert'] = error_message if not params[:redirecting_after_sign_in]
+        # only show the error alert if we are not redirecting after signing in
+        # An error on redirecting after signing in should only happen in two cases:
+        # 1. the user was logged out and then clicked on an restricted link, then the user
+        #    didn't actually log in, but just left the page there. Then a different user
+        #    logged in. This new user didn't have access to the page of the original user
+        #    so this exception was thrown during the automatic redirect to the original
+        # 2. A anonymous user tried to access something they shouldn't access. They should
+        #    have been shown a message and directed to the login page.  Now if the user
+        #    logs in the portal will redirect to this initial page. Since the user already
+        #    saw the message there is no need to show it again.
+        # So instead of showing the error message again, we just send the user to the
+        # default login page for that user.
+        flash['alert'] = error_message if not params[:redirecting_after_sign_in]
 
-          redirect_to view_context.current_user_home_path
-        end
+        redirect_to view_context.current_user_home_path
       else
         flash['alert'] = error_message
         # send the anonymous user to the login page, and then try to send the user back

--- a/rails/app/controllers/report/learner_controller.rb
+++ b/rails/app/controllers/report/learner_controller.rb
@@ -25,7 +25,7 @@ class Report::LearnerController < ApplicationController
 
   def index
     authorize Report::Learner
-    render layout: ENV['RESEARCHER_REPORT_ONLY'] ? "minimal" : "application"
+    render layout: "application"
   end
 
   def updated_at

--- a/rails/app/controllers/report/user_controller.rb
+++ b/rails/app/controllers/report/user_controller.rb
@@ -10,6 +10,6 @@ class Report::UserController < ApplicationController
 
   def index
     authorize Report::User
-    render layout: ENV['RESEARCHER_REPORT_ONLY'] ? "minimal" : "application"
+    render layout: "application"
   end
 end

--- a/rails/app/helpers/application_helper.rb
+++ b/rails/app/helpers/application_helper.rb
@@ -590,8 +590,6 @@ module ApplicationHelper
     if current_user.nil?
       # anonymous home is the '/'
       root_path
-    elsif BoolEnv['RESEARCHER_REPORT_ONLY']
-      learner_report_path
     elsif current_user.portal_student
       my_classes_path
     elsif APP_CONFIG[:recent_activity_on_login] && current_user.portal_teacher

--- a/rails/app/views/report/learner/index.html.haml
+++ b/rails/app/views/report/learner/index.html.haml
@@ -1,13 +1,4 @@
 
-- if BoolEnv['RESEARCHER_REPORT_ONLY']
-  - # in this case we are only showing a minmal layout. So provide the user with a
-  - # simple header
-  %div
-    Welcome
-    = "#{current_visitor.name}"
-    %br
-    = link_to 'Logout', destroy_user_session_path
-
 #form-container
 
 - external_reports = ExternalReport.where(report_type: ExternalReport::ResearcherLearnerReport).map { |r| {url: "#{r.url}", name: "#{r.name}", label: "#{r.launch_text}", useQueryJwt: r.use_query_jwt} }.to_json

--- a/rails/app/views/report/user/index.html.haml
+++ b/rails/app/views/report/user/index.html.haml
@@ -1,13 +1,3 @@
-
-- if BoolEnv['RESEARCHER_REPORT_ONLY']
-  - # in this case we are only showing a minmal layout. So provide the user with a
-  - # simple header
-  %div
-    Welcome
-    = "#{current_visitor.name}"
-    %br
-    = link_to 'Logout', destroy_user_session_path
-
 #form-container
 
 - external_reports = ExternalReport.where(report_type: ExternalReport::ResearcherUserReport).map { |r| {url: "#{r.url}", name: "#{r.name}", label: "#{r.launch_text}"} }.to_json

--- a/rails/config/app_environment_variables.sample.rb
+++ b/rails/config/app_environment_variables.sample.rb
@@ -18,13 +18,6 @@ ENV['ELASTICSEARCH_URL'] ||= 'http://search-has-portal-prod-xruhhhyiv2fugtujtzbg
 # URL for the report server reports used in the sidebar
 # ENV['REPORT_SERVER_REPORTS_URL'] ||= 'https://report-server.concord.org/reports'
 
-# TBD: remove this when the separate report server is no longer needed
-# Researcher report link can point to a different portal instance to avoid overloading the main server.
-# ENV['RESEARCHER_REPORT_HOST'] ||= 'https://research-report-portal.concord.org'
-# Portal that is dedicated to the research report should enable option below to disable all the links that could
-# lead researchers to other parts of the portal.
-# ENV['RESEARCHER_REPORT_ONLY'] ||= 'true'
-
 # CORS_ORIGINS:
 # Sets the allowed CORS origins to a specific whitelist. Requires ENV['PORTAL_FEATURES'] ||= 'allow_cors'
 # ENV['CORS_ORIGINS']    ||= "concord.org"


### PR DESCRIPTION
This removes the report domain configuration from the CloudFormation template.

This also removes all conditional code in the Rails app that was used to support the report domain.