### PR TITLE
feat: add resource type filter to search (RIGSE-312)

### DIFF
--- a/rails/app/controllers/home_controller.rb
+++ b/rails/app/controllers/home_controller.rb
@@ -212,7 +212,7 @@ class HomeController < ApplicationController
 
     if ! params[:id]
       case params[:type]
-      when "activity", "sequence"
+      when "activity", "sequence", "assessment"
 
         # logger.info("INFO loading external_activity")
 

--- a/rails/app/models/search.rb
+++ b/rails/app/models/search.rb
@@ -13,10 +13,12 @@ class Search
   attr_accessor :investigation_page
   attr_accessor :interactive_page
   attr_accessor :collection_page
+  attr_accessor :assessment_page
   attr_accessor :activity_per_page
   attr_accessor :investigation_per_page
   attr_accessor :interactive_per_page
   attr_accessor :collection_per_page
+  attr_accessor :assessment_per_page
   attr_accessor :per_page
   attr_accessor :user_id
   attr_accessor :user
@@ -44,7 +46,8 @@ class Search
   ActivityMaterial        = "Activity"
   InteractiveMaterial     = "Interactive"
   CollectionMaterial      = "Collection"
-  AllMaterials            = [InvestigationMaterial, ActivityMaterial, InteractiveMaterial, CollectionMaterial]
+  AssessmentMaterial      = "Assessment"
+  AllMaterials            = [InvestigationMaterial, ActivityMaterial, InteractiveMaterial, CollectionMaterial, AssessmentMaterial]
 
   AllSearchableModels       = [ ExternalActivity, Interactive ]
 
@@ -144,10 +147,12 @@ class Search
     self.investigation_page     = opts[:investigation_page]     || 1
     self.interactive_page       = opts[:interactive_page]       || 1
     self.collection_page        = opts[:collection_page]        || 1
+    self.assessment_page        = opts[:assessment_page]        || 1
     self.activity_per_page      = opts[:activity_per_page]      || self.per_page
     self.investigation_per_page = opts[:investigation_per_page] || self.per_page
     self.interactive_per_page   = opts[:interactive_per_page]   || self.per_page
     self.collection_per_page    = opts[:collection_per_page]    || self.per_page
+    self.assessment_per_page    = opts[:assessment_per_page]    || self.per_page
     self.without_teacher_only   = opts[:without_teacher_only]   || true
     self.material_properties    = opts[:material_properties]    || []
     self.include_contributed    = opts[:include_contributed]    || false
@@ -267,6 +272,8 @@ class Search
           s.paginate(:page => self.interactive_page, :per_page => self.interactive_per_page)
         elsif (type == CollectionMaterial)
           s.paginate(:page => self.collection_page, :per_page => self.collection_per_page)
+        elsif (type == AssessmentMaterial)
+          s.paginate(:page => self.assessment_page, :per_page => self.assessment_per_page)
         end
 
       end

--- a/rails/app/views/external_activities/_form.html.haml
+++ b/rails/app/views/external_activities/_form.html.haml
@@ -36,6 +36,7 @@
       = f.select :material_type,
         [ [ "Activity", "Activity"       ],
           [ "Sequence",  "Investigation"  ],
+          [ t(:assessment).titleize,     "Assessment" ],
           [ t(:collection).titleize, 'Collection' ],
           [ Interactive.display_name,    Interactive.name    ] ]
       %br

--- a/rails/app/views/search/_filters.html.haml
+++ b/rails/app/views/search/_filters.html.haml
@@ -27,16 +27,19 @@
           %h2.filterheader
             Resource Type
           .filter-group__options.webkit_scrollbars
+            = check_box_tag 'material_types[]', 'Interactive',  @form_model.material_types.include?('Interactive'),:id=>'interactive'
+            = label_tag 'interactive', t(:interactive).titleize
+            %br
+            = check_box_tag 'material_types[]', 'Assessment',  @form_model.material_types.include?('Assessment'),:id=>'assessment'
+            = label_tag 'assessment', t(:assessment).titleize
+            %br
+            = check_box_tag 'material_types[]', 'Activity',  @form_model.material_types.include?('Activity'),:id=>'activity'
+            = label_tag 'activity', t(:activity).titleize
+            %br
             = check_box_tag 'material_types[]', 'Investigation', @form_model.material_types.include?('Investigation'),:id=>'investigation'
             = label_tag 'investigation', t(:investigation).titleize
             %br
-            = check_box_tag 'material_types[]', 'Activity',  @form_model.material_types.include?('Activity'),:id=>'Activity'
-            = label_tag 'activity','Activity'
-            %br
-            = check_box_tag 'material_types[]', 'Interactive',  @form_model.material_types.include?('Interactive'),:id=>'Interactive'
-            = label_tag 'interactive', t(:interactive).titleize
-            %br
-            = check_box_tag 'material_types[]', 'Collection',  @form_model.material_types.include?('Collection'),:id=>'Collection'
+            = check_box_tag 'material_types[]', 'Collection',  @form_model.material_types.include?('Collection'),:id=>'collection'
             = label_tag 'collection', t(:collection).titleize
             %br
         #material-properties-filters.filter-group

--- a/rails/app/views/search/index.html.haml
+++ b/rails/app/views/search/index.html.haml
@@ -14,6 +14,7 @@
     = hidden_field_tag 'activity_page', (@form_model.activity_page rescue 1)
     = hidden_field_tag 'interactive_page', (@form_model.interactive_page rescue 1)
     = hidden_field_tag 'collection_page', (@form_model.collection_page rescue 1)
+    = hidden_field_tag 'assessment_page', (@form_model.assessment_page rescue 1)
   = hidden_field 'prevent','submit',:value=>"0"
   #results
     .search_resultscontainer
@@ -59,7 +60,8 @@
       jQuery("#investigation_page").val(1);
       jQuery("#activity_page").val(1);
       jQuery("#interactive_page").val(1);
-      jQuery("#collection_page").val();
+      jQuery("#collection_page").val(1);
+      jQuery("#assessment_page").val(1);
       var query = jQuery(form).serialize();
 
       window.updateSearchUrl(query);

--- a/rails/config/locales/en.yml
+++ b/rails/config/locales/en.yml
@@ -37,6 +37,7 @@ en:
   investigation: sequence
   activity: activity
   interactive: simulation
+  assessment: assessment
   material: material
   instructional_materials: Instructional Materials
   assignments: Assignments
@@ -57,13 +58,13 @@ en:
   authoring:
     student_report_enabled_description: Show a link to the student so they can see all their answers and see if they are correct
     show_score_description: Show the score in the report
-    is_assessment_item: Student assessment item.
-    is_assessment_item_description: Materials marked as student assessment items are not displayed to students or visitors in search results.
+    is_assessment_item: Student Assessment Item
+    is_assessment_item_description: Hide from students and non-logged-in users.
     author_url_description: This is the URL where the resource can be authored.
-    material_type_label: Material Type
+    material_type_label: Resource Type
     source_type_label: Source Type
     tool_label: Tool
-    material_type_description: Users can see the type of material in various places, use this field to change that type
+    material_type_description: Users can see the type of resource in various places. Use this field to change that type.
     external_report_label: External Reporting
     external_report_description: Specify additional report links to be shown to teachers in the offering view. Unless you know what you are doing selecting none is recommended.
     report_client: Report Auth Client

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -526,7 +526,7 @@ RailsPortal::Application.routes.draw do
 
     get '/resources/:id(/:slug)' => 'browse/external_activities#show', :as => :stem_resources
 
-    get '/resources/:type/:id_or_filter_value(/:slug)' => 'browse/external_activities#show', :as => :redirect_stem_resources
+    get '/resources/:type/:id_or_filter_value(/:slug)' => 'home#stem_resources', :as => :redirect_stem_resources
 
     get 'robots.txt'    => 'robots#index'
     get 'sitemap.xml'   => 'robots#sitemap'

--- a/rails/features/admin_work_with_interactives.feature
+++ b/rails/features/admin_work_with_interactives.feature
@@ -100,7 +100,7 @@ Feature: Admin can work with interactives
       When I enter search text "Geometry" on the search instructional materials page
       And I close the search suggestions
       And I uncheck "Sequence"
-      And I uncheck "Interactive"
+      And I uncheck "Simulation"
       And I check "Activity"
       And I press "Go"
       And I wait 2 seconds
@@ -110,7 +110,7 @@ Feature: Admin can work with interactives
       And I close the search suggestions
       And I check "Sequence"
       And I uncheck "Activity"
-      And I uncheck "Interactive"
+      And I uncheck "Simulation"
       And I press "Go"
       And I wait 2 seconds
       Then I should see "Radioactivity"
@@ -119,7 +119,7 @@ Feature: Admin can work with interactives
       And I close the search suggestions
       And I uncheck "Sequence"
       And I uncheck "Activity"
-      And I check "Interactive"
+      And I check "Simulation"
       And I press "Go"
       And I wait 2 seconds
       Then I should see "Interactive"

--- a/rails/react-components/src/library/components/collections.tsx
+++ b/rails/react-components/src/library/components/collections.tsx
@@ -6,6 +6,7 @@ import css from "./collections.scss";
 
 interface Props {
   collections: any[]
+  expandedByDefault?: boolean;
   numTotalCollections: number;
   searching: boolean;
   showAllCollections: boolean;
@@ -17,9 +18,10 @@ const initialDisplayCount = 2;
 export default class Collections extends React.Component<Props> {
 
   render () {
-    const { collections, numTotalCollections, searching, showAllCollections, enableShowAllCollections } = this.props;
-    const displayCount = showAllCollections ? numTotalCollections : initialDisplayCount;
-    const showingAll = showAllCollections || displayCount >= numTotalCollections;
+    const { collections, numTotalCollections, searching, showAllCollections, enableShowAllCollections, expandedByDefault } = this.props;
+    const expanded = showAllCollections || !!expandedByDefault;
+    const displayCount = expanded ? numTotalCollections : initialDisplayCount;
+    const showingAll = expanded || displayCount >= numTotalCollections;
     const collectionCount = showingAll ? numTotalCollections : displayCount + " of " + numTotalCollections;
     const displayCollections = collections.slice(0, displayCount);
 

--- a/rails/react-components/src/library/components/search/result-group.tsx
+++ b/rails/react-components/src/library/components/search/result-group.tsx
@@ -84,6 +84,10 @@ export default class SearchResultGroup extends React.Component<any, any> {
         this.materialType = "Collection";
         this.pageParam = "collection_page";
         break;
+      case "assessments":
+        this.materialType = "Assessment";
+        this.pageParam = "assessment_page";
+        break;
       default:
         throw new Error("unknown group type");
     }

--- a/rails/react-components/src/library/components/stem-finder.scss
+++ b/rails/react-components/src/library/components/stem-finder.scss
@@ -222,6 +222,33 @@
           content: '\f0c0';
         }
       }
+
+      &#simulation {
+        &:before {
+          content: "\f3f2";
+        }
+      }
+      &#assessment {
+        &:before {
+          content: "\f559";
+        }
+      }
+      &#activity {
+        &:before {
+          content: "\f14b";
+        }
+      }
+      &#sequence {
+        &:before {
+          content: "\f5fd";
+        }
+      }
+      &#collection {
+        &:before {
+          content: "\f49c";
+          left: 7px;
+        }
+      }
     }
   }
 }

--- a/rails/react-components/src/library/components/stem-finder.tsx
+++ b/rails/react-components/src/library/components/stem-finder.tsx
@@ -16,6 +16,12 @@ import css from "./stem-finder.scss";
 
 const DISPLAY_LIMIT_INCREMENT = 6;
 
+const SMALL_SCREEN_MAX_WIDTH = 768;
+const SECTION_KEYS = ["keywords", "subject", "grade-level", "resource-type", "advanced"] as const;
+type SectionKey = typeof SECTION_KEYS[number];
+const defaultSectionsOpen = (open: boolean): Record<SectionKey, boolean> =>
+  SECTION_KEYS.reduce((acc, k) => { acc[k] = open; return acc; }, {} as Record<SectionKey, boolean>);
+
 interface SubjectArea {
   key: string;
   title: string;
@@ -30,10 +36,17 @@ interface GradeLevel {
   searchGroups: string[];
 }
 
+interface ResourceType {
+  key: string;
+  searchMaterialType: string;
+  title: string;
+}
+
 interface Props {
   hideFeatured?: boolean;
   subjectAreaKey?: string;
   gradeLevelKey?: string;
+  resourceTypeKey?: string;
   sortOrder?: string;
 }
 
@@ -50,6 +63,7 @@ interface State {
   includeMine: boolean,
   initPage: boolean,
   isSmallScreen: boolean,
+  sectionsOpen: Record<SectionKey, boolean>,
   keyword: string,
   lastSearchResultCount: number,
   noResourcesFound: boolean,
@@ -63,6 +77,8 @@ interface State {
   sortOrder: string,
   subjectAreasSelected: SubjectArea[],
   subjectAreasSelectedMap: Record<string, SubjectArea|undefined>,
+  resourceTypesSelected: ResourceType[],
+  resourceTypesSelectedMap: Record<string, ResourceType|undefined>,
   usersAuthoredResourcesCount: number,
   showAllCollections: boolean,
 }
@@ -75,9 +91,10 @@ class StemFinder extends React.Component<Props, State> {
     const hideFeatured = this.props.hideFeatured || false;
     let subjectAreaKey = this.props.subjectAreaKey;
     let gradeLevelKey = this.props.gradeLevelKey;
+    let resourceTypeKey = this.props.resourceTypeKey;
     const sortOrder = this.props.sortOrder || "";
 
-    if (!subjectAreaKey && !gradeLevelKey) {
+    if (!subjectAreaKey && !gradeLevelKey && !resourceTypeKey) {
       //
       // If we are not passed props indicating filters to pre-populate
       // then attempt to see if this information is available in the URL.
@@ -85,6 +102,7 @@ class StemFinder extends React.Component<Props, State> {
       const params = this.getFiltersFromURL();
       subjectAreaKey = params.subject;
       gradeLevelKey = params["grade-level"];
+      resourceTypeKey = params["resource-type"];
 
       subjectAreaKey = this.mapSubjectArea(subjectAreaKey);
     }
@@ -92,7 +110,7 @@ class StemFinder extends React.Component<Props, State> {
     //
     // Scroll to stem finder if we have filters specified.
     //
-    if (subjectAreaKey || gradeLevelKey) {
+    if (subjectAreaKey || gradeLevelKey || resourceTypeKey) {
       // this.scrollToFinder()
     }
 
@@ -125,6 +143,21 @@ class StemFinder extends React.Component<Props, State> {
       }
     }
 
+    const resourceTypesSelected: ResourceType[] = [];
+    const resourceTypesSelectedMap: Record<string, ResourceType|undefined> = {};
+
+    if (resourceTypeKey) {
+      const resourceTypesConfig: ResourceType[] = filters.resourceTypeFilters;
+      const match = resourceTypesConfig.find(rt => rt.key === resourceTypeKey);
+      if (match) {
+        resourceTypesSelected.push(match);
+        resourceTypesSelectedMap[match.key] = match;
+      }
+      // Unknown keys (e.g., /resources/resource-type/foo-unknown) are silently ignored.
+    }
+
+    const initialIsSmallScreen = window.innerWidth <= SMALL_SCREEN_MAX_WIDTH;
+
     this.state = {
       collections: [],
       displayLimit: DISPLAY_LIMIT_INCREMENT,
@@ -137,7 +170,8 @@ class StemFinder extends React.Component<Props, State> {
       includeContributed: false,
       includeMine: false,
       initPage: true,
-      isSmallScreen: window.innerWidth <= 768,
+      isSmallScreen: initialIsSmallScreen,
+      sectionsOpen: defaultSectionsOpen(!initialIsSmallScreen),
       keyword: "",
       lastSearchResultCount: 0,
       noResourcesFound: false,
@@ -151,6 +185,8 @@ class StemFinder extends React.Component<Props, State> {
       sortOrder,
       subjectAreasSelected,
       subjectAreasSelectedMap,
+      resourceTypesSelected,
+      resourceTypesSelectedMap,
       usersAuthoredResourcesCount: 0,
       showAllCollections: false,
     };
@@ -217,6 +253,14 @@ class StemFinder extends React.Component<Props, State> {
     }
   };
 
+  private handleResize = () => {
+    const isSmallScreen = window.innerWidth <= SMALL_SCREEN_MAX_WIDTH;
+    this.setState({
+      isSmallScreen,
+      sectionsOpen: defaultSectionsOpen(!isSmallScreen)
+    });
+  };
+
   componentDidMount () {
     if (document.getElementById("pprfl")) {
       document.getElementById("pprfl")?.addEventListener("scroll", this.handleLightboxScroll);
@@ -224,9 +268,7 @@ class StemFinder extends React.Component<Props, State> {
       document.addEventListener("scroll", this.handlePageScroll);
     }
 
-    window.addEventListener("resize", () => {
-      this.setState({ isSmallScreen: window.innerWidth <= 768 });
-    });
+    window.addEventListener("resize", this.handleResize);
   }
 
   componentWillUnmount () {
@@ -235,31 +277,46 @@ class StemFinder extends React.Component<Props, State> {
     } else {
       document.removeEventListener("scroll", this.handlePageScroll);
     }
+
+    window.removeEventListener("resize", this.handleResize);
   }
 
   getQueryParams = (incremental: any, keyword: any) => {
     const searchPage = incremental ? this.state.searchPage + 1 : 1;
     let query = keyword !== undefined ? ["search_term=", encodeURIComponent(keyword)] : [];
+
+    const selectedRTs = this.state.resourceTypesSelected;
+    // "Collection" joins on the first (non-incremental) search only. See legacy behaviour below.
+    const defaultIncrementalTypes = ["Investigation", "Activity", "Interactive", "Assessment"];
+
+    let requestedTypes: string[];
+    if (selectedRTs.length === 0) {
+      // no filter → legacy default
+      requestedTypes = incremental
+        ? defaultIncrementalTypes.slice()
+        : defaultIncrementalTypes.concat(["Collection"]);
+    } else {
+      requestedTypes = selectedRTs.map(rt => rt.searchMaterialType);
+    }
+
     query = query.concat([
       "&skip_lightbox_reloads=true",
       "&sort_order=Alphabetical",
-      "&material_types[]=Investigation",
-      "&material_types[]=Activity",
-      "&material_types[]=Interactive",
       "&include_related=0",
-      "&investigation_page=",
-      String(searchPage),
-      "&activity_page=",
-      String(searchPage),
-      "&interactive_page=",
-      String(searchPage),
-      "&per_page=",
-      String(DISPLAY_LIMIT_INCREMENT)
+      "&investigation_page=", String(searchPage),
+      "&activity_page=",      String(searchPage),
+      "&interactive_page=",   String(searchPage),
+      "&assessment_page=",    String(searchPage),
+      "&per_page=",           String(DISPLAY_LIMIT_INCREMENT)
     ]);
 
-    // only search collections on first search and gather all of them at once
-    if (!incremental) {
-      query.push("&material_types[]=Collection");
+    requestedTypes.forEach(t => {
+      query.push("&material_types[]=");
+      query.push(t);
+    });
+
+    if (!incremental && requestedTypes.indexOf("Collection") !== -1) {
+      // The Collections section component handles its own "show more" UI client-side.
       query.push("&collection_page=1");
       query.push("&collection_per_page=1000");
     }
@@ -398,39 +455,32 @@ class StemFinder extends React.Component<Props, State> {
   }
 
   noOptionsSelected () {
-    if (
-      this.state.subjectAreasSelected.length === 0 &&
-      this.state.gradeLevelsSelected.length === 0
-    ) {
-      return true;
-    } else {
-      return false;
-    }
+    return this.state.subjectAreasSelected.length === 0 &&
+           this.state.gradeLevelsSelected.length === 0 &&
+           this.state.resourceTypesSelected.length === 0;
   }
 
   renderLogo (subjectArea: any) {
     const filterId = this.buildFilterId(subjectArea.key);
-    const selected = this.state.subjectAreasSelectedMap[subjectArea.key];
-    const className = selected ? css.selected : null;
+    const selected = !!this.state.subjectAreasSelectedMap[subjectArea.key];
+    const className = selected ? css.selected : undefined;
 
     const clicked = () => {
       this.setState((prev) => {
         const subjectAreasSelected = prev.subjectAreasSelected.slice();
-        const subjectAreasSelectedMap = prev.subjectAreasSelectedMap;
+        const subjectAreasSelectedMap = { ...prev.subjectAreasSelectedMap };
         const index = subjectAreasSelected.indexOf(subjectArea);
 
         if (index === -1) {
           subjectAreasSelectedMap[subjectArea.key] = subjectArea;
           subjectAreasSelected.push(subjectArea);
-          jQuery("#" + css[filterId]).addClass(css.selected);
           gtag("event", "click", {
             "category": "Home Page Filter",
             "label": subjectArea.title
           });
         } else {
-          subjectAreasSelectedMap[subjectArea.key] = undefined;
+          delete subjectAreasSelectedMap[subjectArea.key];
           subjectAreasSelected.splice(index, 1);
-          jQuery("#" + css[filterId]).removeClass(css.selected);
         }
         this.scrollToFinder();
         return {
@@ -442,40 +492,52 @@ class StemFinder extends React.Component<Props, State> {
       }, this.search);
     };
 
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLLIElement>) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        clicked();
+      }
+    };
+
     return (
-      <li key={subjectArea.key} id={css[filterId]} className={className} onClick={clicked}>
+      <li
+        key={subjectArea.key}
+        id={css[filterId]}
+        className={className}
+        onClick={clicked}
+        onKeyDown={handleKeyDown}
+        role="button"
+        tabIndex={0}
+        aria-pressed={selected}
+      >
         { subjectArea.title }
       </li>
     );
   }
 
   renderGLLogo (gradeLevel: any) {
-    let className = "portal-pages-finder-form-filters-logo";
+    const baseClassName = "portal-pages-finder-form-filters-logo";
     const filterId = this.buildFilterId(gradeLevel.key);
 
-    const selected = this.state.gradeLevelsSelectedMap[gradeLevel.key];
-    if (selected) {
-      className += " " + css.selected;
-    }
+    const selected = !!this.state.gradeLevelsSelectedMap[gradeLevel.key];
+    const className = selected ? `${baseClassName} ${css.selected}` : baseClassName;
 
     const clicked = () => {
       this.setState((prev) => {
         const gradeLevelsSelected = prev.gradeLevelsSelected.slice();
-        const gradeLevelsSelectedMap = prev.gradeLevelsSelectedMap;
+        const gradeLevelsSelectedMap = { ...prev.gradeLevelsSelectedMap };
         const index = gradeLevelsSelected.indexOf(gradeLevel);
 
         if (index === -1) {
           gradeLevelsSelectedMap[gradeLevel.key] = gradeLevel;
           gradeLevelsSelected.push(gradeLevel);
-          jQuery("#" + css[filterId]).addClass(css.selected);
           gtag("event", "click", {
             "category": "Home Page Filter",
             "label": gradeLevel.title
           });
         } else {
-          gradeLevelsSelectedMap[gradeLevel.key] = undefined;
+          delete gradeLevelsSelectedMap[gradeLevel.key];
           gradeLevelsSelected.splice(index, 1);
-          jQuery("#" + css[filterId]).removeClass(css.selected);
         }
         this.scrollToFinder();
         return {
@@ -487,37 +549,164 @@ class StemFinder extends React.Component<Props, State> {
       }, this.search);
     };
 
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLLIElement>) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        clicked();
+      }
+    };
+
     return (
-      <li key={gradeLevel.key} id={css[filterId]} className={className} onClick={clicked}>
+      <li
+        key={gradeLevel.key}
+        id={css[filterId]}
+        className={className}
+        onClick={clicked}
+        onKeyDown={handleKeyDown}
+        role="button"
+        tabIndex={0}
+        aria-pressed={selected}
+      >
         { gradeLevel.title }
       </li>
     );
   }
 
+  renderRTLogo (resourceType: ResourceType) {
+    const filterId = this.buildFilterId(resourceType.key);
+    const selected = !!this.state.resourceTypesSelectedMap[resourceType.key];
+    const className = selected ? css.selected : undefined;
+
+    const toggle = () => {
+      this.setState((prev) => {
+        const resourceTypesSelected = prev.resourceTypesSelected.slice();
+        const resourceTypesSelectedMap = { ...prev.resourceTypesSelectedMap };
+        const index = resourceTypesSelected.indexOf(resourceType);
+
+        if (index === -1) {
+          resourceTypesSelectedMap[resourceType.key] = resourceType;
+          resourceTypesSelected.push(resourceType);
+          gtag("event", "click", {
+            "category": "Home Page Filter",
+            "label": resourceType.title
+          });
+        } else {
+          delete resourceTypesSelectedMap[resourceType.key];
+          resourceTypesSelected.splice(index, 1);
+        }
+        this.scrollToFinder();
+        return {
+          resourceTypesSelected,
+          resourceTypesSelectedMap,
+          hideFeatured: true,
+          initPage: false
+        };
+      }, this.search);
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLLIElement>) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        toggle();
+      }
+    };
+
+    return (
+      <li
+        key={resourceType.key}
+        aria-pressed={selected}
+        className={className}
+        id={css[filterId]}
+        role="button"
+        tabIndex={0}
+        onClick={toggle}
+        onKeyDown={handleKeyDown}
+      >
+        { resourceType.title }
+      </li>
+    );
+  }
+
   renderSubjectAreas () {
-    const containerClassName = this.state.isSmallScreen ? css.finderOptionsContainer : `${css.finderOptionsContainer} ${css.open}`;
+    const isOpen = this.state.sectionsOpen.subject;
+    const containerClassName = isOpen
+      ? `${css.finderOptionsContainer} ${css.open}`
+      : css.finderOptionsContainer;
     return (
       <div className={containerClassName}>
-        <h2 onClick={this.handleFilterHeaderClick}>Subject</h2>
-        <ul>
-          { filters.subjectAreas.map((subjectArea: any) => {
-            return this.renderLogo(subjectArea);
-          }) }
-        </ul>
+        <h2
+          data-section-key="subject"
+          onClick={this.handleFilterHeaderClick}
+          onKeyDown={this.handleFilterHeaderKeyDown}
+          role="button"
+          tabIndex={0}
+          aria-expanded={isOpen}
+        >
+          Subject
+        </h2>
+        {isOpen && (
+          <ul>
+            { filters.subjectAreas.map((subjectArea: any) => {
+              return this.renderLogo(subjectArea);
+            }) }
+          </ul>
+        )}
       </div>
     );
   }
 
   renderGradeLevels () {
-    const containerClassName = this.state.isSmallScreen ? css.finderOptionsContainer : `${css.finderOptionsContainer} ${css.open}`;
+    const isOpen = this.state.sectionsOpen["grade-level"];
+    const containerClassName = isOpen
+      ? `${css.finderOptionsContainer} ${css.open}`
+      : css.finderOptionsContainer;
     return (
       <div className={containerClassName}>
-        <h2 onClick={this.handleFilterHeaderClick}>Grade Level</h2>
-        <ul>
-          { filters.gradeFilters.map((gradeLevel: any) => {
-            return this.renderGLLogo(gradeLevel);
-          }) }
-        </ul>
+        <h2
+          data-section-key="grade-level"
+          onClick={this.handleFilterHeaderClick}
+          onKeyDown={this.handleFilterHeaderKeyDown}
+          role="button"
+          tabIndex={0}
+          aria-expanded={isOpen}
+        >
+          Grade Level
+        </h2>
+        {isOpen && (
+          <ul>
+            { filters.gradeFilters.map((gradeLevel: any) => {
+              return this.renderGLLogo(gradeLevel);
+            }) }
+          </ul>
+        )}
+      </div>
+    );
+  }
+
+  renderResourceTypes () {
+    const isOpen = this.state.sectionsOpen["resource-type"];
+    const containerClassName = isOpen
+      ? `${css.finderOptionsContainer} ${css.open}`
+      : css.finderOptionsContainer;
+
+
+    return (
+      <div className={containerClassName}>
+        <h2
+          data-section-key="resource-type"
+          aria-expanded={isOpen}
+          role="button"
+          tabIndex={0}
+          onClick={this.handleFilterHeaderClick}
+          onKeyDown={this.handleFilterHeaderKeyDown}
+        >
+          Resource Type
+        </h2>
+        {isOpen && (
+          <ul aria-label="Resource Type filter" role="group">
+            { filters.resourceTypeFilters.map((rt: ResourceType) => this.renderRTLogo(rt)) }
+          </ul>
+        )}
       </div>
     );
   }
@@ -551,6 +740,8 @@ class StemFinder extends React.Component<Props, State> {
     this.setState({
       subjectAreasSelected: [],
       gradeLevelsSelected: [],
+      resourceTypesSelected: [],
+      resourceTypesSelectedMap: {},
       keyword: "",
       searchInput: ""
     }, this.search);
@@ -627,23 +818,37 @@ class StemFinder extends React.Component<Props, State> {
   };
 
   renderSearch () {
-    const containerClassName = this.state.isSmallScreen ? css.finderOptionsContainer : `${css.finderOptionsContainer} ${css.open}`;
+    const isOpen = this.state.sectionsOpen.keywords;
+    const containerClassName = isOpen
+      ? `${css.finderOptionsContainer} ${css.open}`
+      : css.finderOptionsContainer;
     return (
       <div className={containerClassName}>
-        <h2 onClick={this.handleFilterHeaderClick}>Keywords</h2>
-        <form onSubmit={this.handleSearchSubmit}>
-          <div className={"portal-pages-search-input-container"}>
-            <AutoSuggest
-              name={"search-terms"}
-              query={this.state.searchInput}
-              getQueryParams={this.getQueryParams}
-              onChange={this.handleSearchInputChange}
-              onSubmit={this.handleAutoSuggestSubmit}
-              placeholder={"Type search term here"}
-              skipAutoSearch
-            />
-          </div>
-        </form>
+        <h2
+          data-section-key="keywords"
+          onClick={this.handleFilterHeaderClick}
+          onKeyDown={this.handleFilterHeaderKeyDown}
+          role="button"
+          tabIndex={0}
+          aria-expanded={isOpen}
+        >
+          Keywords
+        </h2>
+        {isOpen && (
+          <form onSubmit={this.handleSearchSubmit}>
+            <div className={"portal-pages-search-input-container"}>
+              <AutoSuggest
+                name={"search-terms"}
+                query={this.state.searchInput}
+                getQueryParams={this.getQueryParams}
+                onChange={this.handleSearchInputChange}
+                onSubmit={this.handleAutoSuggestSubmit}
+                placeholder={"Type search term here"}
+                skipAutoSearch
+              />
+            </div>
+          </form>
+        )}
       </div>
     );
   }
@@ -654,14 +859,29 @@ class StemFinder extends React.Component<Props, State> {
   }
 
   renderAdvanced () {
+    const isOpen = this.state.sectionsOpen.advanced;
+    const containerClassName = isOpen
+      ? `${css.finderOptionsContainer} ${css.open}`
+      : css.finderOptionsContainer;
     return (
       <>
-        <div className={css.finderOptionsContainer}>
-          <h2 onClick={this.handleFilterHeaderClick}>Advanced</h2>
-          <ul>
-            <li id={css.official} className={css.selected} onClick={(e) => this.handleOfficialClick(e)}>Official</li>
-            <li id={css.community} onClick={(e) => this.handleCommunityClick(e)}>Community</li>
-          </ul>
+        <div className={containerClassName}>
+          <h2
+            data-section-key="advanced"
+            onClick={this.handleFilterHeaderClick}
+            onKeyDown={this.handleFilterHeaderKeyDown}
+            role="button"
+            tabIndex={0}
+            aria-expanded={isOpen}
+          >
+            Advanced
+          </h2>
+          {isOpen && (
+            <ul>
+              <li id={css.official} className={css.selected} onClick={(e) => this.handleOfficialClick(e)}>Official</li>
+              <li id={css.community} onClick={(e) => this.handleCommunityClick(e)}>Community</li>
+            </ul>
+          )}
         </div>
         <div className={css.advancedSearchLink}>
           <a href="/search" title="Advanced Search">Advanced Search</a>
@@ -678,14 +898,26 @@ class StemFinder extends React.Component<Props, State> {
           { this.renderSearch() }
           { this.renderSubjectAreas() }
           { this.renderGradeLevels() }
+          { this.renderResourceTypes() }
           { isAdvancedUser && this.renderAdvanced() }
         </div>
       </div>
     );
   }
 
-  handleFilterHeaderClick = (e: any) => {
-    e.currentTarget.parentElement.classList.toggle(css.open);
+  handleFilterHeaderClick = (e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
+    const key = (e.currentTarget as HTMLElement).dataset.sectionKey as SectionKey | undefined;
+    if (!key) return;
+    this.setState(prev => ({
+      sectionsOpen: { ...prev.sectionsOpen, [key]: !prev.sectionsOpen[key] }
+    }));
+  };
+
+  handleFilterHeaderKeyDown = (e: React.KeyboardEvent<HTMLHeadingElement>) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      this.handleFilterHeaderClick(e);
+    }
   };
 
   handleShowOnlyMine = (e: any) => {
@@ -776,10 +1008,17 @@ class StemFinder extends React.Component<Props, State> {
   };
 
   renderCollections () {
+    const selectedRTs = this.state.resourceTypesSelected;
+    const collectionSelected = selectedRTs.some(rt => rt.key === "collection");
+    if (selectedRTs.length > 0 && !collectionSelected) {
+      return null;
+    }
+    const onlyCollectionSelected = selectedRTs.length === 1 && collectionSelected;
+
     const { collections, numTotalCollections, initPage, hideFeatured, searching, showAllCollections } = this.state;
 
     if (!initPage) {
-      return <Collections collections={collections} numTotalCollections={numTotalCollections} searching={searching} showAllCollections={showAllCollections} enableShowAllCollections={this.handleShowAllCollections} />;
+      return <Collections collections={collections} numTotalCollections={numTotalCollections} searching={searching} showAllCollections={showAllCollections} enableShowAllCollections={this.handleShowAllCollections} expandedByDefault={onlyCollectionSelected} />;
     }
 
     let featuredCollections = this.state.featuredCollections;
@@ -802,18 +1041,24 @@ class StemFinder extends React.Component<Props, State> {
       );
     }
 
+    const selectedRTs = this.state.resourceTypesSelected;
+    const onlyCollectionSelected = selectedRTs.length === 1 && selectedRTs[0].key === "collection";
     const resources = this.state.resources.slice(0, this.state.displayLimit);
     return (
       <>
         { this.renderCollections() }
-        { this.renderResultsHeader() }
-        <div className={css.finderResultsContainer}>
-          { resources.map((resource: any, index: any) => {
-            return <StemFinderResult key={`${resource.external_url}-${index}`} resource={resource} index={index} showResources={this.showResources} />;
-          }) }
-        </div>
-        { this.state.searching ? <div className={css.loading}>Loading</div> : null }
-        { this.renderLoadMore() }
+        { !onlyCollectionSelected && (
+          <>
+            { this.renderResultsHeader() }
+            <div className={css.finderResultsContainer}>
+              { resources.map((resource: any, index: any) => {
+                return <StemFinderResult key={`${resource.external_url}-${index}`} resource={resource} index={index} showResources={this.showResources} />;
+              }) }
+            </div>
+            { this.renderLoadMore() }
+          </>
+        )}
+        { this.state.searching && !onlyCollectionSelected ? <div className={css.loading}>Loading</div> : null }
       </>
     );
   }

--- a/rails/react-components/src/library/components/stem-finder.tsx
+++ b/rails/react-components/src/library/components/stem-finder.tsx
@@ -255,6 +255,7 @@ class StemFinder extends React.Component<Props, State> {
 
   private handleResize = () => {
     const isSmallScreen = window.innerWidth <= SMALL_SCREEN_MAX_WIDTH;
+    if (isSmallScreen === this.state.isSmallScreen) return;
     this.setState({
       isSmallScreen,
       sectionsOpen: defaultSectionsOpen(!isSmallScreen)
@@ -703,7 +704,7 @@ class StemFinder extends React.Component<Props, State> {
           Resource Type
         </h2>
         {isOpen && (
-          <ul aria-label="Resource Type filter" role="group">
+          <ul>
             { filters.resourceTypeFilters.map((rt: ResourceType) => this.renderRTLogo(rt)) }
           </ul>
         )}
@@ -1007,13 +1008,18 @@ class StemFinder extends React.Component<Props, State> {
     this.setState({ showAllCollections: true });
   };
 
+  onlyCollectionSelected () {
+    const selected = this.state.resourceTypesSelected;
+    return selected.length === 1 && selected[0].key === "collection";
+  }
+
   renderCollections () {
     const selectedRTs = this.state.resourceTypesSelected;
     const collectionSelected = selectedRTs.some(rt => rt.key === "collection");
     if (selectedRTs.length > 0 && !collectionSelected) {
       return null;
     }
-    const onlyCollectionSelected = selectedRTs.length === 1 && collectionSelected;
+    const onlyCollectionSelected = this.onlyCollectionSelected();
 
     const { collections, numTotalCollections, initPage, hideFeatured, searching, showAllCollections } = this.state;
 
@@ -1041,8 +1047,7 @@ class StemFinder extends React.Component<Props, State> {
       );
     }
 
-    const selectedRTs = this.state.resourceTypesSelected;
-    const onlyCollectionSelected = selectedRTs.length === 1 && selectedRTs[0].key === "collection";
+    const onlyCollectionSelected = this.onlyCollectionSelected();
     const resources = this.state.resources.slice(0, this.state.displayLimit);
     return (
       <>

--- a/rails/react-components/src/library/helpers/filters.ts
+++ b/rails/react-components/src/library/helpers/filters.ts
@@ -26,6 +26,14 @@ const filters: any = {
     { key: "high-school", title: "High School", grades: ["9", "10", "11", "12"], label: "9-12", searchGroups: ["9-12"] },
     { key: "higher-education", title: "Higher Education", grades: ["Higher Ed"], label: "Higher Education", searchGroups: ["Higher Ed"] }
     // {key: "informal-learning", title: "Informal Learning (TODO)", grades: [], label: "Informal Learning"},
+  ],
+
+  resourceTypeFilters: [
+    { key: "simulation", title: "Simulation", searchMaterialType: "Interactive" },
+    { key: "assessment", title: "Assessment", searchMaterialType: "Assessment" },
+    { key: "activity", title: "Activity", searchMaterialType: "Activity" },
+    { key: "sequence", title: "Sequence", searchMaterialType: "Investigation" },
+    { key: "collection", title: "Collection", searchMaterialType: "Collection" }
   ]
 };
 

--- a/rails/react-components/tests/library/components/collections.test.tsx
+++ b/rails/react-components/tests/library/components/collections.test.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+jest.mock("../../../src/library/components/stem-finder-result", () => {
+  return function MockStemFinderResult ({ resource }: any) {
+    return <div data-testid="stem-finder-result">{resource.name}</div>;
+  };
+});
+
+import Collections from "../../../src/library/components/collections";
+
+const makeCollections = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    name: `Collection ${i + 1}`,
+    external_url: `https://example.com/c/${i + 1}`,
+    material_type: "Collection"
+  }));
+
+describe("Collections", () => {
+  it("shows initial 2 collections + Show More button when expandedByDefault is not set", () => {
+    render(
+      <Collections
+        collections={makeCollections(5)}
+        numTotalCollections={5}
+        searching={false}
+        showAllCollections={false}
+        enableShowAllCollections={() => {}}
+      />
+    );
+    expect(screen.getByText("Collection 1")).toBeInTheDocument();
+    expect(screen.getByText("Collection 2")).toBeInTheDocument();
+    expect(screen.queryByText("Collection 3")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /show more/i })).toBeInTheDocument();
+  });
+
+  it("renders all collections and hides Show More when expandedByDefault is true", () => {
+    render(
+      <Collections
+        collections={makeCollections(5)}
+        numTotalCollections={5}
+        searching={false}
+        showAllCollections={false}
+        enableShowAllCollections={() => {}}
+        expandedByDefault={true}
+      />
+    );
+    expect(screen.getByText("Collection 1")).toBeInTheDocument();
+    expect(screen.getByText("Collection 5")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /show more/i })).not.toBeInTheDocument();
+  });
+
+  it("hides Show More when total fits within initial display count", () => {
+    render(
+      <Collections
+        collections={makeCollections(2)}
+        numTotalCollections={2}
+        searching={false}
+        showAllCollections={false}
+        enableShowAllCollections={() => {}}
+      />
+    );
+    expect(screen.queryByRole("button", { name: /show more/i })).not.toBeInTheDocument();
+  });
+
+  it("renders all collections when showAllCollections is true (post-click)", () => {
+    render(
+      <Collections
+        collections={makeCollections(5)}
+        numTotalCollections={5}
+        searching={false}
+        showAllCollections={true}
+        enableShowAllCollections={() => {}}
+      />
+    );
+    expect(screen.getByText("Collection 5")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /show more/i })).not.toBeInTheDocument();
+  });
+});

--- a/rails/spec/controllers/api/v1/search_controller_spec.rb
+++ b/rails/spec/controllers/api/v1/search_controller_spec.rb
@@ -209,6 +209,43 @@ describe API::V1::SearchController do
     end
   end
 
+  describe "GET #search with Assessment material_type" do
+    before(:each) do
+      FactoryBot.create(:external_activity,
+        publication_status: 'published',
+        material_type: 'Assessment',
+        name: 'Quiz Two')
+      FactoryBot.create(:external_activity,
+        publication_status: 'published',
+        material_type: 'Activity',
+        name: 'Plain Two')
+      FactoryBot.create(:external_activity,
+        publication_status: 'published',
+        material_type: 'Investigation',
+        name: 'Sequence Two')
+      FactoryBot.create(:external_activity,
+        publication_status: 'published',
+        material_type: 'Interactive',
+        name: 'Simulation Two')
+      FactoryBot.create(:external_activity,
+        publication_status: 'published',
+        material_type: 'Collection',
+        name: 'Collection Two')
+      reindex_all
+    end
+
+    it "returns only Assessment materials when filtered" do
+      get :search, params: { material_types: ['Assessment'] }, format: :json
+      body = JSON.parse(response.body)
+      all_names = body["results"].flat_map { |r| r["materials"].map { |m| m["name"] } }
+      expect(all_names).to include('Quiz Two')
+      expect(all_names).not_to include('Plain Two')
+      expect(all_names).not_to include('Sequence Two')
+      expect(all_names).not_to include('Simulation Two')
+      expect(all_names).not_to include('Collection Two')
+    end
+  end
+
   describe "GET search_suggestions" do
     it "should fail without a search_term parameter" do
       get :search_suggestions

--- a/rails/spec/controllers/browse/external_activities_controller_spec.rb
+++ b/rails/spec/controllers/browse/external_activities_controller_spec.rb
@@ -68,30 +68,10 @@ describe Browse::ExternalActivitiesController do
         expect(response).not_to be_successful
       end
   
-      xit "should return 200 when a valid interactive is used" do
-        get :show, params: { :type => "interactive", :id_or_filter_value => interactive.id }
-        expect(response).to redirect_to stem_resources_url(interactive.external_activity_id, activity.name.parameterize)
-        get :show, params: { :type => "interactive", :id_or_filter_value => interactive.id, :slug => "test" }
-        expect(response).to redirect_to stem_resources_url(interactive.external_activity_id, activity.name.parameterize)
-      end
-  
-      it "should return 404 when an unknown interactive is used" do
-        get :show, params: { :type => "interactive", :id_or_filter_value => 999999999999999 }
-        expect(response).not_to be_successful
-        get :show, params: { :type => "interactive", :id_or_filter_value => 999999999999999, :slug => "test" }
-        expect(response).not_to be_successful
-      end
-  
-      #
-      # This should fall through to the home page as a search filter.
-      #
-      xit "should return 200 when an unknown type is used" do
-        get :show, params: { :type => "unknown-type", :id_or_filter_value => 1 }
-        expect(response).to be_successful
-        get :show, params: { :type => "unknown-type", :id_or_filter_value => 1, :slug => "test" }
-        expect(response).to be_successful
-      end
-  
+      # Tests for /resources/:type/:id_or_filter_value (interactive + unknown-type)
+      # have moved to home_controller_spec.rb — the route now points at
+      # home#stem_resources rather than this controller.
+
       xit "should set the start of the page title to the resource name" do
         get :show, params: { :id => activity.id }
         puts @response.inspect

--- a/rails/spec/controllers/home_controller_spec.rb
+++ b/rails/spec/controllers/home_controller_spec.rb
@@ -120,6 +120,56 @@ describe HomeController do
     end
   end
 
+  describe '#stem_resources' do
+    describe "with a resource-detail URL" do
+      let(:assessment) do
+        FactoryBot.create(:external_activity,
+          name: "Quiz One",
+          publication_status: "published",
+          material_type: "Assessment")
+      end
+
+      it "redirects to the resource page when type is 'assessment'" do
+        get :stem_resources, params: { type: "assessment", id_or_filter_value: assessment.id.to_s }
+        expect(response).to redirect_to("/resources/#{assessment.id}/#{assessment.name.parameterize}")
+      end
+
+      it "redirects to the resource page when type is 'activity'" do
+        activity_record = FactoryBot.create(:external_activity,
+          name: "Plain Activity",
+          publication_status: "published",
+          material_type: "Activity")
+        get :stem_resources, params: { type: "activity", id_or_filter_value: activity_record.id.to_s }
+        expect(response).to redirect_to("/resources/#{activity_record.id}/#{activity_record.name.parameterize}")
+      end
+
+      it "returns 404 when type is 'interactive' but the id is unknown" do
+        get :stem_resources, params: { type: "interactive", id_or_filter_value: "999999999999999" }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    describe "with a filter URL" do
+      it "renders the home page when type is 'resource-type'" do
+        get :stem_resources, params: { type: "resource-type", id_or_filter_value: "simulation" }
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template(:home)
+      end
+
+      it "renders the home page when type is 'subject'" do
+        get :stem_resources, params: { type: "subject", id_or_filter_value: "chemistry" }
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template(:home)
+      end
+
+      it "renders the home page when type is 'grade-level'" do
+        get :stem_resources, params: { type: "grade-level", id_or_filter_value: "middle-school" }
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template(:home)
+      end
+    end
+  end
+
   # TODO: auto-generated
   describe '#index' do
     it 'GET index' do

--- a/rails/spec/models/search_spec.rb
+++ b/rails/spec/models/search_spec.rb
@@ -646,4 +646,50 @@ describe Search do
     end
 
   end
+
+  describe "Assessment material_type" do
+    include SolrSpecHelper
+
+    let(:admin) { FactoryBot.generate(:admin_user) }
+
+    let!(:regular_activity) do
+      FactoryBot.create(:external_activity,
+        publication_status: 'published',
+        material_type: 'Activity',
+        name: 'Plain Activity')
+    end
+
+    let!(:assessment_material) do
+      FactoryBot.create(:external_activity,
+        publication_status: 'published',
+        material_type: 'Assessment',
+        name: 'Quiz One')
+    end
+
+    before(:all) do
+      solr_setup
+      clean_solar_index
+    end
+
+    before(:each) { reindex_all }
+
+    after(:each) { clean_solar_index }
+
+    it "accepts 'Assessment' in material_types and clean_material_types" do
+      expect(Search.clean_material_types(['Assessment'])).to eq(['Assessment'])
+      expect(Search::AllMaterials).to include('Assessment')
+    end
+
+    it "returns only Assessment materials when filtered" do
+      search = Search.new(user_id: admin.id, material_types: ['Assessment'])
+      names = search.results[:all].map(&:name)
+      expect(names).to include('Quiz One')
+      expect(names).not_to include('Plain Activity')
+    end
+
+    it "paginates assessments via assessment_page/per_page opts" do
+      search = Search.new(user_id: admin.id, material_types: ['Assessment'], assessment_page: 1, assessment_per_page: 5)
+      expect(search.results['Assessment'].per_page).to eq(5)
+    end
+  end
 end


### PR DESCRIPTION
[RIGSE-312](https://concord-consortium.atlassian.net/browse/RIGSE-312)

Adds a new Assessment resource type and a new Resource Type filter set to the home page search interface. Also modifies some terminology, list ordering, and makes some basic accessibility improvements.

- New filter category for Resource Type below Grade Level on the main search page. Filter options within this category are: Simulation, Assessment, Activity, Sequence, and Collection. Each filter option has its own unique icon.
- Rename Material Type to Resource Type
- Portal Settings for resources updated to provide an option for "Assessment" under Resource Type
- Rephrases the current "Student assessment item" setting to help clarify that it is something different.
- New "Assessment" filter option to the Resource Type filter on the Advanced Search page.
- Reorders advanced search Resource Type checkboxes to Simulation, Assessment, Activity, Sequence, and Collection.

[RIGSE-312]: https://concord-consortium.atlassian.net/browse/RIGSE-312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ