### PR TITLE
chore: rename model to simulation (RIGSE-339)

### DIFF
--- a/rails/config/locales/en.yml
+++ b/rails/config/locales/en.yml
@@ -28,15 +28,15 @@ en:
         zero: external activities
         one: external activity
         other: external activities
-      Interactive: Model
+      Interactive: Simulation
       interactive:
-        zero: models
-        one: model
-        other: models
+        zero: simulations
+        one: simulation
+        other: simulations
   collection: collection
   investigation: sequence
   activity: activity
-  interactive: model
+  interactive: simulation
   material: material
   instructional_materials: Instructional Materials
   assignments: Assignments

--- a/rails/features/admin_work_with_interactives.feature
+++ b/rails/features/admin_work_with_interactives.feature
@@ -15,7 +15,7 @@ Feature: Admin can work with interactives
     And I wait 2 seconds
     And I follow "Interactives"
     Then I should be on the interactives index page
-    And I should see "Displaying all 15 models"
+    And I should see "Displaying all 15 simulations"
     And I should see "Create Interactive"
     And I should see "Export Interactives"
 

--- a/rails/react-components/src/library/components/browse-page/resource-type.tsx
+++ b/rails/react-components/src/library/components/browse-page/resource-type.tsx
@@ -6,7 +6,7 @@ const ResourceType = Component({
   render () {
     const resource = this.props.resource;
     const materialTypeLabels: any = {
-      "Interactive": "model",
+      "Interactive": "simulation",
       "Activity": "activity",
       "Investigation": "sequence",
       "Collection": "collection"

--- a/rails/react-components/src/library/helpers/filters.ts
+++ b/rails/react-components/src/library/helpers/filters.ts
@@ -15,7 +15,7 @@ const filters: any = {
   featureFilters: [
     { key: "sequence", title: "Sequence", searchMaterialType: "Investigation" },
     { key: "activity", title: "Activity", searchMaterialType: "Activity" },
-    { key: "model", title: "Model", searchMaterialType: "Interactive" },
+    { key: "simulation", title: "Simulation", searchMaterialType: "Interactive" },
     { key: "browser-based", title: "Browser-Based", searchMaterialProperty: "Runs in browser" },
     { key: "sensors", title: "Sensor-Based", searchSensors: ["Force", "Humidity (relative)", "Light", "Motion", "Temperature", "Voltage"] }
   ],


### PR DESCRIPTION
[RIGSE-339](https://concord-consortium.atlassian.net/browse/RIGSE-339)

Changes the public label for material type `interactive` from "model" to "simulation".

[RIGSE-339]: https://concord-consortium.atlassian.net/browse/RIGSE-339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ