### PR TITLE
fix: Redesign Portal Search Results (RIGSE-347)

### DIFF
--- a/rails/react-components/src/library/components/stem-finder-result.scss
+++ b/rails/react-components/src/library/components/stem-finder-result.scss
@@ -106,22 +106,6 @@
     }
   }
 
-  &.collection {
-    .metaTags {
-      &:after {
-        background: $light-gray;
-        color: $col-darkgray-75;
-        content: "Curated Collection";
-        display: inline-block;
-        font-size: 12px;
-        font-weight: 300;
-        line-height: 1;
-        margin: 0;
-        padding: 4px 5px;
-      }
-    }
-  }
-
   &.interactive, &.activity, &.sequence {
     background: $white;
   }

--- a/rails/react-components/src/library/components/stem-finder.scss
+++ b/rails/react-components/src/library/components/stem-finder.scss
@@ -425,3 +425,13 @@
     }
   }
 }
+
+@media screen and (max-height: 930px) and (min-width: 951px) {
+  .finderWrapper {
+    .finderForm {
+      margin-bottom: 30px;
+      position: relative;
+      top: 0;
+    }
+  }
+}

--- a/rails/react-components/src/library/components/stem-finder.scss
+++ b/rails/react-components/src/library/components/stem-finder.scss
@@ -11,6 +11,7 @@
     top: 20px;
   }
   #finderResults {
+    scroll-margin-top: 30px;
     margin: 0;
     position: relative;
     width: 73.68421%;

--- a/rails/react-components/src/library/components/stem-finder.scss
+++ b/rails/react-components/src/library/components/stem-finder.scss
@@ -221,6 +221,7 @@
       &#community {
         &:before {
           content: '\f0c0';
+          left: 8px;
         }
       }
 

--- a/rails/react-components/src/library/components/stem-finder.tsx
+++ b/rails/react-components/src/library/components/stem-finder.tsx
@@ -1124,7 +1124,7 @@ class StemFinder extends React.Component<Props, State> {
       );
     }
 
-    // Landing state: show FeaturedCollections strip (no filters, no keyword, initial page).
+    // Landing state: show FeaturedCollections strip (no filters, no keyword).
     const showFeaturedStrip =
       !this.props.hideFeatured &&
       this.noOptionsSelected() &&

--- a/rails/react-components/src/library/components/stem-finder.tsx
+++ b/rails/react-components/src/library/components/stem-finder.tsx
@@ -60,7 +60,6 @@ interface State {
   includeOfficial: boolean,
   includeContributed: boolean,
   includeMine: boolean,
-  initPage: boolean,
   isSmallScreen: boolean,
   sectionsOpen: Record<SectionKey, boolean>,
   keyword: string,
@@ -163,7 +162,6 @@ class StemFinder extends React.Component<Props, State> {
       includeOfficial: true,
       includeContributed: false,
       includeMine: false,
-      initPage: true,
       isSmallScreen: initialIsSmallScreen,
       sectionsOpen: defaultSectionsOpen(!initialIsSmallScreen),
       keyword: "",
@@ -520,7 +518,6 @@ class StemFinder extends React.Component<Props, State> {
         return {
           subjectAreasSelected,
           subjectAreasSelectedMap,
-          initPage: false
         };
       }, this.search);
     };
@@ -576,7 +573,6 @@ class StemFinder extends React.Component<Props, State> {
         return {
           gradeLevelsSelected,
           gradeLevelsSelectedMap,
-          initPage: false
         };
       }, this.search);
     };
@@ -630,7 +626,6 @@ class StemFinder extends React.Component<Props, State> {
         return {
           resourceTypesSelected,
           resourceTypesSelectedMap,
-          initPage: false
         };
       }, this.search);
     };
@@ -794,7 +789,6 @@ class StemFinder extends React.Component<Props, State> {
   }
 
   toggleFilter (type: any, filter: any) {
-    this.setState({ initPage: false });
     const selectedKey: ("gradeLevelsSelected"|"subjectAreasSelected") = (type + "Selected") as any;
     const selectedFilters = this.state[selectedKey].slice();
     const index = selectedFilters.indexOf(filter);
@@ -823,15 +817,9 @@ class StemFinder extends React.Component<Props, State> {
     e.stopPropagation();
     this.search();
     this.scrollToFinder();
-    this.setState({
-      initPage: false,
-    });
   };
 
   handleAutoSuggestSubmit = (searchInput: any) => {
-    this.setState({
-      initPage: false,
-    });
     this.setState({ searchInput }, () => {
       this.search();
       this.scrollToFinder();
@@ -841,9 +829,6 @@ class StemFinder extends React.Component<Props, State> {
   handleSortSelection = (e: any) => {
     e.preventDefault();
     e.stopPropagation();
-    this.setState({
-      initPage: false
-    });
     this.setState({ sortOrder: e.target.value }, () => {
       this.search();
     });
@@ -1142,7 +1127,6 @@ class StemFinder extends React.Component<Props, State> {
     // Landing state: show FeaturedCollections strip (no filters, no keyword, initial page).
     const showFeaturedStrip =
       !this.props.hideFeatured &&
-      this.state.initPage &&
       this.noOptionsSelected() &&
       (this.state.keyword || "").trim().length === 0 &&
       this.state.featuredCollections.length > 0;


### PR DESCRIPTION
[RIGSE-347](https://concord-consortium.atlassian.net/browse/RIGSE-347)

This is a follow-up to #1480. It fixes four issues:

1. Removes the now-redundant "Curated Collection" tag from search result collection cards
2. Featured Collections section should show when there are no search keywords and no filters selected
3. Filter menus should not be sticky on scroll when the viewport is less than 930px high
4. Centers the Community filter icon to better align with the other filters' icons

[RIGSE-347]: https://concord-consortium.atlassian.net/browse/RIGSE-347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ