### PR TITLE
allow project admins to view the roster

### DIFF
--- a/rails/app/controllers/portal/clazzes_controller.rb
+++ b/rails/app/controllers/portal/clazzes_controller.rb
@@ -10,13 +10,6 @@ class Portal::ClazzesController < ApplicationController
   before_action :teacher_admin, :only => [:class_list, :edit]
   before_action :student_teacher_admin, :only => [:show]
 
-  #
-  # Check that the current teacher owns the class they are
-  # accessing.
-  #
-  include RestrictedTeacherController
-  before_action :check_teacher_owns_clazz, :only => [ :roster ]
-
   def current_clazz
     # PUNDIT_REVIEW_AUTHORIZE
     # PUNDIT_CHOOSE_AUTHORIZE
@@ -288,6 +281,8 @@ class Portal::ClazzesController < ApplicationController
   # GET /portal_clazzes/1/roster
   def roster
     @portal_clazz = Portal::Clazz.find(params[:id])
+
+    authorize @portal_clazz, :roster?
 
     # Save the left pane sub-menu item
     Portal::Teacher.save_left_pane_submenu_item(current_visitor, Portal::Teacher.LEFT_PANE_ITEM['STUDENT_ROSTER'])

--- a/rails/app/policies/portal/clazz_policy.rb
+++ b/rails/app/policies/portal/clazz_policy.rb
@@ -43,11 +43,14 @@ class Portal::ClazzPolicy < ApplicationPolicy
 
   # Used by Portal::ClazzesController:
   def materials?
-    if params[:researcher]
-      class_teacher_or_admin? || class_researcher?
-    else
-      class_teacher_or_admin?
-    end
+    class_teacher_or_admin? || 
+    (params[:researcher] && 
+      (class_project_admin? || class_researcher?)
+    )
+  end
+
+  def roster?
+    class_teacher_or_admin? || class_project_admin?
   end
 
   def external_report?

--- a/rails/spec/spec_helper_common.rb
+++ b/rails/spec/spec_helper_common.rb
@@ -94,7 +94,7 @@ RSpec.configure do |config|
     ApplicationRecord.with_database('feature_test') { example.run }
   end
 
-  config.fixture_path = ["#{::Rails.root}/spec/fixtures"]
+  config.fixture_paths = ["#{::Rails.root}/spec/fixtures"]
   config.use_transactional_fixtures = Rails.env == 'test'
   config.infer_spec_type_from_file_location!
   config.expose_current_running_example_as :example


### PR DESCRIPTION
I also allowed project admins to view the researcher view of the materials page.
We plan to give project admins access to the "Research Projects" menu, so they can access the roster from there. Since we are doing that it seemed worthwhile to let them also access the materials page.