### PR TITLE
fix: broken CSS module class names (RIGSE-325)

### DIFF
--- a/rails/react-components/src/library/components/navigation/style.scss
+++ b/rails/react-components/src/library/components/navigation/style.scss
@@ -254,7 +254,7 @@
         padding-bottom: 0;
         transition-duration: 400ms;
 
-        .teacherProjectViews__list {
+        .teacherProjectViewsList {
           height: 1px;
           transition-duration: 400ms;
         }
@@ -288,16 +288,16 @@
     padding: 10px 20px;
     text-align: center;
   }
-  .teacherProjectViews__list {
+  .teacherProjectViewsList {
 
-    .teacherProjectViews__list_item {
+    .teacherProjectViewsListItem {
       font-size: 14px;
       padding-bottom: 0;
       overflow: hidden;
 
       a {
 
-        .teacherProjectViews__list_item_img {
+        .teacherProjectViewsListItemImg {
           background-position: center center;
           background-size: cover;
           float: left;
@@ -305,7 +305,7 @@
           margin: 0 10px 0 0;
           width: 50px;
         }
-        .teacherProjectViews__list_item_name {
+        .teacherProjectViewsListItemName {
           float: right;
           width: calc(100% - 60px);
         }

--- a/rails/react-components/src/library/components/navigation/teacher-project-views.tsx
+++ b/rails/react-components/src/library/components/navigation/teacher-project-views.tsx
@@ -63,17 +63,17 @@ export default class TeacherProjectViews extends React.Component<any, any> {
         return null;
       }
       return (
-        <ul className={css.teacherProjectViews__list}>
+        <ul className={css.teacherProjectViewsList}>
           {
             Object.keys(teacherProjectViews).map(key => {
               const imgStyle = {
                 backgroundImage: "url(" + teacherProjectViews[key].project_card_image_url + ")"
               };
               return (
-                <li className={css.teacherProjectViews__list_item} key={teacherProjectViews[key].id}>
+                <li className={css.teacherProjectViewsListItem} key={teacherProjectViews[key].id}>
                   <a href={"/" + teacherProjectViews[key].landing_page_slug}>
-                    <span className={css.teacherProjectViews__list_item_img} style={imgStyle} />
-                    <span className={css.teacherProjectViews__list_item_name}>
+                    <span className={css.teacherProjectViewsListItemImg} style={imgStyle} />
+                    <span className={css.teacherProjectViewsListItemName}>
                       { teacherProjectViews[key].name }
                     </span>
                   </a>

--- a/rails/react-components/src/library/components/sitewide-alert.scss
+++ b/rails/react-components/src/library/components/sitewide-alert.scss
@@ -14,7 +14,7 @@
   }
 }
 
-.alertBar__Text {
+.alertBarText {
   font-size: 15px;
   font-family: $font-museo-sans;
   max-width: 1170px;
@@ -29,7 +29,7 @@
   }
 }
 
-.alertBar__Close {
+.alertBarClose {
   float: right;
   margin-right: 40px;
   transition: .2s;

--- a/rails/react-components/src/library/components/sitewide-alert.tsx
+++ b/rails/react-components/src/library/components/sitewide-alert.tsx
@@ -32,8 +32,8 @@ const SitewideAlert = Component({
     }
     return (
       <div className={css.alertBarContain}>
-        <div className={css.alertBar__Text}>
-          <div className={css.alertBar__Close} onClick={this.handleAlertClose} />
+        <div className={css.alertBarText}>
+          <div className={css.alertBarClose} onClick={this.handleAlertClose} />
           <span dangerouslySetInnerHTML={{ __html: content }} />
         </div>
       </div>


### PR DESCRIPTION
CSS module class names containing `__` (double underscores) were broken. `css.alertBar__Text` and similar lookups returned `undefined`, so associated elements rendered with no class and no styling. This probably happened at some point during the Ruby on Rails upgrade but was missed.

The affected components are `SitewideAlert` (banner text alignment + close button) and `TeacherProjectViews` (recently visited collections list).

**Fix:** renamed all class names containing `__`  to camelCase in both the SCSS and TSX files.

These changes are needed so an admin can add a sitewide banner announcing retirement of the NGSA portal to the NGSA portal: [RIGSE-325](https://concord-consortium.atlassian.net/browse/RIGSE-325)

[RIGSE-325]: https://concord-consortium.atlassian.net/browse/RIGSE-325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ