### PR TITLE
feat: add extensive logging to OIDC bearer token authentication

### DIFF
--- a/rails/config/initializers/auth_log_subscriber.rb
+++ b/rails/config/initializers/auth_log_subscriber.rb
@@ -7,6 +7,9 @@ module AuthLogSubscriber
     additions << "user=#{req.env['warden'].user&.id}" if req.env['warden']&.user
     additions << "auth=#{req.env['portal.auth_strategy']}" if req.env['portal.auth_strategy']
     additions << "client=#{req.env['portal.auth_client']}" if req.env['portal.auth_client']
+    if (details = req.env['portal.auth_details'])
+      details.each { |k, v| additions << "#{k}=#{v}" }
+    end
     additions << "#{req.request_method} #{req.path}" if additions.any?
     info("  Auth: #{additions.join(' ')}") if additions.any?
     super

--- a/rails/lib/google_oidc_verifier.rb
+++ b/rails/lib/google_oidc_verifier.rb
@@ -19,19 +19,17 @@ module GoogleOidcVerifier
   # Verifies a Google OIDC token and returns the decoded payload.
   # Raises GoogleOidcVerifier::Error on any failure.
   def self.verify(token)
-    # Decode header to get kid (without verification)
-    header = JWT.decode(token, nil, false)[1]
+    # Decode header and payload without verification (single decode)
+    unverified = JWT.decode(token, nil, false)
+    unverified_payload = unverified[0]
+    header = unverified[1]
     kid = header['kid']
-    Rails.logger.info("GoogleOidcVerifier: verifying token kid=#{kid} alg=#{header['alg']}")
-
-    # Peek at unverified claims for diagnostic logging
-    unverified_payload = JWT.decode(token, nil, false)[0]
     token_aud = unverified_payload['aud']
     token_iss = unverified_payload['iss']
     token_sub = unverified_payload['sub']
     token_exp = unverified_payload['exp']
-    token_email = unverified_payload['email']
-    Rails.logger.info("GoogleOidcVerifier: token claims iss=#{token_iss} sub=#{token_sub} aud=#{token_aud} email=#{token_email} exp=#{token_exp} (#{Time.at(token_exp).utc rescue 'invalid'})")
+    Rails.logger.info("GoogleOidcVerifier: verifying token kid=#{sanitize_log(kid)} alg=#{sanitize_log(header['alg'])}")
+    Rails.logger.debug("GoogleOidcVerifier: token claims iss=#{sanitize_log(token_iss)} sub=#{sanitize_log(token_sub)} aud=#{sanitize_log(token_aud)} exp=#{token_exp} (#{Time.at(token_exp).utc rescue 'invalid'})")
 
     # Find the matching public key
     key = find_key(kid)
@@ -43,7 +41,8 @@ module GoogleOidcVerifier
 
     # Verify the token
     expected_audience = APP_CONFIG[:site_url]
-    Rails.logger.info("GoogleOidcVerifier: expected_audience=#{expected_audience} token_audience=#{token_aud} match=#{token_aud == expected_audience}")
+    aud_match = Array(token_aud).include?(expected_audience)
+    Rails.logger.info("GoogleOidcVerifier: expected_audience=#{expected_audience} token_audience=#{sanitize_log(token_aud)} match=#{aud_match}")
     decoded = JWT.decode(
       token,
       key,
@@ -81,6 +80,11 @@ module GoogleOidcVerifier
   end
 
   private
+
+  def self.sanitize_log(value)
+    str = value.to_s[0, 100]
+    str.gsub(/[\r\n]/, ' ')
+  end
 
   def self.find_key(kid)
     keys = cached_keys

--- a/rails/lib/google_oidc_verifier.rb
+++ b/rails/lib/google_oidc_verifier.rb
@@ -22,13 +22,28 @@ module GoogleOidcVerifier
     # Decode header to get kid (without verification)
     header = JWT.decode(token, nil, false)[1]
     kid = header['kid']
+    Rails.logger.info("GoogleOidcVerifier: verifying token kid=#{kid} alg=#{header['alg']}")
+
+    # Peek at unverified claims for diagnostic logging
+    unverified_payload = JWT.decode(token, nil, false)[0]
+    token_aud = unverified_payload['aud']
+    token_iss = unverified_payload['iss']
+    token_sub = unverified_payload['sub']
+    token_exp = unverified_payload['exp']
+    token_email = unverified_payload['email']
+    Rails.logger.info("GoogleOidcVerifier: token claims iss=#{token_iss} sub=#{token_sub} aud=#{token_aud} email=#{token_email} exp=#{token_exp} (#{Time.at(token_exp).utc rescue 'invalid'})")
 
     # Find the matching public key
     key = find_key(kid)
-    raise Error, "Could not find public key for kid=#{kid}" unless key
+    unless key
+      Rails.logger.warn("GoogleOidcVerifier: no public key found for kid=#{kid}, available kids=#{cached_kids.join(',')}")
+      raise Error, "Could not find public key for kid=#{kid}"
+    end
+    Rails.logger.info("GoogleOidcVerifier: found public key for kid=#{kid}")
 
     # Verify the token
     expected_audience = APP_CONFIG[:site_url]
+    Rails.logger.info("GoogleOidcVerifier: expected_audience=#{expected_audience} token_audience=#{token_aud} match=#{token_aud == expected_audience}")
     decoded = JWT.decode(
       token,
       key,
@@ -49,14 +64,19 @@ module GoogleOidcVerifier
       raise Error, "Invalid issuer: #{payload['iss']}"
     end
 
+    Rails.logger.info("GoogleOidcVerifier: token verified successfully sub=#{payload['sub']}")
     payload
   rescue JWT::ExpiredSignature => e
+    Rails.logger.warn("GoogleOidcVerifier: token expired - exp=#{token_exp} (#{Time.at(token_exp).utc rescue 'invalid'}) now=#{Time.now.utc}")
     raise Error, e.message
   rescue JWT::InvalidIssuerError => e
+    Rails.logger.warn("GoogleOidcVerifier: invalid issuer - token_iss=#{token_iss} valid_issuers=#{VALID_ISSUERS}")
     raise Error, e.message
   rescue JWT::InvalidAudError => e
+    Rails.logger.warn("GoogleOidcVerifier: audience mismatch - token_aud=#{token_aud} expected_aud=#{APP_CONFIG[:site_url]}")
     raise Error, "Invalid audience: #{e.message}"
   rescue JWT::DecodeError => e
+    Rails.logger.warn("GoogleOidcVerifier: decode error - #{e.class}: #{e.message}")
     raise Error, e.message
   end
 
@@ -68,8 +88,13 @@ module GoogleOidcVerifier
     return key if key
 
     # Key not found — try refreshing once (handles key rotation)
+    Rails.logger.info("GoogleOidcVerifier: kid=#{kid} not in cache, refreshing JWKS")
     keys = fetch_keys!
     key_for_kid(keys, kid)
+  end
+
+  def self.cached_kids
+    (@jwks_keys || []).map { |k| k[:kid] || k['kid'] }
   end
 
   def self.key_for_kid(keys, kid)
@@ -78,22 +103,24 @@ module GoogleOidcVerifier
 
   def self.cached_keys
     if @jwks_keys && @jwks_fetched_at && (Time.now - @jwks_fetched_at) < JWKS_CACHE_TTL
+      age = (Time.now - @jwks_fetched_at).round
+      Rails.logger.info("GoogleOidcVerifier: using cached JWKS (age=#{age}s, keys=#{@jwks_keys.size})")
       return @jwks_keys
     end
 
+    Rails.logger.info("GoogleOidcVerifier: JWKS cache miss or expired, fetching fresh keys")
     fetch_keys!
   end
 
   def self.fetch_keys!
     uri = URI(JWKS_URI)
+    Rails.logger.info("GoogleOidcVerifier: fetching JWKS from #{JWKS_URI}")
     response = Net::HTTP.get_response(uri)
 
     unless response.is_a?(Net::HTTPSuccess)
       if @jwks_keys
-        # Use stale cache rather than rejecting all requests.
-        # Update fetched_at so we don't retry on every request during an outage.
         @jwks_fetched_at = Time.now
-        Rails.logger.warn("GoogleOidcVerifier: JWKS refresh failed (HTTP #{response.code}), serving stale keys")
+        Rails.logger.warn("GoogleOidcVerifier: JWKS refresh failed (HTTP #{response.code}), serving #{@jwks_keys.size} stale keys")
         return @jwks_keys
       end
       raise Error, "Failed to fetch JWKS: HTTP #{response.code}"
@@ -102,14 +129,16 @@ module GoogleOidcVerifier
     jwks_data = JSON.parse(response.body)
     @jwks_keys = jwks_data['keys']
     @jwks_fetched_at = Time.now
+    kids = @jwks_keys.map { |k| k[:kid] || k['kid'] }
+    Rails.logger.info("GoogleOidcVerifier: JWKS fetched successfully, #{@jwks_keys.size} keys: #{kids.join(', ')}")
     @jwks_keys
   rescue StandardError => e
     if @jwks_keys
-      # Update fetched_at so we don't retry on every request during an outage.
       @jwks_fetched_at = Time.now
-      Rails.logger.warn("GoogleOidcVerifier: JWKS refresh failed (#{e.message}), serving stale keys")
+      Rails.logger.warn("GoogleOidcVerifier: JWKS refresh failed (#{e.class}: #{e.message}), serving #{@jwks_keys.size} stale keys")
       return @jwks_keys
     end
+    Rails.logger.error("GoogleOidcVerifier: JWKS fetch failed with no cache available: #{e.class}: #{e.message}")
     raise Error, "Failed to fetch JWKS: #{e.message}"
   end
 end

--- a/rails/lib/google_oidc_verifier.rb
+++ b/rails/lib/google_oidc_verifier.rb
@@ -28,7 +28,7 @@ module GoogleOidcVerifier
     token_iss = unverified_payload['iss']
     token_sub = unverified_payload['sub']
     token_exp = unverified_payload['exp']
-    Rails.logger.info("GoogleOidcVerifier: verifying token kid=#{sanitize_log(kid)} alg=#{sanitize_log(header['alg'])}")
+    Rails.logger.debug("GoogleOidcVerifier: verifying token kid=#{sanitize_log(kid)} alg=#{sanitize_log(header['alg'])}")
     Rails.logger.debug("GoogleOidcVerifier: token claims iss=#{sanitize_log(token_iss)} sub=#{sanitize_log(token_sub)} aud=#{sanitize_log(token_aud)} exp=#{token_exp} (#{Time.at(token_exp).utc rescue 'invalid'})")
 
     # Find the matching public key
@@ -37,12 +37,12 @@ module GoogleOidcVerifier
       Rails.logger.warn("GoogleOidcVerifier: no public key found for kid=#{kid}, available kids=#{cached_kids.join(',')}")
       raise Error, "Could not find public key for kid=#{kid}"
     end
-    Rails.logger.info("GoogleOidcVerifier: found public key for kid=#{kid}")
+    Rails.logger.debug("GoogleOidcVerifier: found public key for kid=#{kid}")
 
     # Verify the token
     expected_audience = APP_CONFIG[:site_url]
     aud_match = Array(token_aud).include?(expected_audience)
-    Rails.logger.info("GoogleOidcVerifier: expected_audience=#{expected_audience} token_audience=#{sanitize_log(token_aud)} match=#{aud_match}")
+    Rails.logger.debug("GoogleOidcVerifier: expected_audience=#{expected_audience} token_audience=#{sanitize_log(token_aud)} match=#{aud_match}")
     decoded = JWT.decode(
       token,
       key,
@@ -63,7 +63,7 @@ module GoogleOidcVerifier
       raise Error, "Invalid issuer: #{payload['iss']}"
     end
 
-    Rails.logger.info("GoogleOidcVerifier: token verified successfully sub=#{payload['sub']}")
+    Rails.logger.debug("GoogleOidcVerifier: token verified successfully sub=#{payload['sub']}")
     payload
   rescue JWT::ExpiredSignature => e
     Rails.logger.warn("GoogleOidcVerifier: token expired - exp=#{token_exp} (#{Time.at(token_exp).utc rescue 'invalid'}) now=#{Time.now.utc}")
@@ -108,7 +108,7 @@ module GoogleOidcVerifier
   def self.cached_keys
     if @jwks_keys && @jwks_fetched_at && (Time.now - @jwks_fetched_at) < JWKS_CACHE_TTL
       age = (Time.now - @jwks_fetched_at).round
-      Rails.logger.info("GoogleOidcVerifier: using cached JWKS (age=#{age}s, keys=#{@jwks_keys.size})")
+      Rails.logger.debug("GoogleOidcVerifier: using cached JWKS (age=#{age}s, keys=#{@jwks_keys.size})")
       return @jwks_keys
     end
 

--- a/rails/lib/oidc_bearer_token_authenticatable.rb
+++ b/rails/lib/oidc_bearer_token_authenticatable.rb
@@ -11,29 +11,24 @@ module OidcBearerTokenAuthenticatable
       unverified = begin
         JWT.decode(token, nil, false).first
       rescue JWT::DecodeError => e
-        Rails.logger.info("OidcBearer: valid? JWT decode failed: #{e.message}")
+        # Token looked like it should be handled by this strategy (Bearer + dots)
+        # but failed to parse — worth logging since it's unexpected
+        Rails.logger.warn("OidcBearer: valid? JWT decode failed: #{e.message}")
         nil
       end
 
-      unless unverified
-        Rails.logger.info("OidcBearer: valid? could not decode token, skipping strategy")
-        return false
-      end
+      return false unless unverified
 
       issuer = unverified['iss']
       is_google = GoogleOidcVerifier::VALID_ISSUERS.include?(issuer)
-      Rails.logger.info("OidcBearer: valid? issuer=#{sanitize_log(issuer)} is_google=#{is_google}")
-      Rails.logger.debug("OidcBearer: valid? sub=#{sanitize_log(unverified['sub'])} aud=#{sanitize_log(unverified['aud'])}")
+      Rails.logger.debug("OidcBearer: valid? issuer=#{sanitize_log(issuer)} is_google=#{is_google}")
       is_google
     end
 
     def authenticate!
       token = oidc_token_value
-      Rails.logger.info("OidcBearer: authenticate! starting verification")
 
       payload = GoogleOidcVerifier.verify(token)
-      Rails.logger.info("OidcBearer: authenticate! token verified successfully")
-      Rails.logger.debug("OidcBearer: authenticate! sub=#{payload['sub']} email=#{payload['email']} aud=#{payload['aud']}")
 
       oidc_client = Admin::OidcClient.find_by(sub: payload['sub'])
       unless oidc_client
@@ -46,9 +41,9 @@ module OidcBearerTokenAuthenticatable
         return fail(:invalid_token)
       end
 
-      Rails.logger.info("OidcBearer: authenticate! success user_id=#{oidc_client.user_id} client=#{oidc_client.name}")
       request.env['portal.auth_strategy'] = 'oidc_bearer_token'
       request.env['portal.auth_client'] = oidc_client.name
+      request.env['portal.auth_details'] = { sub: payload['sub'], email: payload['email'], aud: payload['aud'] }
       success!(oidc_client.user)
     rescue GoogleOidcVerifier::Error => e
       Rails.logger.warn("OidcBearer: authenticate! verification failed - #{e.message}")

--- a/rails/lib/oidc_bearer_token_authenticatable.rb
+++ b/rails/lib/oidc_bearer_token_authenticatable.rb
@@ -22,7 +22,8 @@ module OidcBearerTokenAuthenticatable
 
       issuer = unverified['iss']
       is_google = GoogleOidcVerifier::VALID_ISSUERS.include?(issuer)
-      Rails.logger.info("OidcBearer: valid? issuer=#{issuer} is_google=#{is_google} sub=#{unverified['sub']} aud=#{unverified['aud']}")
+      Rails.logger.info("OidcBearer: valid? issuer=#{sanitize_log(issuer)} is_google=#{is_google}")
+      Rails.logger.debug("OidcBearer: valid? sub=#{sanitize_log(unverified['sub'])} aud=#{sanitize_log(unverified['aud'])}")
       is_google
     end
 
@@ -31,7 +32,8 @@ module OidcBearerTokenAuthenticatable
       Rails.logger.info("OidcBearer: authenticate! starting verification")
 
       payload = GoogleOidcVerifier.verify(token)
-      Rails.logger.info("OidcBearer: authenticate! token verified successfully sub=#{payload['sub']} email=#{payload['email']} aud=#{payload['aud']}")
+      Rails.logger.info("OidcBearer: authenticate! token verified successfully")
+      Rails.logger.debug("OidcBearer: authenticate! sub=#{payload['sub']} email=#{payload['email']} aud=#{payload['aud']}")
 
       oidc_client = Admin::OidcClient.find_by(sub: payload['sub'])
       unless oidc_client
@@ -54,6 +56,11 @@ module OidcBearerTokenAuthenticatable
     end
 
     private
+
+    def sanitize_log(value)
+      str = value.to_s[0, 100]
+      str.gsub(/[\r\n]/, ' ')
+    end
 
     def oidc_token_value
       header = request.headers['Authorization'] || ''

--- a/rails/lib/oidc_bearer_token_authenticatable.rb
+++ b/rails/lib/oidc_bearer_token_authenticatable.rb
@@ -4,37 +4,52 @@ module OidcBearerTokenAuthenticatable
   class BearerToken < Devise::Strategies::Authenticatable
 
     def valid?
-      return false unless oidc_token_value.present?
+      token = oidc_token_value
+      return false unless token.present?
+
       # Peek at unverified payload to check issuer is Google
       unverified = begin
-        JWT.decode(oidc_token_value, nil, false).first
-      rescue JWT::DecodeError
+        JWT.decode(token, nil, false).first
+      rescue JWT::DecodeError => e
+        Rails.logger.info("OidcBearer: valid? JWT decode failed: #{e.message}")
         nil
       end
-      return false unless unverified
-      GoogleOidcVerifier::VALID_ISSUERS.include?(unverified['iss'])
+
+      unless unverified
+        Rails.logger.info("OidcBearer: valid? could not decode token, skipping strategy")
+        return false
+      end
+
+      issuer = unverified['iss']
+      is_google = GoogleOidcVerifier::VALID_ISSUERS.include?(issuer)
+      Rails.logger.info("OidcBearer: valid? issuer=#{issuer} is_google=#{is_google} sub=#{unverified['sub']} aud=#{unverified['aud']}")
+      is_google
     end
 
     def authenticate!
       token = oidc_token_value
+      Rails.logger.info("OidcBearer: authenticate! starting verification")
+
       payload = GoogleOidcVerifier.verify(token)
+      Rails.logger.info("OidcBearer: authenticate! token verified successfully sub=#{payload['sub']} email=#{payload['email']} aud=#{payload['aud']}")
 
       oidc_client = Admin::OidcClient.find_by(sub: payload['sub'])
       unless oidc_client
-        Rails.logger.warn("OidcBearer: no client found sub=#{payload['sub']} email=#{payload['email']}")
+        Rails.logger.warn("OidcBearer: authenticate! no OidcClient found for sub=#{payload['sub']} email=#{payload['email']}")
         return fail(:invalid_token)
       end
 
       unless oidc_client.active?
-        Rails.logger.warn("OidcBearer: inactive client=#{oidc_client.name}")
+        Rails.logger.warn("OidcBearer: authenticate! inactive client=#{oidc_client.name} (id=#{oidc_client.id})")
         return fail(:invalid_token)
       end
 
+      Rails.logger.info("OidcBearer: authenticate! success user_id=#{oidc_client.user_id} client=#{oidc_client.name}")
       request.env['portal.auth_strategy'] = 'oidc_bearer_token'
       request.env['portal.auth_client'] = oidc_client.name
       success!(oidc_client.user)
     rescue GoogleOidcVerifier::Error => e
-      Rails.logger.warn("OidcBearer: verification failed - #{e.message}")
+      Rails.logger.warn("OidcBearer: authenticate! verification failed - #{e.message}")
       fail(:invalid_token)
     end
 

--- a/rails/spec/libs/bearer_token/oidc_bearer_token_authenticatable_spec.rb
+++ b/rails/spec/libs/bearer_token/oidc_bearer_token_authenticatable_spec.rb
@@ -97,6 +97,14 @@ describe OidcBearerTokenAuthenticatable::BearerToken do
         strategy.authenticate!
         expect(request.env['portal.auth_client']).to eq('Test SA')
       end
+
+      it 'sets portal.auth_details with sub, email, and aud' do
+        strategy.authenticate!
+        details = request.env['portal.auth_details']
+        expect(details[:sub]).to eq(oidc_sub)
+        expect(details[:email]).to eq(oidc_email)
+        expect(details[:aud]).to eq('http://localhost:3000')
+      end
     end
 
     context 'with valid OIDC token but no matching OidcClient' do


### PR DESCRIPTION
Log each decision point in the Warden strategy (valid?, authenticate!) and the full GoogleOidcVerifier pipeline: token claims, JWKS cache status, audience comparison, and specific failure reasons. Enables debugging OIDC auth failures via CloudWatch logs.