### PR TITLE
fix: banner link :hover, :visited styles (RIGSE-325)

### DIFF
--- a/rails/react-components/src/library/components/sitewide-alert.scss
+++ b/rails/react-components/src/library/components/sitewide-alert.scss
@@ -20,8 +20,11 @@
   max-width: 1170px;
   margin: 0 auto;
   padding: 0 15px;
-  a { color: #444; }
-  a:hover { opacity: .8; }
+  a, a:visited, a:active, a:focus { color: #444; }
+  a:hover {
+    color: #444;
+    opacity: .8;
+  }
 
   span {
     display: inline-block;


### PR DESCRIPTION
[RIGSE-325](https://concord-consortium.atlassian.net/browse/RIGSE-325)

This is a follow up to https://github.com/concord-consortium/rigse/pull/1475. It fixes remaining issues with the site wide banner link styling by adding specific styles for `:hover` and `:visited`. That way the default link colors don't get applied making the link difficult to see on the banner's yellow background.

[RIGSE-325]: https://concord-consortium.atlassian.net/browse/RIGSE-325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ